### PR TITLE
Entangled Hadamard

### DIFF
--- a/complex16simd.cpp
+++ b/complex16simd.cpp
@@ -81,8 +81,19 @@ Complex16Simd Complex16Simd::operator/=(const double rhs)
     return Complex16Simd(_val);
 }
 Complex16Simd Complex16Simd::operator-() const { return -1.0 * _val; }
-bool Complex16Simd::operator==(const Complex16Simd& rhs) const { return (real(*this) == real(rhs)) && (imag(*this) == imag(rhs)); }
-bool Complex16Simd::operator!=(const Complex16Simd& rhs) const { return (real(*this) != real(rhs)) || (imag(*this) != imag(rhs)); }
+Complex16Simd Complex16Simd::operator*=(const double& other)
+{
+    _val = _mm_mul_pd(_val, _mm_set1_pd(other));
+    return Complex16Simd(_val);
+}
+bool Complex16Simd::operator==(const Complex16Simd& rhs) const
+{
+    return (real(*this) == real(rhs)) && (imag(*this) == imag(rhs));
+}
+bool Complex16Simd::operator!=(const Complex16Simd& rhs) const
+{
+    return (real(*this) != real(rhs)) || (imag(*this) != imag(rhs));
+}
 
 // Imperative function definitions:
 Complex16Simd operator*(const double lhs, const Complex16Simd& rhs) { return _mm_mul_pd(_mm_set1_pd(lhs), rhs._val); }

--- a/complex16simd.cpp
+++ b/complex16simd.cpp
@@ -81,6 +81,8 @@ Complex16Simd Complex16Simd::operator/=(const double rhs)
     return Complex16Simd(_val);
 }
 Complex16Simd Complex16Simd::operator-() const { return -1.0 * _val; }
+bool Complex16Simd::operator==(const Complex16Simd& rhs) const { return (real(*this) == real(rhs)) && (imag(*this) == imag(rhs)); }
+bool Complex16Simd::operator!=(const Complex16Simd& rhs) const { return (real(*this) != real(rhs)) || (imag(*this) != imag(rhs)); }
 
 // Imperative function definitions:
 Complex16Simd operator*(const double lhs, const Complex16Simd& rhs) { return _mm_mul_pd(_mm_set1_pd(lhs), rhs._val); }

--- a/complex16simd.hpp
+++ b/complex16simd.hpp
@@ -34,6 +34,7 @@ struct Complex16Simd {
     Complex16Simd operator/(const double rhs) const;
     Complex16Simd operator/=(const double rhs);
     Complex16Simd operator-() const;
+    Complex16Simd operator*=(const double& other);
     bool operator==(const Complex16Simd& rhs) const;
     bool operator!=(const Complex16Simd& rhs) const;
 };

--- a/complex16simd.hpp
+++ b/complex16simd.hpp
@@ -34,6 +34,8 @@ struct Complex16Simd {
     Complex16Simd operator/(const double rhs) const;
     Complex16Simd operator/=(const double rhs);
     Complex16Simd operator-() const;
+    bool operator==(const Complex16Simd& rhs) const;
+    bool operator!=(const Complex16Simd& rhs) const;
 };
 
 Complex16Simd operator*(const double lhs, const Complex16Simd& rhs);

--- a/example.cpp
+++ b/example.cpp
@@ -246,16 +246,17 @@ TEST_CASE_METHOD(CoherentUnitTestFixture, "test_grover")
                  "should output 00100110 11011001.)"
               << std::endl;
 
-    unsigned char toSearch[256];
-    for (i = 0; i < 256; i++) {
-        toSearch[i] = i;
-    }
+    //unsigned char toSearch[256];
+    //for (i = 0; i < 256; i++) {
+    //    toSearch[i] = i;
+    //}
 
-    qftReg->SetPermutation(0);
+    qftReg->SetPermutation(15);
     qftReg->SetBit(16, true);
-    qftReg->H(0, 8);
-    qftReg->SuperposeReg8(0, 8, toSearch);
-    qftReg->EntangledH(0, 8, 8);
+    //qftReg->H(0, 8);
+    //qftReg->SuperposeReg8(0, 8, toSearch);
+    qftReg->EntangledH(0, 2, 2);
+    qftReg->EntangledH(0, 2, 2);
 
     // Twelve iterations maximizes the probablity for 256 searched elements.
     /*for (i = 0; i < 12; i++) {

--- a/example.cpp
+++ b/example.cpp
@@ -248,7 +248,7 @@ TEST_CASE_METHOD(CoherentUnitTestFixture, "test_grover")
 
     unsigned char toSearch[256];
     for (i = 0; i < 256; i++) {
-        toSearch[i] = i;
+        toSearch[i] = 255 - i;
     }
 
     qftReg->SetPermutation(0);
@@ -265,8 +265,8 @@ TEST_CASE_METHOD(CoherentUnitTestFixture, "test_grover")
         qftReg->SetZeroFlag(8, 8, 16);
         qftReg->EntangledH(8, 0, 8);
         qftReg->Z(16);
-        std::cout << "Iteration " << i << ", chance of 100:"
-                  << (qftReg->ProbAll(100 + (100 << 8)) + qftReg->ProbAll(100 + (100 << 8) + (1 << 16))) << std::endl;
+        std::cout << "Iteration " << i << ", chance of match:"
+                  << (qftReg->ProbAll(100 + (155 << 8)) + qftReg->ProbAll(100 + (155 << 8) + (1 << 16))) << std::endl;
     }
     int greatestProbIndex = 0;
     double greatestProb = 0;
@@ -292,10 +292,10 @@ TEST_CASE_METHOD(CoherentUnitTestFixture, "test_grover")
         std::cout << "Bit " << i << ", Chance of 1:" << qftReg->Prob(i) << std::endl;
     }
 
-    // qftReg->MReg8(0);
-    // qftReg->SetBit(16, false);
+    qftReg->MReg8(0);
+    qftReg->SetBit(16, false);
 
-    // REQUIRE_THAT(qftReg, HasProbability(0, 8, 100));
+    REQUIRE_THAT(qftReg, HasProbability(0, 16, 100 + (155 << 8)));
 }
 
 TEST_CASE_METHOD(CoherentUnitTestFixture, "test_random_walk")

--- a/example.cpp
+++ b/example.cpp
@@ -246,30 +246,28 @@ TEST_CASE_METHOD(CoherentUnitTestFixture, "test_grover")
                  "should output 00100110 11011001.)"
               << std::endl;
 
-    //unsigned char toSearch[256];
-    //for (i = 0; i < 256; i++) {
-    //    toSearch[i] = i;
-    //}
+    unsigned char toSearch[256];
+    for (i = 0; i < 256; i++) {
+        toSearch[i] = i;
+    }
 
-    qftReg->SetPermutation(15);
+    qftReg->SetPermutation(0);
     qftReg->SetBit(16, true);
-    //qftReg->H(0, 8);
-    //qftReg->SuperposeReg8(0, 8, toSearch);
-    qftReg->EntangledH(0, 2, 2);
-    qftReg->EntangledH(0, 2, 2);
+    qftReg->H(8, 8);
+    qftReg->SuperposeReg8(8, 0, toSearch);
 
     // Twelve iterations maximizes the probablity for 256 searched elements.
-    /*for (i = 0; i < 12; i++) {
-        qftReg->DEC(100 + (100<<8), 0, 16);
-        qftReg->SetZeroFlag(0, 16, 16);
-        qftReg->INC(100 + (100<<8), 0, 16);
-        qftReg->H(0, 16);
-        qftReg->SetZeroFlag(0, 16, 16);
-        qftReg->H(0, 16);
+    for (i = 0; i < 12; i++) {
+        qftReg->DEC(100, 0, 8);
+        qftReg->SetZeroFlag(0, 8, 16);
+        qftReg->INC(100, 0, 8);
+        qftReg->EntangledH(8, 0, 8);
+        qftReg->SetZeroFlag(8, 8, 16);
+        qftReg->EntangledH(8, 0, 8);
         qftReg->Z(16);
-        std::cout << "Iteration " << i
-                  << ", chance of 100:" << (qftReg->ProbAll(100) + qftReg->ProbAll(100 + (1 << 16))) << std::endl;
-    }*/
+        std::cout << "Iteration " << i << ", chance of 100:"
+                  << (qftReg->ProbAll(100 + (100 << 8)) + qftReg->ProbAll(100 + (100 << 8) + (1 << 16))) << std::endl;
+    }
     int greatestProbIndex = 0;
     double greatestProb = 0;
     int greatestZeroProbIndex = 0;
@@ -294,10 +292,10 @@ TEST_CASE_METHOD(CoherentUnitTestFixture, "test_grover")
         std::cout << "Bit " << i << ", Chance of 1:" << qftReg->Prob(i) << std::endl;
     }
 
-    qftReg->MReg8(0);
-    qftReg->SetBit(16, false);
+    // qftReg->MReg8(0);
+    // qftReg->SetBit(16, false);
 
-    REQUIRE_THAT(qftReg, HasProbability(0, 8, 100));
+    // REQUIRE_THAT(qftReg, HasProbability(0, 8, 100));
 }
 
 TEST_CASE_METHOD(CoherentUnitTestFixture, "test_random_walk")

--- a/example.cpp
+++ b/example.cpp
@@ -246,22 +246,29 @@ TEST_CASE_METHOD(CoherentUnitTestFixture, "test_grover")
                  "should output 00100110 11011001.)"
               << std::endl;
 
+    unsigned char toSearch[256];
+    for (i = 0; i < 256; i++) {
+        toSearch[i] = i;
+    }
+
     qftReg->SetPermutation(0);
     qftReg->SetBit(16, true);
     qftReg->H(0, 8);
+    qftReg->SuperposeReg8(0, 8, toSearch);
+    qftReg->EntangledH(0, 8, 8);
 
     // Twelve iterations maximizes the probablity for 256 searched elements.
-    for (i = 0; i < 12; i++) {
-        qftReg->DEC(100, 0, 8);
-        qftReg->SetZeroFlag(0, 8, 16);
-        qftReg->INC(100, 0, 8);
-        qftReg->H(0, 8);
-        qftReg->SetZeroFlag(0, 8, 16);
-        qftReg->H(0, 8);
+    /*for (i = 0; i < 12; i++) {
+        qftReg->DEC(100 + (100<<8), 0, 16);
+        qftReg->SetZeroFlag(0, 16, 16);
+        qftReg->INC(100 + (100<<8), 0, 16);
+        qftReg->H(0, 16);
+        qftReg->SetZeroFlag(0, 16, 16);
+        qftReg->H(0, 16);
         qftReg->Z(16);
         std::cout << "Iteration " << i
                   << ", chance of 100:" << (qftReg->ProbAll(100) + qftReg->ProbAll(100 + (1 << 16))) << std::endl;
-    }
+    }*/
     int greatestProbIndex = 0;
     double greatestProb = 0;
     int greatestZeroProbIndex = 0;

--- a/makefile
+++ b/makefile
@@ -14,7 +14,7 @@ TEST_BIN = example
 QRACK_LIB=libqrack.a
 LIBS     = -lm -lpthread
 CXXINCS  = 
-CXXFLAGS = $(CXXINCS) -ggdb -std=c++11 -Wall -Werror
+CXXFLAGS = $(CXXINCS) -ggdb -std=c++11 -Wall -Werror -DCATCH_CONFIG_FAST_COMPILE
 LDFLAGS  =
 RM       = rm -f
 

--- a/qregister.hpp
+++ b/qregister.hpp
@@ -71,7 +71,10 @@ public:
     void SetRandomSeed(uint32_t seed);
 
     /// Get the count of bits in this register
-    int GetQubitCount();
+    int GetQubitCount() { return qubitCount; }
+
+    /// Get the 1 << GetQubitCount()
+    int GetMaxQPower() { return maxQPower; }
 
     /// PSEUDO-QUANTUM Output the exact quantum state of this register as a permutation basis array of complex numbers
     void CloneRawState(Complex16* output);

--- a/qregister.hpp
+++ b/qregister.hpp
@@ -374,6 +374,9 @@ public:
     /// Quantum Fourier Transform - Apply the quantum Fourier transform to the register.
     void QFT(bitLenInt start, bitLenInt length);
 
+    /// "Entangled Hadamard" - perform an operation on two entangled registers like a bitwise Hadamard on a single unentangled register.
+    void EntangledH(bitLenInt targetStart, bitLenInt entangledStart, bitLenInt length);
+
     /// For chips with a zero flag, set the zero flag after a register operation.
     void SetZeroFlag(bitLenInt start, bitLenInt length, bitLenInt zeroFlag);
 

--- a/qregister.hpp
+++ b/qregister.hpp
@@ -374,7 +374,8 @@ public:
     /// Quantum Fourier Transform - Apply the quantum Fourier transform to the register.
     void QFT(bitLenInt start, bitLenInt length);
 
-    /// "Entangled Hadamard" - perform an operation on two entangled registers like a bitwise Hadamard on a single unentangled register.
+    /// "Entangled Hadamard" - perform an operation on two entangled registers like a bitwise Hadamard on a single
+    /// unentangled register.
     void EntangledH(bitLenInt targetStart, bitLenInt entangledStart, bitLenInt length);
 
     /// For chips with a zero flag, set the zero flag after a register operation.


### PR DESCRIPTION
Grover's search can find a subroutine input from which a desired output results, in O(sqrt(m/n)) time for m possible inputs with n matching outputs. While this algorithm is foundational, generalization would make it more useful.

Suppose one qubit register in superposition is used as a coherent quantum memory address offset for loading another register. We assume that the memory we load from is classical but quantum mechanically isolated, (perhaps cryogenically, the cache of a quantum processing unit, "QPU"). Since the classical memory is isolated, currents could potentially pass in coherent superposition between different memory addresses at once, in order to load a superposition into another register. (Superposed currents could be supplied by superconducting interference devices, "SQUIDs.") The registers would end up entangled, where a subsequent measurement of the registers before further computation would always collapse into a valid key-value pair, where the latter register would always result in a lookup table value byte corresponding with a key byte in the original register, and vice versa if the original register key byte is measured first.

In the 6502, this is useful for loading a lookup table entangled between the X index register and the accumulator. The X is set to zero and then operated on by a Hadamard over all bits. Then, an X-addressed "LDA" instruction is executed, entangling the lookup table key in X with its value in the accumulator. Then, amplitude amplification, a generalization of Grover's algorithm, can be used to search (or "invert") the lookup table key-value pairs.

Grover's uses Hadamard gates to change basis to search for an (upaired) value. We need a Hadamard-like operation for values paired with keys, with the search target being the key that matches a desired value byte. This operation should affect the (entangled) X index register as would a Hadamard operation on a not-entangled X register. In the process, it should maintain the entanglement to the accumulator, in terms of affecting (NOT-ing or X-ing) corresponding bits in the X register and accumulator in a corresponding way.

This "entangled Hadamard" gate has been implemented as "EntangledH." A working example of a lookup value inversion algorithm has been included in example.cpp. These changes have been carried through to vm6502q, (with example,) and its tool chain materials.

(See also:
https://github.com/vm6502q/vm6502q/pull/7
https://github.com/vm6502q/cc65/pull/2
https://github.com/vm6502q/examples/pull/2 )