### PR TITLE
Fixing unitarity in logical comparisons

### DIFF
--- a/example.cpp
+++ b/example.cpp
@@ -134,43 +134,37 @@ TEST_CASE_METHOD(CoherentUnitTestFixture, "test_ror")
 TEST_CASE_METHOD(CoherentUnitTestFixture, "test_and")
 {
     std::cout << "AND Test:" << std::endl;
-    qftReg->SetPermutation(0x2e);
-    REQUIRE_THAT(qftReg, HasProbability(0x2e));
-    qftReg->CLAND(0, 0xff, 0, 8); // 0x2e & 0xff
-    REQUIRE_THAT(qftReg, HasProbability(0x2e));
+    qftReg->SetPermutation(0x0e);
+    REQUIRE_THAT(qftReg, HasProbability(0x0e));
+    qftReg->CLAND(0, 0x0f, 4, 4); // 0x0e & 0x0f
+    REQUIRE_THAT(qftReg, HasProbability(0xee));
     qftReg->SetPermutation(0x3e);
-    qftReg->AND(0, 4, 0, 4); // 0xe & 0x3
-    REQUIRE_THAT(qftReg, HasProbability(0x32));
+    qftReg->AND(0, 4, 8, 4); // 0xe & 0x3
+    REQUIRE_THAT(qftReg, HasProbability(0x23e));
 }
 
 TEST_CASE_METHOD(CoherentUnitTestFixture, "test_or")
 {
     std::cout << "OR Test:" << std::endl;
-    qftReg->SetPermutation(38);
-    std::cout << "[6,9) = [0,3) & [3,6):" << std::endl;
-    WARN(qftReg);
-    qftReg->CLOR(0, 255, 0, 8);
-    WARN(qftReg);
-    qftReg->SetPermutation(58);
-    std::cout << "[0,4) = [0,4) & [4,8):" << std::endl;
-    WARN(qftReg);
-    qftReg->OR(0, 4, 0, 4);
-    WARN(qftReg);
+    qftReg->SetPermutation(0x0e);
+    REQUIRE_THAT(qftReg, HasProbability(0x0e));
+    qftReg->CLOR(0, 0x0f, 4, 4); // 0x0e | 0x0f
+    REQUIRE_THAT(qftReg, HasProbability(0xfe));
+    qftReg->SetPermutation(0x3e);
+    qftReg->OR(0, 4, 8, 4); // 0xe | 0x3
+    REQUIRE_THAT(qftReg, HasProbability(0xe3e));
 }
 
 TEST_CASE_METHOD(CoherentUnitTestFixture, "test_xor")
 {
     std::cout << "XOR Test:" << std::endl;
-    qftReg->SetPermutation(38);
-    std::cout << "[6,9) = [0,3) & [3,6):" << std::endl;
-    WARN(qftReg);
-    qftReg->XOR(0, 3, 6, 3);
-    WARN(qftReg);
-    qftReg->SetPermutation(58);
-    std::cout << "[0,4) = [0,4) & [4,8):" << std::endl;
-    WARN(qftReg);
-    qftReg->XOR(0, 4, 0, 4);
-    WARN(qftReg);
+    qftReg->SetPermutation(0x0e);
+    REQUIRE_THAT(qftReg, HasProbability(0x0e));
+    qftReg->CLXOR(0, 0x0f, 4, 4); // 0x0e ^ 0x0f
+    REQUIRE_THAT(qftReg, HasProbability(0x1e));
+    qftReg->SetPermutation(0x3e);
+    qftReg->XOR(0, 4, 8, 4); // 0xe ^ 0x3
+    REQUIRE_THAT(qftReg, HasProbability(0x23e));
 }
 
 TEST_CASE_METHOD(CoherentUnitTestFixture, "test_m_reg")

--- a/qregister.cpp
+++ b/qregister.cpp
@@ -365,7 +365,7 @@ void CoherentUnit::CLOR(bitLenInt inputQBit, bool inputClassicalBit, bitLenInt o
 void CoherentUnit::XOR(bitLenInt inputBit1, bitLenInt inputBit2, bitLenInt outputBit)
 {
     if (((inputBit1 == inputBit2) && (inputBit2 == outputBit))) {
-        return;
+	throw std::invalid_argument("Invalid XOR arguments.");
     }
 
     if ((inputBit1 == outputBit) && (inputBit2 != outputBit)) {

--- a/qregister.cpp
+++ b/qregister.cpp
@@ -365,7 +365,8 @@ void CoherentUnit::CLOR(bitLenInt inputQBit, bool inputClassicalBit, bitLenInt o
 void CoherentUnit::XOR(bitLenInt inputBit1, bitLenInt inputBit2, bitLenInt outputBit)
 {
     if (((inputBit1 == inputBit2) && (inputBit2 == outputBit))) {
-	throw std::invalid_argument("Invalid XOR arguments.");
+	SetBit(outputBit, false);
+	return;
     }
 
     if (inputBit1 == outputBit) {

--- a/qregister.cpp
+++ b/qregister.cpp
@@ -339,7 +339,7 @@ void CoherentUnit::OR(bitLenInt inputBit1, bitLenInt inputBit2, bitLenInt output
     }
 
     if ((inputBit1 != outputBit) && (inputBit2 != outputBit)) {
-        SetBit(outputBit, false);
+        SetBit(outputBit, true);
         if (inputBit1 == inputBit2) {
             AntiCNOT(inputBit1, outputBit);
         } else {
@@ -368,7 +368,7 @@ void CoherentUnit::XOR(bitLenInt inputBit1, bitLenInt inputBit2, bitLenInt outpu
 	throw std::invalid_argument("Invalid XOR arguments.");
     }
 
-    if ((inputBit1 == outputBit) && (inputBit2 != outputBit)) {
+    if (inputBit1 == outputBit) {
         CNOT(inputBit2, outputBit);
     } else if (inputBit2 == outputBit) {
         CNOT(inputBit1, outputBit);

--- a/qregister.cpp
+++ b/qregister.cpp
@@ -307,19 +307,15 @@ void CoherentUnit::AND(bitLenInt inputBit1, bitLenInt inputBit2, bitLenInt outpu
         return;
     }
 
-    if ((inputBit1 == outputBit) || (inputBit2 == outputBit)) {
-        CoherentUnit extraBit(1, 0);
-        Cohere(extraBit);
-        CCNOT(inputBit1, inputBit2, qubitCount - 1);
-        Swap(qubitCount - 1, outputBit);
-        Dispose(qubitCount - 1, 1);
-    } else {
+    if ((inputBit1 != outputBit) && (inputBit2 != outputBit)) {
         SetBit(outputBit, false);
         if (inputBit1 == inputBit2) {
             CNOT(inputBit1, outputBit);
         } else {
             CCNOT(inputBit1, inputBit2, outputBit);
         }
+    } else {
+        throw std::invalid_argument("Invalid AND arguments.");
     }
 }
 
@@ -342,19 +338,15 @@ void CoherentUnit::OR(bitLenInt inputBit1, bitLenInt inputBit2, bitLenInt output
         return;
     }
 
-    if ((inputBit1 == outputBit) || (inputBit2 == outputBit)) {
-        CoherentUnit extraBit(1, 1);
-        Cohere(extraBit);
-        AntiCCNOT(inputBit1, inputBit2, qubitCount - 1);
-        Swap(qubitCount - 1, outputBit);
-        Dispose(qubitCount - 1, 1);
-    } else {
-        SetBit(outputBit, true);
+    if ((inputBit1 != outputBit) && (inputBit2 != outputBit)) {
+        SetBit(outputBit, false);
         if (inputBit1 == inputBit2) {
             AntiCNOT(inputBit1, outputBit);
         } else {
             AntiCCNOT(inputBit1, inputBit2, outputBit);
         }
+    } else {
+        throw std::invalid_argument("Invalid OR arguments.");
     }
 }
 
@@ -373,17 +365,13 @@ void CoherentUnit::CLOR(bitLenInt inputQBit, bool inputClassicalBit, bitLenInt o
 void CoherentUnit::XOR(bitLenInt inputBit1, bitLenInt inputBit2, bitLenInt outputBit)
 {
     if (((inputBit1 == inputBit2) && (inputBit2 == outputBit))) {
-        SetBit(outputBit, false);
         return;
     }
 
-    if ((inputBit1 == outputBit) || (inputBit2 == outputBit)) {
-        CoherentUnit extraBit(1, 0);
-        Cohere(extraBit);
-        CNOT(inputBit1, qubitCount - 1);
-        CNOT(inputBit2, qubitCount - 1);
-        Swap(qubitCount - 1, outputBit);
-        Dispose(qubitCount - 1, 1);
+    if ((inputBit1 == outputBit) && (inputBit2 != outputBit)) {
+        CNOT(inputBit2, outputBit);
+    } else if (inputBit2 == outputBit) {
+        CNOT(inputBit1, outputBit);
     } else {
         SetBit(outputBit, false);
         CNOT(inputBit1, outputBit);


### PR DESCRIPTION
Strictly, a quantum logical comparison of two bits requires two separate input bits and a third output bit. Qrack had attempted to handle bit overlap, but not correctly. A safer method might be not to allow bit overlap in logical comparison at all. However, 4 cases of overlap could be made sensible:

1. If all three bits to an AND are the same bit, the intended comparison is equivalent to leaving the bit unaltered.
2. If all three bits to an OR are the same bit, the intended comparison is equivalent to leaving the bit unaltered.
3. If the two input bits to an XOR are distinct, but either is the same as the output bit, the intended comparison is equivalent to CNOT from the exclusively input bit to the input/output bit.
4. If all three bits to an XOR are the same bit, this implies 0 bit output.

Rigorously, these operations could performed without breaking unitarity and introducing a random phase factor only if the output bit starts in a guaranteed state, like |0>. However, in register-based systems, there are cases where we would first zero an arbitrary state in a quantum register before we perform these operations, which necessarily requires measurement. These methods are conveniences that target those use cases. Otherwise, CCNOT and "AntiCCNOT" should be used.

The methods have to updated to handle only the completely disjointed and above listed cases, and throw an exception otherwise. The unit tests have also been updated.