### PR TITLE
ADC/SBC superposed

### DIFF
--- a/example.cpp
+++ b/example.cpp
@@ -33,6 +33,47 @@ TEST_CASE_METHOD(CoherentUnitTestFixture, "test_superposition_reg")
     REQUIRE_THAT(qftReg, HasProbability(0, 16, 0x303));
 }
 
+TEST_CASE_METHOD(CoherentUnitTestFixture, "test_adc_superposition_reg")
+{
+    int j;
+
+    qftReg->SetPermutation(0);
+    REQUIRE_THAT(qftReg, HasProbability(0, 16, 0));
+
+    qftReg->H(8, 8);
+    unsigned char testPage[256];
+    for (j = 0; j < 256; j++) {
+        testPage[j] = j;
+    }
+    qftReg->SuperposeReg8(8, 0, testPage);
+
+    for (j = 0; j < 256; j++) {
+        testPage[j] = 255 - j;
+    }
+    qftReg->AdcSuperposeReg8(8, 0, 16, testPage);
+
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0xff));
+}
+
+TEST_CASE_METHOD(CoherentUnitTestFixture, "test_sbc_superposition_reg")
+{
+    int j;
+
+    qftReg->SetPermutation(0);
+    REQUIRE_THAT(qftReg, HasProbability(0, 16, 0));
+
+    qftReg->H(8, 8);
+    unsigned char testPage[256];
+    for (j = 0; j < 256; j++) {
+        testPage[j] = j;
+    }
+    qftReg->SuperposeReg8(8, 0, testPage);
+
+    qftReg->SbcSuperposeReg8(8, 0, 16, testPage);
+
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x00));
+}
+
 TEST_CASE_METHOD(CoherentUnitTestFixture, "test_m") { REQUIRE(qftReg->MReg(0, 8) == 0); }
 
 TEST_CASE_METHOD(CoherentUnitTestFixture, "test_inc")

--- a/example.cpp
+++ b/example.cpp
@@ -29,8 +29,9 @@ TEST_CASE_METHOD(CoherentUnitTestFixture, "test_superposition_reg")
     for (j = 0; j < 256; j++) {
         testPage[j] = j;
     }
-    qftReg->SuperposeReg8(0, 8, testPage);
+    unsigned char expectation = qftReg->SuperposeReg8(0, 8, testPage);
     REQUIRE_THAT(qftReg, HasProbability(0, 16, 0x303));
+    std::cout << (int)expectation << std::endl;
 }
 
 TEST_CASE_METHOD(CoherentUnitTestFixture, "test_adc_superposition_reg")
@@ -50,9 +51,9 @@ TEST_CASE_METHOD(CoherentUnitTestFixture, "test_adc_superposition_reg")
     for (j = 0; j < 256; j++) {
         testPage[j] = 255 - j;
     }
-    qftReg->AdcSuperposeReg8(8, 0, 16, testPage);
-
+    unsigned char expectation = qftReg->AdcSuperposeReg8(8, 0, 16, testPage);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0xff));
+    REQUIRE(expectation == 0xff);
 }
 
 TEST_CASE_METHOD(CoherentUnitTestFixture, "test_sbc_superposition_reg")
@@ -69,9 +70,9 @@ TEST_CASE_METHOD(CoherentUnitTestFixture, "test_sbc_superposition_reg")
     }
     qftReg->SuperposeReg8(8, 0, testPage);
 
-    qftReg->SbcSuperposeReg8(8, 0, 16, testPage);
-
+    unsigned char expectation = qftReg->SbcSuperposeReg8(8, 0, 16, testPage);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x00));
+    REQUIRE(expectation == 0x00);
 }
 
 TEST_CASE_METHOD(CoherentUnitTestFixture, "test_m") { REQUIRE(qftReg->MReg(0, 8) == 0); }

--- a/qregister.cpp
+++ b/qregister.cpp
@@ -1093,6 +1093,16 @@ void CoherentUnit::CZ(bitLenInt control, bitLenInt target, bitLenInt length)
     }
 }
 
+/// Bit-parallel "CNOT" two bit ranges in CoherentUnit, and store result in range starting at output
+void CoherentUnit::CNOT(bitLenInt inputStart1, bitLenInt inputStart2, bitLenInt length)
+{
+    if (inputStart1 != inputStart2) {
+        for (bitLenInt i = 0; i < length; i++) {
+            CNOT(inputStart1 + i, inputStart2 + i);
+        }
+    }
+}
+
 /// "AND" compare two bit ranges in CoherentUnit, and store result in range starting at output
 void CoherentUnit::AND(bitLenInt inputStart1, bitLenInt inputStart2, bitLenInt outputStart, bitLenInt length)
 {

--- a/qregister.cpp
+++ b/qregister.cpp
@@ -2875,12 +2875,13 @@ unsigned char CoherentUnit::SuperposeReg8(bitLenInt inputStart, bitLenInt output
 }
 
 /// Add based on an indexed load from classical memory
-unsigned char CoherentUnit::AdcSuperposeReg8(bitLenInt inputStart, bitLenInt outputStart, bitLenInt carryIndex, unsigned char* values)
+unsigned char CoherentUnit::AdcSuperposeReg8(
+    bitLenInt inputStart, bitLenInt outputStart, bitLenInt carryIndex, unsigned char* values)
 {
     bitCapInt carryIn = 0;
     if (M(carryIndex)) {
-	carryIn = 1;
-	X(carryIndex);
+        carryIn = 1;
+        X(carryIndex);
     }
     std::unique_ptr<Complex16[]> nStateVec(new Complex16[maxQPower]);
     std::fill(&(nStateVec[0]), &(nStateVec[0]) + maxQPower, Complex16(0.0, 0.0));
@@ -2893,22 +2894,22 @@ unsigned char CoherentUnit::AdcSuperposeReg8(bitLenInt inputStart, bitLenInt out
     bitCapInt otherRes, inputRes, outputRes, carryRes, inputInt, outputInt, lcv, i, iLow, iHigh;
     bitCapInt maxLCV = maxQPower >> 1;
     for (lcv = 0; lcv < maxLCV; lcv++) {
-	iHigh = lcv;
+        iHigh = lcv;
         i = 0;
         iLow = iHigh % skipPower;
         i += iLow;
         iHigh = (iHigh - iLow) << 1;
         i += iHigh;
-	otherRes = i & otherMask;
+        otherRes = i & otherMask;
         inputRes = i & inputMask;
         inputInt = inputRes >> inputStart;
-	outputRes = i & outputMask;
+        outputRes = i & outputMask;
         outputInt = (outputRes >> outputStart) + values[inputInt] + carryIn;
-	carryRes = 0;
-	if (outputInt >= lengthPower) {
-		outputInt -= lengthPower;
-		carryRes = carryMask;
-	}
+        carryRes = 0;
+        if (outputInt >= lengthPower) {
+            outputInt -= lengthPower;
+            carryRes = carryMask;
+        }
         outputRes = outputInt << outputStart;
         nStateVec[outputRes | inputRes | otherRes | carryRes] = stateVec[i];
     }
@@ -2925,12 +2926,13 @@ unsigned char CoherentUnit::AdcSuperposeReg8(bitLenInt inputStart, bitLenInt out
 }
 
 /// Subtract based on an indexed load from classical memory
-unsigned char CoherentUnit::SbcSuperposeReg8(bitLenInt inputStart, bitLenInt outputStart, bitLenInt carryIndex, unsigned char* values)
+unsigned char CoherentUnit::SbcSuperposeReg8(
+    bitLenInt inputStart, bitLenInt outputStart, bitLenInt carryIndex, unsigned char* values)
 {
     bitCapInt carryIn = 0;
     if (M(carryIndex)) {
-	carryIn = 1;
-	X(carryIndex);
+        carryIn = 1;
+        X(carryIndex);
     }
     std::unique_ptr<Complex16[]> nStateVec(new Complex16[maxQPower]);
     std::fill(&(nStateVec[0]), &(nStateVec[0]) + maxQPower, Complex16(0.0, 0.0));
@@ -2943,22 +2945,22 @@ unsigned char CoherentUnit::SbcSuperposeReg8(bitLenInt inputStart, bitLenInt out
     bitCapInt otherRes, inputRes, outputRes, carryRes, inputInt, outputInt, lcv, i, iLow, iHigh;
     bitCapInt maxLCV = maxQPower >> 1;
     for (lcv = 0; lcv < maxLCV; lcv++) {
-	iHigh = lcv;
+        iHigh = lcv;
         i = 0;
         iLow = iHigh % skipPower;
         i += iLow;
         iHigh = (iHigh - iLow) << 1;
         i += iHigh;
-	otherRes = i & otherMask;
+        otherRes = i & otherMask;
         inputRes = i & inputMask;
         inputInt = inputRes >> inputStart;
-	outputRes = i & outputMask;
+        outputRes = i & outputMask;
         outputInt = (lengthPower + (outputRes >> outputStart)) - (values[inputInt] + carryIn);
-	carryRes = carryMask;
-	if (outputInt >= lengthPower) {
-		outputInt -= lengthPower;
-		carryRes = 0;
-	}
+        carryRes = carryMask;
+        if (outputInt >= lengthPower) {
+            outputInt -= lengthPower;
+            carryRes = 0;
+        }
         outputRes = outputInt << outputStart;
         nStateVec[outputRes | inputRes | otherRes | carryRes] = stateVec[i];
     }

--- a/qregister.cpp
+++ b/qregister.cpp
@@ -2878,8 +2878,16 @@ unsigned char CoherentUnit::SuperposeReg8(bitLenInt inputStart, bitLenInt output
 unsigned char CoherentUnit::AdcSuperposeReg8(
     bitLenInt inputStart, bitLenInt outputStart, bitLenInt carryIndex, unsigned char* values)
 {
+
+    // This a quantum/classical interface method, similar to SuperposeReg8.
+    // Like SuperposeReg8, up to a page of classical memory is loaded based on a quantum mechanically coherent offset by
+    // the "inputStart" register. Instead of just loading this page superposed into "outputStart," though, its values
+    // are ADded with Carry (ADC) to values entangled in the "outputStart" register with the "inputStart" register.
+
+    // The carry has to first to be measured for its input value.
     bitCapInt carryIn = 0;
     if (M(carryIndex)) {
+        // If the carry is set, we carry 1 in. We always initially clear the carry after testing for carry in.
         carryIn = 1;
         X(carryIndex);
     }
@@ -2904,6 +2912,8 @@ unsigned char CoherentUnit::AdcSuperposeReg8(
         inputRes = i & inputMask;
         inputInt = inputRes >> inputStart;
         outputRes = i & outputMask;
+        // See SuperposeReg8. This is where we load an entangled state into the output register. Instead, we add in
+        // quantum parallel based on entanglement between the input and output registers, analagous to SuperposeReg8.
         outputInt = (outputRes >> outputStart) + values[inputInt] + carryIn;
         carryRes = 0;
         if (outputInt >= lengthPower) {
@@ -2913,6 +2923,7 @@ unsigned char CoherentUnit::AdcSuperposeReg8(
         outputRes = outputInt << outputStart;
         nStateVec[outputRes | inputRes | otherRes | carryRes] = stateVec[i];
     }
+    // At the end, just as a convenience, we return the expectation value for the addition result.
     double prob, average;
     for (i = 0; i < maxQPower; i++) {
         outputRes = i & outputMask;
@@ -2929,8 +2940,16 @@ unsigned char CoherentUnit::AdcSuperposeReg8(
 unsigned char CoherentUnit::SbcSuperposeReg8(
     bitLenInt inputStart, bitLenInt outputStart, bitLenInt carryIndex, unsigned char* values)
 {
+    // This a quantum/classical interface method, similar to SuperposeReg8.
+    // Like SuperposeReg8, up to a page of classical memory is loaded based on a quantum mechanically coherent offset by
+    // the "inputStart" register. Instead of just loading this page superposed into "outputStart," though, its values
+    // are SuBtracted with Carry (SBC) from values entangled in the "outputStart" register with the "inputStart"
+    // register.
+
+    // The carry (or "borrow") has to first to be measured for its input value.
     bitCapInt carryIn = 0;
     if (M(carryIndex)) {
+        // If the carry is set, we borrow 1 going in. We always initially clear the carry after testing for borrow in.
         carryIn = 1;
         X(carryIndex);
     }
@@ -2955,6 +2974,8 @@ unsigned char CoherentUnit::SbcSuperposeReg8(
         inputRes = i & inputMask;
         inputInt = inputRes >> inputStart;
         outputRes = i & outputMask;
+        // See SuperposeReg8. This is where we load an entangled state into the output register. Instead, we subtract in
+        // quantum parallel based on entanglement between the input and output registers, analagous to SuperposeReg8.
         outputInt = (lengthPower + (outputRes >> outputStart)) - (values[inputInt] + carryIn);
         carryRes = carryMask;
         if (outputInt >= lengthPower) {
@@ -2965,6 +2986,7 @@ unsigned char CoherentUnit::SbcSuperposeReg8(
         nStateVec[outputRes | inputRes | otherRes | carryRes] = stateVec[i];
     }
     double prob, average;
+    // At the end, just as a convenience, we return the expectation value for the subtraction result.
     for (i = 0; i < maxQPower; i++) {
         outputRes = i & outputMask;
         outputInt = outputRes >> outputStart;

--- a/qregister.hpp
+++ b/qregister.hpp
@@ -404,10 +404,12 @@ public:
     unsigned char SuperposeReg8(bitLenInt inputStart, bitLenInt outputStart, unsigned char* values);
 
     /// Add based on an indexed load from classical memory
-    unsigned char AdcSuperposeReg8(bitLenInt inputStart, bitLenInt outputStart, bitLenInt carryIndex, unsigned char* values);
+    unsigned char AdcSuperposeReg8(
+        bitLenInt inputStart, bitLenInt outputStart, bitLenInt carryIndex, unsigned char* values);
 
     /// Subtract based on an indexed load from classical memory
-    unsigned char SbcSuperposeReg8(bitLenInt inputStart, bitLenInt outputStart, bitLenInt carryIndex, unsigned char* values);
+    unsigned char SbcSuperposeReg8(
+        bitLenInt inputStart, bitLenInt outputStart, bitLenInt carryIndex, unsigned char* values);
 
 protected:
     double runningNorm;

--- a/qregister.hpp
+++ b/qregister.hpp
@@ -197,6 +197,7 @@ public:
     void Y(bitLenInt start, bitLenInt length);
     void Z(bitLenInt start, bitLenInt length);
 
+    void CNOT(bitLenInt inputStart1, bitLenInt inputStart2, bitLenInt length);
     void AND(bitLenInt inputStart1, bitLenInt inputStart2, bitLenInt outputStart, bitLenInt length);
     void CLAND(bitLenInt qInputStart, bitCapInt classicalInput, bitLenInt outputStart, bitLenInt length);
     void OR(bitLenInt inputStart1, bitLenInt inputStart2, bitLenInt outputStart, bitLenInt length);

--- a/qregister.hpp
+++ b/qregister.hpp
@@ -402,6 +402,12 @@ public:
     /// Set 8 bit register bits based on read from classical memory
     unsigned char SuperposeReg8(bitLenInt inputStart, bitLenInt outputStart, unsigned char* values);
 
+    /// Add based on an indexed load from classical memory
+    unsigned char AdcSuperposeReg8(bitLenInt inputStart, bitLenInt outputStart, bitLenInt carryIndex, unsigned char* values);
+
+    /// Subtract based on an indexed load from classical memory
+    unsigned char SbcSuperposeReg8(bitLenInt inputStart, bitLenInt outputStart, bitLenInt carryIndex, unsigned char* values);
+
 protected:
     double runningNorm;
     bitLenInt qubitCount;


### PR DESCRIPTION
This branch adds ADC/SBC operations (add/sub with carry) that are analogous to "SuperposeReg8," in terms of taking a page of classical memory values as an input, indexed by a specified register. Unit tests are included. The operations pass the unit tests.

(Additionally, it adds a bitwise parallel CNOT method over registers.)