### PR TITLE
Removing 'entangled Hadamard'

### DIFF
--- a/qregister.hpp
+++ b/qregister.hpp
@@ -556,29 +556,6 @@ unitary logical comparison operations.)
     /// Quantum Fourier Transform - Apply the quantum Fourier transform to the register.
     void QFT(bitLenInt start, bitLenInt length);
 
-    /// "Entangled Hadamard" - perform an operation on two entangled registers like a bitwise Hadamard on a single
-    /// unentangled register.
-    /**
-      * The "entangled Hadamard" register operation is an important logical expedient to Qrack. It is a unitary
-operation, which may be complicated in terms of fundamental gates. For two entangled registers, starting with
-"targetStart" and "entangledStart," of "length" bits, it transforms the "targetStart" register as if a bitwise Hadamard
-was applied to a register which is not entangled. It maintains the entanglement to the "entangledStart" register in this
-process, affecting that register as if it were unentangled register to which a bitwise Hadamard gate variant, without
-phase reversal, was applied.
-
-When this gate is applied to a state loaded by SuperposeReg8(), it becomes possible to perform general "amplitude
-amplification" algorithms, generalizations of Grover's search, on entangled key-value pairs in two registers. This
-allows us to do things like "Grover's search" for the key index of an array value element which matches a target value,
-or search for the key index of an array value element which is greater than or less than a target value. See the
-"Grover's search" variants assembler examples in the examples project for practical examples of its application, or see
-the Grover's search unit test in "example.cpp." (The relevant examples are actually properly "amplitude amplification"
-generalizations of Grover's search.)
-
-As this operation is unitary and extremely expedient, Qrack does not concern itself with the physical hardware
-realization of this gate, as Qrack is a practical emulator designed for computational efficiency foremost.
-      */
-    void EntangledH(bitLenInt targetStart, bitLenInt entangledStart, bitLenInt length);
-
     /// Reverse the phase of the state where the register equals zero.
     void ZeroPhaseFlip(bitLenInt start, bitLenInt length);
 

--- a/tests.cpp
+++ b/tests.cpp
@@ -274,28 +274,12 @@ TEST_CASE_METHOD(CoherentUnitTestFixture, "test_grover")
 {
     int i;
 
-    // Search function is true only for an input of 100 (0x64). 100 is in
-    // position 155. First 16 bits should output 00100110 11011001.
-    //
-    // The target probability here is looking for 100 in the low 8 bits, and
-    // expecting to find 155 in the upper register.
+    // Grover's search inverts the function of a black box subroutine.
+    // Our subroutine returns true only for an input of 100.
+
     const int TARGET_PROB = 100;
-
-    // Create a table with decreasing values to search through
-    unsigned char toSearch[256];
-
-    // Create the lookup table
-    for (i = 0; i < 156; i++) {
-        toSearch[i] = 255 - i;
-    }
-    for (i = 156; i < 255; i++) {
-        toSearch[i] = i - 156;
-    }
-
-    // Make sure the value being searched for is in the targetted location.
-    REQUIRE(toSearch[155] == 100);
-
-    // Divide qftReg into two registers of 8 bits each
+    
+    // Our input to the subroutine "oracle" is 8 bits.
     qftReg->SetPermutation(0);
     qftReg->H(0, 8);
 


### PR DESCRIPTION
The intent of "EntangledH" was to reverse a lookup table. It fails at this application. It is superfluous to practical application, and it has been removed. All projects in the organization have had corresponding branches opened to remove this method. Grover's search has been tested and still works, but it has not been generalized to invert a lookup table.