### PR TITLE
Refactor the parallel for functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,8 +48,9 @@ test: $(TEST_BIN)
 
 tests.o : tests.hpp catch.hpp
 test_main.o : tests.hpp catch.hpp
-qregister.o : qregister.hpp
-qregister_opencl.o : qregister.hpp
+qregister.o : qregister.hpp par_for.hpp
+qregister_opencl.o : qregister.hpp par_for.hpp
+qregister_software.o : qregister.hpp par_for.hpp
 
 $(TEST_BIN): $(TEST_OBJ) $(QRACK_LIB)
 	$(CPP) $(TEST_OBJ) $(QRACK_LIB) -o $(TEST_BIN) $(LDFLAGS) $(LIBS)

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ This is equivalent to a physical body having a 50% chance of emitting a fixed un
 1.  Add symlinks for `/opt/AMDAPPSDK-3.0/lib/x86_64/sdk/libOpenCL.so.1` to `/usr/lib`
 1.  Add symlinks for `/opt/AMDAPPSDK-3.0/lib/x86_64/sdk/libamdocl64.so` to `/usr/lib`
 1.  Make sure `clinfo` reports back that there is a valid backend to use (anything other than an error should be fine).
+1.  Install OpenGL headers: `$ sudo apt install mesa-common-dev`
 1.  Adjust the `makefile` to have the appropriate search paths
 
 ## Note about unitarity and arithmetic

--- a/complex16simd.hpp
+++ b/complex16simd.hpp
@@ -10,6 +10,8 @@
 // See LICENSE.md in the project root or https://www.gnu.org/licenses/lgpl-3.0.en.html
 // for details.
 
+#pragma once
+
 #include <emmintrin.h>
 
 namespace Qrack {

--- a/doxygen.config
+++ b/doxygen.config
@@ -177,7 +177,7 @@ SHORT_NAMES            = NO
 # description.)
 # The default value is: NO.
 
-JAVADOC_AUTOBRIEF      = NO
+JAVADOC_AUTOBRIEF      = YES
 
 # If the QT_AUTOBRIEF tag is set to YES then doxygen will interpret the first
 # line (until the first dot) of a Qt-style comment as the brief description. If

--- a/par_for.hpp
+++ b/par_for.hpp
@@ -1,227 +1,35 @@
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-// THE FOLLOWING SECTION IS ADAPTED FROM THE "GILGAMESH" PROJECT, ( https://github.com/andy-thomason/gilgamesh ), UNDER
-// THE MIT LICENSE. AS PART OF Qrack, THE ADAPTED CODE IS LICENSED UNDER THE GNU GENERAL PUBLIC LICENSE V3.
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////////////////
+//
+// (C) Daniel Strano 2017. All rights reserved.
+//
+// This is a header-only, quick-and-dirty, multithreaded, universal quantum register
+// simulation, allowing (nonphysical) register cloning and direct measurement of
+// probability and phase, to leverage what advantages classical emulation of qubits
+// can have.
+//
+// Licensed under the GNU General Public License V3.
+// See LICENSE.md in the project root or https://www.gnu.org/licenses/gpl-3.0.en.html
+// for details.
 
-// Copyright (c) 2016 Andy Thomason
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
-// documentation files (the "Software"), to deal in the  Software without restriction, including without limitation the
-// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,  and to
-// permit persons to whom the Software is furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
-// Software.  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
-// LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A  PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
-// SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
-// CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
+#pragma once
 
 #include <atomic>
 #include <future>
 #include <thread>
 
+#include "qregister.hpp"
+
 namespace Qrack {
-template <class F>
-void par_for_all(const bitCapInt begin, const bitCapInt end, Complex16* stateArray, const Complex16 nrm,
-    const Complex16* mtrx, const bitCapInt* maskArray, F fn)
-{
-    std::atomic<bitCapInt> idx;
-    idx = begin;
-    int num_cpus = std::thread::hardware_concurrency();
-    std::vector<std::future<void>> futures(num_cpus);
-    for (int cpu = 0; cpu < num_cpus; cpu++) {
-        futures[cpu] = std::async(std::launch::async, [cpu, &idx, end, stateArray, nrm, mtrx, maskArray, &fn]() {
-            bitCapInt i;
-            for (;;) {
-                i = idx++;
-                if (i >= end)
-                    break;
-                fn(i, cpu, stateArray, nrm, mtrx, maskArray);
-            }
-        });
-    }
 
-    for (int cpu = 0; cpu < num_cpus; cpu++) {
-        futures[cpu].get();
-    }
-}
+typedef std::function<void(const bitCapInt)> ParallelFunc;
 
-template <class F>
-void par_for_copy(const bitCapInt begin, const bitCapInt end, Complex16* stateArray, const bitCapInt* bciArgs,
-    Complex16* nStateArray, F fn)
-{
-    std::atomic<bitCapInt> idx;
-    idx = begin;
-    int num_cpus = std::thread::hardware_concurrency();
-    std::vector<std::future<void>> futures(num_cpus);
-    for (int cpu = 0; cpu < num_cpus; cpu++) {
-        futures[cpu] = std::async(std::launch::async, [cpu, &idx, end, stateArray, bciArgs, nStateArray, &fn]() {
-            bitCapInt i;
-            for (;;) {
-                i = idx++;
-                if (i >= end)
-                    break;
-                fn(i, cpu, stateArray, bciArgs, nStateArray);
-            }
-        });
-    }
+void par_for(const bitCapInt begin, const bitCapInt end, ParallelFunc fn);
 
-    for (int cpu = 0; cpu < num_cpus; cpu++) {
-        futures[cpu].get();
-    }
-}
-
-template <class F>
-void par_for_cohere(const bitCapInt begin, const bitCapInt end, Complex16* stateArray, const bitCapInt* bciArgs,
-    const Complex16 phaseFac, Complex16* nStateArray, Complex16* toCopyStateArray, F fn)
-{
-    std::atomic<bitCapInt> idx;
-    idx = begin;
-    int num_cpus = std::thread::hardware_concurrency();
-    std::vector<std::future<void>> futures(num_cpus);
-    for (int cpu = 0; cpu < num_cpus; cpu++) {
-        futures[cpu] = std::async(
-            std::launch::async, [cpu, &idx, end, stateArray, bciArgs, phaseFac, nStateArray, toCopyStateArray, &fn]() {
-                bitCapInt i;
-                for (;;) {
-                    i = idx++;
-                    if (i >= end)
-                        break;
-                    fn(i, cpu, stateArray, bciArgs, phaseFac, nStateArray, toCopyStateArray);
-                }
-            });
-    }
-
-    for (int cpu = 0; cpu < num_cpus; cpu++) {
-        futures[cpu].get();
-    }
-}
-
-template <class F>
-void par_for(const bitCapInt begin, const bitCapInt end, Complex16* stateArray, const Complex16 nrm,
-    const Complex16* mtrx, const bitCapInt* maskArray, const bitCapInt offset1, const bitCapInt offset2,
-    const bitLenInt bitCount, F fn)
-{
-    std::atomic<bitCapInt> idx;
-    idx = begin;
-    int num_cpus = std::thread::hardware_concurrency();
-    std::vector<std::future<void>> futures(num_cpus);
-    for (int cpu = 0; cpu != num_cpus; ++cpu) {
-        futures[cpu] = std::async(
-            std::launch::async, [cpu, &idx, end, stateArray, nrm, mtrx, offset1, offset2, bitCount, maskArray, &fn]() {
-                bitCapInt i, iLow, iHigh;
-                bitLenInt p;
-                for (;;) {
-                    iHigh = idx++;
-                    i = 0;
-                    for (p = 0; p < bitCount; p++) {
-                        iLow = iHigh % maskArray[p];
-                        i += iLow;
-                        iHigh = (iHigh - iLow) << 1;
-                    }
-                    i += iHigh;
-                    if (i >= end)
-                        break;
-                    fn(i, cpu, stateArray, nrm, mtrx, offset1, offset2);
-                }
-            });
-    }
-
-    for (int cpu = 0; cpu != num_cpus; ++cpu) {
-        futures[cpu].get();
-    }
-}
-
-template <class F>
 void par_for_skip(const bitCapInt begin, const bitCapInt end, const bitCapInt skipPower, const bitLenInt skipBitCount,
-    const Complex16* stateArray, const bitCapInt* bciArgs, Complex16* nStateVec, F fn)
-{
-    std::atomic<bitCapInt> idx;
-    idx = begin;
-    int num_cpus = std::thread::hardware_concurrency();
-    std::vector<std::future<void>> futures(num_cpus);
-    for (int cpu = 0; cpu != num_cpus; ++cpu) {
-        futures[cpu] = std::async(
-            std::launch::async, [cpu, &idx, end, skipPower, skipBitCount, stateArray, bciArgs, nStateVec, &fn]() {
-                bitCapInt i, iLow, iHigh;
-                for (;;) {
-                    iHigh = idx++;
-                    i = 0;
-                    iLow = iHigh % skipPower;
-                    i += iLow;
-                    iHigh = (iHigh - iLow) << skipBitCount;
-                    i += iHigh;
-                    if (i >= end)
-                        break;
-                    fn(i, cpu, stateArray, bciArgs, nStateVec);
-                }
-            });
-    }
+    ParallelFunc fn);
 
-    for (int cpu = 0; cpu != num_cpus; ++cpu) {
-        futures[cpu].get();
-    }
-}
-
-template <class F>
-void par_for_load(const bitCapInt begin, const bitCapInt end, const bitCapInt skipPower, const bitLenInt skipBitCount,
-    const unsigned char* values, const Complex16* stateArray, const bitCapInt* bciArgs, Complex16* nStateVec, F fn)
-{
-    std::atomic<bitCapInt> idx;
-    idx = begin;
-    int num_cpus = std::thread::hardware_concurrency();
-    std::vector<std::future<void>> futures(num_cpus);
-    for (int cpu = 0; cpu != num_cpus; ++cpu) {
-        futures[cpu] = std::async(std::launch::async,
-            [cpu, &idx, end, skipPower, skipBitCount, values, stateArray, bciArgs, nStateVec, &fn]() {
-                bitCapInt i, iLow, iHigh;
-                for (;;) {
-                    iHigh = idx++;
-                    i = 0;
-                    iLow = iHigh % skipPower;
-                    i += iLow;
-                    iHigh = (iHigh - iLow) << skipBitCount;
-                    i += iHigh;
-                    if (i >= end)
-                        break;
-                    fn(i, cpu, stateArray, bciArgs, values, nStateVec);
-                }
-            });
-    }
-
-    for (int cpu = 0; cpu != num_cpus; ++cpu) {
-        futures[cpu].get();
-    }
-}
-
-template <class F>
-void par_for_mult(const bitCapInt begin, const bitCapInt end, const double toMult, Complex16* stateArray, F fn)
-{
-    std::atomic<bitCapInt> idx;
-    idx = begin;
-    int num_cpus = std::thread::hardware_concurrency();
-    std::vector<std::future<void>> futures(num_cpus);
-    for (int cpu = 0; cpu < num_cpus; cpu++) {
-        futures[cpu] = std::async(std::launch::async, [cpu, &idx, end, toMult, stateArray, &fn]() {
-            bitCapInt i;
-            for (;;) {
-                i = idx++;
-                if (i >= end)
-                    break;
-                fn(i, cpu, toMult, stateArray);
-            }
-        });
-    }
-
-    for (int cpu = 0; cpu < num_cpus; cpu++) {
-        futures[cpu].get();
-    }
-}
+void par_for_mask(const bitCapInt, const bitCapInt, const bitCapInt* maskArray, const bitLenInt bitCount, ParallelFunc);
 
 double par_norm(const bitCapInt maxQPower, const Complex16* stateArray);
 
 } // namespace Qrack
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-// THIS ENDS THE EXCERPTED SECTION FROM "GILGAMESH."
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/qregister.cpp
+++ b/qregister.cpp
@@ -47,7 +47,33 @@ void rotate(BidirectionalIterator first, BidirectionalIterator middle, Bidirecti
  * opcodes-like methods.
  */
 
-/// Initialize a coherent unit with qBitCount number pf bits, to initState unsigned integer permutation state
+/**
+ * Initialize a coherent unit with qBitCount number pf bits, to initState
+ * unsigned integer permutation state.  The `initState` parameter is,
+ * effectively, the initial pattern of |0> and |1>'s that the qubits should be
+ * initialized to.
+ *
+ * For example, in a two qubit system, there are the following values:
+ *
+ *    |00>
+ *    |01>
+ *    |10>
+ *    |11>
+ *
+ * If the desired initial state is |10>, then the index value of 2
+ * will be passed in to initState.  The constructor will then,
+ * using a random \f$ \theta \f$, initialize that state to
+ * Complex16Simd(\f$cos(\theta)\f$, \f$sin(\theta)\f$).  It's worth
+ * noting that this is still a unit vector:
+ *
+ * \f$
+ *   cos(\theta)^2 + sin(\theta)^2 = 1
+ * \f$
+ *
+ * Broadly speaking, a non-random \f$\theta\f$ could be used, but doing so
+ * replicates the unknowable initial phase of a physical QM system, and has
+ * impacts on subsequent operations accordingly.
+ */
 CoherentUnit::CoherentUnit(bitLenInt qBitCount, bitCapInt initState)
     : rand_distribution(0.0, 1.0)
 {
@@ -1892,54 +1918,6 @@ void CoherentUnit::DECBCDC(
         });
     ResetStateVec(std::move(nStateVec));
 }
-
-/// Multiply a quantum register by a classical integer, with sign and without carry.
-/*
-void CoherentUnit::CMUL(bitCapInt toMul, bitLenInt inOutStart, bitLenInt length)
-{
-    if (toMul == 0) {
-        SetPermutation(0);
-        return;
-    }
-    else if (toMul == 1) {
-        return;
-    }
-
-    bitCapInt origPermCount = maxQPower;
-    bitCapInt origQubitCount = qubitCount;
-    if ((inOutStart + length) != origQubitCount) {
-        Swap(inOutStart, origQubitCount - length, length);
-    }
-    CoherentUnit carry = CoherentUnit(length, 0);
-    Cohere(carry);
-
-    bitCapInt lengthPower = 1 << (length * 2);
-    bitCapInt inOutMask = (lengthPower - 1) << (origQubitCount - length);
-    bitCapInt otherMask = (origPermCount - 1) ^ ((1 << length) - 1);
-    std::unique_ptr<Complex16[]> nStateVec(new Complex16[maxQPower]);
-    std::fill(&(nStateVec[0]), &(nStateVec[0]) + (1 << (origQubitCount + length)), Complex16(0.0, 0.0));
-    bitCapInt bciArgs[5] = { inOutMask, toMul, otherMask, lengthPower, (origQubitCount - length) };
-    par_for_copy(0, origPermCount, &(stateVec[0]), bciArgs, &(nStateVec[0]),
-        [](bitCapInt lcv, const int cpu, const Complex16* stateVec, const bitCapInt* bciArgs, Complex16* nStateVec) {
-            bitCapInt otherRes = (lcv & (bciArgs[2]));
-            bitCapInt inOutRes = (lcv & (bciArgs[0]));
-            bitCapInt inOutInt = inOutRes >> (bciArgs[4]);
-            bitCapInt outInt = (inOutInt * bciArgs[1]) & bciArgs[3];
-            bitCapInt outRes = (outInt << (bciArgs[4])) | otherRes;
-            nStateVec[outRes] += stateVec[lcv];
-            if (norm(stateVec[lcv]) > 0.0) {
-                std::cout<<(int)lcv<<", "<<(int)outRes<<std::endl;
-            }
-        });
-    ResetStateVec(std::move(nStateVec));
-
-    MReg(origQubitCount, length);
-    Dispose(origQubitCount, length);
-    if ((inOutStart + length) != origQubitCount) {
-        Swap(inOutStart, origQubitCount - length, length);
-    }
-}
-*/
 
 /// Quantum Fourier Transform - Apply the quantum Fourier transform to the register
 void CoherentUnit::QFT(bitLenInt start, bitLenInt length)

--- a/qregister.cpp
+++ b/qregister.cpp
@@ -176,14 +176,11 @@ void CoherentUnit::Cohere(CoherentUnit& toCopy)
     double angle = Rand() * 2.0 * M_PI;
     Complex16 phaseFac(cos(angle), sin(angle));
     std::unique_ptr<Complex16[]> nStateVec(new Complex16[nMaxQPower]);
-    bitCapInt bciArgs[3] = { startMask, endMask, qubitCount };
-    par_for_cohere(0, nMaxQPower, &(stateVec[0]), bciArgs, phaseFac, &(nStateVec[0]), &(toCopy.stateVec[0]),
-        [](const bitCapInt lcv, const int cpu, const Complex16* stateVec, const bitCapInt* bciArgs,
-            const Complex16 phaseFac, Complex16* nStateVec, Complex16* toCopyStateVec) {
-            nStateVec[lcv] = phaseFac *
-                sqrt(norm(stateVec[(lcv & (bciArgs[0]))]) *
-                    norm(toCopyStateVec[((lcv & (bciArgs[1])) >> (bciArgs[2]))]));
-        });
+
+    par_for(0, nMaxQPower, [&](const bitCapInt lcv) {
+        nStateVec[lcv] =
+            phaseFac * sqrt(norm(stateVec[lcv & startMask]) * norm(toCopy.stateVec[(lcv & endMask) >> qubitCount]));
+    });
 
     qubitCount = nQubitCount;
     maxQPower = nMaxQPower;
@@ -481,9 +478,9 @@ bool CoherentUnit::M(bitLenInt qubitIndex)
     double angle = Rand() * 2.0 * M_PI;
     double cosine = cos(angle);
     double sine = sin(angle);
+    Complex16 nrm;
 
-    bitCapInt qPowers[1];
-    qPowers[0] = 1 << qubitIndex;
+    bitCapInt qPowers = 1 << qubitIndex;
     double oneChance = Prob(qubitIndex);
 
     result = (prob < oneChance) && oneChance > 0.0;
@@ -493,29 +490,29 @@ bool CoherentUnit::M(bitLenInt qubitIndex)
             nrmlzr = oneChance;
         }
 
-        par_for_all(0, maxQPower, &(stateVec[0]), Complex16(cosine, sine) / nrmlzr, NULL, qPowers,
-            [](const bitCapInt lcv, const int cpu, Complex16* stateVec, const Complex16 nrm, const Complex16* mtrx,
-                const bitCapInt* qPowers) {
-                if ((lcv & qPowers[0]) == 0) {
-                    stateVec[lcv] = Complex16(0.0, 0.0);
-                } else {
-                    stateVec[lcv] = nrm * stateVec[lcv];
-                }
-            });
+        nrm = Complex16(cosine, sine) / nrmlzr;
+
+        par_for(0, maxQPower, [&](const bitCapInt lcv) {
+            if ((lcv & qPowers) == 0) {
+                stateVec[lcv] = Complex16(0.0, 0.0);
+            } else {
+                stateVec[lcv] = nrm * stateVec[lcv];
+            }
+        });
     } else {
         if (oneChance < 1.0) {
             nrmlzr = sqrt(1.0 - oneChance);
         }
 
-        par_for_all(0, maxQPower, &(stateVec[0]), Complex16(cosine, sine) / nrmlzr, NULL, qPowers,
-            [](const bitCapInt lcv, const int cpu, Complex16* stateVec, const Complex16 nrm, const Complex16* mtrx,
-                const bitCapInt* qPowers) {
-                if ((lcv & qPowers[0]) == 0) {
-                    stateVec[lcv] = nrm * stateVec[lcv];
-                } else {
-                    stateVec[lcv] = Complex16(0.0, 0.0);
-                }
-            });
+        nrm = Complex16(cosine, sine) / nrmlzr;
+
+        par_for(0, maxQPower, [&](const bitCapInt lcv) {
+            if ((lcv & qPowers) == 0) {
+                stateVec[lcv] = nrm * stateVec[lcv];
+            } else {
+                stateVec[lcv] = Complex16(0.0, 0.0);
+            }
+        });
     }
 
     UpdateRunningNorm();
@@ -864,52 +861,69 @@ void CoherentUnit::CZ(bitLenInt control, bitLenInt target)
 
 // Single register instructions:
 
-/// Apply X ("not") gate to each bit in "length," starting from bit index "start"
+// Apply X ("not") gate to each bit in "length," starting from bit index
+// "start"
 void CoherentUnit::X(bitLenInt start, bitLenInt length)
 {
-    // By fundamental gates, the register-wise X could proceed like so:
-    // for (bitLenInt lcv = 0; lcv < length; lcv++) {
-    //    X(start + lcv);
-    //}
+    // As a fundamental gate, the register-wise X could proceed like so:
+    //
+    //     for (bitLenInt lcv = 0; lcv < length; lcv++) {
+    //         X(start + lcv);
+    //     }
 
-    // Basically ALL register-wise gates proceed by essentially the same algorithm as this simple X gate.
+    // Basically ALL register-wise gates proceed by essentially the same
+    // algorithm as this simple X gate.
 
-    // We first form bit masks for those qubits involved in the operation, and those not involved in the operation. We
-    // might have more than one register involved in the operation in general, but we only have one, in this case.
+    // We first form bit masks for those qubits involved in the operation, and
+    // those not involved in the operation. We might have more than one
+    // register involved in the operation in general, but we only have one, in
+    // this case.
     bitCapInt inOutMask = ((1 << length) - 1) << start;
-    bitCapInt otherMask = (1 << qubitCount) - 1;
-    otherMask ^= inOutMask;
-    // We want to parallelize where possible, so we pack most of the arguments we need in looping into an array, to be
-    // passed into a parallel "for" loop.
-    bitCapInt bciArgs[2] = { inOutMask, otherMask };
-    // Sometimes we transform the state in place. Alternatively, we often allocate a new permutation state vector to
-    // transfer old probabilities and phases into.
+    bitCapInt otherMask = ((1 << qubitCount) - 1) ^ inOutMask;
+
+    // Sometimes we transform the state in place. Alternatively, we often
+    // allocate a new permutation state vector to transfer old probabilities
+    // and phases into.
     std::unique_ptr<Complex16[]> nStateVec(new Complex16[maxQPower]);
-    // This function call is a parallel "for" loop. We have several variants of the parallel for loop. Some skip
-    // certain permutations in order to optimize. Some take a new permutation state vector for output, and some just
-    // transform the permutation state vector in place.
-    par_for_copy(0, maxQPower, &(stateVec[0]), bciArgs, &(nStateVec[0]),
-        [](const bitCapInt lcv, const int cpu, const Complex16* stateVec, const bitCapInt* bciArgs,
-            Complex16* nStateVec) {
-            // This is the body of the parallel "for" loop. We iterate over permutations of bits.
-            // We're going to transform from input permutation state to output permutation state, and transfer the
-            // probability and phase of the input permutation to the output permutation.  These are the bits that aren't
-            // involved in the operation.
-            bitCapInt otherRes = (lcv & bciArgs[1]);
-            // These are the bits in the register that is being operated on. In all permutation states, the bits acted
-            // on by the gate should be transformed in the logically appropriate way from input permutation to output
-            // permutation. Since this is an X gate, we take the involved bits and bitwise NOT them.
-            bitCapInt inOutRes = ((~lcv) & bciArgs[0]);
-            // Now, we just transfer the untransformed input state's phase and probability to the transformed output
-            // state.
-            nStateVec[inOutRes | otherRes] = stateVec[lcv];
-            // For other operations, like the quantum equivalent of a logical "AND," we might have two input registers
-            // and one output register. The transformation would be that we use bit masks to bitwise "AND" the input
-            // values in every permutation and place this logical result into the output register with another bit mask,
-            // for every possible permutation state. Basically all the register-wise operations in Qrack proceed this
-            // same way.
-        });
-    // We replace our old permutation state vector with the new one we just filled, at the end.
+
+    // This function call is a parallel "for" loop. We have several variants of
+    // the parallel for loop. Some skip certain permutations in order to
+    // optimize. Some take a new permutation state vector for output, and some
+    // just transform the permutation state vector in place.
+    par_for(0, maxQPower, [&](const bitCapInt lcv) {
+        // Set nStateVec, indexed by the loop control variable (lcv) with
+        // the X'ed bits inverted, with the value of stateVec indexed by
+        // lcv.
+
+        // This is the body of the parallel "for" loop. We iterate over
+        // permutations of bits.  We're going to transform from input
+        // permutation state to output permutation state, and transfer the
+        // probability and phase of the input permutation to the output
+        // permutation.  These are the bits that aren't involved in the
+        // operation.
+        bitCapInt otherRes = (lcv & otherMask);
+
+        // These are the bits in the register that is being operated on. In
+        // all permutation states, the bits acted on by the gate should be
+        // transformed in the logically appropriate way from input
+        // permutation to output permutation. Since this is an X gate, we
+        // take the involved bits and bitwise NOT them.
+        bitCapInt inOutRes = ((~lcv) & inOutMask);
+
+        // Now, we just transfer the untransformed input state's phase and
+        // probability to the transformed output state.
+        nStateVec[inOutRes | otherRes] = stateVec[lcv];
+
+        // For other operations, like the quantum equivalent of a logical
+        // "AND," we might have two input registers and one output
+        // register. The transformation would be that we use bit masks to
+        // bitwise "AND" the input values in every permutation and place
+        // this logical result into the output register with another bit
+        // mask, for every possible permutation state. Basically all the
+        // register-wise operations in Qrack proceed this same way.
+    });
+    // We replace our old permutation state vector with the new one we just
+    // filled, at the end.
     ResetStateVec(std::move(nStateVec));
 }
 
@@ -930,16 +944,14 @@ void CoherentUnit::Swap(bitLenInt start1, bitLenInt start2, bitLenInt length)
         bitCapInt reg2Mask = ((1 << length) - 1) << start2;
         bitCapInt otherMask = maxQPower - 1;
         otherMask ^= reg1Mask | reg2Mask;
-        bitCapInt bciArgs[5] = { reg1Mask, start1, reg2Mask, start2, otherMask };
         std::unique_ptr<Complex16[]> nStateVec(new Complex16[maxQPower]);
-        par_for_copy(0, maxQPower, &(stateVec[0]), bciArgs, &(nStateVec[0]),
-            [](const bitCapInt lcv, const int cpu, const Complex16* stateVec, const bitCapInt* bciArgs,
-                Complex16* nStateVec) {
-                bitCapInt otherRes = (lcv & bciArgs[4]);
-                bitCapInt reg1Res = ((lcv & bciArgs[0]) >> (bciArgs[1])) << (bciArgs[3]);
-                bitCapInt reg2Res = ((lcv & bciArgs[2]) >> (bciArgs[3])) << (bciArgs[1]);
-                nStateVec[reg1Res | reg2Res | otherRes] = stateVec[lcv];
-            });
+
+        par_for(0, maxQPower, [&](const bitCapInt lcv) {
+            bitCapInt otherRes = (lcv & otherMask);
+            bitCapInt reg1Res = ((lcv & reg1Mask) >> (start1)) << (start2);
+            bitCapInt reg2Res = ((lcv & reg2Mask) >> (start2)) << (start1);
+            nStateVec[reg1Res | reg2Res | otherRes] = stateVec[lcv];
+        });
         // We replace our old permutation state vector with the new one we just filled, at the end.
         ResetStateVec(std::move(nStateVec));
     }
@@ -1310,44 +1322,42 @@ void CoherentUnit::INCBCD(bitCapInt toAdd, bitLenInt inOutStart, bitLenInt lengt
     otherMask ^= inOutMask;
     std::unique_ptr<Complex16[]> nStateVec(new Complex16[maxQPower]);
     std::fill(&(nStateVec[0]), &(nStateVec[0]) + maxQPower, Complex16(0.0, 0.0));
-    bitCapInt bciArgs[5] = { inOutMask, toAdd, otherMask, inOutStart, nibbleCount };
-    par_for_copy(0, maxQPower, &(stateVec[0]), bciArgs, &(nStateVec[0]),
-        [](const bitCapInt lcv, const int cpu, const Complex16* stateVec, const bitCapInt* bciArgs,
-            Complex16* nStateVec) {
-            bitCapInt otherRes = (lcv & (bciArgs[2]));
-            bitCapInt partToAdd = bciArgs[1];
-            bitCapInt inOutRes = (lcv & (bciArgs[0]));
-            bitCapInt inOutInt = inOutRes >> (bciArgs[3]);
-            char test1, test2;
-            unsigned char j;
-            char* nibbles = new char[bciArgs[4]];
-            bool isValid = true;
-            for (j = 0; j < bciArgs[4]; j++) {
-                test1 = (inOutInt & (15 << (j * 4))) >> (j * 4);
-                test2 = (partToAdd % 10);
-                partToAdd /= 10;
-                nibbles[j] = test1 + test2;
-                if (test1 > 9) {
-                    isValid = false;
-                }
+
+    par_for(0, maxQPower, [&](const bitCapInt lcv) {
+        bitCapInt otherRes = (lcv & (otherMask));
+        bitCapInt partToAdd = toAdd;
+        bitCapInt inOutRes = (lcv & (inOutMask));
+        bitCapInt inOutInt = inOutRes >> (inOutStart);
+        char test1, test2;
+        unsigned char j;
+        char* nibbles = new char[nibbleCount];
+        bool isValid = true;
+        for (j = 0; j < nibbleCount; j++) {
+            test1 = (inOutInt & (15 << (j * 4))) >> (j * 4);
+            test2 = (partToAdd % 10);
+            partToAdd /= 10;
+            nibbles[j] = test1 + test2;
+            if (test1 > 9) {
+                isValid = false;
             }
-            if (isValid) {
-                bitCapInt outInt = 0;
-                for (j = 0; j < bciArgs[4]; j++) {
-                    if (nibbles[j] > 9) {
-                        nibbles[j] -= 10;
-                        if ((unsigned char)(j + 1) < bciArgs[4]) {
-                            nibbles[j + 1]++;
-                        }
+        }
+        if (isValid) {
+            bitCapInt outInt = 0;
+            for (j = 0; j < nibbleCount; j++) {
+                if (nibbles[j] > 9) {
+                    nibbles[j] -= 10;
+                    if ((unsigned char)(j + 1) < nibbleCount) {
+                        nibbles[j + 1]++;
                     }
-                    outInt |= nibbles[j] << (j * 4);
                 }
-                nStateVec[(outInt << (bciArgs[3])) | otherRes] = stateVec[lcv];
-            } else {
-                nStateVec[lcv] = stateVec[lcv];
+                outInt |= nibbles[j] << (j * 4);
             }
-            delete[] nibbles;
-        });
+            nStateVec[(outInt << (inOutStart)) | otherRes] = stateVec[lcv];
+        } else {
+            nStateVec[lcv] = stateVec[lcv];
+        }
+        delete[] nibbles;
+    });
     ResetStateVec(std::move(nStateVec));
 }
 
@@ -1367,61 +1377,61 @@ void CoherentUnit::INCBCDC(
     bitCapInt inOutMask = ((1 << length) - 1) << inOutStart;
     bitCapInt otherMask = (1 << qubitCount) - 1;
     bitCapInt carryMask = 1 << carryIndex;
+
     otherMask ^= inOutMask | carryMask;
+
     std::unique_ptr<Complex16[]> nStateVec(new Complex16[maxQPower]);
     std::fill(&(nStateVec[0]), &(nStateVec[0]) + maxQPower, Complex16(0.0, 0.0));
-    bitCapInt bciArgs[6] = { inOutMask, toAdd, carryMask, otherMask, inOutStart, nibbleCount };
-    par_for_skip(0, maxQPower, 1 << carryIndex, 1, &(stateVec[0]), bciArgs, &(nStateVec[0]),
-        [](const bitCapInt lcv, const int cpu, const Complex16* stateVec, const bitCapInt* bciArgs,
-            Complex16* nStateVec) {
-            bitCapInt otherRes = (lcv & (bciArgs[3]));
-            bitCapInt partToAdd = bciArgs[1];
-            bitCapInt inOutRes = (lcv & (bciArgs[0]));
-            bitCapInt inOutInt = inOutRes >> (bciArgs[4]);
-            char test1, test2;
-            unsigned char j;
-            char* nibbles = new char[bciArgs[5]];
-            bool isValid = true;
 
-            test1 = inOutInt & 15;
+    par_for_skip(0, maxQPower, 1 << carryIndex, 1, [&](const bitCapInt lcv) {
+        bitCapInt otherRes = (lcv & (otherMask));
+        bitCapInt partToAdd = toAdd;
+        bitCapInt inOutRes = (lcv & (inOutMask));
+        bitCapInt inOutInt = inOutRes >> (inOutStart);
+        char test1, test2;
+        unsigned char j;
+        char* nibbles = new char[nibbleCount];
+        bool isValid = true;
+
+        test1 = inOutInt & 15;
+        test2 = partToAdd % 10;
+        partToAdd /= 10;
+        nibbles[0] = test1 + test2;
+        if ((test1 > 9) || (test2 > 9)) {
+            isValid = false;
+        }
+
+        for (j = 1; j < nibbleCount; j++) {
+            test1 = (inOutInt & (15 << (j * 4))) >> (j * 4);
             test2 = partToAdd % 10;
             partToAdd /= 10;
-            nibbles[0] = test1 + test2;
+            nibbles[j] = test1 + test2;
             if ((test1 > 9) || (test2 > 9)) {
                 isValid = false;
             }
-
-            for (j = 1; j < bciArgs[5]; j++) {
-                test1 = (inOutInt & (15 << (j * 4))) >> (j * 4);
-                test2 = partToAdd % 10;
-                partToAdd /= 10;
-                nibbles[j] = test1 + test2;
-                if ((test1 > 9) || (test2 > 9)) {
-                    isValid = false;
-                }
-            }
-            if (isValid) {
-                bitCapInt outInt = 0;
-                bitCapInt outRes = 0;
-                bitCapInt carryRes = 0;
-                for (j = 0; j < bciArgs[5]; j++) {
-                    if (nibbles[j] > 9) {
-                        nibbles[j] -= 10;
-                        if ((unsigned char)(j + 1) < bciArgs[5]) {
-                            nibbles[j + 1]++;
-                        } else {
-                            carryRes = bciArgs[2];
-                        }
+        }
+        if (isValid) {
+            bitCapInt outInt = 0;
+            bitCapInt outRes = 0;
+            bitCapInt carryRes = 0;
+            for (j = 0; j < nibbleCount; j++) {
+                if (nibbles[j] > 9) {
+                    nibbles[j] -= 10;
+                    if ((unsigned char)(j + 1) < nibbleCount) {
+                        nibbles[j + 1]++;
+                    } else {
+                        carryRes = carryMask;
                     }
-                    outInt |= nibbles[j] << (j * 4);
                 }
-                outRes = (outInt << (bciArgs[4])) | otherRes | carryRes;
-                nStateVec[outRes] = stateVec[lcv];
-            } else {
-                nStateVec[lcv] = stateVec[lcv];
+                outInt |= nibbles[j] << (j * 4);
             }
-            delete[] nibbles;
-        });
+            outRes = (outInt << (inOutStart)) | otherRes | carryRes;
+            nStateVec[outRes] = stateVec[lcv];
+        } else {
+            nStateVec[lcv] = stateVec[lcv];
+        }
+        delete[] nibbles;
+    });
     ResetStateVec(std::move(nStateVec));
 }
 
@@ -1442,40 +1452,38 @@ void CoherentUnit::INCS(bitCapInt toAdd, bitLenInt inOutStart, bitLenInt length,
     otherMask ^= inOutMask;
     std::unique_ptr<Complex16[]> nStateVec(new Complex16[maxQPower]);
     std::fill(&(nStateVec[0]), &(nStateVec[0]) + maxQPower, Complex16(0.0, 0.0));
-    bitCapInt bciArgs[7] = { inOutMask, toAdd, overflowMask, otherMask, lengthPower, inOutStart, signMask };
-    par_for_copy(0, maxQPower, &(stateVec[0]), bciArgs, &(nStateVec[0]),
-        [](const bitCapInt lcv, const int cpu, const Complex16* stateVec, const bitCapInt* bciArgs,
-            Complex16* nStateVec) {
-            bitCapInt otherRes = (lcv & (bciArgs[3]));
-            bitCapInt inOutRes = (lcv & (bciArgs[0]));
-            bitCapInt inOutInt = inOutRes >> (bciArgs[5]);
-            bitCapInt inInt = bciArgs[1];
-            bitCapInt outInt = inOutInt + bciArgs[1];
-            bitCapInt outRes;
-            if (outInt < bciArgs[4]) {
-                outRes = (outInt << (bciArgs[5])) | otherRes;
-            } else {
-                outRes = ((outInt - bciArgs[4]) << (bciArgs[5])) | otherRes;
-            }
-            bool isOverflow = false;
-            // Both negative:
-            if (inOutInt & inInt & (bciArgs[6])) {
-                inOutInt = ((~inOutInt) & (bciArgs[4] - 1)) + 1;
-                inInt = ((~inInt) & (bciArgs[4] - 1)) + 1;
-                if ((inOutInt + inInt) > (bciArgs[6]))
-                    isOverflow = true;
-            }
-            // Both positive:
-            else if ((~inOutInt) & (~inInt) & (bciArgs[6])) {
-                if ((inOutInt + inInt) >= (bciArgs[6]))
-                    isOverflow = true;
-            }
-            if (isOverflow && ((outRes & bciArgs[2]) == bciArgs[2])) {
-                nStateVec[outRes] = -stateVec[lcv];
-            } else {
-                nStateVec[outRes] = stateVec[lcv];
-            }
-        });
+
+    par_for(0, maxQPower, [&](const bitCapInt lcv) {
+        bitCapInt otherRes = (lcv & (otherMask));
+        bitCapInt inOutRes = (lcv & (inOutMask));
+        bitCapInt inOutInt = inOutRes >> (inOutStart);
+        bitCapInt inInt = toAdd;
+        bitCapInt outInt = inOutInt + toAdd;
+        bitCapInt outRes;
+        if (outInt < lengthPower) {
+            outRes = (outInt << (inOutStart)) | otherRes;
+        } else {
+            outRes = ((outInt - lengthPower) << (inOutStart)) | otherRes;
+        }
+        bool isOverflow = false;
+        // Both negative:
+        if (inOutInt & inInt & (signMask)) {
+            inOutInt = ((~inOutInt) & (lengthPower - 1)) + 1;
+            inInt = ((~inInt) & (lengthPower - 1)) + 1;
+            if ((inOutInt + inInt) > (signMask))
+                isOverflow = true;
+        }
+        // Both positive:
+        else if ((~inOutInt) & (~inInt) & (signMask)) {
+            if ((inOutInt + inInt) >= (signMask))
+                isOverflow = true;
+        }
+        if (isOverflow && ((outRes & overflowMask) == overflowMask)) {
+            nStateVec[outRes] = -stateVec[lcv];
+        } else {
+            nStateVec[outRes] = stateVec[lcv];
+        }
+    });
     ResetStateVec(std::move(nStateVec));
 }
 
@@ -1499,44 +1507,42 @@ void CoherentUnit::INCSC(
     bitCapInt otherMask = (1 << qubitCount) - 1;
     bitCapInt lengthPower = 1 << length;
     bitCapInt inOutMask = (lengthPower - 1) << inOutStart;
-    bitCapInt edgeMask = inOutMask | carryMask;
     otherMask ^= inOutMask | carryMask;
+
     std::unique_ptr<Complex16[]> nStateVec(new Complex16[maxQPower]);
     std::fill(&(nStateVec[0]), &(nStateVec[0]) + maxQPower, Complex16(0.0, 0.0));
-    bitCapInt bciArgs[10] = { inOutMask, toAdd, carryMask, otherMask, lengthPower, inOutStart, carryIndex, edgeMask,
-        overflowMask, signMask };
-    par_for_skip(0, maxQPower, carryMask, 1, &(stateVec[0]), bciArgs, &(nStateVec[0]),
-        [](bitCapInt lcv, const int cpu, const Complex16* stateVec, const bitCapInt* bciArgs, Complex16* nStateVec) {
-            bitCapInt otherRes = (lcv & (bciArgs[3]));
-            bitCapInt inOutRes = (lcv & (bciArgs[0]));
-            bitCapInt inOutInt = inOutRes >> (bciArgs[5]);
-            bitCapInt inInt = bciArgs[1];
-            bitCapInt outInt = inOutInt + bciArgs[1];
-            bitCapInt outRes;
-            if (outInt < (bciArgs[4])) {
-                outRes = (outInt << (bciArgs[5])) | otherRes;
-            } else {
-                outRes = ((outInt - (bciArgs[4])) << (bciArgs[5])) | otherRes | (bciArgs[2]);
-            }
-            bool isOverflow = false;
-            // Both negative:
-            if (inOutInt & inInt & (bciArgs[9])) {
-                inOutInt = ((~inOutInt) & (bciArgs[4] - 1)) + 1;
-                inInt = ((~inInt) & (bciArgs[4] - 1)) + 1;
-                if ((inOutInt + inInt) > (bciArgs[9]))
-                    isOverflow = true;
-            }
-            // Both positive:
-            else if ((~inOutInt) & (~inInt) & (bciArgs[9])) {
-                if ((inOutInt + inInt) >= (bciArgs[9]))
-                    isOverflow = true;
-            }
-            if (isOverflow && ((outRes & bciArgs[8]) == bciArgs[8])) {
-                nStateVec[outRes] = -stateVec[lcv];
-            } else {
-                nStateVec[outRes] = stateVec[lcv];
-            }
-        });
+
+    par_for_skip(0, maxQPower, carryMask, 1, [&](const bitCapInt lcv) {
+        bitCapInt otherRes = (lcv & (otherMask));
+        bitCapInt inOutRes = (lcv & (inOutMask));
+        bitCapInt inOutInt = inOutRes >> (inOutStart);
+        bitCapInt inInt = toAdd;
+        bitCapInt outInt = inOutInt + toAdd;
+        bitCapInt outRes;
+        if (outInt < (lengthPower)) {
+            outRes = (outInt << (inOutStart)) | otherRes;
+        } else {
+            outRes = ((outInt - (lengthPower)) << (inOutStart)) | otherRes | (carryMask);
+        }
+        bool isOverflow = false;
+        // Both negative:
+        if (inOutInt & inInt & (signMask)) {
+            inOutInt = ((~inOutInt) & (lengthPower - 1)) + 1;
+            inInt = ((~inInt) & (lengthPower - 1)) + 1;
+            if ((inOutInt + inInt) > (signMask))
+                isOverflow = true;
+        }
+        // Both positive:
+        else if ((~inOutInt) & (~inInt) & (signMask)) {
+            if ((inOutInt + inInt) >= (signMask))
+                isOverflow = true;
+        }
+        if (isOverflow && ((outRes & overflowMask) == overflowMask)) {
+            nStateVec[outRes] = -stateVec[lcv];
+        } else {
+            nStateVec[outRes] = stateVec[lcv];
+        }
+    });
     ResetStateVec(std::move(nStateVec));
 }
 
@@ -1558,44 +1564,42 @@ void CoherentUnit::INCSC(bitCapInt toAdd, bitLenInt inOutStart, bitLenInt length
     bitCapInt otherMask = (1 << qubitCount) - 1;
     bitCapInt lengthPower = 1 << length;
     bitCapInt inOutMask = (lengthPower - 1) << inOutStart;
-    bitCapInt edgeMask = inOutMask | carryMask;
+
     otherMask ^= inOutMask | carryMask;
     std::unique_ptr<Complex16[]> nStateVec(new Complex16[maxQPower]);
     std::fill(&(nStateVec[0]), &(nStateVec[0]) + maxQPower, Complex16(0.0, 0.0));
-    bitCapInt bciArgs[9] = { inOutMask, toAdd, carryMask, otherMask, lengthPower, inOutStart, carryIndex, edgeMask,
-        signMask };
-    par_for_skip(0, maxQPower, carryMask, 1, &(stateVec[0]), bciArgs, &(nStateVec[0]),
-        [](bitCapInt lcv, const int cpu, const Complex16* stateVec, const bitCapInt* bciArgs, Complex16* nStateVec) {
-            bitCapInt otherRes = (lcv & (bciArgs[3]));
-            bitCapInt inOutRes = (lcv & (bciArgs[0]));
-            bitCapInt inOutInt = inOutRes >> (bciArgs[5]);
-            bitCapInt inInt = bciArgs[1];
-            bitCapInt outInt = inOutInt + bciArgs[1];
-            bitCapInt outRes;
-            if (outInt < (bciArgs[4])) {
-                outRes = (outInt << (bciArgs[5])) | otherRes;
-            } else {
-                outRes = ((outInt - (bciArgs[4])) << (bciArgs[5])) | otherRes | (bciArgs[2]);
-            }
-            bool isOverflow = false;
-            // Both negative:
-            if (inOutInt & inInt & (bciArgs[9])) {
-                inOutInt = ((~inOutInt) & (bciArgs[4] - 1)) + 1;
-                inInt = ((~inInt) & (bciArgs[4] - 1)) + 1;
-                if ((inOutInt + inInt) > (bciArgs[9]))
-                    isOverflow = true;
-            }
-            // Both positive:
-            else if ((~inOutInt) & (~inInt) & (bciArgs[9])) {
-                if ((inOutInt + inInt) >= (bciArgs[9]))
-                    isOverflow = true;
-            }
-            if (isOverflow) {
-                nStateVec[outRes] = -stateVec[lcv];
-            } else {
-                nStateVec[outRes] = stateVec[lcv];
-            }
-        });
+
+    par_for_skip(0, maxQPower, carryMask, 1, [&](const bitCapInt lcv) {
+        bitCapInt otherRes = (lcv & (otherMask));
+        bitCapInt inOutRes = (lcv & (inOutMask));
+        bitCapInt inOutInt = inOutRes >> (inOutStart);
+        bitCapInt inInt = toAdd;
+        bitCapInt outInt = inOutInt + toAdd;
+        bitCapInt outRes;
+        if (outInt < (lengthPower)) {
+            outRes = (outInt << (inOutStart)) | otherRes;
+        } else {
+            outRes = ((outInt - (lengthPower)) << (inOutStart)) | otherRes | (carryMask);
+        }
+        bool isOverflow = false;
+        // Both negative:
+        if (inOutInt & inInt & (signMask)) {
+            inOutInt = ((~inOutInt) & (lengthPower - 1)) + 1;
+            inInt = ((~inInt) & (lengthPower - 1)) + 1;
+            if ((inOutInt + inInt) > (signMask))
+                isOverflow = true;
+        }
+        // Both positive:
+        else if ((~inOutInt) & (~inInt) & (signMask)) {
+            if ((inOutInt + inInt) >= (signMask))
+                isOverflow = true;
+        }
+        if (isOverflow) {
+            nStateVec[outRes] = -stateVec[lcv];
+        } else {
+            nStateVec[outRes] = stateVec[lcv];
+        }
+    });
     ResetStateVec(std::move(nStateVec));
 }
 
@@ -1632,44 +1636,42 @@ void CoherentUnit::DECBCD(bitCapInt toAdd, bitLenInt inOutStart, bitLenInt lengt
     otherMask ^= inOutMask;
     std::unique_ptr<Complex16[]> nStateVec(new Complex16[maxQPower]);
     std::fill(&(nStateVec[0]), &(nStateVec[0]) + maxQPower, Complex16(0.0, 0.0));
-    bitCapInt bciArgs[5] = { inOutMask, toAdd, otherMask, inOutStart, nibbleCount };
-    par_for_copy(0, maxQPower, &(stateVec[0]), bciArgs, &(nStateVec[0]),
-        [](const bitCapInt lcv, const int cpu, const Complex16* stateVec, const bitCapInt* bciArgs,
-            Complex16* nStateVec) {
-            bitCapInt otherRes = (lcv & (bciArgs[2]));
-            bitCapInt partToSub = bciArgs[1];
-            bitCapInt inOutRes = (lcv & (bciArgs[0]));
-            bitCapInt inOutInt = inOutRes >> (bciArgs[3]);
-            char test1, test2;
-            unsigned char j;
-            char* nibbles = new char[bciArgs[4]];
-            bool isValid = true;
-            for (j = 0; j < bciArgs[4]; j++) {
-                test1 = (inOutInt & (15 << (j * 4))) >> (j * 4);
-                test2 = (partToSub % 10);
-                partToSub /= 10;
-                nibbles[j] = test1 - test2;
-                if (test1 > 9) {
-                    isValid = false;
-                }
+
+    par_for(0, maxQPower, [&](const bitCapInt lcv) {
+        bitCapInt otherRes = (lcv & (otherMask));
+        bitCapInt partToSub = toAdd;
+        bitCapInt inOutRes = (lcv & (inOutMask));
+        bitCapInt inOutInt = inOutRes >> (inOutStart);
+        char test1, test2;
+        unsigned char j;
+        char* nibbles = new char[nibbleCount];
+        bool isValid = true;
+        for (j = 0; j < nibbleCount; j++) {
+            test1 = (inOutInt & (15 << (j * 4))) >> (j * 4);
+            test2 = (partToSub % 10);
+            partToSub /= 10;
+            nibbles[j] = test1 - test2;
+            if (test1 > 9) {
+                isValid = false;
             }
-            if (isValid) {
-                bitCapInt outInt = 0;
-                for (j = 0; j < bciArgs[4]; j++) {
-                    if (nibbles[j] < 0) {
-                        nibbles[j] += 10;
-                        if ((unsigned char)(j + 1) < bciArgs[4]) {
-                            nibbles[j + 1]--;
-                        }
+        }
+        if (isValid) {
+            bitCapInt outInt = 0;
+            for (j = 0; j < nibbleCount; j++) {
+                if (nibbles[j] < 0) {
+                    nibbles[j] += 10;
+                    if ((unsigned char)(j + 1) < nibbleCount) {
+                        nibbles[j + 1]--;
                     }
-                    outInt |= nibbles[j] << (j * 4);
                 }
-                nStateVec[(outInt << (bciArgs[3])) | otherRes] = stateVec[lcv];
-            } else {
-                nStateVec[lcv] = stateVec[lcv];
+                outInt |= nibbles[j] << (j * 4);
             }
-            delete[] nibbles;
-        });
+            nStateVec[(outInt << (inOutStart)) | otherRes] = stateVec[lcv];
+        } else {
+            nStateVec[lcv] = stateVec[lcv];
+        }
+        delete[] nibbles;
+    });
     ResetStateVec(std::move(nStateVec));
 }
 
@@ -1688,40 +1690,38 @@ void CoherentUnit::DECS(bitCapInt toSub, bitLenInt inOutStart, bitLenInt length,
     otherMask ^= inOutMask;
     std::unique_ptr<Complex16[]> nStateVec(new Complex16[maxQPower]);
     std::fill(&(nStateVec[0]), &(nStateVec[0]) + maxQPower, Complex16(0.0, 0.0));
-    bitCapInt bciArgs[7] = { inOutMask, toSub, overflowMask, otherMask, lengthPower, inOutStart, signMask };
-    par_for_copy(0, maxQPower, &(stateVec[0]), bciArgs, &(nStateVec[0]),
-        [](const bitCapInt lcv, const int cpu, const Complex16* stateVec, const bitCapInt* bciArgs,
-            Complex16* nStateVec) {
-            bitCapInt otherRes = (lcv & (bciArgs[3]));
-            bitCapInt inOutRes = (lcv & (bciArgs[0]));
-            bitCapInt inOutInt = inOutRes >> (bciArgs[5]);
-            bitCapInt inInt = bciArgs[2];
-            bitCapInt outInt = inOutInt - bciArgs[1] + bciArgs[4];
-            bitCapInt outRes;
-            if (outInt < bciArgs[4]) {
-                outRes = (outInt << (bciArgs[5])) | otherRes;
-            } else {
-                outRes = ((outInt - bciArgs[4]) << (bciArgs[5])) | otherRes;
-            }
-            bool isOverflow = false;
-            // First negative:
-            if (inOutInt & (~inInt) & (bciArgs[6])) {
-                inOutInt = ((~inOutInt) & (bciArgs[4] - 1)) + 1;
-                if ((inOutInt + inInt) > bciArgs[6])
-                    isOverflow = true;
-            }
-            // First positive:
-            else if (inOutInt & (~inInt) & (bciArgs[6])) {
-                inInt = ((~inInt) & (bciArgs[4] - 1)) + 1;
-                if ((inOutInt + inInt) >= bciArgs[6])
-                    isOverflow = true;
-            }
-            if (isOverflow && ((outRes & bciArgs[2]) == bciArgs[2])) {
-                nStateVec[outRes] = -stateVec[lcv];
-            } else {
-                nStateVec[outRes] = stateVec[lcv];
-            }
-        });
+
+    par_for(0, maxQPower, [&](const bitCapInt lcv) {
+        bitCapInt otherRes = (lcv & (otherMask));
+        bitCapInt inOutRes = (lcv & (inOutMask));
+        bitCapInt inOutInt = inOutRes >> (inOutStart);
+        bitCapInt inInt = overflowMask;
+        bitCapInt outInt = inOutInt - toSub + lengthPower;
+        bitCapInt outRes;
+        if (outInt < lengthPower) {
+            outRes = (outInt << (inOutStart)) | otherRes;
+        } else {
+            outRes = ((outInt - lengthPower) << (inOutStart)) | otherRes;
+        }
+        bool isOverflow = false;
+        // First negative:
+        if (inOutInt & (~inInt) & (signMask)) {
+            inOutInt = ((~inOutInt) & (lengthPower - 1)) + 1;
+            if ((inOutInt + inInt) > signMask)
+                isOverflow = true;
+        }
+        // First positive:
+        else if (inOutInt & (~inInt) & (signMask)) {
+            inInt = ((~inInt) & (lengthPower - 1)) + 1;
+            if ((inOutInt + inInt) >= signMask)
+                isOverflow = true;
+        }
+        if (isOverflow && ((outRes & overflowMask) == overflowMask)) {
+            nStateVec[outRes] = -stateVec[lcv];
+        } else {
+            nStateVec[outRes] = stateVec[lcv];
+        }
+    });
     ResetStateVec(std::move(nStateVec));
 }
 
@@ -1745,44 +1745,42 @@ void CoherentUnit::DECSC(
     bitCapInt otherMask = (1 << qubitCount) - 1;
     bitCapInt lengthPower = 1 << length;
     bitCapInt inOutMask = (lengthPower - 1) << inOutStart;
-    bitCapInt edgeMask = inOutMask | carryMask;
+
     otherMask ^= inOutMask | carryMask;
     std::unique_ptr<Complex16[]> nStateVec(new Complex16[maxQPower]);
     std::fill(&(nStateVec[0]), &(nStateVec[0]) + maxQPower, Complex16(0.0, 0.0));
-    bitCapInt bciArgs[10] = { inOutMask, toSub, carryMask, otherMask, lengthPower, inOutStart, carryIndex, edgeMask,
-        overflowMask, signMask };
-    par_for_skip(0, maxQPower, carryMask, 1, &(stateVec[0]), bciArgs, &(nStateVec[0]),
-        [](bitCapInt lcv, const int cpu, const Complex16* stateVec, const bitCapInt* bciArgs, Complex16* nStateVec) {
-            bitCapInt otherRes = (lcv & (bciArgs[3]));
-            bitCapInt inOutRes = (lcv & (bciArgs[0]));
-            bitCapInt inOutInt = inOutRes >> (bciArgs[5]);
-            bitCapInt inInt = bciArgs[1];
-            bitCapInt outInt = (inOutInt - bciArgs[1]) + (bciArgs[4]);
-            bitCapInt outRes;
-            if (outInt < (bciArgs[4])) {
-                outRes = (outInt << (bciArgs[5])) | otherRes | (bciArgs[2]);
-            } else {
-                outRes = ((outInt - (bciArgs[4])) << (bciArgs[5])) | otherRes;
-            }
-            bool isOverflow = false;
-            // First negative:
-            if (inOutInt & (~inInt) & (bciArgs[9])) {
-                inOutInt = ((~inOutInt) & (bciArgs[4] - 1)) + 1;
-                if ((inOutInt + inInt) > bciArgs[9])
-                    isOverflow = true;
-            }
-            // First positive:
-            else if (inOutInt & (~inInt) & (bciArgs[9])) {
-                inInt = ((~inInt) & (bciArgs[4] - 1)) + 1;
-                if ((inOutInt + inInt) >= bciArgs[9])
-                    isOverflow = true;
-            }
-            if (isOverflow && ((outRes & bciArgs[8]) == bciArgs[8])) {
-                nStateVec[outRes] = -stateVec[lcv];
-            } else {
-                nStateVec[outRes] = stateVec[lcv];
-            }
-        });
+
+    par_for_skip(0, maxQPower, carryMask, 1, [&](const bitCapInt lcv) {
+        bitCapInt otherRes = (lcv & (otherMask));
+        bitCapInt inOutRes = (lcv & (inOutMask));
+        bitCapInt inOutInt = inOutRes >> (inOutStart);
+        bitCapInt inInt = toSub;
+        bitCapInt outInt = (inOutInt - toSub) + (lengthPower);
+        bitCapInt outRes;
+        if (outInt < (lengthPower)) {
+            outRes = (outInt << (inOutStart)) | otherRes | (carryMask);
+        } else {
+            outRes = ((outInt - (lengthPower)) << (inOutStart)) | otherRes;
+        }
+        bool isOverflow = false;
+        // First negative:
+        if (inOutInt & (~inInt) & (signMask)) {
+            inOutInt = ((~inOutInt) & (lengthPower - 1)) + 1;
+            if ((inOutInt + inInt) > signMask)
+                isOverflow = true;
+        }
+        // First positive:
+        else if (inOutInt & (~inInt) & (signMask)) {
+            inInt = ((~inInt) & (lengthPower - 1)) + 1;
+            if ((inOutInt + inInt) >= signMask)
+                isOverflow = true;
+        }
+        if (isOverflow && ((outRes & overflowMask) == overflowMask)) {
+            nStateVec[outRes] = -stateVec[lcv];
+        } else {
+            nStateVec[outRes] = stateVec[lcv];
+        }
+    });
     ResetStateVec(std::move(nStateVec));
 }
 
@@ -1804,44 +1802,43 @@ void CoherentUnit::DECSC(bitCapInt toSub, bitLenInt inOutStart, bitLenInt length
     bitCapInt otherMask = (1 << qubitCount) - 1;
     bitCapInt lengthPower = 1 << length;
     bitCapInt inOutMask = (lengthPower - 1) << inOutStart;
-    bitCapInt edgeMask = inOutMask | carryMask;
+
     otherMask ^= inOutMask | carryMask;
+
     std::unique_ptr<Complex16[]> nStateVec(new Complex16[maxQPower]);
     std::fill(&(nStateVec[0]), &(nStateVec[0]) + maxQPower, Complex16(0.0, 0.0));
-    bitCapInt bciArgs[9] = { inOutMask, toSub, carryMask, otherMask, lengthPower, inOutStart, carryIndex, edgeMask,
-        signMask };
-    par_for_skip(0, maxQPower, carryMask, 1, &(stateVec[0]), bciArgs, &(nStateVec[0]),
-        [](bitCapInt lcv, const int cpu, const Complex16* stateVec, const bitCapInt* bciArgs, Complex16* nStateVec) {
-            bitCapInt otherRes = (lcv & (bciArgs[3]));
-            bitCapInt inOutRes = (lcv & (bciArgs[0]));
-            bitCapInt inOutInt = inOutRes >> (bciArgs[5]);
-            bitCapInt inInt = bciArgs[1];
-            bitCapInt outInt = (inOutInt - bciArgs[1]) + (bciArgs[4]);
-            bitCapInt outRes;
-            if (outInt < (bciArgs[4])) {
-                outRes = (outInt << (bciArgs[5])) | otherRes | (bciArgs[2]);
-            } else {
-                outRes = ((outInt - (bciArgs[4])) << (bciArgs[5])) | otherRes;
-            }
-            bool isOverflow = false;
-            // First negative:
-            if (inOutInt & (~inInt) & (bciArgs[9])) {
-                inOutInt = ((~inOutInt) & (bciArgs[4] - 1)) + 1;
-                if ((inOutInt + inInt) > bciArgs[9])
-                    isOverflow = true;
-            }
-            // First positive:
-            else if (inOutInt & (~inInt) & (bciArgs[9])) {
-                inInt = ((~inInt) & (bciArgs[4] - 1)) + 1;
-                if ((inOutInt + inInt) >= bciArgs[9])
-                    isOverflow = true;
-            }
-            if (isOverflow) {
-                nStateVec[outRes] = -stateVec[lcv];
-            } else {
-                nStateVec[outRes] = stateVec[lcv];
-            }
-        });
+
+    par_for_skip(0, maxQPower, carryMask, 1, [&](const bitCapInt lcv) {
+        bitCapInt otherRes = (lcv & (otherMask));
+        bitCapInt inOutRes = (lcv & (inOutMask));
+        bitCapInt inOutInt = inOutRes >> (inOutStart);
+        bitCapInt inInt = toSub;
+        bitCapInt outInt = (inOutInt - toSub) + (lengthPower);
+        bitCapInt outRes;
+        if (outInt < (lengthPower)) {
+            outRes = (outInt << (inOutStart)) | otherRes | (carryMask);
+        } else {
+            outRes = ((outInt - (lengthPower)) << (inOutStart)) | otherRes;
+        }
+        bool isOverflow = false;
+        // First negative:
+        if (inOutInt & (~inInt) & (signMask)) {
+            inOutInt = ((~inOutInt) & (lengthPower - 1)) + 1;
+            if ((inOutInt + inInt) > signMask)
+                isOverflow = true;
+        }
+        // First positive:
+        else if (inOutInt & (~inInt) & (signMask)) {
+            inInt = ((~inInt) & (lengthPower - 1)) + 1;
+            if ((inOutInt + inInt) >= signMask)
+                isOverflow = true;
+        }
+        if (isOverflow) {
+            nStateVec[outRes] = -stateVec[lcv];
+        } else {
+            nStateVec[outRes] = stateVec[lcv];
+        }
+    });
     ResetStateVec(std::move(nStateVec));
 }
 
@@ -1862,60 +1859,59 @@ void CoherentUnit::DECBCDC(
     bitCapInt otherMask = (1 << qubitCount) - 1;
     bitCapInt carryMask = 1 << carryIndex;
     otherMask ^= inOutMask | carryMask;
+
     std::unique_ptr<Complex16[]> nStateVec(new Complex16[maxQPower]);
     std::fill(&(nStateVec[0]), &(nStateVec[0]) + maxQPower, Complex16(0.0, 0.0));
-    bitCapInt bciArgs[8] = { inOutMask, toSub, carryMask, otherMask, inOutStart, nibbleCount };
-    par_for_skip(0, maxQPower, 1 << carryIndex, 1, &(stateVec[0]), bciArgs, &(nStateVec[0]),
-        [](const bitCapInt lcv, const int cpu, const Complex16* stateVec, const bitCapInt* bciArgs,
-            Complex16* nStateVec) {
-            bitCapInt otherRes = (lcv & (bciArgs[3]));
-            bitCapInt partToSub = bciArgs[1];
-            bitCapInt inOutRes = (lcv & (bciArgs[0]));
-            bitCapInt inOutInt = inOutRes >> (bciArgs[4]);
-            char test1, test2;
-            unsigned char j;
-            char* nibbles = new char[bciArgs[5]];
-            bool isValid = true;
 
-            test1 = inOutInt & 15;
+    par_for_skip(0, maxQPower, 1 << carryIndex, 1, [&](const bitCapInt lcv) {
+        bitCapInt otherRes = (lcv & (otherMask));
+        bitCapInt partToSub = toSub;
+        bitCapInt inOutRes = (lcv & (inOutMask));
+        bitCapInt inOutInt = inOutRes >> (inOutStart);
+        char test1, test2;
+        unsigned char j;
+        char* nibbles = new char[nibbleCount];
+        bool isValid = true;
+
+        test1 = inOutInt & 15;
+        test2 = partToSub % 10;
+        partToSub /= 10;
+        nibbles[0] = test1 - test2;
+        if (test1 > 9) {
+            isValid = false;
+        }
+
+        for (j = 1; j < nibbleCount; j++) {
+            test1 = (inOutInt & (15 << (j * 4))) >> (j * 4);
             test2 = partToSub % 10;
             partToSub /= 10;
-            nibbles[0] = test1 - test2;
+            nibbles[j] = test1 - test2;
             if (test1 > 9) {
                 isValid = false;
             }
-
-            for (j = 1; j < bciArgs[5]; j++) {
-                test1 = (inOutInt & (15 << (j * 4))) >> (j * 4);
-                test2 = partToSub % 10;
-                partToSub /= 10;
-                nibbles[j] = test1 - test2;
-                if (test1 > 9) {
-                    isValid = false;
-                }
-            }
-            if (isValid) {
-                bitCapInt outInt = 0;
-                bitCapInt outRes = 0;
-                bitCapInt carryRes = 0;
-                for (j = 0; j < bciArgs[5]; j++) {
-                    if (nibbles[j] < 0) {
-                        nibbles[j] += 10;
-                        if ((unsigned char)(j + 1) < bciArgs[5]) {
-                            nibbles[j + 1]--;
-                        } else {
-                            carryRes = bciArgs[2];
-                        }
+        }
+        if (isValid) {
+            bitCapInt outInt = 0;
+            bitCapInt outRes = 0;
+            bitCapInt carryRes = 0;
+            for (j = 0; j < nibbleCount; j++) {
+                if (nibbles[j] < 0) {
+                    nibbles[j] += 10;
+                    if ((unsigned char)(j + 1) < nibbleCount) {
+                        nibbles[j + 1]--;
+                    } else {
+                        carryRes = carryMask;
                     }
-                    outInt |= nibbles[j] << (j * 4);
                 }
-                outRes = (outInt << (bciArgs[4])) | otherRes | carryRes;
-                nStateVec[outRes] = stateVec[lcv];
-            } else {
-                nStateVec[lcv] = stateVec[lcv];
+                outInt |= nibbles[j] << (j * 4);
             }
-            delete[] nibbles;
-        });
+            outRes = (outInt << (inOutStart)) | otherRes | carryRes;
+            nStateVec[outRes] = stateVec[lcv];
+        } else {
+            nStateVec[lcv] = stateVec[lcv];
+        }
+        delete[] nibbles;
+    });
     ResetStateVec(std::move(nStateVec));
 }
 
@@ -1939,24 +1935,21 @@ void CoherentUnit::ZeroPhaseFlip(bitLenInt start, bitLenInt length)
 {
     bitCapInt lengthPower = 1 << length;
     bitCapInt regMask = (lengthPower - 1) << start;
-    bitCapInt bciArgs[1] = { regMask };
-    par_for_copy(0, maxQPower, &(stateVec[0]), bciArgs, NULL,
-        [](const bitCapInt lcv, const int cpu, Complex16* stateVec, const bitCapInt* bciArgs, Complex16* nStateVec) {
-            if ((lcv & (~(bciArgs[0]))) == lcv)
-                stateVec[lcv] = -stateVec[lcv];
-        });
+    par_for(0, maxQPower, [&](const bitCapInt lcv) {
+        if ((lcv & (~(regMask))) == lcv)
+            stateVec[lcv] = -stateVec[lcv];
+    });
 }
 
 /// For chips with a sign flag, flip the phase of states where the register is negative.
 void CoherentUnit::CPhaseFlip(bitLenInt toTest)
 {
     bitCapInt testMask = 1 << toTest;
-    bitCapInt bciArgs[1] = { testMask };
-    par_for_copy(0, maxQPower, &(stateVec[0]), bciArgs, NULL,
-        [](const bitCapInt lcv, const int cpu, Complex16* stateVec, const bitCapInt* bciArgs, Complex16* nStateVec) {
-            if ((lcv & bciArgs[0]) == bciArgs[0])
-                stateVec[lcv] = -stateVec[lcv];
-        });
+
+    par_for(0, maxQPower, [&](const bitCapInt lcv) {
+        if ((lcv & testMask) == testMask)
+            stateVec[lcv] = -stateVec[lcv];
+    });
 }
 
 /// The 6502 uses its carry flag also as a greater-than/less-than flag, for the CMP operation.
@@ -1964,21 +1957,17 @@ void CoherentUnit::CPhaseFlipIfLess(bitCapInt greaterPerm, bitLenInt start, bitL
 {
     bitCapInt regMask = ((1 << length) - 1) << start;
     bitCapInt flagMask = 1 << flagIndex;
-    bitCapInt bciArgs[4] = { regMask, flagMask, start, greaterPerm };
-    par_for_copy(0, maxQPower, &(stateVec[0]), bciArgs, NULL,
-        [](const bitCapInt lcv, const int cpu, Complex16* stateVec, const bitCapInt* bciArgs, Complex16* nStateVec) {
-            if ((((lcv & bciArgs[0]) >> (bciArgs[2])) < bciArgs[3]) & ((lcv & bciArgs[1]) == bciArgs[1]))
-                stateVec[lcv] = -stateVec[lcv];
-        });
+
+    par_for(0, maxQPower, [&](const bitCapInt lcv) {
+        if ((((lcv & regMask) >> (start)) < greaterPerm) & ((lcv & flagMask) == flagMask))
+            stateVec[lcv] = -stateVec[lcv];
+    });
 }
 
 /// Phase flip always - equivalent to Z X Z X on any bit in the CoherentUnit
 void CoherentUnit::PhaseFlip()
 {
-    par_for_copy(0, maxQPower, &(stateVec[0]), NULL, NULL,
-        [](const bitCapInt lcv, const int cpu, Complex16* stateVec, const bitCapInt* bciArgs, Complex16* nStateVec) {
-            stateVec[lcv] = -stateVec[lcv];
-        });
+    par_for(0, maxQPower, [&](const bitCapInt lcv) { stateVec[lcv] = -stateVec[lcv]; });
 }
 
 /// Set register bits to given permutation
@@ -2040,16 +2029,16 @@ bitCapInt CoherentUnit::MReg(bitLenInt start, bitLenInt length)
         }
     }
 
-    bitCapInt resultPtr[1] = { result << start };
-    par_for_all(0, maxQPower, &(stateVec[0]), Complex16(cosine, sine) / nrmlzr, NULL, resultPtr,
-        [](const bitCapInt lcv, const int cpu, Complex16* stateVec, const Complex16 nrm, const Complex16* mtrx,
-            const bitCapInt* resultPtr) {
-            if ((lcv & (*resultPtr)) == (*resultPtr)) {
-                stateVec[lcv] = nrm * stateVec[lcv];
-            } else {
-                stateVec[lcv] = Complex16(0.0, 0.0);
-            }
-        });
+    bitCapInt resultPtr = result << start;
+    Complex16 nrm = Complex16(cosine, sine) / nrmlzr;
+
+    par_for(0, maxQPower, [&](const bitCapInt lcv) {
+        if ((lcv & resultPtr) == resultPtr) {
+            stateVec[lcv] = nrm * stateVec[lcv];
+        } else {
+            stateVec[lcv] = Complex16(0.0, 0.0);
+        }
+    });
 
     UpdateRunningNorm();
 
@@ -2102,13 +2091,12 @@ void CoherentUnit::ApplyAntiControlled2x2(bitLenInt control, bitLenInt target, c
 
 void CoherentUnit::NormalizeState()
 {
-    par_for_mult(0, maxQPower, runningNorm, &(stateVec[0]),
-        [](const bitCapInt lcv, const int cpu, const double runningNorm, Complex16* stateVec) {
-            stateVec[lcv] /= runningNorm;
-            if (norm(stateVec[lcv]) < 1e-15) {
-                stateVec[lcv] = Complex16(0.0, 0.0);
-            }
-        });
+    par_for(0, maxQPower, [&](const bitCapInt lcv) {
+        stateVec[lcv] /= runningNorm;
+        if (norm(stateVec[lcv]) < 1e-15) {
+            stateVec[lcv] = Complex16(0.0, 0.0);
+        }
+    });
     runningNorm = 1.0;
 }
 

--- a/qregister.hpp
+++ b/qregister.hpp
@@ -94,7 +94,8 @@ public:
     int GetMaxQPower() { return maxQPower; }
 
     /**
-     * Output the exact quantum state of this register as a permutation basis array of complex numbers
+     * Output the exact quantum state of this register as a permutation basis
+     * array of complex numbers
      *
      * \warning PSEUDO-QUANTUM
      */
@@ -186,7 +187,8 @@ public:
     void Decohere(bitLenInt start, bitLenInt length, CoherentUnit& destination);
 
     /**
-     * Minimally decohere a set of contigious bits from the full coherent unit, throwing these qubits away.
+     * Minimally decohere a set of contigious bits from the full coherent unit,
+     * throwing these qubits away.
      *
      * Minimally decohere a set of contigious bits from the full coherent unit,
      * discarding these bits. The length of this coherent unit is reduced by
@@ -310,7 +312,8 @@ public:
     /**
      * Measurement gate
      *
-     * Measures the qubit at "qubitIndex" and returns either "true" or "false." (This "gate" breaks unitarity.)
+     * Measures the qubit at "qubitIndex" and returns either "true" or "false."
+     * (This "gate" breaks unitarity.)
      *
      * All physical evolution of a quantum state should be "unitary," except
      * measurement. Measurement of a qubit "collapses" the quantum state into
@@ -786,7 +789,8 @@ public:
     /**
      * Entangled Hadamard
      *
-     * Perform an operation on two entangled registers like a bitwise Hadamard on a single
+     * Perform an operation on two entangled registers like a bitwise Hadamard
+     * on a single
      *
      * The "entangled Hadamard" register operation is an important logical
      * expedient to Qrack. It is a unitary operation, which may be complicated
@@ -839,7 +843,8 @@ public:
     unsigned char MReg8(bitLenInt start);
 
     /**
-     * Set 8 bit register bits by a superposed index-offset-based read from classical memory
+     * Set 8 bit register bits by a superposed index-offset-based read from
+     * classical memory
      *
      * "inputStart" is the start index of 8 qubits that act as an index into
      * the 256 byte "values" array. The "outputStart" bits are first cleared,
@@ -897,7 +902,8 @@ public:
     unsigned char SuperposeReg8(bitLenInt inputStart, bitLenInt outputStart, unsigned char* values);
 
     /**
-     * Add to entangled 8 bit register state with a superposed index-offset-based read from classical memory
+     * Add to entangled 8 bit register state with a superposed
+     * index-offset-based read from classical memory
      *
      * inputStart" is the start index of 8 qubits that act as an index into the
      * 256 byte "values" array. The "outputStart" bits would usually already be
@@ -923,7 +929,8 @@ public:
         bitLenInt inputStart, bitLenInt outputStart, bitLenInt carryIndex, unsigned char* values);
 
     /**
-     * Subtract from an entangled 8 bit register state with a superposed index-offset-based read from classical memory
+     * Subtract from an entangled 8 bit register state with a superposed
+     * index-offset-based read from classical memory
      *
      * "inputStart" is the start index of 8 qubits that act as an index into
      * the 256 byte "values" array. The "outputStart" bits would usually
@@ -972,9 +979,11 @@ public:
     /**
      * Set individual bit to pure |0> (false) or |1> (true) state
      *
-     * To set a bit, the bit is first measured. If the result of measurement matches "value," the bit is considered set.
-     * If the result of measurement is the opposite of "value," an X gate is applied to the bit. The state ends up
-     * entirely in the "value" state, with a random phase factor.
+     * To set a bit, the bit is first measured. If the result of measurement
+     * matches "value," the bit is considered set.  If the result of
+     * measurement is the opposite of "value," an X gate is applied to the bit.
+     * The state ends up entirely in the "value" state, with a random phase
+     * factor.
      */
     void SetBit(bitLenInt qubitIndex1, bool value);
 

--- a/qregister.hpp
+++ b/qregister.hpp
@@ -35,234 +35,366 @@ namespace Qrack {
 
 class CoherentUnit;
 
-/*
- * Enumerated list of supported engines.
- *
- * Not currently published since selection isn't supported by the API.
- */
+/** Enumerated list of supported engines. */
 enum CoherentUnitEngine {
-    COHERENT_UNIT_ENGINE_SOFTWARE = 0,
+    COHERENT_UNIT_ENGINE_SOFTWARE_SERIAL = 0,
+    COHERENT_UNIT_ENGINE_SOFTWARE_PARALLEL,
+    COHERENT_UNIT_ENGINE_SOFTWARE = COHERENT_UNIT_ENGINE_SOFTWARE_PARALLEL,
+
     COHERENT_UNIT_ENGINE_OPENCL,
 
     COHERENT_UNIT_ENGINE_MAX
 };
 
+/** Create a CoherentUnit leveraging the specified engine. */
 CoherentUnit* CreateCoherentUnit(CoherentUnitEngine engine, bitLenInt qBitCount, bitCapInt initState);
 
-/// The "Qrack::CoherentUnit" class represents one or more coherent quantum processor registers, including primitive bit
-/// logic gates and (abstract) opcodes-like methods.
 /**
- * A "Qrack::CoherentUnit" is a qubit permutation state vector with methods to operate on it as by gates and
-register-like instructions. In brief: All directly interacting qubits must be contained in a single CoherentUnit object,
-by requirement of quantum mechanics, unless a certain collection of bits represents a "separable quantum subsystem." All
-registers of a virtual chip will usually be contained in a single CoherentUnit, and they are accesible similar to a
-one-dimensional array of qubits.
-
-See README.md for an overview of the algorithms Qrack employs.
+ * A "Qrack::CoherentUnit" is a qubit permutation state vector with methods to
+ * operate on it as by gates and register-like instructions. In brief: All
+ * directly interacting qubits must be contained in a single CoherentUnit
+ * object, by requirement of quantum mechanics, unless a certain collection of
+ * bits represents a "separable quantum subsystem." All registers of a virtual
+ * chip will usually be contained in a single CoherentUnit, and they are
+ * accesible similar to a one-dimensional array of qubits.
+ *
+ * See README.md for an overview of the algorithms Qrack employs.
  */
 class CoherentUnit {
 public:
-    /// Initialize a coherent unit with qBitCount number of bits, all to |0> state.
+    /**
+     * Initialize a coherent unit with qBitCount number of bits, all to |0>
+     * state.
+     */
     CoherentUnit(bitLenInt qBitCount);
 
-    /// Initialize a coherent unit with qBitCount number of bits, to initState unsigned integer permutation state
+    /**
+     * Initialize a coherent unit with qBitCount number of bits, to initState
+     * unsigned integer permutation state.
+     */
     CoherentUnit(bitLenInt qBitCount, bitCapInt initState);
 
-    /// PSEUDO-QUANTUM Initialize a cloned register with same exact quantum state as pqs
+    /**
+     * Initialize a cloned register with same exact quantum state as pqs
+     *
+     * \warning PSEUDO-QUANTUM
+     */
     CoherentUnit(const CoherentUnit& pqs);
 
-    /// Destructor of CoherentUnit. (Permutation state vector is declared on heap, as well as some OpenCL objects.)
+    /** Destructor of CoherentUnit */
     virtual ~CoherentUnit() {}
 
-    /// Set the random seed (primarily used for testing)
+    /** Set the random seed (primarily used for testing) */
     void SetRandomSeed(uint32_t seed);
 
-    /// Get the count of bits in this register
+    /** Get the count of bits in this register */
     int GetQubitCount() { return qubitCount; }
 
-    /// Get the 1 << GetQubitCount()
+    /** Get the 1 << GetQubitCount() */
     int GetMaxQPower() { return maxQPower; }
 
-    /// PSEUDO-QUANTUM Output the exact quantum state of this register as a permutation basis array of complex numbers
+    /**
+     * Output the exact quantum state of this register as a permutation basis array of complex numbers
+     *
+     * \warning PSEUDO-QUANTUM
+     */
     void CloneRawState(Complex16* output);
 
-    /// Generate a random double from 0 to 1
+    /** Generate a random double from 0 to 1 */
     double Rand();
 
-    /// Set |0>/|1> bit basis pure quantum permutation state, as an unsigned int
+    /** Set |0>/|1> bit basis pure quantum permutation state, as an unsigned int */
     void SetPermutation(bitCapInt perm);
 
-    /// Set arbitrary pure quantum state, in unsigned int permutation basis
+    /** Set an arbitrary pure quantum state */
     void SetQuantumState(Complex16* inputState);
 
-    /// Combine (a copy of) another CoherentUnit with this one, after the last bit index of this one.
     /**
-     * "Cohere" combines the quantum description of state of two independent CoherentUnit objects into one object,
-containing the full permutation basis of the full object. The "inputState" bits are added after the last qubit index of
-the CoherentUnit to which we "Cohere." Informally, "Cohere" is equivalent to "just setting another group of qubits down
-next to the first" without interacting them. Schroedinger's equation can form a description of state for two independent
-subsystems at once or "separable quantum subsystems" without interacting them. Once the description of state of the
-independent systems is combined, we can interact them, and we can describe their entanglements to each other, in which
-case they are no longer independent. A full entangled description of quantum state is not possible for two independent
-quantum subsystems until we "Cohere" them.
-
-"Cohere" multiplies the probabilities of the indepedent permutation states of the two subsystems to find the
-probabilites of the entire set of combined permutations, by simple combinatorial reasoning. If the probablity of the
-"left-hand" subsystem being in |00> is 1/4, and the probablity of the "right-hand" subsystem being in |101> is 1/8, than
-the probability of the combined |00101> permutation state is 1/32, and so on for all permutations of the new combined
-state.
-
-If the programmer doesn't want to "cheat" quantum mechanically, then the original copy of the state which is duplicated
-into the larger CoherentUnit should be "thrown away" to satisfy "no clone theorem." This is not semantically enforced in
-Qrack, because optimization of an emulator might be acheived by "cloning" "under-the-hood" while only exposing a quantum
-mechanically consistent API or instruction set.
+     * Combine (a copy of) another CoherentUnit with this one, after the last
+     * bit index of this one.
+     *
+     * "Cohere" combines the quantum description of state of two independent
+     * CoherentUnit objects into one object, containing the full permutation
+     * basis of the full object. The "inputState" bits are added after the last
+     * qubit index of the CoherentUnit to which we "Cohere." Informally,
+     * "Cohere" is equivalent to "just setting another group of qubits down
+     * next to the first" without interacting them. Schroedinger's equation can
+     * form a description of state for two independent subsystems at once or
+     * "separable quantum subsystems" without interacting them. Once the
+     * description of state of the independent systems is combined, we can
+     * interact them, and we can describe their entanglements to each other, in
+     * which case they are no longer independent. A full entangled description
+     * of quantum state is not possible for two independent quantum subsystems
+     * until we "Cohere" them.
+     *
+     * "Cohere" multiplies the probabilities of the indepedent permutation
+     * states of the two subsystems to find the probabilites of the entire set
+     * of combined permutations, by simple combinatorial reasoning. If the
+     * probablity of the "left-hand" subsystem being in |00> is 1/4, and the
+     * probablity of the "right-hand" subsystem being in |101> is 1/8, than the
+     * probability of the combined |00101> permutation state is 1/32, and so on
+     * for all permutations of the new combined state.
+     *
+     * If the programmer doesn't want to "cheat" quantum mechanically, then the
+     * original copy of the state which is duplicated into the larger
+     * CoherentUnit should be "thrown away" to satisfy "no clone theorem." This
+     * is not semantically enforced in Qrack, because optimization of an
+     * emulator might be acheived by "cloning" "under-the-hood" while only
+     * exposing a quantum mechanically consistent API or instruction set.
      */
     void Cohere(CoherentUnit& toCopy);
 
-    /// Minimally decohere a set of contiguous bits from the full coherent unit, into "destination."
     /**
-     * Minimally decohere a set of contigious bits from the full coherent unit. The length of this coherent unit is
-reduced by the length of bits decohered, and the bits removed are output in the destination CoherentUnit pointer. The
-destination object must be initialized to the correct number of bits, in 0 permutation state. For quantum mechanical
-accuracy, the bit set removed and the bit set left behind should be quantum mechanically "separable."
-
-Like how "Cohere" is like "just setting another group of qubits down next to the first," <b><i>if two sets of qubits are
-not entangled,</i></b> then "Decohere" is like "just moving a few qubits away from the rest." Schroedinger's equation
-does not require bits to be explicitly interacted in order to describe their permutation basis, and the descriptions of
-state of <b>separable</b> subsystems, those which are not entangled with other subsystems, are just as easily removed
-from the description of state.
-
-If we have for example 5 qubits, and we wish to separate into "left" and "right" subsystems of 3 and 2 qubits, we sum
-probabilities of one permutation of the "left" three over ALL permutations of the "right" two, for all permutations, and
-vice versa, like so:
-
-prob(|(left) 1000>) = prob(|1000 00>) + prob(|1000 10>) + prob(|1000 01>) + prob(|1000 11>).
-
-If the subsystems are not "separable," i.e. if they are entangled, this operation is not well-motivated, and its output
-is not necessarily defined. (The summing of probabilities over permutations of subsytems will be performed as described
-above, but this is not quantum mechanically meaningful.) To ensure that the subsystem is "separable," i.e. that it has
-no entanglements to other subsystems in the CoherentUnit, it can be measured with M(), or else all qubits <i>other
-than</i> the subsystem can be measured.
+     * Minimally decohere a set of contiguous bits from the full coherent unit,
+     * into "destination."
+     *
+     * Minimally decohere a set of contigious bits from the full coherent unit.
+     * The length of this coherent unit is reduced by the length of bits
+     * decohered, and the bits removed are output in the destination
+     * CoherentUnit pointer. The destination object must be initialized to the
+     * correct number of bits, in 0 permutation state. For quantum mechanical
+     * accuracy, the bit set removed and the bit set left behind should be
+     * quantum mechanically "separable."
+     *
+     * Like how "Cohere" is like "just setting another group of qubits down
+     * next to the first," <b><i>if two sets of qubits are not
+     * entangled,</i></b> then "Decohere" is like "just moving a few qubits
+     * away from the rest." Schroedinger's equation does not require bits to be
+     * explicitly interacted in order to describe their permutation basis, and
+     * the descriptions of state of <b>separable</b> subsystems, those which
+     * are not entangled with other subsystems, are just as easily removed from
+     * the description of state.
+     *
+     * If we have for example 5 qubits, and we wish to separate into "left" and
+     * "right" subsystems of 3 and 2 qubits, we sum probabilities of one
+     * permutation of the "left" three over ALL permutations of the "right"
+     * two, for all permutations, and vice versa, like so:
+     *
+     * \f$
+     *     prob(|(left) 1000>) = prob(|1000 00>) + prob(|1000 10>) + prob(|1000 01>) + prob(|1000 11>).
+     * \f$
+     *
+     * If the subsystems are not "separable," i.e. if they are entangled, this
+     * operation is not well-motivated, and its output is not necessarily
+     * defined. (The summing of probabilities over permutations of subsytems
+     * will be performed as described above, but this is not quantum
+     * mechanically meaningful.) To ensure that the subsystem is "separable,"
+     * i.e. that it has no entanglements to other subsystems in the
+     * CoherentUnit, it can be measured with M(), or else all qubits <i>other
+     * than</i> the subsystem can be measured.
      */
     void Decohere(bitLenInt start, bitLenInt length, CoherentUnit& destination);
 
-    /// Minimally decohere a set of contigious bits from the full coherent unit, throwing these qubits away.
     /**
-     * Minimally decohere a set of contigious bits from the full coherent unit, discarding these bits. The length of
-this coherent unit is reduced by the length of bits decohered. For quantum mechanical accuracy, the bit set removed and
-the bit set left behind should be quantum mechanically "separable."
-
-Like how "Cohere" is like "just setting another group of qubits down next to the first," <b><i>if two sets of qubits are
-not entangled,</i></b> then "Dispose" is like "just moving a few qubits away from the rest, and throwing them in the
-trash." Schroedinger's equation does not require bits to be explicitly interacted in order to describe their permutation
-basis, and the descriptions of state of <b>separable</b> subsystems, those which are not entangled with other
-subsystems, are just as easily removed from the description of state.
-
-If we have for example 5 qubits, and we wish to separate into "left" and "right" subsystems of 3 and 2 qubits, we sum
-probabilities of one permutation of the "left" three over ALL permutations of the "right" two, for all permutations, and
-vice versa, like so:
-
-prob(|(left) 1000>) = prob(|1000 00>) + prob(|1000 10>) + prob(|1000 01>) + prob(|1000 11>).
-
-If the subsystems are not "separable," i.e. if they are entangled, this operation is not well-motivated, and its output
-is not necessarily defined. (The summing of probabilities over permutations of subsytems will be performed as described
-above, but this is not quantum mechanically meaningful.) To ensure that the subsystem is "separable," i.e. that it has
-no entanglements to other subsystems in the CoherentUnit, it can be measured with M(), or else all qubits <i>other
-than</i> the subsystem can be measured.
+     * Minimally decohere a set of contigious bits from the full coherent unit, throwing these qubits away.
+     *
+     * Minimally decohere a set of contigious bits from the full coherent unit,
+     * discarding these bits. The length of this coherent unit is reduced by
+     * the length of bits decohered. For quantum mechanical accuracy, the bit
+     * set removed and the bit set left behind should be quantum mechanically
+     * "separable."
+     *
+     * Like how "Cohere" is like "just setting another group of qubits down
+     * next to the first," <b><i>if two sets of qubits are not
+     * entangled,</i></b> then "Dispose" is like "just moving a few qubits away
+     * from the rest, and throwing them in the trash." Schroedinger's equation
+     * does not require bits to be explicitly interacted in order to describe
+     * their permutation basis, and the descriptions of state of
+     * <b>separable</b> subsystems, those which are not entangled with other
+     * subsystems, are just as easily removed from the description of state.
+     *
+     * If we have for example 5 qubits, and we wish to separate into "left" and
+     * "right" subsystems of 3 and 2 qubits, we sum probabilities of one
+     * permutation of the "left" three over ALL permutations of the "right"
+     * two, for all permutations, and vice versa, like so:
+     *
+     * \f$
+     *      prob(|(left) 1000>) = prob(|1000 00>) + prob(|1000 10>) + prob(|1000 01>) + prob(|1000 11>).
+     * \f$
+     *
+     * If the subsystems are not "separable," i.e. if they are entangled, this
+     * operation is not well-motivated, and its output is not necessarily
+     * defined. (The summing of probabilities over permutations of subsytems
+     * will be performed as described above, but this is not quantum
+     * mechanically meaningful.) To ensure that the subsystem is "separable,"
+     * i.e. that it has no entanglements to other subsystems in the
+     * CoherentUnit, it can be measured with M(), or else all qubits <i>other
+     * than</i> the subsystem can be measured.
      */
     void Dispose(bitLenInt start, bitLenInt length);
 
-    // Logic Gates
-    //
-    // Each bit is paired with a CL* variant that utilizes a classical bit as
-    // an input.
+    /*
+     * Logic Gates
+     *
+     * Each bit is paired with a CL* variant that utilizes a classical bit as
+     * an input.
+     */
 
-    /// Quantum analog of classical "AND" gate. Measures the outputBit, then overwrites it with result.
+    /**
+     * Quantum analog of classical "AND" gate
+     *
+     * Measures the outputBit, then overwrites it with result.
+     */
     void AND(bitLenInt inputBit1, bitLenInt inputBit2, bitLenInt outputBit);
-    /// Quantum analog of classical "AND" gate. Takes one qubit input and one classical bit input. Measures the
-    /// outputBit, then overwrites it with result.
+
+    /**
+     * Quantum analog of classical "OR" gate
+     *
+     * Measures the outputBit, then overwrites it with result.
+     */
+    void OR(bitLenInt inputBit1, bitLenInt inputBit2, bitLenInt outputBit);
+
+    /**
+     * Quantum analog of classical "XOR" gate
+     *
+     * Measures the outputBit, then overwrites it with result.
+     */
+    void XOR(bitLenInt inputBit1, bitLenInt inputBit2, bitLenInt outputBit);
+
+    /**
+     *  Quantum analog of classical "AND" gate. Takes one qubit input and one
+     *  classical bit input. Measures the outputBit, then overwrites it with
+     *  result.
+     */
     void CLAND(bitLenInt inputQBit, bool inputClassicalBit, bitLenInt outputBit);
 
-    /// Quantum analog of classical "OR" gate. Measures the outputBit, then overwrites it with result.
-    void OR(bitLenInt inputBit1, bitLenInt inputBit2, bitLenInt outputBit);
-    /// Quantum analog of classical "AND" gate. Takes one qubit input and one classical bit input. Measures the
-    /// outputBit, then overwrites it with result.
+    /**
+     * Quantum analog of classical "OR" gate. Takes one qubit input and one
+     * classical bit input. Measures the outputBit, then overwrites it with
+     * result.
+     */
     void CLOR(bitLenInt inputQBit, bool inputClassicalBit, bitLenInt outputBit);
 
-    /// Quantum analog of classical "exclusive-OR" or "XOR" gate. Measures the outputBit, then overwrites it with
-    /// result.
-    void XOR(bitLenInt inputBit1, bitLenInt inputBit2, bitLenInt outputBit);
-    /// Quantum analog of classical "exclusive-OR" or "XOR" gate. Takes one qubit input and one classical bit input.
-    /// Measures the outputBit, then overwrites it with result.
+    /**
+     * Quantum analog of classical "XOR" gate. Takes one qubit input and one
+     * classical bit input. Measures the outputBit, then overwrites it with
+     * result.
+     */
     void CLXOR(bitLenInt inputQBit, bool inputClassicalBit, bitLenInt outputBit);
 
-    /// "Doubly-controlled NOT gate." If both controls are set to 1, the target bit is NOT-ed or X-ed.
+    /**
+     * Doubly-controlled NOT gate
+     *
+     * If both controls are set to 1, the target bit is NOT-ed or X-ed.
+     */
     void CCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target);
-    /// "Anti doubly-controlled NOT gate." If both controls are set to 0, the target bit is NOT-ed or X-ed.
+
+    /**
+     * Anti doubly-controlled NOT gate
+     *
+     * If both controls are set to 0, the target bit is NOT-ed or X-ed.
+     */
     void AntiCCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target);
 
-    /// "Controlled NOT gate." If the control is set to 1, the target bit is NOT-ed or X-ed.
+    /**
+     * Controlled NOT gate
+     *
+     * If the control is set to 1, the target bit is NOT-ed or X-ed.
+     */
     void CNOT(bitLenInt control, bitLenInt target);
-    /// "Anti controlled NOT gate." If the control is set to 0, the target bit is NOT-ed or X-ed.
+
+    /**
+     * Anti controlled NOT gate
+     *
+     * If the control is set to 0, the target bit is NOT-ed or X-ed.
+     */
     void AntiCNOT(bitLenInt control, bitLenInt target);
 
-    /// Hadamard gate. Applies a Hadamard gate on qubit at "qubitIndex."
-    void H(bitLenInt qubitIndex);
-    /// "Measurement gate." Measures the qubit at "qubitIndex" and returns either "true" or "false." (This "gate" breaks
-    /// unitarity.)
     /**
-        All physical evolution of a quantum state should be "unitary," except measurement. Measurement of a qubit
-"collapses" the quantum state into either only permutation states consistent with a |0> state for the bit, or else only
-permutation states consistent with a |1> state for the bit. Measurement also effectively multiplies the overall quantum
-state vector of the system by a random phase factor, equiprobable over all possible phase angles.
+     * Hadamard gate
+     *
+     * Applies a Hadamard gate on qubit at "qubitIndex."
+     */
+    void H(bitLenInt qubitIndex);
 
-Effectively, when a bit measurement is emulated, Qrack calculates the norm of all permutation state components, to find
-their respective probabilities. The probabilities of all states in which the measured bit is "0" can be summed to give
-the probability of the bit being "0," and separately the probabilities of all states in which the measured bit is "1"
-can be summed to give the probability of the bit being "1." To simulate measurement, a random float between 0 and 1 is
-compared to the sum of the probability of all permutation states in which the bit is equal to "1". Depending on whether
-the random float is higher or lower than the probability, the qubit is determined to be either |0> or |1>, (up to
-phase). If the bit is determined to be |1>, then all permutation eigenstates in which the bit would be equal to |0> have
-their probability set to zero, and vice versa if the bit is determined to be |0>. Then, all remaining permutation states
-with nonzero probability are linearly rescaled so that the total probability of all permutation states is again
-"normalized" to exactly 100% or 1, (within double precision rounding error). Physically, the act of measurement should
-introduce an overall random phase factor on the state vector, which is emulated by generating another constantly
-distributed random float to select a phase angle between 0 and 2 * Pi.
-
-Measurement breaks unitary evolution of state. All quantum gates except measurement should generally act as a unitary
-matrix on a permutation state vector. (Note that Boolean comparison convenience methods in Qrack such as "AND," "OR,"
-and "XOR" employ the measurement operation in the act of first clearing output bits before filling them with the result
-of comparison, and these convenience methods therefore break unitary evolution of state, but in a physically realistic
-way. Comparable unitary operations would be performed with a combination of X and CCNOT gates, also called "Toffoli"
-gates, but the output bits would have to be assumed to be in a known fixed state, like all |0>, ahead of time to produce
-unitary logical comparison operations.)
-      */
+    /**
+     * Measurement gate
+     *
+     * Measures the qubit at "qubitIndex" and returns either "true" or "false." (This "gate" breaks unitarity.)
+     *
+     * All physical evolution of a quantum state should be "unitary," except
+     * measurement. Measurement of a qubit "collapses" the quantum state into
+     * either only permutation states consistent with a |0> state for the bit,
+     * or else only permutation states consistent with a |1> state for the bit.
+     * Measurement also effectively multiplies the overall quantum state vector
+     * of the system by a random phase factor, equiprobable over all possible
+     * phase angles.
+     *
+     * Effectively, when a bit measurement is emulated, Qrack calculates the
+     * norm of all permutation state components, to find their respective
+     * probabilities. The probabilities of all states in which the measured
+     * bit is "0" can be summed to give the probability of the bit being "0,"
+     * and separately the probabilities of all states in which the measured
+     * bit is "1" can be summed to give the probability of the bit being "1."
+     * To simulate measurement, a random float between 0 and 1 is compared to
+     * the sum of the probability of all permutation states in which the bit
+     * is equal to "1". Depending on whether the random float is higher or
+     * lower than the probability, the qubit is determined to be either |0> or
+     * |1>, (up to phase). If the bit is determined to be |1>, then all
+     * permutation eigenstates in which the bit would be equal to |0> have
+     * their probability set to zero, and vice versa if the bit is determined
+     * to be |0>. Then, all remaining permutation states with nonzero
+     * probability are linearly rescaled so that the total probability of all
+     * permutation states is again "normalized" to exactly 100% or 1, (within
+     * double precision rounding error). Physically, the act of measurement
+     * should introduce an overall random phase factor on the state vector,
+     * which is emulated by generating another constantly distributed random
+     * float to select a phase angle between 0 and 2 * Pi.
+     *
+     * Measurement breaks unitary evolution of state. All quantum gates except
+     * measurement should generally act as a unitary matrix on a permutation
+     * state vector. (Note that Boolean comparison convenience methods in Qrack
+     * such as "AND," "OR," and "XOR" employ the measurement operation in the
+     * act of first clearing output bits before filling them with the result of
+     * comparison, and these convenience methods therefore break unitary
+     * evolution of state, but in a physically realistic way. Comparable
+     * unitary operations would be performed with a combination of X and CCNOT
+     * gates, also called "Toffoli" gates, but the output bits would have to be
+     * assumed to be in a known fixed state, like all |0>, ahead of time to
+     * produce unitary logical comparison operations.)
+     */
     bool M(bitLenInt qubitIndex);
 
-    /// "X gate." Applies the Pauli "X" operator to the qubit at "qubitIndex." The Pauli "X" operator is equivalent to a
-    /// logical "NOT."
+    /**
+     * X gate
+     *
+     * Applies the Pauli "X" operator to the qubit at "qubitIndex." The Pauli
+     * "X" operator is equivalent to a logical "NOT."
+     */
     void X(bitLenInt qubitIndex);
-    /// "Y gate." Applies the Pauli "Y" operator to the qubit at "qubitIndex." The Pauli "Y" operator is similar to a
-    /// logical "NOT" with permutation phase effects.
+
+    /**
+     * Y gate
+     *
+     * Applies the Pauli "Y" operator to the qubit at "qubitIndex." The Pauli
+     * "Y" operator is similar to a logical "NOT" with permutation phase
+     * effects.
+     */
     void Y(bitLenInt qubitIndex);
-    /// "Z gate." Applies the Pauli "Z" operator to the qubit at "qubitIndex." The Pauli "Z" operator reverses the phase
-    /// of |1> and leaves |0> unchanged.
+
+    /**
+     * Z gate
+     *
+     * Applies the Pauli "Z" operator to the qubit at "qubitIndex." The Pauli
+     * "Z" operator reverses the phase of |1> and leaves |0> unchanged.
+     */
     void Z(bitLenInt qubitIndex);
 
-    // Controlled variants
-    /// "Controlled Y gate." If the "control" bit is set to 1, then the Pauli "Y" operator is applied to "target."
+    /**
+     * Controlled Y gate
+     *
+     * If the "control" bit is set to 1, then the Pauli "Y" operator is applied
+     * to "target."
+     */
     void CY(bitLenInt control, bitLenInt target);
-    /// "Controlled Z gate." If the "control" bit is set to 1, then the Pauli "Z" operator is applied to "target."
+
+    /**
+     * Controlled Z gate
+     *
+     * If the "control" bit is set to 1, then the Pauli "Z" operator is applied
+     * to "target."
+     */
     void CZ(bitLenInt control, bitLenInt target);
-
-    /// PSEUDO-QUANTUM Direct measure of bit probability to be in |1> state
-    double Prob(bitLenInt qubitIndex);
-
-    /// PSEUDO-QUANTUM Direct measure of full register probability to be in permutation state
-    double ProbAll(bitCapInt fullRegister);
-
-    /// PSEUDO-QUANTUM Direct measure of all bit probabilities in register to be in |1> state
-    void ProbArray(double* probArray);
 
     /*
      * Rotational gates:
@@ -271,461 +403,586 @@ unitary logical comparison operations.)
      * operators and lacks a division by a factor of two.
      */
 
-    /// "Phase shift gate" - Rotates as \f$ e^{-i*\theta/2} \f$ around |1> state
+    /**
+     * Phase shift gate
+     *
+     * Rotates as \f$ e^{-i*\theta/2} \f$ around |1> state
+     */
     void RT(double radians, bitLenInt qubitIndex);
 
-    /// Dyadic fraction "phase shift gate" - Rotates as \f$ e^{i*{\pi * numerator} / denominator} \f$ around |1> state.
+    /**
+     * Dyadic fraction phase shift gate
+     *
+     * Rotates as \f$ e^{i*{\pi * numerator} / denominator} \f$ around |1>
+     * state.
+     */
     void RTDyad(int numerator, int denominator, bitLenInt qubitIndex);
 
-    /// x axis rotation gate - Rotates as \f$ e^{-i*\theta/2} \f$ around Pauli x axis
+    /**
+     * X axis rotation gate
+     *
+     * Rotates as \f$ e^{-i*\theta/2} \f$ around Pauli X axis
+     */
     void RX(double radians, bitLenInt qubitIndex);
 
-    /// Dyadic fraction x axis rotation gate - Rotates as \f$ e^{i*{\pi * numerator} / denominator} \f$ around Pauli x
-    /// axis.
+    /**
+     * Dyadic fraction X axis rotation gate
+     *
+     * Rotates \f$ e^{i*{\pi * numerator} / denominator} \f$ on Pauli x axis.
+     */
     void RXDyad(int numerator, int denominator, bitLenInt qubitIndex);
 
-    /// Controlled x axis rotation gate - If "control" is set to 1, rotates as \f$ e^{-i*\theta/2} \f$ around Pauli x
-    /// axis
+    /**
+     * Controlled X axis rotation gate
+     *
+     * If "control" is 1, rotates as \f$ e^{-i*\theta/2} \f$ on Pauli x axis.
+     */
     void CRX(double radians, bitLenInt control, bitLenInt target);
 
-    /// Controlled dyadic fraction x axis rotation gate - If "control" is set to 1, rotates as \f$ e^{i*{\pi *
-    /// numerator} / denominator} \f$ around Pauli x axis.
+    /**
+     * Controlled dyadic fraction X axis rotation gate
+     *
+     * If "control" is 1, rotates as \f$ e^{i*{\pi * numerator} /
+     * denominator} \f$ around Pauli x axis.
+     */
     void CRXDyad(int numerator, int denominator, bitLenInt control, bitLenInt target);
 
-    /// y axis rotation gate - Rotates as \f$ e^{-i*\theta/2} \f$ around Pauli y axis
+    /**
+     * Y axis rotation gate
+     *
+     * Rotates as \f$ e^{-i*\theta/2} \f$ around Pauli y axis.
+     */
     void RY(double radians, bitLenInt qubitIndex);
 
-    /// Dyadic fraction y axis rotation gate - Rotates as \f$ e^{i*{\pi * numerator} / denominator} \f$ around Pauli y
-    /// axis.
+    /**
+     * Dyadic fraction Y axis rotation gate
+     *
+     * Rotates as \f$ e^{i*{\pi * numerator} / denominator} \f$ around Pauli Y
+     * axis.
+     */
     void RYDyad(int numerator, int denominator, bitLenInt qubitIndex);
 
-    /// Controlled y axis rotation gate - If "control" is set to 1, rotates as \f$ e^{-i*\theta/2} \f$ around Pauli y
-    /// axis
+    /**
+     * Controlled Y axis rotation gate
+     *
+     * If "control" is set to 1, rotates as \f$ e^{-i*\theta/2} \f$ around
+     * Pauli Y axis.
+     */
     void CRY(double radians, bitLenInt control, bitLenInt target);
 
-    /// Controlled dyadic fraction y axis rotation gate - If "control" is set to 1, rotates as \f$ e^{i*{\pi *
-    /// numerator} / denominator} \f$ around Pauli y axis.
+    /**
+     * Controlled dyadic fraction y axis rotation gate
+     *
+     * If "control" is set to 1, rotates as \f$ e^{i*{\pi * numerator} /
+     * denominator} \f$ around Pauli Y axis.
+     */
     void CRYDyad(int numerator, int denominator, bitLenInt control, bitLenInt target);
 
-    /// z axis rotation gate - Rotates as \f$ e^{-i*\theta/2} \f$ around Pauli z axis
+    /**
+     * Z axis rotation gate
+     *
+     * Rotates as \f$ e^{-i*\theta/2} \f$ around Pauli Z axis.
+     */
     void RZ(double radians, bitLenInt qubitIndex);
 
-    /// Dyadic fraction z axis rotation gate - Rotates as \f$ e^{i*{\pi * numerator} / denominator} \f$ around Pauli z
-    /// axis.
+    /**
+     * Dyadic fraction Z axis rotation gate
+     *
+     * Rotates as \f$ e^{i*{\pi * numerator} / denominator} \f$ around Pauli Z
+     * axis.
+     */
     void RZDyad(int numerator, int denominator, bitLenInt qubitIndex);
 
-    /// Controlled z axis rotation gate - If "control" is set to 1, rotates as \f$ e^{-i*\theta/2} \f$ around Pauli z
-    /// axis
+    /**
+     * Controlled Z axis rotation gate
+     *
+     * If "control" is set to 1, rotates as \f$ e^{-i*\theta/2} \f$ around
+     * Pauli Zaxis.
+     */
     void CRZ(double radians, bitLenInt control, bitLenInt target);
 
-    /// Controlled dyadic fraction z axis rotation gate - If "control" is set to 1, rotates as \f$ e^{i*{\pi *
-    /// numerator} / denominator} \f$ around Pauli z axis.
+    /**
+     * Controlled dyadic fraction Z axis rotation gate
+     *
+     * If "control" is set to 1, rotates as \f$ e^{i*{\pi * numerator} /
+     * denominator} \f$ around Pauli Z axis.
+     */
     void CRZDyad(int numerator, int denominator, bitLenInt control, bitLenInt target);
 
-    /// Set individual bit to pure |0> (false) or |1> (true) state
     /**
+     * Controlled "phase shift gate"
+     *
+     * If control bit is set to 1, rotates target bit as \f$ e^{-i*\theta/2}
+     * \f$ around |1> state.
+     */
+    void CRT(double radians, bitLenInt control, bitLenInt target);
+
+    /**
+     * Controlled dyadic fraction "phase shift gate"
+     *
+     * If control bit is set to 1, rotates target bit as \f$ e^{i*{\pi *
+     * numerator} / denominator} \f$ around |1> state.
+     */
+    void CRTDyad(int numerator, int denominator, bitLenInt control, bitLenInt target);
+
+    /*
+     * Register-spanning gates
+     *
+     * Convienence and optimized functions implementing gates are applied from
+     * the bit 'start' for 'length' bits for the register.
+     */
+
+    /** Bitwise Hadamard */
+    void H(bitLenInt start, bitLenInt length);
+
+    /** Bitwise Pauli X (or logical "NOT") operator */
+    void X(bitLenInt start, bitLenInt length);
+
+    /** Bitwise Pauli Y operator */
+    void Y(bitLenInt start, bitLenInt length);
+
+    /** Bitwise Pauli Z operator */
+    void Z(bitLenInt start, bitLenInt length);
+
+    /** Bitwise controlled-not */
+    void CNOT(bitLenInt inputBits, bitLenInt targetBits, bitLenInt length);
+
+    /**
+     * Bitwise "AND"
+     *
+     * "AND" registers at "inputStart1" and "inputStart2," of "length" bits,
+     * placing the result in "outputStart".
+     */
+    void AND(bitLenInt inputStart1, bitLenInt inputStart2, bitLenInt outputStart, bitLenInt length);
+
+    /**
+     * Classical bitwise "AND"
+     *
+     * "AND" registers at "inputStart1" and the classic bits of "classicalInput," of "length" bits,
+     * placing the result in "outputStart".
+     */
+    void CLAND(bitLenInt qInputStart, bitCapInt classicalInput, bitLenInt outputStart, bitLenInt length);
+
+    /** Bitwise "OR" */
+    void OR(bitLenInt inputStart1, bitLenInt inputStart2, bitLenInt outputStart, bitLenInt length);
+
+    /** Classical bitwise "OR" */
+    void CLOR(bitLenInt qInputStart, bitCapInt classicalInput, bitLenInt outputStart, bitLenInt length);
+
+    /** Bitwise "XOR" */
+    void XOR(bitLenInt inputStart1, bitLenInt inputStart2, bitLenInt outputStart, bitLenInt length);
+
+    /** Classical bitwise "XOR" */
+    void CLXOR(bitLenInt qInputStart, bitCapInt classicalInput, bitLenInt outputStart, bitLenInt length);
+
+    /**
+     * Bitwise phase shift gate
+     *
+     * Rotates as \f$ e^{-i*\theta/2} \f$ around |1> state
+     */
+    void RT(double radians, bitLenInt start, bitLenInt length);
+
+    /**
+     * Bitwise dyadic fraction phase shift gate
+     *
+     * Rotates as \f$ e^{i*{\pi * numerator} / denominator} \f$ around |1>
+     * state.
+     */
+    void RTDyad(int numerator, int denominator, bitLenInt start, bitLenInt length);
+
+    /**
+     * Bitwise X axis rotation gate
+     *
+     * Rotates as \f$ e^{-i*\theta/2} \f$ around Pauli X axis
+     */
+    void RX(double radians, bitLenInt start, bitLenInt length);
+
+    /**
+     * Bitwise dyadic fraction X axis rotation gate
+     *
+     * Rotates \f$ e^{i*{\pi * numerator} / denominator} \f$ on Pauli x axis.
+     */
+    void RXDyad(int numerator, int denominator, bitLenInt start, bitLenInt length);
+
+    /**
+     * Bitwise controlled X axis rotation gate
+     *
+     * If "control" is 1, rotates as \f$ e^{-i*\theta/2} \f$ on Pauli x axis.
+     */
+    void CRX(double radians, bitLenInt control, bitLenInt target, bitLenInt length);
+
+    /**
+     * Bitwise controlled dyadic fraction X axis rotation gate
+     *
+     * If "control" is 1, rotates as \f$ e^{i*{\pi * numerator} /
+     * denominator} \f$ around Pauli x axis.
+     */
+    void CRXDyad(int numerator, int denominator, bitLenInt control, bitLenInt target, bitLenInt length);
+
+    /**
+     * Bitwise Y axis rotation gate
+     *
+     * Rotates as \f$ e^{-i*\theta/2} \f$ around Pauli y axis.
+     */
+    void RY(double radians, bitLenInt start, bitLenInt length);
+
+    /**
+     * Bitwise dyadic fraction Y axis rotation gate
+     *
+     * Rotates as \f$ e^{i*{\pi * numerator} / denominator} \f$ around Pauli Y
+     * axis.
+     */
+    void RYDyad(int numerator, int denominator, bitLenInt start, bitLenInt length);
+
+    /**
+     * Bitwise controlled Y axis rotation gate
+     *
+     * If "control" is set to 1, rotates as \f$ e^{-i*\theta/2} \f$ around
+     * Pauli Y axis.
+     */
+    void CRY(double radians, bitLenInt control, bitLenInt target, bitLenInt length);
+
+    /**
+     * Bitwise controlled dyadic fraction y axis rotation gate
+     *
+     * If "control" is set to 1, rotates as \f$ e^{i*{\pi * numerator} /
+     * denominator} \f$ around Pauli Y axis.
+     */
+    void CRYDyad(int numerator, int denominator, bitLenInt control, bitLenInt target, bitLenInt length);
+
+    /**
+     * Bitwise Z axis rotation gate
+     *
+     * Rotates as \f$ e^{-i*\theta/2} \f$ around Pauli Z axis.
+     */
+    void RZ(double radians, bitLenInt start, bitLenInt length);
+
+    /**
+     * Bitwise dyadic fraction Z axis rotation gate
+     *
+     * Rotates as \f$ e^{i*{\pi * numerator} / denominator} \f$ around Pauli Z
+     * axis.
+     */
+    void RZDyad(int numerator, int denominator, bitLenInt start, bitLenInt length);
+
+    /**
+     * Bitwise controlled Z axis rotation gate
+     *
+     * If "control" is set to 1, rotates as \f$ e^{-i*\theta/2} \f$ around
+     * Pauli Zaxis.
+     */
+    void CRZ(double radians, bitLenInt control, bitLenInt target, bitLenInt length);
+
+    /**
+     * Bitwise controlled dyadic fraction Z axis rotation gate
+     *
+     * If "control" is set to 1, rotates as \f$ e^{i*{\pi * numerator} /
+     * denominator} \f$ around Pauli Z axis.
+     */
+    void CRZDyad(int numerator, int denominator, bitLenInt control, bitLenInt target, bitLenInt length);
+
+    /**
+     * Bitwise controlled "phase shift gate"
+     *
+     * If control bit is set to 1, rotates target bit as \f$ e^{-i*\theta/2}
+     * \f$ around |1> state.
+     */
+    void CRT(double radians, bitLenInt control, bitLenInt target, bitLenInt length);
+
+    /**
+     * Bitwise controlled dyadic fraction "phase shift gate"
+     *
+     * If control bit is set to 1, rotates target bit as \f$ e^{i*{\pi *
+     * numerator} / denominator} \f$ around |1> state.
+     */
+    void CRTDyad(int numerator, int denominator, bitLenInt control, bitLenInt target, bitLenInt length);
+
+    /**
+     * Bitwise controlled Y gate
+     *
+     * If the "control" bit is set to 1, then the Pauli "Y" operator is applied
+     * to "target."
+     */
+    void CY(bitLenInt control, bitLenInt target, bitLenInt length);
+
+    /**
+     * Bitwise controlled Z gate
+     *
+     * If the "control" bit is set to 1, then the Pauli "Z" operator is applied
+     * to "target."
+     */
+    void CZ(bitLenInt control, bitLenInt target, bitLenInt length);
+
+    /*
+     * Arithmetic and other opcode-like gate implemenations.
+     */
+
+    /** Arithmetic shift left, with last 2 bits as sign and carry */
+    void ASL(bitLenInt shift, bitLenInt start, bitLenInt length);
+
+    /** Arithmetic shift right, with last 2 bits as sign and carry */
+    void ASR(bitLenInt shift, bitLenInt start, bitLenInt length);
+
+    /** Logical shift left, filling the extra bits with |0> */
+    void LSL(bitLenInt shift, bitLenInt start, bitLenInt length);
+
+    /** Logical shift right, filling the extra bits with |0> */
+    void LSR(bitLenInt shift, bitLenInt start, bitLenInt length);
+
+    /** Circular shift left - shift bits left, and carry last bits. */
+    virtual void ROL(bitLenInt shift, bitLenInt start, bitLenInt length);
+
+    /** Circular shift right - shift bits right, and carry first bits. */
+    virtual void ROR(bitLenInt shift, bitLenInt start, bitLenInt length);
+
+    /** Add integer (without sign) */
+    void INC(bitCapInt toAdd, bitLenInt start, bitLenInt length);
+
+    /** Add integer (without sign, with carry) */
+    virtual void INCC(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt carryIndex);
+
+    /** Add a classical integer to the register, with sign and without carry. */
+    void INCS(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt overflowIndex);
+
+    /** Add a classical integer to the register, with sign and with carry. */
+    void INCSC(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt overflowIndex, bitLenInt carryIndex);
+
+    /** Add a classical integer to the register, with sign and with (phase-based) carry. */
+    void INCSC(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt carryIndex);
+
+    /** Add classical BCD integer (without sign) */
+    void INCBCD(bitCapInt toAdd, bitLenInt start, bitLenInt length);
+
+    /** Add classical BCD integer (without sign, with carry) */
+    void INCBCDC(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt carryIndex);
+
+    /** Subtract classical integer (without sign) */
+    void DEC(bitCapInt toSub, bitLenInt start, bitLenInt length);
+
+    /** Subtract classical integer (without sign, with carry) */
+    virtual void DECC(bitCapInt toSub, bitLenInt start, bitLenInt length, bitLenInt carryIndex);
+
+    /** Subtract a classical integer from the register, with sign and without carry. */
+    void DECS(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt overflowIndex);
+
+    /** Subtract a classical integer from the register, with sign and with carry. */
+    void DECSC(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt overflowIndex, bitLenInt carryIndex);
+
+    /** Subtract a classical integer from the register, with sign and with carry. */
+    void DECSC(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt carryIndex);
+
+    /** Subtract BCD integer (without sign) */
+    void DECBCD(bitCapInt toAdd, bitLenInt start, bitLenInt length);
+
+    /** Subtract BCD integer (without sign, with carry) */
+    void DECBCDC(bitCapInt toSub, bitLenInt start, bitLenInt length, bitLenInt carryIndex);
+
+    /** Multiply a quantum register by a classical integer, without sign and without carry. */
+    void CMUL(bitCapInt toMul, bitLenInt start, bitLenInt length);
+
+    /** Quantum Fourier Transform - Apply the quantum Fourier transform to the register. */
+    void QFT(bitLenInt start, bitLenInt length);
+
+    /**
+     * Entangled Hadamard
+     *
+     * Perform an operation on two entangled registers like a bitwise Hadamard on a single
+     *
+     * The "entangled Hadamard" register operation is an important logical
+     * expedient to Qrack. It is a unitary operation, which may be complicated
+     * in terms of fundamental gates. For two entangled registers, starting
+     * with "targetStart" and "entangledStart," of "length" bits, it transforms
+     * the "targetStart" register as if a bitwise Hadamard was applied to a
+     * register which is not entangled. It maintains the entanglement to the
+     * "entangledStart" register in this process, affecting that register as if
+     * it were unentangled register to which a bitwise Hadamard gate variant,
+     * without phase reversal, was applied.
+     *
+     * When this gate is applied to a state loaded by SuperposeReg8(), it
+     * becomes possible to perform general "amplitude amplification"
+     * algorithms, generalizations of Grover's search, on entangled key-value
+     * pairs in two registers. This allows us to do things like "Grover's
+     * search" for the key index of an array value element which matches a
+     * target value, or search for the key index of an array value element
+     * which is greater than or less than a target value. See the "Grover's
+     * search" variants assembler examples in the examples project for
+     * practical examples of its application, or see the Grover's search unit
+     * test in "example.cpp." (The relevant examples are actually properly
+     * "amplitude amplification" generalizations of Grover's search.)
+     *
+     * As this operation is unitary and extremely expedient, Qrack does not
+     * concern itself with the physical hardware realization of this gate, as
+     * Qrack is a practical emulator designed for computational efficiency
+     * foremost.
+     */
+    void EntangledH(bitLenInt targetStart, bitLenInt entangledStart, bitLenInt length);
+
+    /** Reverse the phase of the state where the register equals zero. */
+    void ZeroPhaseFlip(bitLenInt start, bitLenInt length);
+
+    /** Reverse the phase of permutations where the bit at index "toTest" is 1. */
+    void CPhaseFlip(bitLenInt toTest);
+
+    /** The 6502 uses its carry flag also as a greater-than/less-than flag, for the CMP operation. */
+    void CPhaseFlipIfLess(bitCapInt greaterPerm, bitLenInt start, bitLenInt length, bitLenInt flagIndex);
+
+    /** Phase flip always - equivalent to Z X Z X on any bit in the CoherentUnit */
+    void PhaseFlip();
+
+    /** Set register bits to given permutation */
+    void SetReg(bitLenInt start, bitLenInt length, bitCapInt value);
+
+    /** Measure permutation state of a register */
+    bitCapInt MReg(bitLenInt start, bitLenInt length);
+
+    /** Measure permutation state of an 8 bit register */
+    unsigned char MReg8(bitLenInt start);
+
+    /**
+     * Set 8 bit register bits by a superposed index-offset-based read from classical memory
+     *
+     * "inputStart" is the start index of 8 qubits that act as an index into
+     * the 256 byte "values" array. The "outputStart" bits are first cleared,
+     * then the separable |input, 00000000> permutation state is mapped to
+     * |input, values[input]>, with "values[input]" placed in the "outputStart"
+     * register.
+     *
+     * While a CoherentUnit represents an interacting set of qubit-based
+     * registers, or a virtual quantum chip, the registers need to interact in
+     * some way with (classical or quantum) RAM. SuperposeReg8 is a RAM access
+     * method similar to the X addressing mode of the MOS 6502 chip, if the X
+     * register can be in a state of coherent superposition when it loads from
+     * RAM.
+     *
+     * The physical motivation for this addressing mode can be explained as
+     * follows: say that we have a superconducting quantum interface device
+     * (SQUID) based chip. SQUIDs have already been demonstrated passing
+     * coherently superposed electrical currents. In a sufficiently
+     * quantum-mechanically isolated qubit chip with a classical cache, with
+     * both classical RAM and registers likely cryogenically isolated from the
+     * environment, SQUIDs could (hopefully) pass coherently superposed
+     * electrical currents into the classical RAM cache to load values into a
+     * qubit register. The state loaded would be a superposition of the values
+     * of all RAM to which coherently superposed electrical currents were
+     * passed.
+     *
+     * In qubit system similar to the MOS 6502, say we have qubit-based
+     * "accumulator" and "X index" registers, and say that we start with a
+     * superposed X index register. In (classical) X addressing mode, the X
+     * index register value acts an offset into RAM from a specified starting
+     * address. The X addressing mode of a LoaD Accumulator (LDA) instruction,
+     * by the physical mechanism described above, should load the accumulator
+     * in quantum parallel with the values of every different address of RAM
+     * pointed to in superposition by the X index register. The superposed
+     * values in the accumulator are entangled with those in the X index
+     * register, by way of whatever values the classical RAM pointed to by X
+     * held at the time of the load. (If the RAM at index "36" held an unsigned
+     * char value of "27," then the value "36" in the X index register becomes
+     * entangled with the value "27" in the accumulator, and so on in quantum
+     * parallel for all superposed values of the X index register, at once.) If
+     * the X index register or accumulator are then measured, the two registers
+     * will both always collapse into a random but valid key-value pair of X
+     * index offset and value at that classical RAM address.
+     *
+     * Note that a "superposed store operation in classical RAM" is not
+     * possible by analagous reasoning. Classical RAM would become entangled
+     * with both the accumulator and the X register. When the state of the
+     * registers was collapsed, we would find that only one "store" operation
+     * to a single memory address had actually been carried out, consistent
+     * with the address offset in the collapsed X register and the byte value
+     * in the collapsed accumulator. It would not be possible by this model to
+     * write in quantum parallel to more than one address of classical memory
+     * at a time.
+     */
+    unsigned char SuperposeReg8(bitLenInt inputStart, bitLenInt outputStart, unsigned char* values);
+
+    /**
+     * Add to entangled 8 bit register state with a superposed index-offset-based read from classical memory
+     *
+     * inputStart" is the start index of 8 qubits that act as an index into the
+     * 256 byte "values" array. The "outputStart" bits would usually already be
+     * entangled with the "inputStart" bits via a SuperposeReg8() operation.
+     * With the "inputStart" bits being a "key" and the "outputStart" bits
+     * being a value, the permutation state |key, value> is mapped to |key,
+     * value + values[key]>. This is similar to classical parallel addition of
+     * two arrays.  However, when either of the registers are measured, both
+     * registers will collapse into one random VALID key-value pair, with any
+     * addition or subtraction done to the "value." See SuperposeReg8() for
+     * context.
+     *
+     * While a CoherentUnit represents an interacting set of qubit-based
+     * registers, or a virtual quantum chip, the registers need to interact in
+     * some way with (classical or quantum) RAM. SuperposeReg8 is a RAM access
+     * method similar to the X addressing mode of the MOS 6502 chip, if the X
+     * register can be in a state of coherent superposition when it loads from
+     * RAM. "AdcSuperposReg8" and "SbcSuperposeReg8" perform add and subtract
+     * (with carry) operations on a state usually initially prepared with
+     * SuperposeReg8().
+     */
+    unsigned char AdcSuperposeReg8(
+        bitLenInt inputStart, bitLenInt outputStart, bitLenInt carryIndex, unsigned char* values);
+
+    /**
+     * Subtract from an entangled 8 bit register state with a superposed index-offset-based read from classical memory
+     *
+     * "inputStart" is the start index of 8 qubits that act as an index into
+     * the 256 byte "values" array. The "outputStart" bits would usually
+     * already be entangled with the "inputStart" bits via a SuperposeReg8()
+     * operation.  With the "inputStart" bits being a "key" and the
+     * "outputStart" bits being a value, the permutation state |key, value> is
+     * mapped to |key, value - values[key]>. This is similar to classical
+     * parallel addition of two arrays.  However, when either of the registers
+     * are measured, both registers will collapse into one random VALID
+     * key-value pair, with any addition or subtraction done to the "value."
+     * See CoherentUnit::SuperposeReg8 for context.
+     *
+     * While a CoherentUnit represents an interacting set of qubit-based
+     * registers, or a virtual quantum chip, the registers need to interact in
+     * some way with (classical or quantum) RAM. SuperposeReg8 is a RAM access
+     * method similar to the X addressing mode of the MOS 6502 chip, if the X
+     * register can be in a state of coherent superposition when it loads from
+     * RAM. "AdcSuperposReg8" and "SbcSuperposeReg8" perform add and subtract
+     * (with carry) operations on a state usually initially prepared with
+     * SuperposeReg8().
+     */
+    unsigned char SbcSuperposeReg8(
+        bitLenInt inputStart, bitLenInt outputStart, bitLenInt carryIndex, unsigned char* values);
+
+    /**
+     * Direct measure of bit probability to be in |1> state
+     *
+     * \warning PSEUDO-QUANTUM
+     */
+    double Prob(bitLenInt qubitIndex);
+
+    /**
+     * Direct measure of full register probability to be in permutation state
+     *
+     * \warning PSEUDO-QUANTUM
+     */
+    double ProbAll(bitCapInt fullRegister);
+
+    /**
+     * Direct measure of all bit probabilities in register to be in |1> state
+     *
+     * \warning PSEUDO-QUANTUM
+     */
+    void ProbArray(double* probArray);
+
+    /**
+     * Set individual bit to pure |0> (false) or |1> (true) state
+     *
      * To set a bit, the bit is first measured. If the result of measurement matches "value," the bit is considered set.
      * If the result of measurement is the opposite of "value," an X gate is applied to the bit. The state ends up
      * entirely in the "value" state, with a random phase factor.
      */
     void SetBit(bitLenInt qubitIndex1, bool value);
 
-    /// Swap values of two bits in register
+    /** Swap values of two bits in register */
     void Swap(bitLenInt qubitIndex1, bitLenInt qubitIndex2);
 
-    /// Controlled "phase shift gate" - if control bit is set to 1, rotates target bit as \f$ e^{-i*\theta/2} \f$ around
-    /// |1> state
-    void CRT(double radians, bitLenInt control, bitLenInt target);
-
-    /// Controlled dyadic fraction "phase shift gate" - if control bit is set to 1, rotates target bit as \f$ e^{i*{\pi
-    /// * numerator} / denominator} \f$ around |1> state
-    void CRTDyad(int numerator, int denominator, bitLenInt control, bitLenInt target);
-
-    // Register-spanning gates
-    //
-    // Convienence functions implementing gates are applied from the bit
-    // 'start' for 'length' bits for the register.
-
-    /// Bitwise Hadamard
-    void H(bitLenInt start, bitLenInt length);
-
-    /// Bitwise Pauli X (or logical "NOT") operator
-    void X(bitLenInt start, bitLenInt length);
-
-    /// Bitwise Pauli Y operator
-    void Y(bitLenInt start, bitLenInt length);
-
-    /// Bitwise Pauli Z operator
-    void Z(bitLenInt start, bitLenInt length);
-
-    /// Bitwise swap
+    /** Bitwise swap */
     void Swap(bitLenInt start1, bitLenInt start2, bitLenInt length);
-
-    /// Bitwise controlled-not with "inputStart1" bits as controls and "inputStart2" bits as targets, with registers of
-    /// "length" bits.
-    void CNOT(bitLenInt inputStart1, bitLenInt inputStart2, bitLenInt length);
-
-    /// Bitwise "AND" between registers at "inputStart1" and "inputStart2," with registers of "length" bits.
-    void AND(bitLenInt inputStart1, bitLenInt inputStart2, bitLenInt outputStart, bitLenInt length);
-
-    /// Bitwise "AND" between qubit register at "qInputStart" and the classical bits of "classicalInput," with registers
-    /// of "length" bits.
-    void CLAND(bitLenInt qInputStart, bitCapInt classicalInput, bitLenInt outputStart, bitLenInt length);
-
-    /// Bitwise "OR" between registers at "inputStart1" and "inputStart2," with registers of "length" bits.
-    void OR(bitLenInt inputStart1, bitLenInt inputStart2, bitLenInt outputStart, bitLenInt length);
-
-    /// Bitwise "OR" between qubit register at "qInputStart" and the classical bits of "classicalInput," with registers
-    /// of "length" bits.
-    void CLOR(bitLenInt qInputStart, bitCapInt classicalInput, bitLenInt outputStart, bitLenInt length);
-
-    /// Bitwise "exclusive OR" or "XOR" between registers at "inputStart1" and "inputStart2," with registers of "length"
-    /// bits.
-    void XOR(bitLenInt inputStart1, bitLenInt inputStart2, bitLenInt outputStart, bitLenInt length);
-
-    /// Bitwise "exclusive OR" or "XOR" between qubit register at "qInputStart" and the classical bits of
-    /// "classicalInput," with registers of "length" bits.
-    void CLXOR(bitLenInt qInputStart, bitCapInt classicalInput, bitLenInt outputStart, bitLenInt length);
-
-    /// Bitwise |1> axis rotation gate - Rotates each bit from "start" for "length" as \f$ e^{-i*\theta/2} \f$ around
-    /// the |1> state.
-    void RT(double radians, bitLenInt start, bitLenInt length);
-
-    /// Bitwise dyadic |1> axis rotation gate - Rotates each bit from "start" for "length" as \f$ e^{i*{\pi * numerator}
-    /// / denominator} \f$ around the |1> state.
-    void RTDyad(int numerator, int denominator, bitLenInt start, bitLenInt length);
-
-    /// Bitwise x axis rotation gate - Rotates each bit from "start" for "length" as \f$ e^{-i*\theta/2} \f$ around the
-    /// Pauli x axis.
-    void RX(double radians, bitLenInt start, bitLenInt length);
-
-    /// Bitwise dyadic x axis rotation gate - Rotates each bit from "start" for "length" as \f$ e^{i*{\pi * numerator} /
-    /// denominator} \f$ around the Pauli x axis.
-    void RXDyad(int numerator, int denominator, bitLenInt start, bitLenInt length);
-
-    /// Bitwise controlled x axis rotation gate - For each bit pair in "length," if "control" bit is set to 1, rotates
-    /// "target" as \f$ e^{-i*\theta/2} \f$ around the Pauli x axis.
-    void CRX(double radians, bitLenInt control, bitLenInt target, bitLenInt length);
-
-    /// Bitwise dyadic controlled x axis rotation gate - For each bit pair in "length," if "control" bit is set to 1,
-    /// rotates "target" as \f$ e^{i*{\pi * numerator} / denominator} \f$ around the Pauli x axis.
-    void CRXDyad(int numerator, int denominator, bitLenInt control, bitLenInt target, bitLenInt length);
-
-    /// Bitwise y axis rotation gate - Rotates each bit from "start" for "length" as \f$ e^{-i*\theta/2} \f$ around the
-    /// Pauli y axis.
-    void RY(double radians, bitLenInt start, bitLenInt length);
-
-    /// Bitwise dyadic y axis rotation gate - Rotates each bit from "start" for "length" as \f$ e^{i*{\pi * numerator} /
-    /// denominator} \f$ around the Pauli y axis.
-    void RYDyad(int numerator, int denominator, bitLenInt start, bitLenInt length);
-
-    /// Bitwise controlled y axis rotation gate - For each bit pair in "length," if "control" bit is set to 1, rotates
-    /// "target" as \f$ e^{-i*\theta/2} \f$ around the Pauli y axis.
-    void CRY(double radians, bitLenInt control, bitLenInt target, bitLenInt length);
-
-    /// Bitwise dyadic controlled y axis rotation gate - For each bit pair in "length," if "control" bit is set to 1,
-    /// rotates "target" as \f$ e^{i*{\pi * numerator} / denominator} \f$ around the Pauli y axis.
-    void CRYDyad(int numerator, int denominator, bitLenInt control, bitLenInt target, bitLenInt length);
-
-    /// Bitwise z axis rotation gate - Rotates each bit from "start" for "length" as \f$ e^{-i*\theta/2} \f$ around the
-    /// Pauli z axis.
-    void RZ(double radians, bitLenInt start, bitLenInt length);
-
-    /// Bitwise dyadic z axis rotation gate - Rotates each bit from "start" for "length" as \f$ e^{i*{\pi * numerator} /
-    /// denominator} \f$ around the Pauli z axis.
-    void RZDyad(int numerator, int denominator, bitLenInt start, bitLenInt length);
-
-    /// Bitwise controlled z axis rotation gate - For each bit pair in "length," if "control" bit is set to 1, rotates
-    /// "target" as \f$ e^{-i*\theta/2} \f$ around the Pauli z axis.
-    void CRZ(double radians, bitLenInt control, bitLenInt target, bitLenInt length);
-
-    /// Bitwise dyadic controlled z axis rotation gate - For each bit pair in "length," if "control" bit is set to 1,
-    /// rotates "target" as \f$ e^{i*{\pi * numerator} / denominator} \f$ around the Pauli z axis.
-    void CRZDyad(int numerator, int denominator, bitLenInt control, bitLenInt target, bitLenInt length);
-
-    /// Bitwise controlled |1> axis rotation gate - For each bit pair in "length," if "control" bit is set to 1, rotates
-    /// "target" as \f$ e^{-i*\theta/2} \f$ around the |1> state.
-    void CRT(double radians, bitLenInt control, bitLenInt target, bitLenInt length);
-
-    /// Bitwise dyadic controlled |1> axis rotation gate - For each bit pair in "length," if "control" bit is set to 1,
-    /// rotates "target" as \f$ e^{i*{\pi * numerator} / denominator} \f$ around the |1> state.
-    void CRTDyad(int numerator, int denominator, bitLenInt control, bitLenInt target, bitLenInt length);
-
-    /// Bitwise controlled y for registers of "length" bits
-    void CY(bitLenInt control, bitLenInt target, bitLenInt length);
-
-    /// Bitwise controlled z for registers of "length" bits
-    void CZ(bitLenInt control, bitLenInt target, bitLenInt length);
-
-    /// Arithmetic shift left, with last 2 bits as sign and carry
-    void ASL(bitLenInt shift, bitLenInt start, bitLenInt length);
-
-    /// Arithmetic shift right, with last 2 bits as sign and carry
-    void ASR(bitLenInt shift, bitLenInt start, bitLenInt length);
-
-    /// Logical shift left, filling the extra bits with |0>
-    void LSL(bitLenInt shift, bitLenInt start, bitLenInt length);
-
-    /// Logical shift right, filling the extra bits with |0>
-    void LSR(bitLenInt shift, bitLenInt start, bitLenInt length);
-
-    /// "Circular shift left" - shift bits left, and carry last bits.
-    virtual void ROL(bitLenInt shift, bitLenInt start, bitLenInt length);
-
-    /// "Circular shift right" - shift bits right, and carry first bits.
-    virtual void ROR(bitLenInt shift, bitLenInt start, bitLenInt length);
-
-    /// Add integer (without sign)
-    void INC(bitCapInt toAdd, bitLenInt start, bitLenInt length);
-
-    /// Add integer (without sign, with carry)
-    virtual void INCC(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt carryIndex);
-
-    /// Add a classical integer to the register, with sign and without carry.
-    void INCS(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt overflowIndex);
-
-    /// Add a classical integer to the register, with sign and with carry.
-    void INCSC(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt overflowIndex, bitLenInt carryIndex);
-
-    /// Add a classical integer to the register, with sign and with (phase-based) carry.
-    void INCSC(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt carryIndex);
-
-    /// Add classical BCD integer (without sign)
-    void INCBCD(bitCapInt toAdd, bitLenInt start, bitLenInt length);
-
-    /// Add classical BCD integer (without sign, with carry)
-    void INCBCDC(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt carryIndex);
-
-    /// Subtract classical integer (without sign)
-    void DEC(bitCapInt toSub, bitLenInt start, bitLenInt length);
-
-    /// Subtract classical integer (without sign, with carry)
-    virtual void DECC(bitCapInt toSub, bitLenInt start, bitLenInt length, bitLenInt carryIndex);
-
-    /// Subtract a classical integer from the register, with sign and without carry.
-    void DECS(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt overflowIndex);
-
-    /// Subtract a classical integer from the register, with sign and with carry.
-    void DECSC(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt overflowIndex, bitLenInt carryIndex);
-
-    /// Subtract a classical integer from the register, with sign and with carry.
-    void DECSC(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt carryIndex);
-
-    /// Subtract BCD integer (without sign)
-    void DECBCD(bitCapInt toAdd, bitLenInt start, bitLenInt length);
-
-    /// Subtract BCD integer (without sign, with carry)
-    void DECBCDC(bitCapInt toSub, bitLenInt start, bitLenInt length, bitLenInt carryIndex);
-
-    /// Multiply a quantum register by a classical integer, without sign and without carry.
-    void CMUL(bitCapInt toMul, bitLenInt start, bitLenInt length);
-
-    /*
-     * Add integer of "length" bits in "inStart" to integer of "length" bits in "inOutStart," and store result in
-     * "inOutStart."
-     */
-    // virtual void ADD(const bitLenInt inOutStart, const bitLenInt inStart, const bitLenInt length);
-
-    /*
-     * Add integer of "length" bits in "inStart" to integer of "length" bits in "inOutStart," and store result in
-     * "inOutStart." Get carry value from bit at "carryIndex" and place end result into this bit.
-     */
-    // void ADDC(const bitLenInt inOutStart, const bitLenInt inStart, const bitLenInt length, const bitLenInt
-    // carryIndex);
-
-    /*
-     * Add signed integer of "length" bits in "inStart" to signed integer of "length" bits in "inOutStart," and store
-     * result in "inOutStart." Set overflow bit when input to output wraps past minimum or maximum integer.
-     */
-    // void ADDS(
-    //    const bitLenInt inOutStart, const bitLenInt inStart, const bitLenInt length, const bitLenInt overflowIndex);
-
-    /*
-     * Add integer of "length" bits in "inStart" to integer of "length" bits in "inOutStart," and store result in
-     * "inOutStart." Get carry value from bit at "carryIndex" and place end result into this bit. Set overflow for
-     * signed addition if result wraps past the minimum or maximum signed integer.
-     */
-    // void ADDSC(const bitLenInt inOutStart, const bitLenInt inStart, const bitLenInt length,
-    //    const bitLenInt overflowIndex, const bitLenInt carryIndex);
-
-    /*
-     * Add BCD number of "length" bits in "inStart" to BCD number of "length" bits in "inOutStart," and store result in
-     * "inOutStart."
-     */
-    // void ADDBCD(const bitLenInt inOutStart, const bitLenInt inStart, const bitLenInt length);
-
-    /*
-     * Add BCD number of "length" bits in "inStart" to BCD number of "length" bits in "inOutStart," and store result in
-     * "inOutStart," with carry in/out.
-     */
-    // void ADDBCDC(
-    //    const bitLenInt inOutStart, const bitLenInt inStart, const bitLenInt length, const bitLenInt carryIndex);
-
-    /*
-     * Subtract integer of "length" bits in "toSub" from integer of "length" bits in "inOutStart," and store result in
-     * "inOutStart."
-     */
-    // virtual void SUB(const bitLenInt inOutStart, const bitLenInt toSub, const bitLenInt length);
-
-    /*
-     * Subtract BCD number of "length" bits in "inStart" from BCD number of "length" bits in "inOutStart," and store
-     * result in "inOutStart."
-     */
-    // void SUBBCD(const bitLenInt inOutStart, const bitLenInt inStart, const bitLenInt length);
-
-    /*
-     * Subtract BCD number of "length" bits in "inStart" from BCD number of "length" bits in "inOutStart," and store
-     * result in "inOutStart," with carry in/out.
-     */
-    // void SUBBCDC(
-    //    const bitLenInt inOutStart, const bitLenInt inStart, const bitLenInt length, const bitLenInt carryIndex);
-
-    /*
-     * Subtract integer of "length" bits in "toSub" from integer of "length" bits in "inOutStart," and store result in
-     * "inOutStart." Get carry value from bit at "carryIndex" and place end result into this bit.
-     */
-    // void SUBC(const bitLenInt inOutStart, const bitLenInt toSub, const bitLenInt length, const bitLenInt carryIndex);
-
-    /*
-     * Subtract signed integer of "length" bits in "inStart" from signed integer of "length" bits in "inOutStart," and
-     * store result in "inOutStart." Set overflow bit when input to output wraps past minimum or maximum integer.
-     */
-    // void SUBS(
-    //    const bitLenInt inOutStart, const bitLenInt inStart, const bitLenInt length, const bitLenInt overflowIndex);
-
-    /*
-     *Subtract integer of "length" bits in "inStart" from integer of "length" bits in "inOutStart," and store result
-     * in "inOutStart." Get carry value from bit at "carryIndex" and place end result into this bit. Set overflow for
-     * signed addition if result wraps past the minimum or maximum signed integer.
-     */
-    // void SUBSC(const bitLenInt inOutStart, const bitLenInt toSub, const bitLenInt length, const bitLenInt
-    // overflowIndex,
-    //    const bitLenInt carryIndex);
-
-    /// Quantum Fourier Transform - Apply the quantum Fourier transform to the register.
-    void QFT(bitLenInt start, bitLenInt length);
-
-    /// "Entangled Hadamard" - perform an operation on two entangled registers like a bitwise Hadamard on a single
-    /// unentangled register.
-    /**
-      * The "entangled Hadamard" register operation is an important logical expedient to Qrack. It is a unitary
-    operation, which may be complicated in terms of fundamental gates. For two entangled registers, starting with
-    "targetStart" and "entangledStart," of "length" bits, it transforms the "targetStart" register as if a bitwise
-    Hadamard was applied to a register which is not entangled. It maintains the entanglement to the "entangledStart"
-    register in this process, affecting that register as if it were unentangled register to which a bitwise Hadamard
-    gate variant, without phase reversal, was applied.
-
-    When this gate is applied to a state loaded by SuperposeReg8(), it becomes possible to perform general "amplitude
-    amplification" algorithms, generalizations of Grover's search, on entangled key-value pairs in two registers. This
-    allows us to do things like "Grover's search" for the key index of an array value element which matches a target
-    value, or search for the key index of an array value element which is greater than or less than a target value. See
-    the "Grover's search" variants assembler examples in the examples project for practical examples of its application,
-    or see the Grover's search unit test in "example.cpp." (The relevant examples are actually properly "amplitude
-    amplification" generalizations of Grover's search.)
-
-    As this operation is unitary and extremely expedient, Qrack does not concern itself with the physical hardware
-    realization of this gate, as Qrack is a practical emulator designed for computational efficiency foremost.
-      */
-    void EntangledH(bitLenInt targetStart, bitLenInt entangledStart, bitLenInt length);
-
-    /// Reverse the phase of the state where the register equals zero.
-    void ZeroPhaseFlip(bitLenInt start, bitLenInt length);
-
-    /// Reverse the phase of permutations where the bit at index "toTest" is 1.
-    void CPhaseFlip(bitLenInt toTest);
-
-    /// The 6502 uses its carry flag also as a greater-than/less-than flag, for the CMP operation.
-    void CPhaseFlipIfLess(bitCapInt greaterPerm, bitLenInt start, bitLenInt length, bitLenInt flagIndex);
-
-    /// Phase flip always - equivalent to Z X Z X on any bit in the CoherentUnit
-    void PhaseFlip();
-
-    /// Set register bits to given permutation
-    void SetReg(bitLenInt start, bitLenInt length, bitCapInt value);
-
-    /// Measure permutation state of a register
-    bitCapInt MReg(bitLenInt start, bitLenInt length);
-
-    /// Measure permutation state of an 8 bit register
-    unsigned char MReg8(bitLenInt start);
-
-    /// Set 8 bit register bits by a superposed index-offset-based read from classical memory
-    /**
-      * "inputStart" is the start index of 8 qubits that act as an index into the 256 byte "values" array. The
-    "outputStart" bits are first cleared, then the separable |input, 00000000> permutation state is mapped to |input,
-    values[input]>, with "values[input]" placed in the "outputStart" register.
-
-    While a CoherentUnit represents an interacting set of qubit-based registers, or a virtual quantum chip, the
-    registers need to interact in some way with (classical or quantum) RAM. SuperposeReg8 is a RAM access method similar
-    to the X addressing mode of the MOS 6502 chip, if the X register can be in a state of coherent superposition when it
-    loads from RAM.
-
-    The physical motivation for this addressing mode can be explained as follows: say that we have a superconducting
-    quantum interface device (SQUID) based chip. SQUIDs have already been demonstrated passing coherently superposed
-    electrical currents. In a sufficiently quantum-mechanically isolated qubit chip with a classical cache, with both
-    classical RAM and registers likely cryogenically isolated from the environment, SQUIDs could (hopefully) pass
-    coherently superposed electrical currents into the classical RAM cache to load values into a qubit register. The
-    state loaded would be a superposition of the values of all RAM to which coherently superposed electrical currents
-    were passed.
-
-    In qubit system similar to the MOS 6502, say we have qubit-based "accumulator" and "X index" registers, and say that
-    we start with a superposed X index register. In (classical) X addressing mode, the X index register value acts an
-    offset into RAM from a specified starting address. The X addressing mode of a LoaD Accumulator (LDA) instruction, by
-    the physical mechanism described above, should load the accumulator in quantum parallel with the values of every
-    different address of RAM pointed to in superposition by the X index register. The superposed values in the
-    accumulator are entangled with those in the X index register, by way of whatever values the classical RAM pointed to
-    by X held at the time of the load. (If the RAM at index "36" held an unsigned char value of "27," then the value
-    "36" in the X index register becomes entangled with the value "27" in the accumulator, and so on in quantum parallel
-    for all superposed values of the X index register, at once.) If the X index register or accumulator are then
-    measured, the two registers will both always collapse into a random but valid key-value pair of X index offset and
-    value at that classical RAM address.
-
-    Note that a "superposed store operation in classical RAM" is not possible by analagous reasoning. Classical RAM
-    would become entangled with both the accumulator and the X register. When the state of the registers was collapsed,
-    we would find that only one "store" operation to a single memory address had actually been carried out, consistent
-    with the address offset in the collapsed X register and the byte value in the collapsed accumulator. It would not be
-    possible by this model to write in quantum parallel to more than one address of classical memory at a time.
-
-     */
-    unsigned char SuperposeReg8(bitLenInt inputStart, bitLenInt outputStart, unsigned char* values);
-
-    /// Add to entangled 8 bit register state with a superposed index-offset-based read from classical memory
-    /**
-      * "inputStart" is the start index of 8 qubits that act as an index into the 256 byte "values" array. The
-    "outputStart" bits would usually already be entangled with the "inputStart" bits via a SuperposeReg8() operation.
-    With the "inputStart" bits being a "key" and the "outputStart" bits being a value, the permutation state |key,
-    value> is mapped to |key, value + values[key]>. This is similar to classical parallel addition of two arrays.
-    However, when either of the registers are measured, both registers will collapse into one random VALID key-value
-    pair, with any addition or subtraction done to the "value." See SuperposeReg8() for context.
-
-    While a CoherentUnit represents an interacting set of qubit-based registers, or a virtual quantum chip, the
-    registers need to interact in some way with (classical or quantum) RAM. SuperposeReg8 is a RAM access method similar
-    to the X addressing mode of the MOS 6502 chip, if the X register can be in a state of coherent superposition when it
-    loads from RAM. "AdcSuperposReg8" and "SbcSuperposeReg8" perform add and subtract (with carry) operations on a state
-    usually initially prepared with SuperposeReg8().
-
-     */
-    unsigned char AdcSuperposeReg8(
-        bitLenInt inputStart, bitLenInt outputStart, bitLenInt carryIndex, unsigned char* values);
-
-    /// Subtract from an entangled 8 bit register state with a superposed index-offset-based read from classical memory
-    /**
-      * "inputStart" is the start index of 8 qubits that act as an index into the 256 byte "values" array. The
-    "outputStart" bits would usually already be entangled with the "inputStart" bits via a SuperposeReg8() operation.
-    With the "inputStart" bits being a "key" and the "outputStart" bits being a value, the permutation state |key,
-    value> is mapped to |key, value - values[key]>. This is similar to classical parallel addition of two arrays.
-    However, when either of the registers are measured, both registers will collapse into one random VALID key-value
-    pair, with any addition or subtraction done to the "value." See CoherentUnit::SuperposeReg8 for context.
-
-    While a CoherentUnit represents an interacting set of qubit-based registers, or a virtual quantum chip, the
-    registers need to interact in some way with (classical or quantum) RAM. SuperposeReg8 is a RAM access method similar
-    to the X addressing mode of the MOS 6502 chip, if the X register can be in a state of coherent superposition when it
-    loads from RAM. "AdcSuperposReg8" and "SbcSuperposeReg8" perform add and subtract (with carry) operations on a state
-    usually initially prepared with SuperposeReg8().
-
-     */
-    unsigned char SbcSuperposeReg8(
-        bitLenInt inputStart, bitLenInt outputStart, bitLenInt carryIndex, unsigned char* values);
 
 protected:
     double runningNorm;

--- a/tests.cpp
+++ b/tests.cpp
@@ -3,6 +3,7 @@
 #include <stdlib.h>
 
 #include "catch.hpp"
+#include "par_for.hpp"
 #include "qregister.hpp"
 
 #include "tests.hpp"
@@ -10,6 +11,21 @@
 using namespace Qrack;
 
 /* Begin Test Cases. */
+TEST_CASE("test_par_for")
+{
+    size_t NUM_ENTRIES = 2000;
+    std::atomic_bool hit[NUM_ENTRIES];
+
+    for (int i = 0; i < 2000; i++) {
+        hit[i].store(false);
+    }
+
+    par_for(0, NUM_ENTRIES, [&hit](const bitCapInt lcv) {
+        bool old = true;
+        old = hit[lcv].exchange(old);
+        REQUIRE(old == false);
+    });
+}
 
 TEST_CASE_METHOD(CoherentUnitTestFixture, "test_set_reg")
 {
@@ -165,7 +181,7 @@ TEST_CASE_METHOD(CoherentUnitTestFixture, "test_incsc")
 
 TEST_CASE_METHOD(CoherentUnitTestFixture, "test_not")
 {
-    qftReg->SetPermutation(31);
+    qftReg->SetPermutation(0x1f);
     qftReg->X(0, 8);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0xe0));
 }

--- a/tests.hpp
+++ b/tests.hpp
@@ -1,3 +1,16 @@
+//////////////////////////////////////////////////////////////////////////////////////
+//
+// (C) Daniel Strano 2017. All rights reserved.
+//
+// This is a header-only, quick-and-dirty, multithreaded, universal quantum register
+// simulation, allowing (nonphysical) register cloning and direct measurement of
+// probability and phase, to leverage what advantages classical emulation of qubits
+// can have.
+//
+// Licensed under the GNU General Public License V3.
+// See LICENSE.md in the project root or https://www.gnu.org/licenses/gpl-3.0.en.html
+// for details.
+
 #pragma once
 
 #include <iomanip>


### PR DESCRIPTION
* Refactor the duplicate implementations of the different `par_for` methods
* Adjust comments in the header to unify on a style