### PR TITLE
Manual merge: Normalization and Depth Optimization

### DIFF
--- a/include/common/parallel_for.hpp
+++ b/include/common/parallel_for.hpp
@@ -35,8 +35,8 @@ public:
      */
 
     /** Called once per value between begin and end. */
-    typedef std::function<void(const bitCapInt)> ParallelFunc;
-    typedef std::function<bitCapInt(const bitCapInt)> IncrementFunc;
+    typedef std::function<void(const bitCapInt, const int)> ParallelFunc;
+    typedef std::function<bitCapInt(const bitCapInt, const int)> IncrementFunc;
 
     /**
      * Iterate through the permutations a maximum of end-begin times, allowing

--- a/include/qengine_cpu.hpp
+++ b/include/qengine_cpu.hpp
@@ -238,7 +238,7 @@ protected:
 
     virtual void ResetStateVec(Complex16 *nStateVec);
     virtual void Apply2x2(bitCapInt offset1, bitCapInt offset2, const Complex16* mtrx, const bitLenInt bitCount,
-        const bitCapInt* qPowersSorted, bool doApplyNorm, bool doCalcNorm);
+        const bitCapInt* qPowersSorted, bool doCalcNorm);
     virtual void ApplySingleBit(bitLenInt qubitIndex, const Complex16* mtrx, bool doCalcNorm);
     virtual void ApplyControlled2x2(bitLenInt control, bitLenInt target, const Complex16* mtrx, bool doCalcNorm);
     virtual void ApplyAntiControlled2x2(bitLenInt control, bitLenInt target, const Complex16* mtrx, bool doCalcNorm);

--- a/include/qengine_cpu.hpp
+++ b/include/qengine_cpu.hpp
@@ -41,8 +41,6 @@ protected:
     bitLenInt qubitCount;
     bitCapInt maxQPower;
     Complex16 *stateVec;
-    std::vector<Complex16*> gateQueue;
-    std::vector<bool> isQueued;
 
     std::shared_ptr<std::default_random_engine> rand_generator;
     std::uniform_real_distribution<double> rand_distribution;
@@ -249,9 +247,5 @@ protected:
     virtual void NormalizeState();
     virtual void Reverse(bitLenInt first, bitLenInt last);
     virtual void UpdateRunningNorm();
-    virtual void Mul2x2(const Complex16* leftIn, Complex16* rightOut);
-    virtual void FlushQueue(bitLenInt index);
-    virtual void FlushQueue(bitLenInt start, bitLenInt length);
-    virtual bool CheckQueued(bitLenInt start, bitLenInt length);
 };
 } // namespace Qrack

--- a/include/qengine_cpu.hpp
+++ b/include/qengine_cpu.hpp
@@ -41,7 +41,7 @@ protected:
     bitLenInt qubitCount;
     bitCapInt maxQPower;
     Complex16 *stateVec;
-    std::vector<std::unique_ptr<Complex16[]>> gateQueue;
+    std::vector<Complex16*> gateQueue;
     std::vector<bool> isQueued;
 
     std::shared_ptr<std::default_random_engine> rand_generator;
@@ -251,8 +251,6 @@ protected:
     virtual void Mul2x2(const Complex16* leftIn, Complex16* rightOut);
     virtual void FlushQueue(bitLenInt index);
     virtual void FlushQueue(bitLenInt start, bitLenInt length);
-    virtual void ResetQueue(bitLenInt index);
-    virtual void ResetQueue(bitLenInt start, bitLenInt length);
     virtual bool CheckQueued(bitLenInt start, bitLenInt length);
 };
 } // namespace Qrack

--- a/include/qengine_cpu.hpp
+++ b/include/qengine_cpu.hpp
@@ -14,6 +14,7 @@
 
 #include <random>
 #include <memory>
+#include <future>
 
 #include "qinterface.hpp"
 
@@ -40,6 +41,8 @@ protected:
     bitLenInt qubitCount;
     bitCapInt maxQPower;
     Complex16 *stateVec;
+    std::vector<std::unique_ptr<Complex16[]>> gateQueue;
+    std::vector<bool> isQueued;
 
     std::shared_ptr<std::default_random_engine> rand_generator;
     std::uniform_real_distribution<double> rand_distribution;
@@ -245,5 +248,11 @@ protected:
     virtual void NormalizeState();
     virtual void Reverse(bitLenInt first, bitLenInt last);
     virtual void UpdateRunningNorm();
+    virtual void Mul2x2(const Complex16* leftIn, Complex16* rightOut);
+    virtual void FlushQueue(bitLenInt index);
+    virtual void FlushQueue(bitLenInt start, bitLenInt length);
+    virtual void ResetQueue(bitLenInt index);
+    virtual void ResetQueue(bitLenInt start, bitLenInt length);
+    virtual bool CheckQueued(bitLenInt start, bitLenInt length);
 };
 } // namespace Qrack

--- a/include/qengine_cpu.hpp
+++ b/include/qengine_cpu.hpp
@@ -59,6 +59,7 @@ public:
     virtual void Decohere(bitLenInt start, bitLenInt length, QInterfacePtr dest) { Decohere(start, length, std::dynamic_pointer_cast<QEngineCPU>(dest)); }
 
     virtual void Cohere(QEngineCPUPtr toCopy);
+    virtual void Cohere(std::vector<QEngineCPUPtr> toCopy);
     virtual void Decohere(bitLenInt start, bitLenInt length, QEngineCPUPtr dest);
     virtual void Dispose(bitLenInt start, bitLenInt length);
 

--- a/include/qengine_opencl.hpp
+++ b/include/qengine_opencl.hpp
@@ -70,7 +70,7 @@ protected:
 
     void DispatchCall(cl::Kernel *call, bitCapInt (&bciArgs)[BCI_ARG_LEN], Complex16 *nVec = NULL, unsigned char* values = NULL);
 
-    void Apply2x2(bitCapInt offset1, bitCapInt offset2, const Complex16* mtrx, const bitLenInt bitCount, const bitCapInt* qPowersSorted, bool doApplyNorm, bool doCalcNorm);
+    void Apply2x2(bitCapInt offset1, bitCapInt offset2, const Complex16* mtrx, const bitLenInt bitCount, const bitCapInt* qPowersSorted, bool doCalcNorm);
 
     /* A couple utility functions used by the operations above. */
     void ROx(cl::Kernel *call, bitLenInt shift, bitLenInt start, bitLenInt length);

--- a/src/qengine/gates.cpp
+++ b/src/qengine/gates.cpp
@@ -51,7 +51,7 @@ void QEngineCPU::CCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target)
     qPowersSorted[2] = qPowers[3];
     qPowers[0] = qPowers[1] + qPowers[2] + qPowers[3];
     std::sort(qPowersSorted, qPowersSorted + 3);
-    Apply2x2(qPowers[0], qPowers[1] + qPowers[2], pauliX, 3, qPowersSorted, false, false);
+    Apply2x2(qPowers[0], qPowers[1] + qPowers[2], pauliX, 3, qPowersSorted, false);
 }
 
 /// "Anti-doubly-controlled not" - Apply "not" if control bits are both zero, do not apply if either control bit is one.
@@ -78,7 +78,7 @@ void QEngineCPU::AntiCCNOT(bitLenInt control1, bitLenInt control2, bitLenInt tar
     qPowersSorted[2] = qPowers[3];
     qPowers[0] = qPowers[1] + qPowers[2] + qPowers[3];
     std::sort(qPowersSorted, qPowersSorted + 3);
-    Apply2x2(0, qPowers[3], pauliX, 3, qPowersSorted, false, false);
+    Apply2x2(0, qPowers[3], pauliX, 3, qPowersSorted, false);
 }
 
 /// Controlled not

--- a/src/qengine/gates.cpp
+++ b/src/qengine/gates.cpp
@@ -37,12 +37,6 @@ void QEngineCPU::CCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target)
         throw std::invalid_argument("CCNOT control bits cannot also be target.");
     }
 
-    // Does not necessarily commute with single bit gates
-    FlushQueue(control1);
-    FlushQueue(control2);
-    FlushQueue(target);
-
-
     const Complex16 pauliX[4] = {
             Complex16(0.0, 0.0), Complex16(1.0, 0.0),
             Complex16(1.0, 0.0), Complex16(0.0, 0.0) };
@@ -72,11 +66,6 @@ void QEngineCPU::AntiCCNOT(bitLenInt control1, bitLenInt control2, bitLenInt tar
         throw std::invalid_argument("CCNOT control bits cannot also be target.");
     }
 
-    // Does not necessarily commute with single bit gates
-    FlushQueue(control1);
-    FlushQueue(control2);
-    FlushQueue(target);
-
     const Complex16 pauliX[4] = { Complex16(0.0, 0.0), Complex16(1.0, 0.0), Complex16(1.0, 0.0), Complex16(0.0, 0.0) };
 
     bitCapInt qPowers[4];
@@ -101,11 +90,6 @@ void QEngineCPU::CNOT(bitLenInt control, bitLenInt target)
         throw std::invalid_argument("CNOT control bit cannot also be target.");
     }
 
-    // Does not necessarily commute with single bit gates
-    FlushQueue(control);
-    FlushQueue(target);
-
-
     const Complex16 pauliX[4] = { Complex16(0.0, 0.0), Complex16(1.0, 0.0), Complex16(1.0, 0.0), Complex16(0.0, 0.0) };
     ApplyControlled2x2(control, target, pauliX, false);
 }
@@ -118,10 +102,6 @@ void QEngineCPU::AntiCNOT(bitLenInt control, bitLenInt target)
     if (control == target) {
         throw std::invalid_argument("CNOT control bit cannot also be target.");
     }
-
-    // Does not necessarily commute with single bit gates
-    FlushQueue(control);
-    FlushQueue(target);
 
     const Complex16 pauliX[4] = { Complex16(0.0, 0.0), Complex16(1.0, 0.0), Complex16(1.0, 0.0), Complex16(0.0, 0.0) };
     ApplyAntiControlled2x2(control, target, pauliX, false);
@@ -172,10 +152,6 @@ void QEngineCPU::CY(bitLenInt control, bitLenInt target)
     if (control == target)
         throw std::invalid_argument("CY control bit cannot also be target.");
 
-    // Does not necessarily commute with single bit gates
-    FlushQueue(control);
-    FlushQueue(target);
-
     const Complex16 pauliY[4] = { Complex16(0.0, 0.0), Complex16(0.0, -1.0), Complex16(0.0, 1.0), Complex16(0.0, 0.0) };
     ApplyControlled2x2(control, target, pauliY, false);
 }
@@ -187,10 +163,6 @@ void QEngineCPU::CZ(bitLenInt control, bitLenInt target)
     // bits.");
     if (control == target)
         throw std::invalid_argument("CZ control bit cannot also be target.");
-
-    // Does not necessarily commute with single bit gates
-    FlushQueue(control);
-    FlushQueue(target);
 
     const Complex16 pauliZ[4] = { Complex16(1.0, 0.0), Complex16(0.0, 0.0), Complex16(0.0, 0.0), Complex16(-1.0, 0.0) };
     ApplyControlled2x2(control, target, pauliZ, false);

--- a/src/qengine/gates.cpp
+++ b/src/qengine/gates.cpp
@@ -37,6 +37,12 @@ void QEngineCPU::CCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target)
         throw std::invalid_argument("CCNOT control bits cannot also be target.");
     }
 
+    // Does not necessarily commute with single bit gates
+    FlushQueue(control1);
+    FlushQueue(control2);
+    FlushQueue(target);
+
+
     const Complex16 pauliX[4] = {
             Complex16(0.0, 0.0), Complex16(1.0, 0.0),
             Complex16(1.0, 0.0), Complex16(0.0, 0.0) };
@@ -66,6 +72,11 @@ void QEngineCPU::AntiCCNOT(bitLenInt control1, bitLenInt control2, bitLenInt tar
         throw std::invalid_argument("CCNOT control bits cannot also be target.");
     }
 
+    // Does not necessarily commute with single bit gates
+    FlushQueue(control1);
+    FlushQueue(control2);
+    FlushQueue(target);
+
     const Complex16 pauliX[4] = { Complex16(0.0, 0.0), Complex16(1.0, 0.0), Complex16(1.0, 0.0), Complex16(0.0, 0.0) };
 
     bitCapInt qPowers[4];
@@ -90,6 +101,11 @@ void QEngineCPU::CNOT(bitLenInt control, bitLenInt target)
         throw std::invalid_argument("CNOT control bit cannot also be target.");
     }
 
+    // Does not necessarily commute with single bit gates
+    FlushQueue(control);
+    FlushQueue(target);
+
+
     const Complex16 pauliX[4] = { Complex16(0.0, 0.0), Complex16(1.0, 0.0), Complex16(1.0, 0.0), Complex16(0.0, 0.0) };
     ApplyControlled2x2(control, target, pauliX, false);
 }
@@ -102,6 +118,10 @@ void QEngineCPU::AntiCNOT(bitLenInt control, bitLenInt target)
     if (control == target) {
         throw std::invalid_argument("CNOT control bit cannot also be target.");
     }
+
+    // Does not necessarily commute with single bit gates
+    FlushQueue(control);
+    FlushQueue(target);
 
     const Complex16 pauliX[4] = { Complex16(0.0, 0.0), Complex16(1.0, 0.0), Complex16(1.0, 0.0), Complex16(0.0, 0.0) };
     ApplyAntiControlled2x2(control, target, pauliX, false);
@@ -151,6 +171,11 @@ void QEngineCPU::CY(bitLenInt control, bitLenInt target)
     // bits.");
     if (control == target)
         throw std::invalid_argument("CY control bit cannot also be target.");
+
+    // Does not necessarily commute with single bit gates
+    FlushQueue(control);
+    FlushQueue(target);
+
     const Complex16 pauliY[4] = { Complex16(0.0, 0.0), Complex16(0.0, -1.0), Complex16(0.0, 1.0), Complex16(0.0, 0.0) };
     ApplyControlled2x2(control, target, pauliY, false);
 }
@@ -162,6 +187,11 @@ void QEngineCPU::CZ(bitLenInt control, bitLenInt target)
     // bits.");
     if (control == target)
         throw std::invalid_argument("CZ control bit cannot also be target.");
+
+    // Does not necessarily commute with single bit gates
+    FlushQueue(control);
+    FlushQueue(target);
+
     const Complex16 pauliZ[4] = { Complex16(1.0, 0.0), Complex16(0.0, 0.0), Complex16(0.0, 0.0), Complex16(-1.0, 0.0) };
     ApplyControlled2x2(control, target, pauliZ, false);
 }
@@ -181,14 +211,6 @@ void QEngineCPU::Y(bitLenInt start, bitLenInt length)
 {
     for (bitLenInt lcv = 0; lcv < length; lcv++) {
         Y(start + lcv);
-    }
-}
-
-/// Apply Pauli Z matrix to each bit
-void QEngineCPU::Z(bitLenInt start, bitLenInt length)
-{
-    for (bitLenInt lcv = 0; lcv < length; lcv++) {
-        Z(start + lcv);
     }
 }
 

--- a/src/qengine/operators.cpp
+++ b/src/qengine/operators.cpp
@@ -24,6 +24,11 @@ void QEngineCPU::AND(bitLenInt inputBit1, bitLenInt inputBit2, bitLenInt outputB
         return;
     }
 
+    // Does not necessarily commute with single bit gates
+    FlushQueue(inputBit1);
+    FlushQueue(inputBit2);
+    FlushQueue(outputBit);
+
     if ((inputBit1 != outputBit) && (inputBit2 != outputBit)) {
         SetBit(outputBit, false);
         if (inputBit1 == inputBit2) {
@@ -39,6 +44,10 @@ void QEngineCPU::AND(bitLenInt inputBit1, bitLenInt inputBit2, bitLenInt outputB
 /// "AND" compare a qubit in QEngineCPU with a classical bit, and store result in outputBit
 void QEngineCPU::CLAND(bitLenInt inputQBit, bool inputClassicalBit, bitLenInt outputBit)
 {
+    // Does not necessarily commute with single bit gates
+    FlushQueue(inputQBit);
+    FlushQueue(outputBit);
+
     if (!inputClassicalBit) {
         SetBit(outputBit, false);
     } else if (inputQBit != outputBit) {
@@ -55,6 +64,11 @@ void QEngineCPU::OR(bitLenInt inputBit1, bitLenInt inputBit2, bitLenInt outputBi
         return;
     }
 
+    // Does not necessarily commute with single bit gates
+    FlushQueue(inputBit1);
+    FlushQueue(inputBit2);
+    FlushQueue(outputBit);
+
     if ((inputBit1 != outputBit) && (inputBit2 != outputBit)) {
         SetBit(outputBit, true);
         if (inputBit1 == inputBit2) {
@@ -70,6 +84,10 @@ void QEngineCPU::OR(bitLenInt inputBit1, bitLenInt inputBit2, bitLenInt outputBi
 /// "OR" compare a qubit in QEngineCPU with a classical bit, and store result in outputBit
 void QEngineCPU::CLOR(bitLenInt inputQBit, bool inputClassicalBit, bitLenInt outputBit)
 {
+    // Does not necessarily commute with single bit gates
+    FlushQueue(inputQBit);
+    FlushQueue(outputBit);
+
     if (inputClassicalBit) {
         SetBit(outputBit, true);
     } else if (inputQBit != outputBit) {
@@ -81,6 +99,11 @@ void QEngineCPU::CLOR(bitLenInt inputQBit, bool inputClassicalBit, bitLenInt out
 /// "XOR" compare two bits in QEngineCPU, and store result in outputBit
 void QEngineCPU::XOR(bitLenInt inputBit1, bitLenInt inputBit2, bitLenInt outputBit)
 {
+    // Does not necessarily commute with single bit gates
+    FlushQueue(inputBit1);
+    FlushQueue(inputBit2);
+    FlushQueue(outputBit);
+
     if (((inputBit1 == inputBit2) && (inputBit2 == outputBit))) {
         SetBit(outputBit, false);
         return;
@@ -100,6 +123,10 @@ void QEngineCPU::XOR(bitLenInt inputBit1, bitLenInt inputBit2, bitLenInt outputB
 /// "XOR" compare a qubit in QEngineCPU with a classical bit, and store result in outputBit
 void QEngineCPU::CLXOR(bitLenInt inputQBit, bool inputClassicalBit, bitLenInt outputBit)
 {
+    // Does not necessarily commute with single bit gates
+    FlushQueue(inputQBit);
+    FlushQueue(outputBit);
+
     if (inputQBit != outputBit) {
         SetBit(outputBit, inputClassicalBit);
         CNOT(inputQBit, outputBit);

--- a/src/qengine/operators.cpp
+++ b/src/qengine/operators.cpp
@@ -24,11 +24,6 @@ void QEngineCPU::AND(bitLenInt inputBit1, bitLenInt inputBit2, bitLenInt outputB
         return;
     }
 
-    // Does not necessarily commute with single bit gates
-    FlushQueue(inputBit1);
-    FlushQueue(inputBit2);
-    FlushQueue(outputBit);
-
     if ((inputBit1 != outputBit) && (inputBit2 != outputBit)) {
         SetBit(outputBit, false);
         if (inputBit1 == inputBit2) {
@@ -44,10 +39,6 @@ void QEngineCPU::AND(bitLenInt inputBit1, bitLenInt inputBit2, bitLenInt outputB
 /// "AND" compare a qubit in QEngineCPU with a classical bit, and store result in outputBit
 void QEngineCPU::CLAND(bitLenInt inputQBit, bool inputClassicalBit, bitLenInt outputBit)
 {
-    // Does not necessarily commute with single bit gates
-    FlushQueue(inputQBit);
-    FlushQueue(outputBit);
-
     if (!inputClassicalBit) {
         SetBit(outputBit, false);
     } else if (inputQBit != outputBit) {
@@ -64,11 +55,6 @@ void QEngineCPU::OR(bitLenInt inputBit1, bitLenInt inputBit2, bitLenInt outputBi
         return;
     }
 
-    // Does not necessarily commute with single bit gates
-    FlushQueue(inputBit1);
-    FlushQueue(inputBit2);
-    FlushQueue(outputBit);
-
     if ((inputBit1 != outputBit) && (inputBit2 != outputBit)) {
         SetBit(outputBit, true);
         if (inputBit1 == inputBit2) {
@@ -84,10 +70,6 @@ void QEngineCPU::OR(bitLenInt inputBit1, bitLenInt inputBit2, bitLenInt outputBi
 /// "OR" compare a qubit in QEngineCPU with a classical bit, and store result in outputBit
 void QEngineCPU::CLOR(bitLenInt inputQBit, bool inputClassicalBit, bitLenInt outputBit)
 {
-    // Does not necessarily commute with single bit gates
-    FlushQueue(inputQBit);
-    FlushQueue(outputBit);
-
     if (inputClassicalBit) {
         SetBit(outputBit, true);
     } else if (inputQBit != outputBit) {
@@ -99,11 +81,6 @@ void QEngineCPU::CLOR(bitLenInt inputQBit, bool inputClassicalBit, bitLenInt out
 /// "XOR" compare two bits in QEngineCPU, and store result in outputBit
 void QEngineCPU::XOR(bitLenInt inputBit1, bitLenInt inputBit2, bitLenInt outputBit)
 {
-    // Does not necessarily commute with single bit gates
-    FlushQueue(inputBit1);
-    FlushQueue(inputBit2);
-    FlushQueue(outputBit);
-
     if (((inputBit1 == inputBit2) && (inputBit2 == outputBit))) {
         SetBit(outputBit, false);
         return;
@@ -123,10 +100,6 @@ void QEngineCPU::XOR(bitLenInt inputBit1, bitLenInt inputBit2, bitLenInt outputB
 /// "XOR" compare a qubit in QEngineCPU with a classical bit, and store result in outputBit
 void QEngineCPU::CLXOR(bitLenInt inputQBit, bool inputClassicalBit, bitLenInt outputBit)
 {
-    // Does not necessarily commute with single bit gates
-    FlushQueue(inputQBit);
-    FlushQueue(outputBit);
-
     if (inputQBit != outputBit) {
         SetBit(outputBit, inputClassicalBit);
         CNOT(inputQBit, outputBit);

--- a/src/qengine/qengine.cpp
+++ b/src/qengine/qengine.cpp
@@ -69,9 +69,12 @@ void QEngineCPU::ApplySingleBit(bitLenInt qubit, const Complex16* mtrx, bool doC
         qPowers[0] = 1 << qubit;
         Apply2x2(0, qPowers[0], mtrx, 1, qPowers, doCalcNorm);
     }
+    else if (isQueued[qubit]) {
+        Mul2x2(mtrx, &(gateQueue[qubit][0]));
+    }
     else {
         isQueued[qubit] = true;
-        Mul2x2(mtrx, &(gateQueue[qubit][0]));
+        std::copy(mtrx, mtrx + 4, &(gateQueue[qubit][0]));
     }
 }
 
@@ -147,33 +150,18 @@ void QEngineCPU::Mul2x2(const Complex16* leftIn, Complex16* rightOut) {
     }
 }
 
-const Complex16 CMPLX_I_2X2[4] = { Complex16(1.0, 0.0), Complex16(0.0, 0.0), Complex16(0.0, 0.0), Complex16(1.0, 0.0) };
 void QEngineCPU::FlushQueue(bitLenInt index) {
     if (isQueued[index]) {
         isQueued[index] = false;
         bitCapInt qPowers[1];
         qPowers[0] = 1 << index;
         Apply2x2(0, qPowers[0], &(gateQueue[index][0]), 1, qPowers, true);
-        std::copy(CMPLX_I_2X2, CMPLX_I_2X2 + 4, &(gateQueue[index][0]));
     }
 }
 
 void QEngineCPU::FlushQueue(bitLenInt start, bitLenInt length) {
     for (bitLenInt i = 0; i < length; i++) {
         FlushQueue(start + i);
-    }
-}
-
-void QEngineCPU::ResetQueue(bitLenInt index) {
-    if (isQueued[index]) {
-        isQueued[index] = false;
-        std::copy(CMPLX_I_2X2, CMPLX_I_2X2 + 4, &(gateQueue[index][0]));
-    }
-}
-
-void QEngineCPU::ResetQueue(bitLenInt start, bitLenInt length) {
-    for (bitLenInt i = 0; i < length; i++) {
-        ResetQueue(start + i);
     }
 }
 

--- a/src/qengine/qengine.cpp
+++ b/src/qengine/qengine.cpp
@@ -37,8 +37,10 @@ template void rotate<Complex16 *>(Complex16 *first, Complex16 *middle, Complex16
 /// Swap values of two bits in register
 void QEngineCPU::Swap(bitLenInt qubit1, bitLenInt qubit2)
 {
-    // if ((qubit1 >= qubitCount) || (qubit2 >= qubitCount))
-    //     throw std::invalid_argument("operation on bit index greater than total bits.");
+    // Does not necessarily commute with single bit gates
+    FlushQueue(qubit1);
+    FlushQueue(qubit2);
+
     if (qubit1 != qubit2) {
         const Complex16 pauliX[4] = { Complex16(0.0, 0.0), Complex16(1.0, 0.0), Complex16(1.0, 0.0),
             Complex16(0.0, 0.0) };
@@ -62,13 +64,23 @@ void QEngineCPU::Swap(bitLenInt qubit1, bitLenInt qubit2)
 
 void QEngineCPU::ApplySingleBit(bitLenInt qubit, const Complex16* mtrx, bool doCalcNorm)
 {
-    bitCapInt qPowers[1];
-    qPowers[0] = 1 << qubit;
-    Apply2x2(0, qPowers[0], mtrx, 1, qPowers, doCalcNorm);
+    if (qubitCount <= 2) {
+        bitCapInt qPowers[1];
+        qPowers[0] = 1 << qubit;
+        Apply2x2(0, qPowers[0], mtrx, 1, qPowers, doCalcNorm);
+    }
+    else {
+        isQueued[qubit] = true;
+        Mul2x2(mtrx, &(gateQueue[qubit][0]));
+    }
 }
 
 void QEngineCPU::ApplyControlled2x2(bitLenInt control, bitLenInt target, const Complex16* mtrx, bool doCalcNorm)
 {
+    // Does not necessarily commute with single bit gates
+    FlushQueue(control);
+    FlushQueue(target);
+
     bitCapInt qPowers[3];
     bitCapInt qPowersSorted[2];
     qPowers[1] = 1 << control;
@@ -86,6 +98,10 @@ void QEngineCPU::ApplyControlled2x2(bitLenInt control, bitLenInt target, const C
 
 void QEngineCPU::ApplyAntiControlled2x2(bitLenInt control, bitLenInt target, const Complex16* mtrx, bool doCalcNorm)
 {
+    // Does not necessarily commute with single bit gates
+    FlushQueue(control);
+    FlushQueue(target);
+
     bitCapInt qPowers[3];
     bitCapInt qPowersSorted[2];
     qPowers[1] = 1 << control;
@@ -108,6 +124,66 @@ void QEngineCPU::Reverse(bitLenInt first, bitLenInt last)
         Swap(first, last);
         first++;
     }
+}
+
+void QEngineCPU::Mul2x2(const Complex16* leftIn, Complex16* rightOut) {
+    Complex16 rightDupe[4];
+    std::copy(rightOut, rightOut + 4, rightDupe);
+    std::vector<std::future<void>> futures(4);
+    futures[0] = std::async(std::launch::async, [rightOut, leftIn, rightDupe]() {
+        rightOut[0] = leftIn[0] * rightDupe[0] + leftIn[1] * rightDupe[2];
+    });
+    futures[1] = std::async(std::launch::async, [rightOut, leftIn, rightDupe]() {
+        rightOut[1] = leftIn[0] * rightDupe[1] + leftIn[1] * rightDupe[3];
+    });
+    futures[2] = std::async(std::launch::async, [rightOut, leftIn, rightDupe]() {
+        rightOut[2] = leftIn[2] * rightDupe[0] + leftIn[3] * rightDupe[2];
+    });
+    futures[3] = std::async(std::launch::async, [rightOut, leftIn, rightDupe]() {
+        rightOut[3] = leftIn[2] * rightDupe[1] + leftIn[3] * rightDupe[3];
+    });
+    for (int i = 0; i < 4; i++) {
+        futures[i].get();
+    }
+}
+
+const Complex16 CMPLX_I_2X2[4] = { Complex16(1.0, 0.0), Complex16(0.0, 0.0), Complex16(0.0, 0.0), Complex16(1.0, 0.0) };
+void QEngineCPU::FlushQueue(bitLenInt index) {
+    if (isQueued[index]) {
+        isQueued[index] = false;
+        bitCapInt qPowers[1];
+        qPowers[0] = 1 << index;
+        Apply2x2(0, qPowers[0], &(gateQueue[index][0]), 1, qPowers, true);
+        std::copy(CMPLX_I_2X2, CMPLX_I_2X2 + 4, &(gateQueue[index][0]));
+    }
+}
+
+void QEngineCPU::FlushQueue(bitLenInt start, bitLenInt length) {
+    for (bitLenInt i = 0; i < length; i++) {
+        FlushQueue(start + i);
+    }
+}
+
+void QEngineCPU::ResetQueue(bitLenInt index) {
+    if (isQueued[index]) {
+        isQueued[index] = false;
+        std::copy(CMPLX_I_2X2, CMPLX_I_2X2 + 4, &(gateQueue[index][0]));
+    }
+}
+
+void QEngineCPU::ResetQueue(bitLenInt start, bitLenInt length) {
+    for (bitLenInt i = 0; i < length; i++) {
+        ResetQueue(start + i);
+    }
+}
+
+bool QEngineCPU::CheckQueued(bitLenInt start, bitLenInt length) {
+    for (bitLenInt i = 0; i < length; i++) {
+        if (isQueued[start + i]) {
+            return true;
+        }
+    }
+    return false;
 }
 
 } // namespace Qrack

--- a/src/qengine/qengine.cpp
+++ b/src/qengine/qengine.cpp
@@ -64,7 +64,7 @@ void QEngineCPU::Swap(bitLenInt qubit1, bitLenInt qubit2)
 
 void QEngineCPU::ApplySingleBit(bitLenInt qubit, const Complex16* mtrx, bool doCalcNorm)
 {
-    if (qubitCount <= 2) {
+    if (qubitCount <= 3) {
         bitCapInt qPowers[1];
         qPowers[0] = 1 << qubit;
         Apply2x2(0, qPowers[0], mtrx, 1, qPowers, doCalcNorm);

--- a/src/qengine/qengine.cpp
+++ b/src/qengine/qengine.cpp
@@ -37,10 +37,6 @@ template void rotate<Complex16 *>(Complex16 *first, Complex16 *middle, Complex16
 /// Swap values of two bits in register
 void QEngineCPU::Swap(bitLenInt qubit1, bitLenInt qubit2)
 {
-    // Does not necessarily commute with single bit gates
-    FlushQueue(qubit1);
-    FlushQueue(qubit2);
-
     if (qubit1 != qubit2) {
         const Complex16 pauliX[4] = { Complex16(0.0, 0.0), Complex16(1.0, 0.0), Complex16(1.0, 0.0),
             Complex16(0.0, 0.0) };
@@ -64,26 +60,13 @@ void QEngineCPU::Swap(bitLenInt qubit1, bitLenInt qubit2)
 
 void QEngineCPU::ApplySingleBit(bitLenInt qubit, const Complex16* mtrx, bool doCalcNorm)
 {
-    if (qubitCount <= 3) {
-        bitCapInt qPowers[1];
-        qPowers[0] = 1 << qubit;
-        Apply2x2(0, qPowers[0], mtrx, 1, qPowers, doCalcNorm);
-    }
-    else if (isQueued[qubit]) {
-        Mul2x2(mtrx, &(gateQueue[qubit][0]));
-    }
-    else {
-        isQueued[qubit] = true;
-        std::copy(mtrx, mtrx + 4, &(gateQueue[qubit][0]));
-    }
+    bitCapInt qPowers[1];
+    qPowers[0] = 1 << qubit;
+    Apply2x2(0, qPowers[0], mtrx, 1, qPowers, doCalcNorm);
 }
 
 void QEngineCPU::ApplyControlled2x2(bitLenInt control, bitLenInt target, const Complex16* mtrx, bool doCalcNorm)
 {
-    // Does not necessarily commute with single bit gates
-    FlushQueue(control);
-    FlushQueue(target);
-
     bitCapInt qPowers[3];
     bitCapInt qPowersSorted[2];
     qPowers[1] = 1 << control;
@@ -101,10 +84,6 @@ void QEngineCPU::ApplyControlled2x2(bitLenInt control, bitLenInt target, const C
 
 void QEngineCPU::ApplyAntiControlled2x2(bitLenInt control, bitLenInt target, const Complex16* mtrx, bool doCalcNorm)
 {
-    // Does not necessarily commute with single bit gates
-    FlushQueue(control);
-    FlushQueue(target);
-
     bitCapInt qPowers[3];
     bitCapInt qPowersSorted[2];
     qPowers[1] = 1 << control;
@@ -127,51 +106,6 @@ void QEngineCPU::Reverse(bitLenInt first, bitLenInt last)
         Swap(first, last);
         first++;
     }
-}
-
-void QEngineCPU::Mul2x2(const Complex16* leftIn, Complex16* rightOut) {
-    Complex16 rightDupe[4];
-    std::copy(rightOut, rightOut + 4, rightDupe);
-    std::vector<std::future<void>> futures(4);
-    futures[0] = std::async(std::launch::async, [rightOut, leftIn, rightDupe]() {
-        rightOut[0] = leftIn[0] * rightDupe[0] + leftIn[1] * rightDupe[2];
-    });
-    futures[1] = std::async(std::launch::async, [rightOut, leftIn, rightDupe]() {
-        rightOut[1] = leftIn[0] * rightDupe[1] + leftIn[1] * rightDupe[3];
-    });
-    futures[2] = std::async(std::launch::async, [rightOut, leftIn, rightDupe]() {
-        rightOut[2] = leftIn[2] * rightDupe[0] + leftIn[3] * rightDupe[2];
-    });
-    futures[3] = std::async(std::launch::async, [rightOut, leftIn, rightDupe]() {
-        rightOut[3] = leftIn[2] * rightDupe[1] + leftIn[3] * rightDupe[3];
-    });
-    for (int i = 0; i < 4; i++) {
-        futures[i].get();
-    }
-}
-
-void QEngineCPU::FlushQueue(bitLenInt index) {
-    if (isQueued[index]) {
-        isQueued[index] = false;
-        bitCapInt qPowers[1];
-        qPowers[0] = 1 << index;
-        Apply2x2(0, qPowers[0], &(gateQueue[index][0]), 1, qPowers, true);
-    }
-}
-
-void QEngineCPU::FlushQueue(bitLenInt start, bitLenInt length) {
-    for (bitLenInt i = 0; i < length; i++) {
-        FlushQueue(start + i);
-    }
-}
-
-bool QEngineCPU::CheckQueued(bitLenInt start, bitLenInt length) {
-    for (bitLenInt i = 0; i < length; i++) {
-        if (isQueued[start + i]) {
-            return true;
-        }
-    }
-    return false;
 }
 
 } // namespace Qrack

--- a/src/qengine/qengine.cpp
+++ b/src/qengine/qengine.cpp
@@ -56,7 +56,7 @@ void QEngineCPU::Swap(bitLenInt qubit1, bitLenInt qubit2)
             qPowersSorted[1] = qPowers[1];
         }
 
-        Apply2x2(qPowers[2], qPowers[1], pauliX, 2, qPowersSorted, false, false);
+        Apply2x2(qPowers[2], qPowers[1], pauliX, 2, qPowersSorted, false);
     }
 }
 
@@ -64,7 +64,7 @@ void QEngineCPU::ApplySingleBit(bitLenInt qubit, const Complex16* mtrx, bool doC
 {
     bitCapInt qPowers[1];
     qPowers[0] = 1 << qubit;
-    Apply2x2(0, qPowers[0], mtrx, 1, qPowers, true, doCalcNorm);
+    Apply2x2(0, qPowers[0], mtrx, 1, qPowers, doCalcNorm);
 }
 
 void QEngineCPU::ApplyControlled2x2(bitLenInt control, bitLenInt target, const Complex16* mtrx, bool doCalcNorm)
@@ -81,7 +81,7 @@ void QEngineCPU::ApplyControlled2x2(bitLenInt control, bitLenInt target, const C
         qPowersSorted[0] = qPowers[2];
         qPowersSorted[1] = qPowers[1];
     }
-    Apply2x2(qPowers[0], qPowers[1], mtrx, 2, qPowersSorted, false, doCalcNorm);
+    Apply2x2(qPowers[0], qPowers[1], mtrx, 2, qPowersSorted, doCalcNorm);
 }
 
 void QEngineCPU::ApplyAntiControlled2x2(bitLenInt control, bitLenInt target, const Complex16* mtrx, bool doCalcNorm)
@@ -98,7 +98,7 @@ void QEngineCPU::ApplyAntiControlled2x2(bitLenInt control, bitLenInt target, con
         qPowersSorted[0] = qPowers[2];
         qPowersSorted[1] = qPowers[1];
     }
-    Apply2x2(0, qPowers[2], mtrx, 2, qPowersSorted, false, doCalcNorm);
+    Apply2x2(0, qPowers[2], mtrx, 2, qPowersSorted, doCalcNorm);
 }
 
 void QEngineCPU::Reverse(bitLenInt first, bitLenInt last)

--- a/src/qengine/rotational.cpp
+++ b/src/qengine/rotational.cpp
@@ -125,10 +125,6 @@ void QEngineCPU::CRT(double radians, bitLenInt control, bitLenInt target)
         throw std::invalid_argument("control bit cannot also be target.");
     }
 
-    // Does not necessarily commute with single bit gates
-    FlushQueue(control);
-    FlushQueue(target);
-
     double cosine = cos(radians / 2.0);
     double sine = sin(radians / 2.0);
     const Complex16 mtrx[4] = { Complex16(1.0, 0), Complex16(0.0, 0.0), Complex16(0.0, 0.0), Complex16(cosine, sine) };
@@ -154,10 +150,6 @@ void QEngineCPU::CRX(double radians, bitLenInt control, bitLenInt target)
     //     throw std::invalid_argument("operation on bit index greater than total bits.");
     if (control == target)
         throw std::invalid_argument("CRX control bit cannot also be target.");
-
-    // Does not necessarily commute with single bit gates
-    FlushQueue(control);
-    FlushQueue(target);
 
     double cosine = cos(radians / 2.0);
     double sine = sin(radians / 2.0);
@@ -190,10 +182,6 @@ void QEngineCPU::CRY(double radians, bitLenInt control, bitLenInt target)
     if (control == target)
         throw std::invalid_argument("CRY control bit cannot also be target.");
 
-    // Does not necessarily commute with single bit gates
-    FlushQueue(control);
-    FlushQueue(target);
-
     double cosine = cos(radians / 2.0);
     double sine = sin(radians / 2.0);
     Complex16 pauliRY[4] = { Complex16(cosine, 0.0), Complex16(-sine, 0.0), Complex16(sine, 0.0),
@@ -220,10 +208,6 @@ void QEngineCPU::CRZ(double radians, bitLenInt control, bitLenInt target)
 {
     if (control == target)
         throw std::invalid_argument("CRZ control bit cannot also be target.");
-
-    // Does not necessarily commute with single bit gates
-    FlushQueue(control);
-    FlushQueue(target);
 
     double cosine = cos(radians / 2.0);
     double sine = sin(radians / 2.0);

--- a/src/qengine/rotational.cpp
+++ b/src/qengine/rotational.cpp
@@ -125,6 +125,10 @@ void QEngineCPU::CRT(double radians, bitLenInt control, bitLenInt target)
         throw std::invalid_argument("control bit cannot also be target.");
     }
 
+    // Does not necessarily commute with single bit gates
+    FlushQueue(control);
+    FlushQueue(target);
+
     double cosine = cos(radians / 2.0);
     double sine = sin(radians / 2.0);
     const Complex16 mtrx[4] = { Complex16(1.0, 0), Complex16(0.0, 0.0), Complex16(0.0, 0.0), Complex16(cosine, sine) };
@@ -150,6 +154,11 @@ void QEngineCPU::CRX(double radians, bitLenInt control, bitLenInt target)
     //     throw std::invalid_argument("operation on bit index greater than total bits.");
     if (control == target)
         throw std::invalid_argument("CRX control bit cannot also be target.");
+
+    // Does not necessarily commute with single bit gates
+    FlushQueue(control);
+    FlushQueue(target);
+
     double cosine = cos(radians / 2.0);
     double sine = sin(radians / 2.0);
     Complex16 pauliRX[4] = { Complex16(cosine, 0.0), Complex16(0.0, -sine), Complex16(0.0, -sine),
@@ -180,6 +189,11 @@ void QEngineCPU::CRY(double radians, bitLenInt control, bitLenInt target)
     //     throw std::invalid_argument("operation on bit index greater than total bits.");
     if (control == target)
         throw std::invalid_argument("CRY control bit cannot also be target.");
+
+    // Does not necessarily commute with single bit gates
+    FlushQueue(control);
+    FlushQueue(target);
+
     double cosine = cos(radians / 2.0);
     double sine = sin(radians / 2.0);
     Complex16 pauliRY[4] = { Complex16(cosine, 0.0), Complex16(-sine, 0.0), Complex16(sine, 0.0),
@@ -206,6 +220,11 @@ void QEngineCPU::CRZ(double radians, bitLenInt control, bitLenInt target)
 {
     if (control == target)
         throw std::invalid_argument("CRZ control bit cannot also be target.");
+
+    // Does not necessarily commute with single bit gates
+    FlushQueue(control);
+    FlushQueue(target);
+
     double cosine = cos(radians / 2.0);
     double sine = sin(radians / 2.0);
     const Complex16 pauliRZ[4] = { Complex16(cosine, -sine), Complex16(0.0, 0.0), Complex16(0.0, 0.0),

--- a/src/qengine/state/gates.cpp
+++ b/src/qengine/state/gates.cpp
@@ -25,11 +25,15 @@ bool QEngineCPU::M(bitLenInt qubit)
     }
 
     bool result;
+    double prob = Rand();
+    double angle = Rand() * 2.0 * M_PI;
+    double cosine = cos(angle);
+    double sine = sin(angle);
     Complex16 nrm;
 
     bitCapInt qPowers = 1 << qubit;
     double oneChance = Prob(qubit);
-    double prob = Rand();
+
     result = (prob < oneChance) && oneChance > 0.0;
     double nrmlzr = 1.0;
     if (result) {
@@ -37,7 +41,7 @@ bool QEngineCPU::M(bitLenInt qubit)
             nrmlzr = oneChance;
         }
 
-        nrm = Complex16(1.0 / nrmlzr, 0.0);
+        nrm = Complex16(cosine, sine) / nrmlzr;
 
         par_for(0, maxQPower, [&](const bitCapInt lcv, const int cpu) {
             if ((lcv & qPowers) == 0) {
@@ -51,7 +55,7 @@ bool QEngineCPU::M(bitLenInt qubit)
             nrmlzr = sqrt(1.0 - oneChance);
         }
 
-        nrm = Complex16(1.0 / nrmlzr, 0.0);
+        nrm = Complex16(cosine, sine) / nrmlzr;
 
         par_for(0, maxQPower, [&](const bitCapInt lcv, const int cpu) {
             if ((lcv & qPowers) == 0) {

--- a/src/qengine/state/gates.cpp
+++ b/src/qengine/state/gates.cpp
@@ -146,7 +146,7 @@ void QEngineCPU::X(bitLenInt start, bitLenInt length)
     });
     // We replace our old permutation state vector with the new one we just
     // filled, at the end.
-    ResetStateVec(std::move(nStateVec));
+    ResetStateVec(nStateVec);
 }
 
 /// Apply Pauli Z matrix to each bit
@@ -176,7 +176,7 @@ void QEngineCPU::Z(bitLenInt start, bitLenInt length)
             }
             nStateVec[inOutRes | otherRes] = (bitCount & 1) ? -stateVec[lcv] : stateVec[lcv];
         });
-        ResetStateVec(std::move(nStateVec));
+        ResetStateVec(nStateVec);
     }
 }
 

--- a/src/qengine/state/gates.cpp
+++ b/src/qengine/state/gates.cpp
@@ -40,7 +40,7 @@ bool QEngineCPU::M(bitLenInt qubit)
 
         nrm = Complex16(cosine, sine) / nrmlzr;
 
-        par_for(0, maxQPower, [&](const bitCapInt lcv) {
+        par_for(0, maxQPower, [&](const bitCapInt lcv, const int cpu) {
             if ((lcv & qPowers) == 0) {
                 stateVec[lcv] = Complex16(0.0, 0.0);
             } else {
@@ -54,7 +54,7 @@ bool QEngineCPU::M(bitLenInt qubit)
 
         nrm = Complex16(cosine, sine) / nrmlzr;
 
-        par_for(0, maxQPower, [&](const bitCapInt lcv) {
+        par_for(0, maxQPower, [&](const bitCapInt lcv, const int cpu) {
             if ((lcv & qPowers) == 0) {
                 stateVec[lcv] = nrm * stateVec[lcv];
             } else {
@@ -103,7 +103,7 @@ void QEngineCPU::X(bitLenInt start, bitLenInt length)
     // the parallel for loop. Some skip certain permutations in order to
     // optimize. Some take a new permutation state vector for output, and some
     // just transform the permutation state vector in place.
-    par_for(0, maxQPower, [&](const bitCapInt lcv) {
+    par_for(0, maxQPower, [&](const bitCapInt lcv, const int cpu) {
         // Set nStateVec, indexed by the loop control variable (lcv) with
         // the X'ed bits inverted, with the value of stateVec indexed by
         // lcv.
@@ -165,7 +165,7 @@ void QEngineCPU::Swap(bitLenInt start1, bitLenInt start2, bitLenInt length)
         otherMask ^= reg1Mask | reg2Mask;
         Complex16 *nStateVec = new Complex16[maxQPower];
 
-        par_for(0, maxQPower, [&](const bitCapInt lcv) {
+        par_for(0, maxQPower, [&](const bitCapInt lcv, const int cpu) {
             bitCapInt otherRes = (lcv & otherMask);
             bitCapInt reg1Res = ((lcv & reg1Mask) >> (start1)) << (start2);
             bitCapInt reg2Res = ((lcv & reg2Mask) >> (start2)) << (start1);
@@ -179,7 +179,7 @@ void QEngineCPU::Swap(bitLenInt start1, bitLenInt start2, bitLenInt length)
 /// Phase flip always - equivalent to Z X Z X on any bit in the QEngineCPU
 void QEngineCPU::PhaseFlip()
 {
-    par_for(0, maxQPower, [&](const bitCapInt lcv) { stateVec[lcv] = -stateVec[lcv]; });
+    par_for(0, maxQPower, [&](const bitCapInt lcv, const int cpu) { stateVec[lcv] = -stateVec[lcv]; });
 }
 
 }

--- a/src/qengine/state/opencl.cpp
+++ b/src/qengine/state/opencl.cpp
@@ -127,6 +127,9 @@ void QEngineOCL::Apply2x2(bitCapInt offset1, bitCapInt offset2, const Complex16*
 
 void QEngineOCL::ROx(cl::Kernel *call, bitLenInt shift, bitLenInt start, bitLenInt length)
 {
+    // Does not necessarily commute with single bit gates
+    FlushQueue(start, length);
+
     bitCapInt lengthPower = 1 << length;
     bitCapInt regMask = (lengthPower - 1) << start;
     bitCapInt otherMask = (maxQPower - 1) & (~regMask);
@@ -151,6 +154,10 @@ void QEngineOCL::ROR(bitLenInt shift, bitLenInt start, bitLenInt length)
 void QEngineOCL::INTC(cl::Kernel* call,
     bitCapInt toMod, const bitLenInt start, const bitLenInt length, const bitLenInt carryIndex)
 {
+    // Does not necessarily commute with single bit gates
+    FlushQueue(start, length);
+    FlushQueue(carryIndex);
+
     bitCapInt carryMask = 1 << carryIndex;
     bitCapInt lengthPower = 1 << length;
     bitCapInt regMask = (lengthPower - 1) << start;
@@ -169,8 +176,11 @@ void QEngineOCL::INCC(
     bool hasCarry = M(carryIndex);
     if (hasCarry) {
         X(carryIndex);
+        FlushQueue(carryIndex);
         toAdd++;
     }
+
+    FlushQueue(start, length);
 
     INTC(clObj->GetINCCPtr(), toAdd, start, length, carryIndex);
 }
@@ -182,9 +192,12 @@ void QEngineOCL::DECC(
     bool hasCarry = M(carryIndex);
     if (hasCarry) {
         X(carryIndex);
+        FlushQueue(carryIndex);
     } else {
         toSub++;
     }
+
+    FlushQueue(start, length);
 
     INTC(clObj->GetDECCPtr(), toSub, start, length, carryIndex);
 }
@@ -192,7 +205,9 @@ void QEngineOCL::DECC(
 /** Set 8 bit register bits based on read from classical memory */
 unsigned char QEngineOCL::SuperposeReg8(bitLenInt inputStart, bitLenInt outputStart, unsigned char* values)
 {
+    FlushQueue(inputStart, 8);
     SetReg(outputStart, 8, 0);
+
     bitCapInt inputMask = 0xff << inputStart;
     bitCapInt outputMask = 0xff << outputStart;
     bitCapInt bciArgs[10] = { maxQPower >> 8, inputStart, inputMask, outputStart, 0, 0, 0, 0, 0, 0 };
@@ -224,7 +239,11 @@ unsigned char QEngineOCL::OpSuperposeReg8(cl::Kernel *call, bitCapInt carryIn,
          */
         carryIn = !carryIn;
         X(carryIndex);
+        FlushQueue(carryIndex);
     }
+
+    FlushQueue(inputStart, 8);
+    FlushQueue(outputStart, 8);
 
     bitCapInt lengthPower = 1 << 8;
     bitCapInt carryMask = 1 << carryIndex;

--- a/src/qengine/state/opencl.cpp
+++ b/src/qengine/state/opencl.cpp
@@ -90,13 +90,13 @@ void QEngineOCL::DispatchCall(cl::Kernel *call, bitCapInt (&bciArgs)[BCI_ARG_LEN
 }
 
 void QEngineOCL::Apply2x2(bitCapInt offset1, bitCapInt offset2, const Complex16* mtrx, const bitLenInt bitCount,
-    const bitCapInt* qPowersSorted, bool doApplyNorm, bool doCalcNorm)
+    const bitCapInt* qPowersSorted, bool doCalcNorm)
 {
     Complex16 cmplx[CMPLX_NORM_LEN];
     for (int i = 0; i < 4; i++) {
         cmplx[i] = mtrx[i];
     }
-    cmplx[4] = Complex16(doApplyNorm ? (1.0 / runningNorm) : 1.0, 0.0);
+    cmplx[4] = Complex16((bitCount == 1) ? (1.0 / runningNorm) : 1.0, 0.0);
     bitCapInt bciArgs[BCI_ARG_LEN] = { bitCount, maxQPower, offset1, offset2, 0, 0, 0, 0, 0, 0 };
     for (int i = 0; i < bitCount; i++) {
         bciArgs[4 + i] = qPowersSorted[i];

--- a/src/qengine/state/operators.cpp
+++ b/src/qengine/state/operators.cpp
@@ -103,7 +103,7 @@ void QEngineCPU::INCC(bitCapInt toAdd, const bitLenInt inOutStart, const bitLenI
         }
         nStateVec[outRes] = stateVec[lcv];
     });
-    ResetStateVec(std::move(nStateVec));
+    ResetStateVec(nStateVec);
 }
 
 /// Subtract integer (without sign, with carry)
@@ -141,7 +141,7 @@ void QEngineCPU::DECC(bitCapInt toSub, const bitLenInt inOutStart, const bitLenI
         }
         nStateVec[outRes] = stateVec[lcv];
     });
-    ResetStateVec(std::move(nStateVec));
+    ResetStateVec(nStateVec);
 }
 
 /// Add integer (without sign)
@@ -171,7 +171,7 @@ void QEngineCPU::INC(bitCapInt toAdd, bitLenInt start, bitLenInt length)
             }
             nStateVec[outRes] = stateVec[lcv];
         });
-        ResetStateVec(std::move(nStateVec));
+        ResetStateVec(nStateVec);
     }
 }
 
@@ -226,7 +226,7 @@ void QEngineCPU::INCBCD(bitCapInt toAdd, bitLenInt inOutStart, bitLenInt length)
         }
         delete[] nibbles;
     });
-    ResetStateVec(std::move(nStateVec));
+    ResetStateVec(nStateVec);
 }
 
 /// Add BCD integer (without sign, with carry)
@@ -305,7 +305,7 @@ void QEngineCPU::INCBCDC(
         }
         delete[] nibbles;
     });
-    ResetStateVec(std::move(nStateVec));
+    ResetStateVec(nStateVec);
 }
 
 /**
@@ -360,7 +360,7 @@ void QEngineCPU::INCS(bitCapInt toAdd, bitLenInt inOutStart, bitLenInt length, b
             nStateVec[outRes] = stateVec[lcv];
         }
     });
-    ResetStateVec(std::move(nStateVec));
+    ResetStateVec(nStateVec);
 }
 
 /**
@@ -424,7 +424,7 @@ void QEngineCPU::INCSC(
             nStateVec[outRes] = stateVec[lcv];
         }
     });
-    ResetStateVec(std::move(nStateVec));
+    ResetStateVec(nStateVec);
 }
 
 /**
@@ -484,7 +484,7 @@ void QEngineCPU::INCSC(bitCapInt toAdd, bitLenInt inOutStart, bitLenInt length, 
             nStateVec[outRes] = stateVec[lcv];
         }
     });
-    ResetStateVec(std::move(nStateVec));
+    ResetStateVec(nStateVec);
 }
 
 /// Subtract integer (without sign)
@@ -514,7 +514,7 @@ void QEngineCPU::DEC(bitCapInt toSub, bitLenInt start, bitLenInt length)
             }
             nStateVec[outRes] = stateVec[lcv];
         });
-        ResetStateVec(std::move(nStateVec));
+        ResetStateVec(nStateVec);
     }
 }
 
@@ -569,7 +569,7 @@ void QEngineCPU::DECBCD(bitCapInt toAdd, bitLenInt inOutStart, bitLenInt length)
         }
         delete[] nibbles;
     });
-    ResetStateVec(std::move(nStateVec));
+    ResetStateVec(nStateVec);
 }
 
 /**
@@ -622,7 +622,7 @@ void QEngineCPU::DECS(bitCapInt toSub, bitLenInt inOutStart, bitLenInt length, b
             nStateVec[outRes] = stateVec[lcv];
         }
     });
-    ResetStateVec(std::move(nStateVec));
+    ResetStateVec(nStateVec);
 }
 
 /**
@@ -687,7 +687,7 @@ void QEngineCPU::DECSC(
             nStateVec[outRes] = stateVec[lcv];
         }
     });
-    ResetStateVec(std::move(nStateVec));
+    ResetStateVec(nStateVec);
 }
 
 /**
@@ -749,7 +749,7 @@ void QEngineCPU::DECSC(bitCapInt toSub, bitLenInt inOutStart, bitLenInt length, 
             nStateVec[outRes] = stateVec[lcv];
         }
     });
-    ResetStateVec(std::move(nStateVec));
+    ResetStateVec(nStateVec);
 }
 
 /// Subtract BCD integer (without sign, with carry)
@@ -826,7 +826,7 @@ void QEngineCPU::DECBCDC(
         }
         delete[] nibbles;
     });
-    ResetStateVec(std::move(nStateVec));
+    ResetStateVec(nStateVec);
 }
 
 /// For chips with a zero flag, flip the phase of the state where the register equals zero.
@@ -987,7 +987,7 @@ unsigned char QEngineCPU::SuperposeReg8(bitLenInt inputStart, bitLenInt outputSt
         average += prob * outputInt;
     }
 
-    ResetStateVec(std::move(nStateVec));
+    ResetStateVec(nStateVec);
 
     return (unsigned char)(average + 0.5);
 }
@@ -1083,7 +1083,7 @@ unsigned char QEngineCPU::AdcSuperposeReg8(
 
     // Finally, we dealloc the old state vector and replace it with the one we
     // just calculated.
-    ResetStateVec(std::move(nStateVec));
+    ResetStateVec(nStateVec);
 
     // Return the expectation value.
     return (unsigned char)(average + 0.5);
@@ -1184,7 +1184,7 @@ unsigned char QEngineCPU::SbcSuperposeReg8(
 
     // Finally, we dealloc the old state vector and replace it with the one we
     // just calculated.
-    ResetStateVec(std::move(nStateVec));
+    ResetStateVec(nStateVec);
 
     // Return the expectation value.
     return (unsigned char)(average + 0.5);

--- a/src/qengine/state/operators.cpp
+++ b/src/qengine/state/operators.cpp
@@ -28,7 +28,7 @@ void QEngineCPU::ROL(bitLenInt shift, bitLenInt start, bitLenInt length)
 
     Complex16 *nStateVec = new Complex16[maxQPower];
 
-    par_for(0, maxQPower, [&](const bitCapInt lcv) {
+    par_for(0, maxQPower, [&](const bitCapInt lcv, const int cpu) {
         bitCapInt otherRes = (lcv & (otherMask));
         bitCapInt regRes = (lcv & (regMask));
         bitCapInt regInt = regRes >> (start);
@@ -54,7 +54,7 @@ void QEngineCPU::ROR(bitLenInt shift, bitLenInt start, bitLenInt length)
 
     Complex16 *nStateVec = new Complex16[maxQPower];
 
-    par_for(0, maxQPower, [&](const bitCapInt lcv) {
+    par_for(0, maxQPower, [&](const bitCapInt lcv, const int cpu) {
         bitCapInt otherRes = (lcv & (otherMask));
         bitCapInt regRes = (lcv & (regMask));
         bitCapInt regInt = regRes >> (start);
@@ -83,7 +83,7 @@ void QEngineCPU::INCC(bitCapInt toAdd, const bitLenInt inOutStart, const bitLenI
     Complex16 *nStateVec = new Complex16[maxQPower];
     std::fill(nStateVec, nStateVec + maxQPower, Complex16(0.0, 0.0));
 
-    par_for_skip(0, maxQPower, 1 << carryIndex, 1, [&](const bitCapInt lcv) {
+    par_for_skip(0, maxQPower, 1 << carryIndex, 1, [&](const bitCapInt lcv, const int cpu) {
         bitCapInt otherRes = (lcv & (otherMask));
         bitCapInt inOutRes = (lcv & (inOutMask));
         bitCapInt inOutInt = inOutRes >> (inOutStart);
@@ -118,7 +118,7 @@ void QEngineCPU::DECC(bitCapInt toSub, const bitLenInt inOutStart, const bitLenI
     Complex16 *nStateVec = new Complex16[maxQPower];
     std::fill(nStateVec, nStateVec + maxQPower, Complex16(0.0, 0.0));
 
-    par_for_skip(0, maxQPower, 1 << carryIndex, 1, [&](const bitCapInt lcv) {
+    par_for_skip(0, maxQPower, 1 << carryIndex, 1, [&](const bitCapInt lcv, const int cpu) {
         bitCapInt otherRes = (lcv & (otherMask));
         bitCapInt inOutRes = (lcv & (inOutMask));
         bitCapInt inOutInt = inOutRes >> (inOutStart);
@@ -140,19 +140,26 @@ void QEngineCPU::INC(bitCapInt toAdd, bitLenInt start, bitLenInt length)
     bitCapInt lengthPower = 1 << length;
     toAdd %= lengthPower;
     if ((length > 0) && (toAdd > 0)) {
-        bitCapInt i, j;
-        bitLenInt end = start + length;
-        bitCapInt startPower = 1 << start;
-        bitCapInt endPower = 1 << end;
-        bitCapInt iterPower = 1 << (qubitCount - end);
-        bitCapInt maxLCV = iterPower * endPower;
+        bitCapInt otherMask = (1 << qubitCount) - 1;
+        bitCapInt inOutMask = (lengthPower - 1) << start;
+        otherMask ^= inOutMask;
+        Complex16 *nStateVec = new Complex16[maxQPower];
+        std::fill(nStateVec, nStateVec + maxQPower, Complex16(0.0, 0.0));
 
-        for (i = 0; i < startPower; i++) {
-            for (j = 0; j < maxLCV; j += endPower) {
-                rotate(stateVec + i + j, stateVec + ((lengthPower - toAdd) * startPower) + i + j,
-                    stateVec + endPower + i + j, startPower);
+        par_for(0, maxQPower, [&](const bitCapInt lcv, const int cpu) {
+            bitCapInt otherRes = (lcv & otherMask);
+            bitCapInt inOutRes = (lcv & inOutMask);
+            bitCapInt inOutInt = inOutRes >> start;
+            bitCapInt outInt = inOutInt + toAdd;
+            bitCapInt outRes;
+            if (outInt < lengthPower) {
+                outRes = (outInt << start) | otherRes;
+            } else {
+                outRes = ((outInt - lengthPower) << start) | otherRes;
             }
-        }
+            nStateVec[outRes] = stateVec[lcv];
+        });
+        ResetStateVec(std::move(nStateVec));
     }
 }
 
@@ -169,7 +176,7 @@ void QEngineCPU::INCBCD(bitCapInt toAdd, bitLenInt inOutStart, bitLenInt length)
     Complex16 *nStateVec = new Complex16[maxQPower];
     std::fill(nStateVec, nStateVec + maxQPower, Complex16(0.0, 0.0));
 
-    par_for(0, maxQPower, [&](const bitCapInt lcv) {
+    par_for(0, maxQPower, [&](const bitCapInt lcv, const int cpu) {
         bitCapInt otherRes = (lcv & (otherMask));
         bitCapInt partToAdd = toAdd;
         bitCapInt inOutRes = (lcv & (inOutMask));
@@ -229,7 +236,7 @@ void QEngineCPU::INCBCDC(
     Complex16 *nStateVec = new Complex16[maxQPower];
     std::fill(nStateVec, nStateVec + maxQPower, Complex16(0.0, 0.0));
 
-    par_for_skip(0, maxQPower, 1 << carryIndex, 1, [&](const bitCapInt lcv) {
+    par_for_skip(0, maxQPower, 1 << carryIndex, 1, [&](const bitCapInt lcv, const int cpu) {
         bitCapInt otherRes = (lcv & (otherMask));
         bitCapInt partToAdd = toAdd;
         bitCapInt inOutRes = (lcv & (inOutMask));
@@ -299,7 +306,7 @@ void QEngineCPU::INCS(bitCapInt toAdd, bitLenInt inOutStart, bitLenInt length, b
     Complex16 *nStateVec = new Complex16[maxQPower];
     std::fill(nStateVec, nStateVec + maxQPower, Complex16(0.0, 0.0));
 
-    par_for(0, maxQPower, [&](const bitCapInt lcv) {
+    par_for(0, maxQPower, [&](const bitCapInt lcv, const int cpu) {
         bitCapInt otherRes = (lcv & (otherMask));
         bitCapInt inOutRes = (lcv & (inOutMask));
         bitCapInt inOutInt = inOutRes >> (inOutStart);
@@ -358,7 +365,7 @@ void QEngineCPU::INCSC(
     Complex16 *nStateVec = new Complex16[maxQPower];
     std::fill(nStateVec, nStateVec + maxQPower, Complex16(0.0, 0.0));
 
-    par_for_skip(0, maxQPower, carryMask, 1, [&](const bitCapInt lcv) {
+    par_for_skip(0, maxQPower, carryMask, 1, [&](const bitCapInt lcv, const int cpu) {
         bitCapInt otherRes = (lcv & (otherMask));
         bitCapInt inOutRes = (lcv & (inOutMask));
         bitCapInt inOutInt = inOutRes >> (inOutStart);
@@ -415,7 +422,7 @@ void QEngineCPU::INCSC(bitCapInt toAdd, bitLenInt inOutStart, bitLenInt length, 
     Complex16 *nStateVec = new Complex16[maxQPower];
     std::fill(nStateVec, nStateVec + maxQPower, Complex16(0.0, 0.0));
 
-    par_for_skip(0, maxQPower, carryMask, 1, [&](const bitCapInt lcv) {
+    par_for_skip(0, maxQPower, carryMask, 1, [&](const bitCapInt lcv, const int cpu) {
         bitCapInt otherRes = (lcv & (otherMask));
         bitCapInt inOutRes = (lcv & (inOutMask));
         bitCapInt inOutInt = inOutRes >> (inOutStart);
@@ -455,18 +462,27 @@ void QEngineCPU::DEC(bitCapInt toSub, bitLenInt start, bitLenInt length)
     bitCapInt lengthPower = 1 << length;
     toSub %= lengthPower;
     if ((length > 0) && (toSub > 0)) {
-        bitCapInt i, j;
-        bitLenInt end = start + length;
-        bitCapInt startPower = 1 << start;
-        bitCapInt endPower = 1 << end;
-        bitCapInt iterPower = 1 << (qubitCount - end);
-        bitCapInt maxLCV = iterPower * endPower;
-        for (i = 0; i < startPower; i++) {
-            for (j = 0; j < maxLCV; j += endPower) {
-                rotate(stateVec + i + j, stateVec + (toSub * startPower) + i + j,
-                    stateVec + endPower + i + j, startPower);
+
+        bitCapInt otherMask = (1 << qubitCount) - 1;
+        bitCapInt inOutMask = (lengthPower - 1) << start;
+        otherMask ^= inOutMask;
+        Complex16 *nStateVec = new Complex16[maxQPower];
+        std::fill(nStateVec, nStateVec + maxQPower, Complex16(0.0, 0.0));
+
+        par_for(0, maxQPower, [&](const bitCapInt lcv, const int cpu) {
+            bitCapInt otherRes = (lcv & otherMask);
+            bitCapInt inOutRes = (lcv & inOutMask);
+            bitCapInt inOutInt = inOutRes >> start;
+            bitCapInt outInt = inOutInt - toSub + lengthPower;
+            bitCapInt outRes;
+            if (outInt < lengthPower) {
+                outRes = (outInt << start) | otherRes;
+            } else {
+                outRes = ((outInt - lengthPower) << start) | otherRes;
             }
-        }
+            nStateVec[outRes] = stateVec[lcv];
+        });
+        ResetStateVec(std::move(nStateVec));
     }
 }
 
@@ -483,7 +499,7 @@ void QEngineCPU::DECBCD(bitCapInt toAdd, bitLenInt inOutStart, bitLenInt length)
     Complex16 *nStateVec = new Complex16[maxQPower];
     std::fill(nStateVec, nStateVec + maxQPower, Complex16(0.0, 0.0));
 
-    par_for(0, maxQPower, [&](const bitCapInt lcv) {
+    par_for(0, maxQPower, [&](const bitCapInt lcv, const int cpu) {
         bitCapInt otherRes = (lcv & (otherMask));
         bitCapInt partToSub = toAdd;
         bitCapInt inOutRes = (lcv & (inOutMask));
@@ -537,7 +553,7 @@ void QEngineCPU::DECS(bitCapInt toSub, bitLenInt inOutStart, bitLenInt length, b
     Complex16 *nStateVec = new Complex16[maxQPower];
     std::fill(nStateVec, nStateVec + maxQPower, Complex16(0.0, 0.0));
 
-    par_for(0, maxQPower, [&](const bitCapInt lcv) {
+    par_for(0, maxQPower, [&](const bitCapInt lcv, const int cpu) {
         bitCapInt otherRes = (lcv & (otherMask));
         bitCapInt inOutRes = (lcv & (inOutMask));
         bitCapInt inOutInt = inOutRes >> (inOutStart);
@@ -597,7 +613,7 @@ void QEngineCPU::DECSC(
     Complex16 *nStateVec = new Complex16[maxQPower];
     std::fill(nStateVec, nStateVec + maxQPower, Complex16(0.0, 0.0));
 
-    par_for_skip(0, maxQPower, carryMask, 1, [&](const bitCapInt lcv) {
+    par_for_skip(0, maxQPower, carryMask, 1, [&](const bitCapInt lcv, const int cpu) {
         bitCapInt otherRes = (lcv & (otherMask));
         bitCapInt inOutRes = (lcv & (inOutMask));
         bitCapInt inOutInt = inOutRes >> (inOutStart);
@@ -655,7 +671,7 @@ void QEngineCPU::DECSC(bitCapInt toSub, bitLenInt inOutStart, bitLenInt length, 
     Complex16 *nStateVec = new Complex16[maxQPower];
     std::fill(nStateVec, nStateVec + maxQPower, Complex16(0.0, 0.0));
 
-    par_for_skip(0, maxQPower, carryMask, 1, [&](const bitCapInt lcv) {
+    par_for_skip(0, maxQPower, carryMask, 1, [&](const bitCapInt lcv, const int cpu) {
         bitCapInt otherRes = (lcv & (otherMask));
         bitCapInt inOutRes = (lcv & (inOutMask));
         bitCapInt inOutInt = inOutRes >> (inOutStart);
@@ -710,7 +726,7 @@ void QEngineCPU::DECBCDC(
     Complex16 *nStateVec = new Complex16[maxQPower];
     std::fill(nStateVec, nStateVec + maxQPower, Complex16(0.0, 0.0));
 
-    par_for_skip(0, maxQPower, 1 << carryIndex, 1, [&](const bitCapInt lcv) {
+    par_for_skip(0, maxQPower, 1 << carryIndex, 1, [&](const bitCapInt lcv, const int cpu) {
         bitCapInt otherRes = (lcv & (otherMask));
         bitCapInt partToSub = toSub;
         bitCapInt inOutRes = (lcv & (inOutMask));
@@ -767,7 +783,7 @@ void QEngineCPU::ZeroPhaseFlip(bitLenInt start, bitLenInt length)
 {
     bitCapInt lengthPower = 1 << length;
     bitCapInt regMask = (lengthPower - 1) << start;
-    par_for(0, maxQPower, [&](const bitCapInt lcv) {
+    par_for(0, maxQPower, [&](const bitCapInt lcv, const int cpu) {
         if ((lcv & (~(regMask))) == lcv)
             stateVec[lcv] = -stateVec[lcv];
     });
@@ -779,7 +795,7 @@ void QEngineCPU::CPhaseFlipIfLess(bitCapInt greaterPerm, bitLenInt start, bitLen
     bitCapInt regMask = ((1 << length) - 1) << start;
     bitCapInt flagMask = 1 << flagIndex;
 
-    par_for(0, maxQPower, [&](const bitCapInt lcv) {
+    par_for(0, maxQPower, [&](const bitCapInt lcv, const int cpu) {
         if ((((lcv & regMask) >> (start)) < greaterPerm) & ((lcv & flagMask) == flagMask))
             stateVec[lcv] = -stateVec[lcv];
     });
@@ -867,7 +883,7 @@ bitCapInt QEngineCPU::MReg(bitLenInt start, bitLenInt length)
     bitCapInt resultPtr = result << start;
     Complex16 nrm = Complex16(cosine, sine) / nrmlzr;
 
-    par_for(0, maxQPower, [&](const bitCapInt lcv) {
+    par_for(0, maxQPower, [&](const bitCapInt lcv, const int cpu) {
         if ((lcv & resultPtr) == resultPtr) {
             stateVec[lcv] = nrm * stateVec[lcv];
         } else {
@@ -893,7 +909,7 @@ unsigned char QEngineCPU::SuperposeReg8(bitLenInt inputStart, bitLenInt outputSt
     Complex16 *nStateVec = new Complex16[maxQPower];
     std::fill(nStateVec, nStateVec + maxQPower, Complex16(0.0, 0.0));
 
-    par_for_skip(0, maxQPower, skipPower, 8, [&](const bitCapInt lcv) {
+    par_for_skip(0, maxQPower, skipPower, 8, [&](const bitCapInt lcv, const int cpu) {
         bitCapInt inputRes = lcv & (inputMask);
         bitCapInt inputInt = inputRes >> (inputStart);
         bitCapInt outputInt = values[inputInt];
@@ -952,7 +968,7 @@ unsigned char QEngineCPU::AdcSuperposeReg8(
     bitCapInt otherMask = (maxQPower - 1) & (~(inputMask | outputMask));
     bitCapInt skipPower = 1 << carryIndex;
 
-    par_for_skip(0, maxQPower, skipPower, 1, [&](const bitCapInt lcv) {
+    par_for_skip(0, maxQPower, skipPower, 1, [&](const bitCapInt lcv, const int cpu) {
         // These are qubits that are not directly involved in the
         // operation. We iterate over all of their possibilities, but their
         // input value matches their output value:
@@ -1044,7 +1060,7 @@ unsigned char QEngineCPU::SbcSuperposeReg8(
     bitCapInt otherMask = (maxQPower - 1) & (~(inputMask | outputMask));
     bitCapInt skipPower = 1 << carryIndex;
 
-    par_for_skip(0, maxQPower, skipPower, 1, [&](const bitCapInt lcv) {
+    par_for_skip(0, maxQPower, skipPower, 1, [&](const bitCapInt lcv, const int cpu) {
         // These are qubits that are not directly involved in the
         // operation. We iterate over all of their possibilities, but their
         // input value matches their output value:

--- a/src/qengine/state/operators.cpp
+++ b/src/qengine/state/operators.cpp
@@ -17,8 +17,6 @@ namespace Qrack {
 /// "Circular shift left" - shift bits left, and carry last bits.
 void QEngineCPU::ROL(bitLenInt shift, bitLenInt start, bitLenInt length)
 {
-    FlushQueue(start, length);
-
     bitCapInt regMask = 0;
     bitCapInt otherMask = (1 << qubitCount) - 1;
     bitCapInt lengthPower = 1 << length;
@@ -44,8 +42,6 @@ void QEngineCPU::ROL(bitLenInt shift, bitLenInt start, bitLenInt length)
 /// "Circular shift right" - shift bits right, and carry first bits.
 void QEngineCPU::ROR(bitLenInt shift, bitLenInt start, bitLenInt length)
 {
-    FlushQueue(start, length);
-
     bitCapInt regMask = 0;
     bitCapInt otherMask = (1 << qubitCount) - 1;
     bitCapInt lengthPower = 1 << length;
@@ -75,10 +71,8 @@ void QEngineCPU::INCC(bitCapInt toAdd, const bitLenInt inOutStart, const bitLenI
     bool hasCarry = M(carryIndex);
     if (hasCarry) {
         X(carryIndex);
-        FlushQueue(carryIndex);
         toAdd++;
     }
-    FlushQueue(inOutStart, length);
 
     bitCapInt carryMask = 1 << carryIndex;
     bitCapInt lengthPower = 1 << length;
@@ -112,11 +106,9 @@ void QEngineCPU::DECC(bitCapInt toSub, const bitLenInt inOutStart, const bitLenI
     bool hasCarry = M(carryIndex);
     if (hasCarry) {
         X(carryIndex);
-        FlushQueue(carryIndex);
     } else {
         toSub++;
     }
-    FlushQueue(inOutStart, length);
 
     bitCapInt carryMask = 1 << carryIndex;
     bitCapInt lengthPower = 1 << length;
@@ -150,8 +142,6 @@ void QEngineCPU::INC(bitCapInt toAdd, bitLenInt start, bitLenInt length)
     bitCapInt lengthPower = 1 << length;
     toAdd %= lengthPower;
     if ((length > 0) && (toAdd > 0)) {
-        FlushQueue(start, length);
-
         bitCapInt otherMask = (1 << qubitCount) - 1;
         bitCapInt inOutMask = (lengthPower - 1) << start;
         otherMask ^= inOutMask;
@@ -182,8 +172,6 @@ void QEngineCPU::INCBCD(bitCapInt toAdd, bitLenInt inOutStart, bitLenInt length)
     if (nibbleCount * 4 != length) {
         throw std::invalid_argument("BCD word bit length must be a multiple of 4.");
     }
-
-    FlushQueue(inOutStart, length);
 
     bitCapInt inOutMask = ((1 << length) - 1) << inOutStart;
     bitCapInt otherMask = (1 << qubitCount) - 1;
@@ -241,11 +229,8 @@ void QEngineCPU::INCBCDC(
     bool hasCarry = M(carryIndex);
     if (hasCarry) {
         X(carryIndex);
-        FlushQueue(carryIndex);
         toAdd++;
     }
-
-    FlushQueue(inOutStart, length);
 
     bitCapInt inOutMask = ((1 << length) - 1) << inOutStart;
     bitCapInt otherMask = (1 << qubitCount) - 1;
@@ -317,9 +302,6 @@ void QEngineCPU::INCBCDC(
  */
 void QEngineCPU::INCS(bitCapInt toAdd, bitLenInt inOutStart, bitLenInt length, bitLenInt overflowIndex)
 {
-    FlushQueue(inOutStart, length);
-    FlushQueue(overflowIndex);
-
     bitCapInt overflowMask = 1 << overflowIndex;
     bitCapInt signMask = 1 << (length - 1);
     bitCapInt otherMask = (1 << qubitCount) - 1;
@@ -375,12 +357,8 @@ void QEngineCPU::INCSC(
     bool hasCarry = M(carryIndex);
     if (hasCarry) {
         X(carryIndex);
-        FlushQueue(carryIndex);
         toAdd++;
     }
-
-    FlushQueue(inOutStart, length);
-    FlushQueue(overflowIndex);
 
     bitCapInt overflowMask = 1 << overflowIndex;
     bitCapInt signMask = 1 << (length - 1);
@@ -438,10 +416,8 @@ void QEngineCPU::INCSC(bitCapInt toAdd, bitLenInt inOutStart, bitLenInt length, 
     bool hasCarry = M(carryIndex);
     if (hasCarry) {
         X(carryIndex);
-        FlushQueue(carryIndex);
         toAdd++;
     }
-    FlushQueue(inOutStart, length);
 
     bitCapInt signMask = 1 << (length - 1);
     bitCapInt carryMask = 1 << carryIndex;
@@ -493,8 +469,6 @@ void QEngineCPU::DEC(bitCapInt toSub, bitLenInt start, bitLenInt length)
     bitCapInt lengthPower = 1 << length;
     toSub %= lengthPower;
     if ((length > 0) && (toSub > 0)) {
-        FlushQueue(start, length);
-
         bitCapInt otherMask = (1 << qubitCount) - 1;
         bitCapInt inOutMask = (lengthPower - 1) << start;
         otherMask ^= inOutMask;
@@ -525,8 +499,6 @@ void QEngineCPU::DECBCD(bitCapInt toAdd, bitLenInt inOutStart, bitLenInt length)
     if (nibbleCount * 4 != length) {
         throw std::invalid_argument("BCD word bit length must be a multiple of 4.");
     }
-
-    FlushQueue(inOutStart, length);
 
     bitCapInt otherMask = (1 << qubitCount) - 1;
     bitCapInt inOutMask = ((1 << length) - 1) << inOutStart;
@@ -579,9 +551,6 @@ void QEngineCPU::DECBCD(bitCapInt toAdd, bitLenInt inOutStart, bitLenInt length)
  */
 void QEngineCPU::DECS(bitCapInt toSub, bitLenInt inOutStart, bitLenInt length, bitLenInt overflowIndex)
 {
-    FlushQueue(inOutStart, length);
-    FlushQueue(overflowIndex);
-
     bitCapInt overflowMask = 1 << overflowIndex;
     bitCapInt signMask = 1 << (length - 1);
     bitCapInt otherMask = (1 << qubitCount) - 1;
@@ -637,13 +606,9 @@ void QEngineCPU::DECSC(
     bool hasCarry = M(carryIndex);
     if (hasCarry) {
         X(carryIndex);
-        FlushQueue(carryIndex);
     } else {
         toSub++;
     }
-
-    FlushQueue(inOutStart, length);
-    FlushQueue(overflowIndex);
 
     bitCapInt overflowMask = 1 << overflowIndex;
     bitCapInt signMask = 1 << (length - 1);
@@ -701,11 +666,8 @@ void QEngineCPU::DECSC(bitCapInt toSub, bitLenInt inOutStart, bitLenInt length, 
     bool hasCarry = M(carryIndex);
     if (hasCarry) {
         X(carryIndex);
-        FlushQueue(carryIndex);
         toSub++;
     }
-
-    FlushQueue(inOutStart, length);
 
     bitCapInt signMask = 1 << (length - 1);
     bitCapInt carryMask = 1 << carryIndex;
@@ -759,11 +721,8 @@ void QEngineCPU::DECBCDC(
     bool hasCarry = M(carryIndex);
     if (hasCarry) {
         X(carryIndex);
-        FlushQueue(carryIndex);
         toSub++;
     }
-
-    FlushQueue(inOutStart, length);
 
     bitCapInt nibbleCount = length / 4;
     if (nibbleCount * 4 != length) {
@@ -832,9 +791,6 @@ void QEngineCPU::DECBCDC(
 /// For chips with a zero flag, flip the phase of the state where the register equals zero.
 void QEngineCPU::ZeroPhaseFlip(bitLenInt start, bitLenInt length)
 {
-    // Does not necessarily commute with single bit gates
-    FlushQueue(start, length);
-
     bitCapInt lengthPower = 1 << length;
     bitCapInt regMask = (lengthPower - 1) << start;
     par_for(0, maxQPower, [&](const bitCapInt lcv, const int cpu) {
@@ -846,9 +802,6 @@ void QEngineCPU::ZeroPhaseFlip(bitLenInt start, bitLenInt length)
 /// The 6502 uses its carry flag also as a greater-than/less-than flag, for the CMP operation.
 void QEngineCPU::CPhaseFlipIfLess(bitCapInt greaterPerm, bitLenInt start, bitLenInt length, bitLenInt flagIndex)
 {
-    // Does not necessarily commute with single bit gates
-    FlushQueue(start, length);
-
     bitCapInt regMask = ((1 << length) - 1) << start;
     bitCapInt flagMask = 1 << flagIndex;
 
@@ -861,8 +814,6 @@ void QEngineCPU::CPhaseFlipIfLess(bitCapInt greaterPerm, bitLenInt start, bitLen
 /// Set register bits to given permutation
 void QEngineCPU::SetReg(bitLenInt start, bitLenInt length, bitCapInt value)
 {
-    FlushQueue(start, length);
-
     // First, single bit operations are better optimized for this special case:
     if (length == 1) {
         SetBit(start, (value == 1));
@@ -894,8 +845,6 @@ bitCapInt QEngineCPU::MReg(bitLenInt start, bitLenInt length)
             return 0;
         }
     }
-
-    FlushQueue(start, length);
 
     if (runningNorm != 1.0) {
         NormalizeState();
@@ -960,7 +909,6 @@ bitCapInt QEngineCPU::MReg(bitLenInt start, bitLenInt length)
 /// Set 8 bit register bits based on read from classical memory
 unsigned char QEngineCPU::SuperposeReg8(bitLenInt inputStart, bitLenInt outputStart, unsigned char* values)
 {
-    FlushQueue(inputStart, 8);
     SetReg(outputStart, 8, 0);
 
     bitCapInt i, outputInt;
@@ -1012,11 +960,7 @@ unsigned char QEngineCPU::AdcSuperposeReg8(
         // If the carry is set, we carry 1 in. We always initially clear the carry after testing for carry in.
         carryIn = 1;
         X(carryIndex);
-        FlushQueue(carryIndex);
     }
-
-    FlushQueue(inputStart, 8);
-    FlushQueue(outputStart, 8);
 
     // We calloc a new stateVector for output.
     Complex16 *nStateVec = new Complex16[maxQPower];
@@ -1109,11 +1053,7 @@ unsigned char QEngineCPU::SbcSuperposeReg8(
         // If the carry is set, we borrow 1 going in. We always initially clear the carry after testing for borrow in.
         carryIn = 0;
         X(carryIndex);
-        FlushQueue(carryIndex);
     }
-
-    FlushQueue(inputStart, 8);
-    FlushQueue(outputStart, 8);
 
     // We calloc a new stateVector for output.
     Complex16 *nStateVec = new Complex16[maxQPower];

--- a/src/qengine/state/state.cpp
+++ b/src/qengine/state/state.cpp
@@ -153,7 +153,7 @@ void QEngineCPU::Cohere(QEngineCPUPtr toCopy)
 
     std::vector<Complex16*> nGateQueue(nQubitCount);
     std::vector<bool> nIsQueued(nQubitCount);
-    std::copy(isQueued.begin(), isQueued.begin() + qubitCount, nIsQueued.begin());
+    std::copy(isQueued.begin(), isQueued.end(), nIsQueued.begin());
     std::copy(gateQueue.begin(), gateQueue.end(), nGateQueue.begin());
     for (i = 0; i < toCopy->qubitCount; i++) {
         nIsQueued[i + qubitCount] = toCopy->isQueued[i];
@@ -176,7 +176,6 @@ void QEngineCPU::Cohere(QEngineCPUPtr toCopy)
     UpdateRunningNorm();
 }
 
-#if 0
 /**
  * Combine (copies) each QEngineCPU in the vector with this one, after the last bit
  * index of this one. (If the programmer doesn't want to "cheat," it is left up
@@ -190,7 +189,7 @@ void QEngineCPU::Cohere(std::vector<QEngineCPUPtr> toCopy)
     std::vector<bitLenInt> offset(toCohereCount);
     std::vector<bitCapInt> mask(toCohereCount);
 
-    bitCapInt startMask = (1 << qubitCount) - 1;
+    bitCapInt startMask = maxQPower - 1;
     bitCapInt nQubitCount = qubitCount;
     bitCapInt nMaxQPower;
 
@@ -209,7 +208,7 @@ void QEngineCPU::Cohere(std::vector<QEngineCPUPtr> toCopy)
 
     std::vector<Complex16*> nGateQueue(nQubitCount);
     std::vector<bool> nIsQueued(nQubitCount);
-    std::copy(isQueued.begin(), isQueued.begin() + qubitCount, nIsQueued.begin());
+    std::copy(isQueued.begin(), isQueued.end(), nIsQueued.begin());
     std::copy(gateQueue.begin(), gateQueue.end(), nGateQueue.begin());
     k = 0;
     for (i = 0; i < toCohereCount; i++) {
@@ -227,7 +226,7 @@ void QEngineCPU::Cohere(std::vector<QEngineCPUPtr> toCopy)
 
     Complex16 *nStateVec = new Complex16[nMaxQPower];
 
-    par_for(0, nMaxQPower, [&](const bitCapInt lcv) {
+    par_for(0, nMaxQPower, [&](const bitCapInt lcv, const int cpu) {
         nStateVec[lcv] = stateVec[lcv & startMask];
         for (bitLenInt j = 0; j < toCohereCount; j++) {
             nStateVec[lcv] *= toCopy[j]->stateVec[(lcv & mask[j]) >> offset[j]];
@@ -240,7 +239,6 @@ void QEngineCPU::Cohere(std::vector<QEngineCPUPtr> toCopy)
     ResetStateVec(nStateVec);
     UpdateRunningNorm();
 }
-#endif
 
 /**
  * Minimally decohere a set of contigious bits from the full coherent unit. The

--- a/src/qengine/state/state.cpp
+++ b/src/qengine/state/state.cpp
@@ -73,28 +73,55 @@ void QEngineCPU::SetQuantumState(Complex16* inputState)
  * A fundamental operation used by almost all gates.
  */
 void QEngineCPU::Apply2x2(bitCapInt offset1, bitCapInt offset2, const Complex16* mtrx, const bitLenInt bitCount,
-    const bitCapInt* qPowersSorted, bool doApplyNorm, bool doCalcNorm)
+    const bitCapInt* qPowersSorted, bool doCalcNorm)
 {
-    Complex16 nrm = Complex16(doApplyNorm ? (1.0 / runningNorm) : 1.0, 0.0);
+    Complex16 nrm = Complex16((bitCount == 1) ? (1.0 / runningNorm) : 1.0, 0.0);
+    int numCores = GetConcurrencyLevel();
 
-    par_for_mask(0, maxQPower, qPowersSorted, bitCount, [&](const bitCapInt lcv) {
-        Complex16 qubit[2];
+    if (doCalcNorm && (bitCount == 1)) {
+        double* rngNrm = new double[numCores]; 
+        std::fill(rngNrm, rngNrm + numCores, 0.0);
+        par_for_mask(0, maxQPower, qPowersSorted, bitCount, [&](const bitCapInt lcv, const int cpu) {
+            Complex16 qubit[2];
 
-        qubit[0] = stateVec[lcv + offset1];
-        qubit[1] = stateVec[lcv + offset2];
+            qubit[0] = stateVec[lcv + offset1];
+            qubit[1] = stateVec[lcv + offset2];
 
-        Complex16 Y0 = qubit[0];
-        qubit[0] = nrm * ((mtrx[0] * Y0) + (mtrx[1] * qubit[1]));
-        qubit[1] = nrm * ((mtrx[2] * Y0) + (mtrx[3] * qubit[1]));
+            Complex16 Y0 = qubit[0];
+            qubit[0] = nrm * ((mtrx[0] * Y0) + (mtrx[1] * qubit[1]));
+            qubit[1] = nrm * ((mtrx[2] * Y0) + (mtrx[3] * qubit[1]));
+            rngNrm[cpu] += norm(qubit[0]) + norm(qubit[1]);
 
-        stateVec[lcv + offset1] = qubit[0];
-        stateVec[lcv + offset2] = qubit[1];
-    });
+            stateVec[lcv + offset1] = qubit[0];
+            stateVec[lcv + offset2] = qubit[1];
+        });
+        runningNorm = 0.0;
+        for (int i = 0; i < numCores; i++) {
+            runningNorm += rngNrm[i];
+        }
+        delete[] rngNrm;
+        runningNorm = sqrt(runningNorm);
+    }
+    else {
+        par_for_mask(0, maxQPower, qPowersSorted, bitCount, [&](const bitCapInt lcv, const int cpu) {
+            Complex16 qubit[2];
 
-    if (doCalcNorm) {
-        UpdateRunningNorm();
-    } else {
-        runningNorm = 1.0;
+            qubit[0] = stateVec[lcv + offset1];
+            qubit[1] = stateVec[lcv + offset2];
+
+            Complex16 Y0 = qubit[0];
+            qubit[0] = nrm * ((mtrx[0] * Y0) + (mtrx[1] * qubit[1]));
+            qubit[1] = nrm * ((mtrx[2] * Y0) + (mtrx[3] * qubit[1]));
+
+            stateVec[lcv + offset1] = qubit[0];
+            stateVec[lcv + offset2] = qubit[1];
+        });
+        if (doCalcNorm) {
+            UpdateRunningNorm();
+        }
+        else {
+            runningNorm = 1.0;
+        }
     }
 }/**
  * Combine (a copy of) another QEngineCPU with this one, after the last bit
@@ -118,7 +145,7 @@ void QEngineCPU::Cohere(QEngineCPUPtr toCopy)
 
     Complex16 *nStateVec = new Complex16[nMaxQPower];
 
-    par_for(0, nMaxQPower, [&](const bitCapInt lcv) {
+    par_for(0, nMaxQPower, [&](const bitCapInt lcv, const int cpu) {
         nStateVec[lcv] = stateVec[lcv & startMask] * toCopy->stateVec[(lcv & endMask) >> qubitCount];
     });
 
@@ -321,7 +348,7 @@ void QEngineCPU::ProbArray(double* probArray)
 
 void QEngineCPU::NormalizeState()
 {
-    par_for(0, maxQPower, [&](const bitCapInt lcv) {
+    par_for(0, maxQPower, [&](const bitCapInt lcv, const int cpu) {
         stateVec[lcv] /= runningNorm;
         if (norm(stateVec[lcv]) < 1e-15) {
             stateVec[lcv] = Complex16(0.0, 0.0);

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -37,7 +37,7 @@ TEST_CASE("test_par_for")
         hit[i].store(false);
     }
 
-    qengine->par_for(0, NUM_ENTRIES, [&](const bitCapInt lcv) {
+    qengine->par_for(0, NUM_ENTRIES, [&](const bitCapInt lcv, const int cpu) {
         bool old = true;
         old = hit[lcv].exchange(old);
         REQUIRE(old == false);
@@ -69,7 +69,7 @@ TEST_CASE("test_par_for_skip")
         hit[i].store(false);
     }
 
-    qengine->par_for_skip(0, NUM_ENTRIES, 4, 1, [&](const bitCapInt lcv) {
+    qengine->par_for_skip(0, NUM_ENTRIES, 4, 1, [&](const bitCapInt lcv, const int cpu) {
         bool old = true;
         old = hit[lcv].exchange(old);
         REQUIRE(old == false);
@@ -99,7 +99,7 @@ TEST_CASE("test_par_for_skip_wide")
         hit[i].store(false);
     }
 
-    qengine->par_for_skip(0, NUM_ENTRIES, 4, 3, [&](const bitCapInt lcv) {
+    qengine->par_for_skip(0, NUM_ENTRIES, 4, 3, [&](const bitCapInt lcv, const int cpu) {
         REQUIRE(lcv < NUM_ENTRIES);
         bool old = true;
         old = hit[lcv].exchange(old);
@@ -131,7 +131,7 @@ TEST_CASE("test_par_for_mask")
 
     qengine->SetConcurrencyLevel(1);
 
-    qengine->par_for_mask(0, NUM_ENTRIES, skipArray, 2, [&](const bitCapInt lcv) {
+    qengine->par_for_mask(0, NUM_ENTRIES, skipArray, 2, [&](const bitCapInt lcv, const int cpu) {
         bool old = true;
         old = hit[lcv].exchange(old);
         REQUIRE(old == false);


### PR DESCRIPTION
This pull request takes the place of #40 

Finding the normalization constant can be done in the same loop as applying the single bit gate, saving on order of 1/2 the iterations in a single bit gate. To offload normalization to the par_for variants without changing the method return types, and to generally offload method work to a par_for variant, the processing unit ID is useful to have in the par_for body to keep parallel reads/writes to memory straight.

Additionally, single bit gates are now "queued" in a buffer that captures the full generality of any sequence of single bit gates while reducing the "queue" of operations to successive multiplications of 2x2 complex number matrices in the buffer. When an operation can not be applied solely in the buffer, the buffers are flushed only for each single dependent bit before the other operation is carried out. Worst case, there is no noticeable difference in speed, but there should be significant gains for the successive application of several single bit or bitwise parallel gates, possibly 3 or more before a buffer flush.