### PR TITLE
Normalization and par_for stride optimization

### DIFF
--- a/include/common/parallel_for.hpp
+++ b/include/common/parallel_for.hpp
@@ -35,8 +35,8 @@ public:
      */
 
     /** Called once per value between begin and end. */
-    typedef std::function<void(const bitCapInt)> ParallelFunc;
-    typedef std::function<bitCapInt(const bitCapInt)> IncrementFunc;
+    typedef std::function<void(const bitCapInt, const int cpu)> ParallelFunc;
+    typedef std::function<bitCapInt(const bitCapInt, const int cpu)> IncrementFunc;
 
     /**
      * Iterate through the permutations a maximum of end-begin times, allowing

--- a/include/qengine_cpu.hpp
+++ b/include/qengine_cpu.hpp
@@ -208,7 +208,7 @@ protected:
 
     virtual void ResetStateVec(Complex16 *nStateVec);
     virtual void Apply2x2(bitCapInt offset1, bitCapInt offset2, const Complex16* mtrx, const bitLenInt bitCount,
-        const bitCapInt* qPowersSorted, bool doApplyNorm, bool doCalcNorm);
+        const bitCapInt* qPowersSorted, bool doCalcNorm);
     virtual void ApplySingleBit(bitLenInt qubitIndex, const Complex16* mtrx, bool doCalcNorm);
     virtual void ApplyControlled2x2(bitLenInt control, bitLenInt target, const Complex16* mtrx, bool doCalcNorm);
     virtual void ApplyAntiControlled2x2(bitLenInt control, bitLenInt target, const Complex16* mtrx, bool doCalcNorm);

--- a/include/qengine_opencl.hpp
+++ b/include/qengine_opencl.hpp
@@ -70,7 +70,7 @@ protected:
 
     void DispatchCall(cl::Kernel *call, bitCapInt (&bciArgs)[BCI_ARG_LEN], Complex16 *nVec = NULL, unsigned char* values = NULL);
 
-    void Apply2x2(bitCapInt offset1, bitCapInt offset2, const Complex16* mtrx, const bitLenInt bitCount, const bitCapInt* qPowersSorted, bool doApplyNorm, bool doCalcNorm);
+    void Apply2x2(bitCapInt offset1, bitCapInt offset2, const Complex16* mtrx, const bitLenInt bitCount, const bitCapInt* qPowersSorted, bool doCalcNorm);
 
     /* A couple utility functions used by the operations above. */
     void ROx(cl::Kernel *call, bitLenInt shift, bitLenInt start, bitLenInt length);

--- a/src/common/parallel_for.cpp
+++ b/src/common/parallel_for.cpp
@@ -16,6 +16,8 @@
 
 #include "common/parallel_for.hpp"
 
+#define ParStride 8
+
 namespace Qrack {
 
 /*
@@ -26,30 +28,57 @@ void ParallelFor::par_for_inc(const bitCapInt begin, const bitCapInt end, Increm
 {
     std::atomic<bitCapInt> idx;
     idx = begin;
+    bitCapInt pStride = ParStride;
 
-    std::vector<std::future<void>> futures(numCores);
-
-    for (int cpu = 0; cpu < numCores; cpu++) {
-        futures[cpu] = std::async(std::launch::async, [&]() {
-            for (bitCapInt i = idx++; i < end; i = idx++) {
-                i = inc(i);
-                /* Easiest to clamp on end. */
-                if (i >= end) {
-                    break;
-                }
-                fn(i);
+    if ((int)((end - begin) / ParStride) < numCores) {
+        std::vector<std::future<void>> futures(end - begin);
+        bitCapInt j;
+        int cpu, count;
+        for (cpu = begin; cpu < (int)end; cpu++) {
+            j = inc(cpu, 0);
+            if (j >= end) {
+                break;
             }
-        });
+            futures[cpu] = std::async(std::launch::async, [j, cpu, fn]() {
+                fn(j, cpu);
+            });
+        }
+        count = cpu;
+        for (cpu = 0; cpu < count; cpu++) {
+            futures[cpu].get();
+        }
     }
+    else {
+        std::vector<std::future<void>> futures(numCores);
+        for (int cpu = 0; cpu < numCores; cpu++) {
+            futures[cpu] = std::async(std::launch::async, [cpu, &idx, end, inc, fn, pStride]() {
+                bitCapInt j, k;
+                bitCapInt strideEnd = end / pStride;
+                for (bitCapInt i = idx++; i < strideEnd; i = idx++) {
+                    for (j = 0; j < pStride; j++) {
+                        k = inc(i * pStride + j, cpu);
+                        /* Easiest to clamp on end. */
+                        if (k >= end) {
+                            break;
+                        }
+                        fn(k, cpu);
+                    }
+                    if (k >= end) {
+                        break;
+                    }
+                }
+            });
+        }
 
-    for (int cpu = 0; cpu < numCores; cpu++) {
-        futures[cpu].get();
+        for (int cpu = 0; cpu < numCores; cpu++) {
+            futures[cpu].get();
+        }
     }
 }
 
 void ParallelFor::par_for(const bitCapInt begin, const bitCapInt end, ParallelFunc fn)
 {
-    par_for_inc(begin, end, [](const bitCapInt i) { return i; }, fn);
+    par_for_inc(begin, end, [](const bitCapInt i, int cpu) { return i; }, fn);
 }
 
 void ParallelFor::par_for_skip(
@@ -67,7 +96,7 @@ void ParallelFor::par_for_skip(
     bitCapInt highMask = (~(lowMask + skipMask)) << (maskWidth - 1);
 
     IncrementFunc incFn = [lowMask, highMask, maskWidth](
-                              bitCapInt i) { return ((i << maskWidth) & highMask) | (i & lowMask); };
+                              bitCapInt i, int cpu) { return ((i << maskWidth) & highMask) | (i & lowMask); };
 
     par_for_inc(begin, end, incFn, fn);
 }
@@ -89,7 +118,7 @@ void ParallelFor::par_for_mask(
         masks[i][1] = (~(masks[i][0] + maskArray[i])); // high mask
     }
 
-    IncrementFunc incFn = [&masks, maskLen](bitCapInt i) {
+    IncrementFunc incFn = [&masks, maskLen](bitCapInt i, int cpu) {
         /* Push i apart, one mask at a time. */
         for (int m = 0; m < maskLen; m++) {
             i = ((i << 1) & masks[m][1]) | (i & masks[m][0]);
@@ -107,42 +136,45 @@ double ParallelFor::par_norm(const bitCapInt maxQPower, const Complex16* stateAr
     // std::partial_sort_copy(sAD, sAD + (maxQPower * 2), sSAD, sSAD + (maxQPower * 2));
     // Complex16* sorted = reinterpret_cast<Complex16*>(sSAD);
 
-    std::atomic<bitCapInt> idx;
-    idx = 0;
-    double* nrmPart = new double[numCores];
-    std::vector<std::future<void>> futures(numCores);
-    for (int cpu = 0; cpu != numCores; ++cpu) {
-        futures[cpu] = std::async(std::launch::async, [cpu, &idx, maxQPower, stateArray, nrmPart]() {
-            double sqrNorm = 0.0;
-            // double smallSqrNorm = 0.0;
-            bitCapInt i;
-            for (;;) {
-                i = idx++;
-                // if (i >= maxQPower) {
-                //	sqrNorm += smallSqrNorm;
-                //	break;
-                //}
-                // smallSqrNorm += norm(sorted[i]);
-                // if (smallSqrNorm > sqrNorm) {
-                //	sqrNorm += smallSqrNorm;
-                //	smallSqrNorm = 0;
-                //}
-                if (i >= maxQPower)
-                    break;
-                sqrNorm += norm(stateArray[i]);
-            }
-            nrmPart[cpu] = sqrNorm;
-        });
-    }
-
     double nrmSqr = 0;
-    for (int cpu = 0; cpu != numCores; ++cpu) {
-        futures[cpu].get();
-        nrmSqr += nrmPart[cpu];
+    if ((int)(maxQPower / ParStride) < numCores) {
+        for (bitCapInt i = 0; i < maxQPower; i++) {
+            nrmSqr += norm(stateArray[i]);
+        }
     }
+    else {
+        std::atomic<bitCapInt> idx;
+        idx = 0;
+        double* nrmPart = new double[numCores];
+        std::vector<std::future<void>> futures(numCores);
+        bitCapInt pStride = ParStride;
+        for (int cpu = 0; cpu != numCores; ++cpu) {
+            futures[cpu] = std::async(std::launch::async, [cpu, &idx, maxQPower, stateArray, nrmPart, pStride]() {
+                double sqrNorm = 0.0;
+                // double smallSqrNorm = 0.0;
+                bitCapInt i, j , k;
+                for (;;) {
+                    i = idx++;
+                    for (j = 0; j < pStride; j++) {
+                        k = i * pStride + j;
+                        if (k >= maxQPower)
+                            break;
+                        sqrNorm += norm(stateArray[k]);
+                    }
+                    if (k >= maxQPower)
+                        break;
+                }
+                nrmPart[cpu] = sqrNorm;
+            });
+        }
 
-    delete []nrmPart;
+        for (int cpu = 0; cpu != numCores; ++cpu) {
+            futures[cpu].get();
+            nrmSqr += nrmPart[cpu];
+        }
+        delete[] nrmPart;
+    }
+    
     return sqrt(nrmSqr);
 }
-
 }

--- a/src/qengine/gates.cpp
+++ b/src/qengine/gates.cpp
@@ -51,7 +51,7 @@ void QEngineCPU::CCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target)
     qPowersSorted[2] = qPowers[3];
     qPowers[0] = qPowers[1] + qPowers[2] + qPowers[3];
     std::sort(qPowersSorted, qPowersSorted + 3);
-    Apply2x2(qPowers[0], qPowers[1] + qPowers[2], pauliX, 3, qPowersSorted, false, false);
+    Apply2x2(qPowers[0], qPowers[1] + qPowers[2], pauliX, 3, qPowersSorted, false);
 }
 
 /// "Anti-doubly-controlled not" - Apply "not" if control bits are both zero, do not apply if either control bit is one.
@@ -78,7 +78,7 @@ void QEngineCPU::AntiCCNOT(bitLenInt control1, bitLenInt control2, bitLenInt tar
     qPowersSorted[2] = qPowers[3];
     qPowers[0] = qPowers[1] + qPowers[2] + qPowers[3];
     std::sort(qPowersSorted, qPowersSorted + 3);
-    Apply2x2(0, qPowers[3], pauliX, 3, qPowersSorted, false, false);
+    Apply2x2(0, qPowers[3], pauliX, 3, qPowersSorted, false);
 }
 
 /// Controlled not

--- a/src/qengine/qengine.cpp
+++ b/src/qengine/qengine.cpp
@@ -46,7 +46,7 @@ void QEngineCPU::ApplySingleBit(bitLenInt qubit, const Complex16* mtrx, bool doC
 {
     bitCapInt qPowers[1];
     qPowers[0] = 1 << qubit;
-    Apply2x2(0, qPowers[0], mtrx, 1, qPowers, true, doCalcNorm);
+    Apply2x2(0, qPowers[0], mtrx, 1, qPowers, doCalcNorm);
 }
 
 void QEngineCPU::ApplyControlled2x2(bitLenInt control, bitLenInt target, const Complex16* mtrx, bool doCalcNorm)
@@ -63,7 +63,7 @@ void QEngineCPU::ApplyControlled2x2(bitLenInt control, bitLenInt target, const C
         qPowersSorted[0] = qPowers[2];
         qPowersSorted[1] = qPowers[1];
     }
-    Apply2x2(qPowers[0], qPowers[1], mtrx, 2, qPowersSorted, false, doCalcNorm);
+    Apply2x2(qPowers[0], qPowers[1], mtrx, 2, qPowersSorted, doCalcNorm);
 }
 
 void QEngineCPU::ApplyAntiControlled2x2(bitLenInt control, bitLenInt target, const Complex16* mtrx, bool doCalcNorm)
@@ -80,7 +80,7 @@ void QEngineCPU::ApplyAntiControlled2x2(bitLenInt control, bitLenInt target, con
         qPowersSorted[0] = qPowers[2];
         qPowersSorted[1] = qPowers[1];
     }
-    Apply2x2(0, qPowers[2], mtrx, 2, qPowersSorted, false, doCalcNorm);
+    Apply2x2(0, qPowers[2], mtrx, 2, qPowersSorted, doCalcNorm);
 }
 
 } // namespace Qrack

--- a/src/qengine/state/gates.cpp
+++ b/src/qengine/state/gates.cpp
@@ -40,7 +40,7 @@ bool QEngineCPU::M(bitLenInt qubit)
 
         nrm = Complex16(cosine, sine) / nrmlzr;
 
-        par_for(0, maxQPower, [&](const bitCapInt lcv) {
+        par_for(0, maxQPower, [&](const bitCapInt lcv, const int cpu) {
             if ((lcv & qPowers) == 0) {
                 stateVec[lcv] = Complex16(0.0, 0.0);
             } else {
@@ -54,7 +54,7 @@ bool QEngineCPU::M(bitLenInt qubit)
 
         nrm = Complex16(cosine, sine) / nrmlzr;
 
-        par_for(0, maxQPower, [&](const bitCapInt lcv) {
+        par_for(0, maxQPower, [&](const bitCapInt lcv, const int cpu) {
             if ((lcv & qPowers) == 0) {
                 stateVec[lcv] = nrm * stateVec[lcv];
             } else {
@@ -102,7 +102,7 @@ void QEngineCPU::X(bitLenInt start, bitLenInt length)
     // the parallel for loop. Some skip certain permutations in order to
     // optimize. Some take a new permutation state vector for output, and some
     // just transform the permutation state vector in place.
-    par_for(0, maxQPower, [&](const bitCapInt lcv) {
+    par_for(0, maxQPower, [&](const bitCapInt lcv, const int cpu) {
         // Set nStateVec, indexed by the loop control variable (lcv) with
         // the X'ed bits inverted, with the value of stateVec indexed by
         // lcv.
@@ -161,7 +161,7 @@ void QEngineCPU::Swap(bitLenInt start1, bitLenInt start2, bitLenInt length)
         otherMask ^= reg1Mask | reg2Mask;
         Complex16 *nStateVec = new Complex16[maxQPower];
 
-        par_for(0, maxQPower, [&](const bitCapInt lcv) {
+        par_for(0, maxQPower, [&](const bitCapInt lcv, const int cpu) {
             bitCapInt otherRes = (lcv & otherMask);
             bitCapInt reg1Res = ((lcv & reg1Mask) >> (start1)) << (start2);
             bitCapInt reg2Res = ((lcv & reg2Mask) >> (start2)) << (start1);
@@ -175,7 +175,7 @@ void QEngineCPU::Swap(bitLenInt start1, bitLenInt start2, bitLenInt length)
 /// Phase flip always - equivalent to Z X Z X on any bit in the QEngineCPU
 void QEngineCPU::PhaseFlip()
 {
-    par_for(0, maxQPower, [&](const bitCapInt lcv) { stateVec[lcv] = -stateVec[lcv]; });
+    par_for(0, maxQPower, [&](const bitCapInt lcv, const int cpu) { stateVec[lcv] = -stateVec[lcv]; });
 }
 
 }

--- a/src/qengine/state/opencl.cpp
+++ b/src/qengine/state/opencl.cpp
@@ -90,13 +90,13 @@ void QEngineOCL::DispatchCall(cl::Kernel *call, bitCapInt (&bciArgs)[BCI_ARG_LEN
 }
 
 void QEngineOCL::Apply2x2(bitCapInt offset1, bitCapInt offset2, const Complex16* mtrx, const bitLenInt bitCount,
-    const bitCapInt* qPowersSorted, bool doApplyNorm, bool doCalcNorm)
+    const bitCapInt* qPowersSorted, bool doCalcNorm)
 {
     Complex16 cmplx[CMPLX_NORM_LEN];
     for (int i = 0; i < 4; i++) {
         cmplx[i] = mtrx[i];
     }
-    cmplx[4] = Complex16(doApplyNorm ? (1.0 / runningNorm) : 1.0, 0.0);
+    cmplx[4] = Complex16((bitCount == 1) ? (1.0 / runningNorm) : 1.0, 0.0);
     bitCapInt bciArgs[BCI_ARG_LEN] = { bitCount, maxQPower, offset1, offset2, 0, 0, 0, 0, 0, 0 };
     for (int i = 0; i < bitCount; i++) {
         bciArgs[4 + i] = qPowersSorted[i];
@@ -124,6 +124,7 @@ void QEngineOCL::Apply2x2(bitCapInt offset1, bitCapInt offset2, const Complex16*
     }
 
 }
+
 
 void QEngineOCL::ROx(cl::Kernel *call, bitLenInt shift, bitLenInt start, bitLenInt length)
 {

--- a/src/qengine/state/operators.cpp
+++ b/src/qengine/state/operators.cpp
@@ -32,7 +32,7 @@ void QEngineCPU::ROL(bitLenInt shift, bitLenInt start, bitLenInt length)
 
     Complex16 *nStateVec = new Complex16[maxQPower];
 
-    par_for(0, maxQPower, [&](const bitCapInt lcv) {
+    par_for(0, maxQPower, [&](const bitCapInt lcv, const int cpu) {
         bitCapInt otherRes = (lcv & (otherMask));
         bitCapInt regRes = (lcv & (regMask));
         bitCapInt regInt = regRes >> (start);
@@ -62,7 +62,7 @@ void QEngineCPU::ROR(bitLenInt shift, bitLenInt start, bitLenInt length)
 
     Complex16 *nStateVec = new Complex16[maxQPower];
 
-    par_for(0, maxQPower, [&](const bitCapInt lcv) {
+    par_for(0, maxQPower, [&](const bitCapInt lcv, const int cpu) {
         bitCapInt otherRes = (lcv & (otherMask));
         bitCapInt regRes = (lcv & (regMask));
         bitCapInt regInt = regRes >> (start);
@@ -91,7 +91,7 @@ void QEngineCPU::INCC(bitCapInt toAdd, const bitLenInt inOutStart, const bitLenI
     Complex16 *nStateVec = new Complex16[maxQPower];
     std::fill(nStateVec, nStateVec + maxQPower, Complex16(0.0, 0.0));
 
-    par_for_skip(0, maxQPower, 1 << carryIndex, 1, [&](const bitCapInt lcv) {
+    par_for_skip(0, maxQPower, 1 << carryIndex, 1, [&](const bitCapInt lcv, const int cpu) {
         bitCapInt otherRes = (lcv & (otherMask));
         bitCapInt inOutRes = (lcv & (inOutMask));
         bitCapInt inOutInt = inOutRes >> (inOutStart);
@@ -126,7 +126,7 @@ void QEngineCPU::DECC(bitCapInt toSub, const bitLenInt inOutStart, const bitLenI
     Complex16 *nStateVec = new Complex16[maxQPower];
     std::fill(nStateVec, nStateVec + maxQPower, Complex16(0.0, 0.0));
 
-    par_for_skip(0, maxQPower, 1 << carryIndex, 1, [&](const bitCapInt lcv) {
+    par_for_skip(0, maxQPower, 1 << carryIndex, 1, [&](const bitCapInt lcv, const int cpu) {
         bitCapInt otherRes = (lcv & (otherMask));
         bitCapInt inOutRes = (lcv & (inOutMask));
         bitCapInt inOutInt = inOutRes >> (inOutStart);
@@ -177,7 +177,7 @@ void QEngineCPU::INCBCD(bitCapInt toAdd, bitLenInt inOutStart, bitLenInt length)
     Complex16 *nStateVec = new Complex16[maxQPower];
     std::fill(nStateVec, nStateVec + maxQPower, Complex16(0.0, 0.0));
 
-    par_for(0, maxQPower, [&](const bitCapInt lcv) {
+    par_for(0, maxQPower, [&](const bitCapInt lcv, const int cpu) {
         bitCapInt otherRes = (lcv & (otherMask));
         bitCapInt partToAdd = toAdd;
         bitCapInt inOutRes = (lcv & (inOutMask));
@@ -237,7 +237,7 @@ void QEngineCPU::INCBCDC(
     Complex16 *nStateVec = new Complex16[maxQPower];
     std::fill(nStateVec, nStateVec + maxQPower, Complex16(0.0, 0.0));
 
-    par_for_skip(0, maxQPower, 1 << carryIndex, 1, [&](const bitCapInt lcv) {
+    par_for_skip(0, maxQPower, 1 << carryIndex, 1, [&](const bitCapInt lcv, const int cpu) {
         bitCapInt otherRes = (lcv & (otherMask));
         bitCapInt partToAdd = toAdd;
         bitCapInt inOutRes = (lcv & (inOutMask));
@@ -307,7 +307,7 @@ void QEngineCPU::INCS(bitCapInt toAdd, bitLenInt inOutStart, bitLenInt length, b
     Complex16 *nStateVec = new Complex16[maxQPower];
     std::fill(nStateVec, nStateVec + maxQPower, Complex16(0.0, 0.0));
 
-    par_for(0, maxQPower, [&](const bitCapInt lcv) {
+    par_for(0, maxQPower, [&](const bitCapInt lcv, const int cpu) {
         bitCapInt otherRes = (lcv & (otherMask));
         bitCapInt inOutRes = (lcv & (inOutMask));
         bitCapInt inOutInt = inOutRes >> (inOutStart);
@@ -366,7 +366,7 @@ void QEngineCPU::INCSC(
     Complex16 *nStateVec = new Complex16[maxQPower];
     std::fill(nStateVec, nStateVec + maxQPower, Complex16(0.0, 0.0));
 
-    par_for_skip(0, maxQPower, carryMask, 1, [&](const bitCapInt lcv) {
+    par_for_skip(0, maxQPower, carryMask, 1, [&](const bitCapInt lcv, const int cpu) {
         bitCapInt otherRes = (lcv & (otherMask));
         bitCapInt inOutRes = (lcv & (inOutMask));
         bitCapInt inOutInt = inOutRes >> (inOutStart);
@@ -423,7 +423,7 @@ void QEngineCPU::INCSC(bitCapInt toAdd, bitLenInt inOutStart, bitLenInt length, 
     Complex16 *nStateVec = new Complex16[maxQPower];
     std::fill(nStateVec, nStateVec + maxQPower, Complex16(0.0, 0.0));
 
-    par_for_skip(0, maxQPower, carryMask, 1, [&](const bitCapInt lcv) {
+    par_for_skip(0, maxQPower, carryMask, 1, [&](const bitCapInt lcv, const int cpu) {
         bitCapInt otherRes = (lcv & (otherMask));
         bitCapInt inOutRes = (lcv & (inOutMask));
         bitCapInt inOutInt = inOutRes >> (inOutStart);
@@ -491,7 +491,7 @@ void QEngineCPU::DECBCD(bitCapInt toAdd, bitLenInt inOutStart, bitLenInt length)
     Complex16 *nStateVec = new Complex16[maxQPower];
     std::fill(nStateVec, nStateVec + maxQPower, Complex16(0.0, 0.0));
 
-    par_for(0, maxQPower, [&](const bitCapInt lcv) {
+    par_for(0, maxQPower, [&](const bitCapInt lcv, const int cpu) {
         bitCapInt otherRes = (lcv & (otherMask));
         bitCapInt partToSub = toAdd;
         bitCapInt inOutRes = (lcv & (inOutMask));
@@ -545,7 +545,7 @@ void QEngineCPU::DECS(bitCapInt toSub, bitLenInt inOutStart, bitLenInt length, b
     Complex16 *nStateVec = new Complex16[maxQPower];
     std::fill(nStateVec, nStateVec + maxQPower, Complex16(0.0, 0.0));
 
-    par_for(0, maxQPower, [&](const bitCapInt lcv) {
+    par_for(0, maxQPower, [&](const bitCapInt lcv, const int cpu) {
         bitCapInt otherRes = (lcv & (otherMask));
         bitCapInt inOutRes = (lcv & (inOutMask));
         bitCapInt inOutInt = inOutRes >> (inOutStart);
@@ -605,7 +605,7 @@ void QEngineCPU::DECSC(
     Complex16 *nStateVec = new Complex16[maxQPower];
     std::fill(nStateVec, nStateVec + maxQPower, Complex16(0.0, 0.0));
 
-    par_for_skip(0, maxQPower, carryMask, 1, [&](const bitCapInt lcv) {
+    par_for_skip(0, maxQPower, carryMask, 1, [&](const bitCapInt lcv, const int cpu) {
         bitCapInt otherRes = (lcv & (otherMask));
         bitCapInt inOutRes = (lcv & (inOutMask));
         bitCapInt inOutInt = inOutRes >> (inOutStart);
@@ -663,7 +663,7 @@ void QEngineCPU::DECSC(bitCapInt toSub, bitLenInt inOutStart, bitLenInt length, 
     Complex16 *nStateVec = new Complex16[maxQPower];
     std::fill(nStateVec, nStateVec + maxQPower, Complex16(0.0, 0.0));
 
-    par_for_skip(0, maxQPower, carryMask, 1, [&](const bitCapInt lcv) {
+    par_for_skip(0, maxQPower, carryMask, 1, [&](const bitCapInt lcv, const int cpu) {
         bitCapInt otherRes = (lcv & (otherMask));
         bitCapInt inOutRes = (lcv & (inOutMask));
         bitCapInt inOutInt = inOutRes >> (inOutStart);
@@ -718,7 +718,7 @@ void QEngineCPU::DECBCDC(
     Complex16 *nStateVec = new Complex16[maxQPower];
     std::fill(nStateVec, nStateVec + maxQPower, Complex16(0.0, 0.0));
 
-    par_for_skip(0, maxQPower, 1 << carryIndex, 1, [&](const bitCapInt lcv) {
+    par_for_skip(0, maxQPower, 1 << carryIndex, 1, [&](const bitCapInt lcv, const int cpu) {
         bitCapInt otherRes = (lcv & (otherMask));
         bitCapInt partToSub = toSub;
         bitCapInt inOutRes = (lcv & (inOutMask));
@@ -775,7 +775,7 @@ void QEngineCPU::ZeroPhaseFlip(bitLenInt start, bitLenInt length)
 {
     bitCapInt lengthPower = 1 << length;
     bitCapInt regMask = (lengthPower - 1) << start;
-    par_for(0, maxQPower, [&](const bitCapInt lcv) {
+    par_for(0, maxQPower, [&](const bitCapInt lcv, const int cpu) {
         if ((lcv & (~(regMask))) == lcv)
             stateVec[lcv] = -stateVec[lcv];
     });
@@ -787,7 +787,7 @@ void QEngineCPU::CPhaseFlipIfLess(bitCapInt greaterPerm, bitLenInt start, bitLen
     bitCapInt regMask = ((1 << length) - 1) << start;
     bitCapInt flagMask = 1 << flagIndex;
 
-    par_for(0, maxQPower, [&](const bitCapInt lcv) {
+    par_for(0, maxQPower, [&](const bitCapInt lcv, const int cpu) {
         if ((((lcv & regMask) >> (start)) < greaterPerm) & ((lcv & flagMask) == flagMask))
             stateVec[lcv] = -stateVec[lcv];
     });
@@ -881,7 +881,7 @@ bitCapInt QEngineCPU::MReg(bitLenInt start, bitLenInt length)
     bitCapInt resultPtr = result << start;
     Complex16 nrm = Complex16(cosine, sine) / nrmlzr;
 
-    par_for(0, maxQPower, [&](const bitCapInt lcv) {
+    par_for(0, maxQPower, [&](const bitCapInt lcv, const int cpu) {
         if ((lcv & resultPtr) == resultPtr) {
             stateVec[lcv] = nrm * stateVec[lcv];
         } else {
@@ -907,7 +907,7 @@ unsigned char QEngineCPU::SuperposeReg8(bitLenInt inputStart, bitLenInt outputSt
     Complex16 *nStateVec = new Complex16[maxQPower];
     std::fill(nStateVec, nStateVec + maxQPower, Complex16(0.0, 0.0));
 
-    par_for_skip(0, maxQPower, skipPower, 8, [&](const bitCapInt lcv) {
+    par_for_skip(0, maxQPower, skipPower, 8, [&](const bitCapInt lcv, const int cpu) {
         bitCapInt inputRes = lcv & (inputMask);
         bitCapInt inputInt = inputRes >> (inputStart);
         bitCapInt outputInt = values[inputInt];
@@ -966,7 +966,7 @@ unsigned char QEngineCPU::AdcSuperposeReg8(
     bitCapInt otherMask = (maxQPower - 1) & (~(inputMask | outputMask));
     bitCapInt skipPower = 1 << carryIndex;
 
-    par_for_skip(0, maxQPower, skipPower, 1, [&](const bitCapInt lcv) {
+    par_for_skip(0, maxQPower, skipPower, 1, [&](const bitCapInt lcv, const int cpu) {
         // These are qubits that are not directly involved in the
         // operation. We iterate over all of their possibilities, but their
         // input value matches their output value:
@@ -1058,7 +1058,7 @@ unsigned char QEngineCPU::SbcSuperposeReg8(
     bitCapInt otherMask = (maxQPower - 1) & (~(inputMask | outputMask));
     bitCapInt skipPower = 1 << carryIndex;
 
-    par_for_skip(0, maxQPower, skipPower, 1, [&](const bitCapInt lcv) {
+    par_for_skip(0, maxQPower, skipPower, 1, [&](const bitCapInt lcv, const int cpu) {
         // These are qubits that are not directly involved in the
         // operation. We iterate over all of their possibilities, but their
         // input value matches their output value:

--- a/src/qengine/state/state.cpp
+++ b/src/qengine/state/state.cpp
@@ -87,30 +87,58 @@ void QEngineCPU::SetQuantumState(Complex16* inputState)
  * A fundamental operation used by almost all gates.
  */
 void QEngineCPU::Apply2x2(bitCapInt offset1, bitCapInt offset2, const Complex16* mtrx, const bitLenInt bitCount,
-    const bitCapInt* qPowersSorted, bool doApplyNorm, bool doCalcNorm)
+    const bitCapInt* qPowersSorted, bool doCalcNorm)
 {
-    Complex16 nrm = Complex16(doApplyNorm ? (1.0 / runningNorm) : 1.0, 0.0);
+    Complex16 nrm = Complex16((bitCount == 1) ? (1.0 / runningNorm) : 1.0, 0.0);
+    int numCores = GetConcurrencyLevel();
 
-    par_for_mask(0, maxQPower, qPowersSorted, bitCount, [&](const bitCapInt lcv) {
-        Complex16 qubit[2];
+    if (doCalcNorm && (bitCount == 1)) {
+        double* rngNrm = new double[numCores]; 
+        std::fill(rngNrm, rngNrm + numCores, 0.0);
+        par_for_mask(0, maxQPower, qPowersSorted, bitCount, [&](const bitCapInt lcv, const int cpu) {
+            Complex16 qubit[2];
 
-        qubit[0] = stateVec[lcv + offset1];
-        qubit[1] = stateVec[lcv + offset2];
+            qubit[0] = stateVec[lcv + offset1];
+            qubit[1] = stateVec[lcv + offset2];
 
-        Complex16 Y0 = qubit[0];            // Save from being overwritten.
-        qubit[0] = nrm * ((mtrx[0] * Y0) + (mtrx[1] * qubit[1]));
-        qubit[1] = nrm * ((mtrx[2] * Y0) + (mtrx[3] * qubit[1]));
+            Complex16 Y0 = qubit[0];
+            qubit[0] = nrm * ((mtrx[0] * Y0) + (mtrx[1] * qubit[1]));
+            qubit[1] = nrm * ((mtrx[2] * Y0) + (mtrx[3] * qubit[1]));
+            rngNrm[cpu] += norm(qubit[0]) + norm(qubit[1]);
 
-        stateVec[lcv + offset1] = qubit[0];
-        stateVec[lcv + offset2] = qubit[1];
-    });
-
-    if (doCalcNorm) {
-        UpdateRunningNorm();
-    } else {
-        runningNorm = 1.0;
+            stateVec[lcv + offset1] = qubit[0];
+            stateVec[lcv + offset2] = qubit[1];
+        });
+        runningNorm = 0.0;
+        for (int i = 0; i < numCores; i++) {
+            runningNorm += rngNrm[i];
+        }
+        delete[] rngNrm;
+        runningNorm = sqrt(runningNorm);
     }
-}/**
+    else {
+        par_for_mask(0, maxQPower, qPowersSorted, bitCount, [&](const bitCapInt lcv, const int cpu) {
+            Complex16 qubit[2];
+
+            qubit[0] = stateVec[lcv + offset1];
+            qubit[1] = stateVec[lcv + offset2];
+
+            Complex16 Y0 = qubit[0];
+            qubit[0] = nrm * ((mtrx[0] * Y0) + (mtrx[1] * qubit[1]));
+            qubit[1] = nrm * ((mtrx[2] * Y0) + (mtrx[3] * qubit[1]));
+
+            stateVec[lcv + offset1] = qubit[0];
+            stateVec[lcv + offset2] = qubit[1];
+        });
+        if (doCalcNorm) {
+            UpdateRunningNorm();
+        }
+        else {
+            runningNorm = 1.0;
+        }
+    }
+}
+/**
  * Combine (a copy of) another QEngineCPU with this one, after the last bit
  * index of this one. (If the programmer doesn't want to "cheat," it is left up
  * to them to delete the old coherent unit that was added.
@@ -134,7 +162,7 @@ bitLenInt QEngineCPU::Cohere(QEngineCPUPtr toCopy)
 
     Complex16 *nStateVec = new Complex16[nMaxQPower];
 
-    par_for(0, nMaxQPower, [&](const bitCapInt lcv) {
+    par_for(0, nMaxQPower, [&](const bitCapInt lcv, const int cpu) {
         nStateVec[lcv] = stateVec[lcv & startMask] * toCopy->stateVec[(lcv & endMask) >> qubitCount];
     });
 
@@ -186,7 +214,7 @@ std::map<QInterfacePtr, bitLenInt> QEngineCPU::Cohere(std::vector<QInterfacePtr>
 
     Complex16 *nStateVec = new Complex16[nMaxQPower];
 
-    par_for(0, nMaxQPower, [&](const bitCapInt lcv) {
+    par_for(0, nMaxQPower, [&](const bitCapInt lcv, const int cpu) {
         nStateVec[lcv] = stateVec[lcv & startMask];
 
         for (bitLenInt j = 0; j < toCohereCount; j++) {
@@ -356,7 +384,7 @@ void QEngineCPU::ProbArray(double* probArray)
 
 void QEngineCPU::NormalizeState()
 {
-    par_for(0, maxQPower, [&](const bitCapInt lcv) {
+    par_for(0, maxQPower, [&](const bitCapInt lcv, const int cpu) {
         stateVec[lcv] /= runningNorm;
         if (norm(stateVec[lcv]) < 1e-15) {
             stateVec[lcv] = Complex16(0.0, 0.0);

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -89,7 +89,7 @@ TEST_CASE("test_qengine_cpu_par_for")
         hit[i].store(false);
     }
 
-    qengine->par_for(0, NUM_ENTRIES, [&](const bitCapInt lcv) {
+    qengine->par_for(0, NUM_ENTRIES, [&](const bitCapInt lcv, const int cpu) {
         bool old = true;
         old = hit[lcv].exchange(old);
         REQUIRE(old == false);
@@ -121,7 +121,7 @@ TEST_CASE("test_qengine_cpu_par_for_skip")
         hit[i].store(false);
     }
 
-    qengine->par_for_skip(0, NUM_ENTRIES, 4, 1, [&](const bitCapInt lcv) {
+    qengine->par_for_skip(0, NUM_ENTRIES, 4, 1, [&](const bitCapInt lcv, const int cpu) {
         bool old = true;
         old = hit[lcv].exchange(old);
         REQUIRE(old == false);
@@ -151,7 +151,7 @@ TEST_CASE("test_qengine_cpu_par_for_skip_wide")
         hit[i].store(false);
     }
 
-    qengine->par_for_skip(0, NUM_ENTRIES, 4, 3, [&](const bitCapInt lcv) {
+    qengine->par_for_skip(0, NUM_ENTRIES, 4, 3, [&](const bitCapInt lcv, const int cpu) {
         REQUIRE(lcv < NUM_ENTRIES);
         bool old = true;
         old = hit[lcv].exchange(old);
@@ -183,7 +183,7 @@ TEST_CASE("test_qengine_cpu_par_for_mask")
 
     qengine->SetConcurrencyLevel(1);
 
-    qengine->par_for_mask(0, NUM_ENTRIES, skipArray, 2, [&](const bitCapInt lcv) {
+    qengine->par_for_mask(0, NUM_ENTRIES, skipArray, 2, [&](const bitCapInt lcv, const int cpu) {
         bool old = true;
         old = hit[lcv].exchange(old);
         REQUIRE(old == false);


### PR DESCRIPTION
This branch adds a stride to the par_for loops, to reduce blocking on updating the atomic loop control variable, and normalization has also been moved into the same single loop as gate application in Apply2x2 when possible.

One OpenCL unit test fails. I have not yet determined whether this bug is present in the master branch.