### PR TITLE
Fixing controlled gate matrix operations

### DIFF
--- a/include/qengine_cpu.hpp
+++ b/include/qengine_cpu.hpp
@@ -14,6 +14,7 @@
 
 #include <random>
 #include <memory>
+#include <algorithm>
 
 #include "qinterface.hpp"
 
@@ -219,6 +220,8 @@ protected:
     virtual void ApplySingleBit(bitLenInt qubitIndex, const Complex16* mtrx, bool doCalcNorm);
     virtual void ApplyControlled2x2(bitLenInt control, bitLenInt target, const Complex16* mtrx, bool doCalcNorm);
     virtual void ApplyAntiControlled2x2(bitLenInt control, bitLenInt target, const Complex16* mtrx, bool doCalcNorm);
+    virtual void ApplyDoublyControlled2x2(bitLenInt control1, bitLenInt control2, bitLenInt target, const Complex16* mtrx, bool doCalcNorm);
+    virtual void ApplyDoublyAntiControlled2x2(bitLenInt control1, bitLenInt control2, bitLenInt target, const Complex16* mtrx, bool doCalcNorm);
     virtual void NormalizeState();
     virtual void UpdateRunningNorm();
 };

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -941,7 +941,7 @@ public:
     virtual void Swap(bitLenInt qubitIndex1, bitLenInt qubitIndex2) = 0;
 
     /** Bitwise swap */
-    virtual void Swap(bitLenInt start1, bitLenInt start2, bitLenInt length) = 0;
+    virtual void Swap(bitLenInt start1, bitLenInt start2, bitLenInt length);
 
     /** Reverse all of the bits in a sequence. */
     virtual void Reverse(bitLenInt first, bitLenInt last)

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -157,7 +157,6 @@ public:
     virtual unsigned char AdcSuperposeReg8(bitLenInt inputStart, bitLenInt outputStart, bitLenInt carryIndex, unsigned char* values);
     virtual unsigned char SbcSuperposeReg8(bitLenInt inputStart, bitLenInt outputStart, bitLenInt carryIndex, unsigned char* values);
     virtual void Swap(bitLenInt qubit1, bitLenInt qubit2);
-    virtual void Swap(bitLenInt start1, bitLenInt start2, bitLenInt length);
 
     /** @} */
 

--- a/src/qengine/gates.cpp
+++ b/src/qengine/gates.cpp
@@ -24,6 +24,14 @@ void QEngineCPU::SetBit(bitLenInt qubit1, bool value)
     }
 }
 
+/// Swap values of two bits in register
+void QEngineCPU::Swap(bitLenInt qubit1, bitLenInt qubit2)
+{
+    if (qubit1 != qubit2) {
+        Swap(qubit1, qubit2, 1);
+    }
+}
+
 /// Doubly-controlled not
 void QEngineCPU::CCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target)
 {
@@ -37,7 +45,8 @@ void QEngineCPU::CCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target)
         throw std::invalid_argument("CCNOT control bits cannot also be target.");
     }
 
-    CCNOT(control1, control2, target, 1);
+    const Complex16 pauliX[4] = { Complex16(0.0, 0.0), Complex16(1.0, 0.0), Complex16(1.0, 0.0), Complex16(0.0, 0.0) };
+    ApplyDoublyControlled2x2(control1, control2, target, pauliX, false);
 }
 
 /// "Anti-doubly-controlled not" - Apply "not" if control bits are both zero, do not apply if either control bit is one.
@@ -52,16 +61,21 @@ void QEngineCPU::AntiCCNOT(bitLenInt control1, bitLenInt control2, bitLenInt tar
         throw std::invalid_argument("CCNOT control bits cannot also be target.");
     }
 
-    AntiCCNOT(control1, control2, target, 1);
+    const Complex16 pauliX[4] = { Complex16(0.0, 0.0), Complex16(1.0, 0.0), Complex16(1.0, 0.0), Complex16(0.0, 0.0) };
+    ApplyDoublyAntiControlled2x2(control1, control2, target, pauliX, false);
 }
 
 /// Controlled not
 void QEngineCPU::CNOT(bitLenInt control, bitLenInt target)
 {
+    // if ((control >= qubitCount) || (target >= qubitCount))
+    //	throw std::invalid_argument("CNOT tried to operate on bit index greater than total bits.");
     if (control == target) {
         throw std::invalid_argument("CNOT control bit cannot also be target.");
     }
-    CNOT(control, target, 1);
+
+    const Complex16 pauliX[4] = { Complex16(0.0, 0.0), Complex16(1.0, 0.0), Complex16(1.0, 0.0), Complex16(0.0, 0.0) };
+    ApplyControlled2x2(control, target, pauliX, false);
 }
 
 /// "Anti-controlled not" - Apply "not" if control bit is zero, do not apply if control bit is one.
@@ -72,8 +86,11 @@ void QEngineCPU::AntiCNOT(bitLenInt control, bitLenInt target)
     if (control == target) {
         throw std::invalid_argument("CNOT control bit cannot also be target.");
     }
-    AntiCNOT(control, target, 1);
+
+    const Complex16 pauliX[4] = { Complex16(0.0, 0.0), Complex16(1.0, 0.0), Complex16(1.0, 0.0), Complex16(0.0, 0.0) };
+    ApplyAntiControlled2x2(control, target, pauliX, false);
 }
+
 
 /// Hadamard gate
 void QEngineCPU::H(bitLenInt qubit)

--- a/src/qengine/qengine.cpp
+++ b/src/qengine/qengine.cpp
@@ -34,14 +34,6 @@ void rotate(BidirectionalIterator first, BidirectionalIterator middle, Bidirecti
 
 template void rotate<Complex16 *>(Complex16 *first, Complex16 *middle, Complex16 *last, bitCapInt stride);
 
-/// Swap values of two bits in register
-void QEngineCPU::Swap(bitLenInt qubit1, bitLenInt qubit2)
-{
-    if (qubit1 != qubit2) {
-        Swap(qubit1, qubit2, 1);
-    }
-}
-
 void QEngineCPU::ApplySingleBit(bitLenInt qubit, const Complex16* mtrx, bool doCalcNorm)
 {
     bitCapInt qPowers[1];
@@ -51,36 +43,48 @@ void QEngineCPU::ApplySingleBit(bitLenInt qubit, const Complex16* mtrx, bool doC
 
 void QEngineCPU::ApplyControlled2x2(bitLenInt control, bitLenInt target, const Complex16* mtrx, bool doCalcNorm)
 {
-    bitCapInt qPowers[3];
+    bitCapInt qPowers[2];
     bitCapInt qPowersSorted[2];
-    qPowers[1] = 1 << control;
-    qPowers[2] = 1 << target;
-    qPowers[0] = qPowers[1] + qPowers[2];
-    if (control < target) {
-        qPowersSorted[0] = qPowers[1];
-        qPowersSorted[1] = qPowers[2];
-    } else {
-        qPowersSorted[0] = qPowers[2];
-        qPowersSorted[1] = qPowers[1];
-    }
-    Apply2x2(qPowers[0], qPowers[1], mtrx, 2, qPowersSorted, doCalcNorm);
+    qPowers[0] = 1 << control;
+    qPowers[1] = 1 << target;
+    std::copy(qPowers, qPowers + 2, qPowersSorted);
+    std::sort(qPowersSorted, qPowersSorted + 2);
+    Apply2x2(qPowers[0], qPowers[0] + qPowers[1], mtrx, 2, qPowersSorted, doCalcNorm);
 }
 
 void QEngineCPU::ApplyAntiControlled2x2(bitLenInt control, bitLenInt target, const Complex16* mtrx, bool doCalcNorm)
 {
-    bitCapInt qPowers[3];
+    bitCapInt qPowers[2];
     bitCapInt qPowersSorted[2];
-    qPowers[1] = 1 << control;
+    qPowers[0] = 1 << control;
+    qPowers[1] = 1 << target;
+    std::copy(qPowers, qPowers + 2, qPowersSorted);
+    std::sort(qPowersSorted, qPowersSorted + 2);
+    Apply2x2(0, qPowers[1], mtrx, 2, qPowersSorted, doCalcNorm);
+}
+
+void QEngineCPU::ApplyDoublyControlled2x2(bitLenInt control1, bitLenInt control2, bitLenInt target, const Complex16* mtrx, bool doCalcNorm)
+{
+    bitCapInt qPowers[3];
+    bitCapInt qPowersSorted[3];
+    qPowers[0] = 1 << control1;
+    qPowers[1] = 1 << control2;
     qPowers[2] = 1 << target;
-    qPowers[0] = qPowers[1] + qPowers[2];
-    if (control < target) {
-        qPowersSorted[0] = qPowers[1];
-        qPowersSorted[1] = qPowers[2];
-    } else {
-        qPowersSorted[0] = qPowers[2];
-        qPowersSorted[1] = qPowers[1];
-    }
-    Apply2x2(0, qPowers[2], mtrx, 2, qPowersSorted, doCalcNorm);
+    std::copy(qPowers, qPowers + 3, qPowersSorted);
+    std::sort(qPowersSorted, qPowersSorted + 3);
+    Apply2x2(qPowers[0] + qPowers[1], qPowers[0] + qPowers[1] + qPowers[2], mtrx, 3, qPowersSorted, doCalcNorm);
+}
+
+void QEngineCPU::ApplyDoublyAntiControlled2x2(bitLenInt control1, bitLenInt control2, bitLenInt target, const Complex16* mtrx, bool doCalcNorm)
+{
+    bitCapInt qPowers[3];
+    bitCapInt qPowersSorted[3];
+    qPowers[0] = 1 << control1;
+    qPowers[1] = 1 << control2;
+    qPowers[2] = 1 << target;
+    std::copy(qPowers, qPowers + 3, qPowersSorted);
+    std::sort(qPowersSorted, qPowersSorted + 3);
+    Apply2x2(0, qPowers[2], mtrx, 3, qPowersSorted, doCalcNorm);
 }
 
 } // namespace Qrack

--- a/src/qinterface/qinterface.cpp
+++ b/src/qinterface/qinterface.cpp
@@ -15,6 +15,14 @@
 namespace Qrack {
 
 // Bit-wise apply "anti-"controlled-not to three registers
+void QInterface::Swap(bitLenInt qubit1, bitLenInt qubit2, bitLenInt length)
+{
+    for (bitLenInt bit = 0; bit < length; bit++) {
+        Swap(qubit1 + bit, qubit2 + bit);
+    }
+}
+
+// Bit-wise apply "anti-"controlled-not to three registers
 void QInterface::AntiCCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target, bitLenInt length)
 {
     for (bitLenInt bit = 0; bit < length; bit++) {

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -403,13 +403,6 @@ void QUnit::Swap(bitLenInt qubit1, bitLenInt qubit2)
     shard2.unit = tmp.unit;
 }
 
-void QUnit::Swap(bitLenInt qubit1, bitLenInt qubit2, bitLenInt length)
-{
-    for (bitLenInt i = 0; i < length; i++) {
-        Swap(qubit1 + i, qubit2 + i);
-    }
-}
-
 /* Unfortunately, many methods are overloaded, which prevents using just the address-to-member. */
 #define PTR3(OP) (void (QInterface::*)(bitLenInt, bitLenInt, bitLenInt)) &QInterface::OP
 #define PTR2(OP) (void (QInterface::*)(bitLenInt, bitLenInt)) &QInterface::OP


### PR DESCRIPTION
This fixes the matrix multiplication based controlled gates. The old implementations were based on a misunderstanding of permutation vector numbering convention. This was easily corrected.

However, similar logic was tested for "Swap" and failed. The swap gate has been left as the length=1 case of the register method.