### PR TITLE
Fixing partial collapse of entanglement

### DIFF
--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -193,7 +193,7 @@ protected:
 
     void OrderContiguous(QInterfacePtr unit);
 
-    void Detach(bitLenInt start, bitLenInt length, bool keepBits, QInterfacePtr dest);
+    void Detach(bitLenInt start, bitLenInt length, QInterfacePtr dest);
 
     struct QSortEntry
     {

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -180,8 +180,6 @@ protected:
     void INCx(INCxFn fn, bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt flagIndex);
     void INCxx(INCxxFn fn, bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt flag1Index, bitLenInt flag2Index);
 
-    void Decompose(bitLenInt qubit);
-
     QInterfacePtr Entangle(std::initializer_list<bitLenInt *> bits);
     QInterfacePtr EntangleRange(bitLenInt start, bitLenInt length);
     QInterfacePtr EntangleRange(bitLenInt start, bitLenInt length, bitLenInt start2, bitLenInt length2);
@@ -195,7 +193,7 @@ protected:
 
     void OrderContiguous(QInterfacePtr unit);
 
-    void Detach(bitLenInt start, bitLenInt length, QInterfacePtr dest);
+    void Detach(bitLenInt start, bitLenInt length, bool keepBits, QInterfacePtr dest);
 
     struct QSortEntry
     {

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -370,7 +370,7 @@ bitCapInt QUnit::MReg(bitLenInt start, bitLenInt length)
 
     for (bitLenInt bit = 0; bit < length; bit++) {
         if (M(bit + start)) {
-            result |= 1 << (bit + start);
+            result |= 1 << bit;
         }
     }
 


### PR DESCRIPTION
The "Decompose" method in QUnit assumed that any measurement of a bit in a QEngine leads to full collapse of entanglement within the QEngine. This is not accurate. Partial collapse of entanglement would usually happen among more than two entangled qubits. This PR correctly partially collapses entanglement as necessary. All unit tests pass.