### PR TITLE
Fixing partial collapse of entanglement and Qunit optimization

### DIFF
--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -1,10 +1,10 @@
 //////////////////////////////////////////////////////////////////////////////////////
 //
-// (C) Daniel Strano 2017, 2018. All rights reserved.
+// (C) Benn Bollay and Daniel Strano 2017, 2018. All rights reserved.
 //
-// This is a multithreaded, universal quantum register simulation, allowing
-// (nonphysical) register cloning and direct measurement of probability and
-// phase, to leverage what advantages classical emulation of qubits can have.
+// QUnit maintains explicit separability of qubits as on optimization on a QEngine.
+// See https://arxiv.org/abs/1710.05867
+// (The makers of Qrack have no affiliation with the authors of that paper.)
 //
 // Licensed under the GNU General Public License V3.
 // See LICENSE.md in the project root or https://www.gnu.org/licenses/gpl-3.0.en.html

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////////////////
 //
-// (C) Benn Bollay and Daniel Strano 2017, 2018. All rights reserved.
+// (C) Copyright 2017-2018, Daniel Strano and the Qrack and VM6502Q contributors.
 //
 // QUnit maintains explicit separability of qubits as an optimization on a QEngine.
 // See https://arxiv.org/abs/1710.05867

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -180,8 +180,6 @@ protected:
     void INCx(INCxFn fn, bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt flagIndex);
     void INCxx(INCxxFn fn, bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt flag1Index, bitLenInt flag2Index);
 
-    void Decompose(bitLenInt qubit);
-
     QInterfacePtr Entangle(std::initializer_list<bitLenInt *> bits);
     QInterfacePtr EntangleRange(bitLenInt start, bitLenInt length);
     QInterfacePtr EntangleRange(bitLenInt start, bitLenInt length, bitLenInt start2, bitLenInt length2);
@@ -195,7 +193,7 @@ protected:
 
     void OrderContiguous(QInterfacePtr unit);
 
-    void Detach(bitLenInt start, bitLenInt length, QInterfacePtr dest);
+    void Detach(bitLenInt start, bitLenInt length, bool keepBits, QInterfacePtr dest);
 
     struct QSortEntry
     {

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -2,7 +2,7 @@
 //
 // (C) Benn Bollay and Daniel Strano 2017, 2018. All rights reserved.
 //
-// QUnit maintains explicit separability of qubits as on optimization on a QEngine.
+// QUnit maintains explicit separability of qubits as an optimization on a QEngine.
 // See https://arxiv.org/abs/1710.05867
 // (The makers of Qrack have no affiliation with the authors of that paper.)
 //

--- a/src/qengine/state/operators.cpp
+++ b/src/qengine/state/operators.cpp
@@ -26,18 +26,18 @@ void QEngineCPU::ROL(bitLenInt shift, bitLenInt start, bitLenInt length)
     bitCapInt lengthPower = 1 << length;
     bitCapInt i;
     for (i = 0; i < length; i++) {
-        regMask += 1 << (start + i);
+        regMask |= 1 << (start + i);
     }
     otherMask -= regMask;
 
     Complex16 *nStateVec = new Complex16[maxQPower];
 
     par_for(0, maxQPower, [&](const bitCapInt lcv, const int cpu) {
-        bitCapInt otherRes = (lcv & (otherMask));
-        bitCapInt regRes = (lcv & (regMask));
-        bitCapInt regInt = regRes >> (start);
-        bitCapInt outInt = (regInt >> (length - shift)) | ((regInt << (shift)) & (lengthPower - 1));
-        nStateVec[(outInt << (start)) + otherRes] = stateVec[lcv];
+        bitCapInt otherRes = lcv & otherMask;
+        bitCapInt regRes = lcv & regMask;
+        bitCapInt regInt = regRes >> start;
+        bitCapInt outInt = (regInt >> (length - shift)) | ((regInt << shift) & (lengthPower - 1));
+        nStateVec[(outInt << start) + otherRes] = stateVec[lcv];
     });
     delete []stateVec;
     stateVec = nStateVec;
@@ -56,18 +56,18 @@ void QEngineCPU::ROR(bitLenInt shift, bitLenInt start, bitLenInt length)
     bitCapInt i;
 
     for (i = 0; i < length; i++) {
-        regMask += 1 << (start + i);
+        regMask |= 1 << (start + i);
     }
     otherMask -= regMask;
 
     Complex16 *nStateVec = new Complex16[maxQPower];
 
     par_for(0, maxQPower, [&](const bitCapInt lcv, const int cpu) {
-        bitCapInt otherRes = (lcv & (otherMask));
-        bitCapInt regRes = (lcv & (regMask));
-        bitCapInt regInt = regRes >> (start);
-        bitCapInt outInt = (regInt >> (shift)) | ((regInt << (length - shift)) & (lengthPower - 1));
-        nStateVec[(outInt << (start)) + otherRes] = stateVec[lcv];
+        bitCapInt otherRes = lcv & otherMask;
+        bitCapInt regRes = lcv & regMask;
+        bitCapInt regInt = regRes >> start;
+        bitCapInt outInt = (regInt >> shift) | ((regInt << (length - shift)) & (lengthPower - 1));
+        nStateVec[(outInt << start) + otherRes] = stateVec[lcv];
     });
     delete []stateVec;
     stateVec = nStateVec;

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -370,7 +370,7 @@ bitCapInt QUnit::MReg(bitLenInt start, bitLenInt length)
 
     for (bitLenInt bit = 0; bit < length; bit++) {
         if (M(bit + start)) {
-            result |= 1 << (bit + start);
+            result |= 1 << bit;
         }
     }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -599,18 +599,34 @@ void QUnit::CRZDyad(int numerator, int denominator, bitLenInt control, bitLenInt
         }, control, target);
 }
 
+/// "Circular shift right" - (Uses swap-based algorithm for speed)
 void QUnit::ROL(bitLenInt shift, bitLenInt start, bitLenInt length)
 {
-    EntangleRange(start, length);
-    OrderContiguous(shards[start].unit);
-    shards[start].unit->ROL(shift, shards[start].mapped, length);
+    if ((length > 0) && (shift > 0)) {
+        bitLenInt end = start + length;
+        if (shift >= length) {
+            SetReg(start, length, 0);
+        } else {
+            Reverse(start, end);
+            Reverse(start, start + shift);
+            Reverse(start + shift, end);
+        }
+    }
 }
 
+/// "Circular shift right" - (Uses swap-based algorithm for speed)
 void QUnit::ROR(bitLenInt shift, bitLenInt start, bitLenInt length)
 {
-    EntangleRange(start, length);
-    OrderContiguous(shards[start].unit);
-    shards[start].unit->ROR(shift, shards[start].mapped, length);
+    if ((length > 0) && (shift > 0)) {
+        bitLenInt end = start + length;
+        if (shift >= length) {
+            SetReg(start, length, 0);
+        } else {
+            Reverse(start + shift, end);
+            Reverse(start, start + shift);
+            Reverse(start, end);
+        }
+    }
 }
 
 void QUnit::INC(bitCapInt toMod, bitLenInt start, bitLenInt length)

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -359,7 +359,7 @@ bool QUnit::M(bitLenInt qubit)
                 shard.mapped--;
             }
         }
-}
+    }
 
     return result;
 }

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -378,8 +378,8 @@ bitCapInt QUnit::MReg(bitLenInt start, bitLenInt length)
 
 void QUnit::SetBit(bitLenInt qubit, bool value)
 {
+    M(qubit);
     shards[qubit].unit->SetBit(shards[qubit].mapped, value);
-    Detach(qubit, 1, nullptr);
 }
 
 /// Set register bits to given permutation

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -125,14 +125,16 @@ void QUnit::Detach(bitLenInt start, bitLenInt length, QInterfacePtr dest)
         unit->Dispose(mapped, length);
     }
 
-        shards.erase(shards.begin() + start, shards.begin() + start + length);
+    shards.erase(shards.begin() + start, shards.begin() + start + length);
 
-    if (unit->GetQubitCount() != length) {
-        /* Find the rest of the qubits. */
-        for (auto &&shard : shards) {
-            if (shard.unit == unit && shard.mapped > (mapped + length)) {
-                shard.mapped -= length;
-            }
+    if (unit->GetQubitCount() == length) {
+        return;
+    }
+
+    /* Find the rest of the qubits. */
+    for (auto shard : shards) {
+        if (shard.unit == unit && shard.mapped > (mapped + length)) {
+            shard.mapped -= length;
         }
     }
 
@@ -346,18 +348,9 @@ bool QUnit::M(bitLenInt qubit)
     QInterfacePtr dest = CreateQuantumInterface(engine, engine, 1, 0, rand_generator);
     unit->Decohere(mapped, 1, dest);
 
-    /* Update the mappings. */
-    for (auto &&shard : shards) {
-        if (shard.unit == unit && shard.mapped >= mapped) {
-            if (shard.mapped == mapped) {
-                shard.unit = dest;
-                shard.mapped -= mapped;
-            }
-            else {
-                shard.mapped--;
-            }
-        }
-    }
+    /* Update the mapping. */
+    shards[qubit].unit = dest;
+    shards[qubit].mapped = 0;
 
     return result;
 }

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1,10 +1,10 @@
 //////////////////////////////////////////////////////////////////////////////////////
 //
-// (C) Daniel Strano 2017, 2018. All rights reserved.
+// (C) Benn Bollay and Daniel Strano 2017, 2018. All rights reserved.
 //
-// This is a multithreaded, universal quantum register simulation, allowing
-// (nonphysical) register cloning and direct measurement of probability and
-// phase, to leverage what advantages classical emulation of qubits can have.
+// QUnit maintains explicit separability of qubits as on optimization on a QEngine.
+// See https://arxiv.org/abs/1710.05867
+// (The makers of Qrack have no affiliation with the authors of that paper.)
 //
 // Licensed under the GNU General Public License V3.
 // See LICENSE.md in the project root or https://www.gnu.org/licenses/gpl-3.0.en.html

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -347,17 +347,12 @@ bool QUnit::M(bitLenInt qubit)
     QInterfacePtr dest = CreateQuantumInterface(engine, engine, 1, 0, rand_generator);
     unit->Decohere(mapped, 1, dest);
 
-    /* Update the mapping. */
     /* Update the mappings. */
+    shards[qubit].unit = dest;
+    shards[qubit].mapped = 0;
     for (auto &&shard : shards) {
-        if (shard.unit == unit && shard.mapped >= mapped) {
-            if (shard.mapped == mapped) {
-                shard.unit = dest;
-                shard.mapped = 0;
-            }
-            else {
-                shard.mapped--;
-            }
+        if (shard.unit == unit && shard.mapped > mapped) {
+            shard.mapped--;
         }
     }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -378,8 +378,9 @@ bitCapInt QUnit::MReg(bitLenInt start, bitLenInt length)
 
 void QUnit::SetBit(bitLenInt qubit, bool value)
 {
-    M(qubit);
-    shards[qubit].unit->SetBit(shards[qubit].mapped, value);
+    if (M(qubit) != value) {
+        shards[qubit].unit->X(shards[qubit].mapped, value);
+    }
 }
 
 /// Set register bits to given permutation

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////////////////
 //
-// (C) Benn Bollay and Daniel Strano 2017, 2018. All rights reserved.
+// (C) Copyright 2017-2018, Daniel Strano and the Qrack and VM6502Q contributors.
 //
 // QUnit maintains explicit separability of qubits as an optimization on a QEngine.
 // See https://arxiv.org/abs/1710.05867

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -602,30 +602,24 @@ void QUnit::CRZDyad(int numerator, int denominator, bitLenInt control, bitLenInt
 /// "Circular shift right" - (Uses swap-based algorithm for speed)
 void QUnit::ROL(bitLenInt shift, bitLenInt start, bitLenInt length)
 {
+    shift %= length;
     if ((length > 0) && (shift > 0)) {
         bitLenInt end = start + length;
-        if (shift >= length) {
-            SetReg(start, length, 0);
-        } else {
-            Reverse(start, end);
-            Reverse(start, start + shift);
-            Reverse(start + shift, end);
-        }
+        Reverse(start, end);
+        Reverse(start, start + shift);
+        Reverse(start + shift, end);
     }
 }
 
 /// "Circular shift right" - (Uses swap-based algorithm for speed)
 void QUnit::ROR(bitLenInt shift, bitLenInt start, bitLenInt length)
 {
+    shift %= length;
     if ((length > 0) && (shift > 0)) {
         bitLenInt end = start + length;
-        if (shift >= length) {
-            SetReg(start, length, 0);
-        } else {
-            Reverse(start + shift, end);
-            Reverse(start, start + shift);
-            Reverse(start, end);
-        }
+        Reverse(start + shift, end);
+        Reverse(start, start + shift);
+        Reverse(start, end);
     }
 }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -2,7 +2,7 @@
 //
 // (C) Benn Bollay and Daniel Strano 2017, 2018. All rights reserved.
 //
-// QUnit maintains explicit separability of qubits as on optimization on a QEngine.
+// QUnit maintains explicit separability of qubits as an optimization on a QEngine.
 // See https://arxiv.org/abs/1710.05867
 // (The makers of Qrack have no affiliation with the authors of that paper.)
 //


### PR DESCRIPTION
This only replaces ROL/ROR in QUnit with swap-based versions that are virtually free compared to other quantum gates in QUnit. All shift operations should see a major improvement. It also safe to assume that these operations don't entangle any bits, as is manifest in a swap-based implementation.