### PR TITLE
Indexed generalize

### DIFF
--- a/include/qengine_cpu.hpp
+++ b/include/qengine_cpu.hpp
@@ -185,11 +185,9 @@ public:
     virtual void PhaseFlip();
     virtual void SetReg(bitLenInt start, bitLenInt length, bitCapInt value);
     virtual bitCapInt MReg(bitLenInt start, bitLenInt length);
-    virtual unsigned char SuperposeReg8(bitLenInt inputStart, bitLenInt outputStart, unsigned char* values);
-    virtual unsigned char AdcSuperposeReg8(
-        bitLenInt inputStart, bitLenInt outputStart, bitLenInt carryIndex, unsigned char* values);
-    virtual unsigned char SbcSuperposeReg8(
-        bitLenInt inputStart, bitLenInt outputStart, bitLenInt carryIndex, unsigned char* values);
+    virtual unsigned char IndexedLDA(bitLenInt indexStart, bitLenInt indexLength, bitLenInt valueStart, bitLenInt valueLength, unsigned char* values);
+    virtual unsigned char IndexedADC(bitLenInt indexStart, bitLenInt indexLength, bitLenInt valueStart, bitLenInt valueLength, bitLenInt carryIndex, unsigned char* values);
+    virtual unsigned char IndexedSBC(bitLenInt indexStart, bitLenInt indexLength, bitLenInt valueStart, bitLenInt valueLength, bitLenInt carryIndex, unsigned char* values);
     virtual void Swap(bitLenInt qubitIndex1, bitLenInt qubitIndex2);
     virtual void Swap(bitLenInt start1, bitLenInt start2, bitLenInt length);
 

--- a/include/qengine_opencl.hpp
+++ b/include/qengine_opencl.hpp
@@ -55,11 +55,6 @@ public:
     virtual void ROR(bitLenInt shift, bitLenInt start, bitLenInt length);
     virtual void INCC(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt carryIndex);
     virtual void DECC(bitCapInt toSub, bitLenInt start, bitLenInt length, bitLenInt carryIndex);
-    virtual unsigned char SuperposeReg8(bitLenInt inputStart, bitLenInt outputStart, unsigned char* values);
-    virtual unsigned char AdcSuperposeReg8(
-        bitLenInt inputStart, bitLenInt outputStart, bitLenInt carryIndex, unsigned char* values);
-    virtual unsigned char SbcSuperposeReg8(
-        bitLenInt inputStart, bitLenInt outputStart, bitLenInt carryIndex, unsigned char* values);
 
 protected:
     static const int BCI_ARG_LEN = 10;

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -881,7 +881,7 @@ public:
      * write in quantum parallel to more than one address of classical memory
      * at a time.
      */
-    virtual unsigned char SuperposeReg8(bitLenInt inputStart, bitLenInt outputStart, unsigned char* values) = 0;
+    virtual unsigned char IndexedLDA(bitLenInt indexStart, bitLenInt indexLength, bitLenInt valueStart, bitLenInt valueLength, unsigned char* values) = 0;
 
     /**
      * Add to entangled 8 bit register state with a superposed
@@ -907,8 +907,7 @@ public:
      * (with carry) operations on a state usually initially prepared with
      * SuperposeReg8().
      */
-    virtual unsigned char AdcSuperposeReg8(
-        bitLenInt inputStart, bitLenInt outputStart, bitLenInt carryIndex, unsigned char* values) = 0;
+    virtual unsigned char IndexedADC(bitLenInt indexStart, bitLenInt indexLength, bitLenInt valueStart, bitLenInt valueLength, bitLenInt carryIndex, unsigned char* values) = 0;
 
     /**
      * Subtract from an entangled 8 bit register state with a superposed
@@ -934,8 +933,7 @@ public:
      * (with carry) operations on a state usually initially prepared with
      * SuperposeReg8().
      */
-    virtual unsigned char SbcSuperposeReg8(
-        bitLenInt inputStart, bitLenInt outputStart, bitLenInt carryIndex, unsigned char* values) = 0;
+    virtual unsigned char IndexedSBC(bitLenInt indexStart, bitLenInt indexLength, bitLenInt valueStart, bitLenInt valueLength, bitLenInt carryIndex, unsigned char* values) = 0;
 
     /** Swap values of two bits in register */
     virtual void Swap(bitLenInt qubitIndex1, bitLenInt qubitIndex2) = 0;

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -153,9 +153,9 @@ public:
     virtual void PhaseFlip();
     virtual void SetReg(bitLenInt start, bitLenInt length, bitCapInt value);
     virtual bitCapInt MReg(bitLenInt start, bitLenInt length);
-    virtual unsigned char SuperposeReg8(bitLenInt inputStart, bitLenInt outputStart, unsigned char* values);
-    virtual unsigned char AdcSuperposeReg8(bitLenInt inputStart, bitLenInt outputStart, bitLenInt carryIndex, unsigned char* values);
-    virtual unsigned char SbcSuperposeReg8(bitLenInt inputStart, bitLenInt outputStart, bitLenInt carryIndex, unsigned char* values);
+    virtual unsigned char IndexedLDA(bitLenInt indexStart, bitLenInt indexLength, bitLenInt valueStart, bitLenInt valueLength, unsigned char* values);
+    virtual unsigned char IndexedADC(bitLenInt indexStart, bitLenInt indexLength, bitLenInt valueStart, bitLenInt valueLength, bitLenInt carryIndex, unsigned char* values);
+    virtual unsigned char IndexedSBC(bitLenInt indexStart, bitLenInt indexLength, bitLenInt valueStart, bitLenInt valueLength, bitLenInt carryIndex, unsigned char* values);
     virtual void Swap(bitLenInt qubit1, bitLenInt qubit2);
 
     /** @} */

--- a/src/qengine/state/opencl.cpp
+++ b/src/qengine/state/opencl.cpp
@@ -190,28 +190,6 @@ void QEngineOCL::DECC(
     INTC(clObj->GetDECCPtr(), toSub, start, length, carryIndex);
 }
 
-/** Set 8 bit register bits based on read from classical memory */
-unsigned char QEngineOCL::SuperposeReg8(bitLenInt inputStart, bitLenInt outputStart, unsigned char* values)
-{
-    SetReg(outputStart, 8, 0);
-    bitCapInt inputMask = 0xff << inputStart;
-    bitCapInt outputMask = 0xff << outputStart;
-    bitCapInt bciArgs[10] = { maxQPower >> 8, inputStart, inputMask, outputStart, 0, 0, 0, 0, 0, 0 };
-
-    Complex16 *nStateVec = new Complex16[maxQPower];
-    DispatchCall(clObj->GetSR8Ptr(), bciArgs, nStateVec, values);
-
-    bitCapInt i, outputInt;
-    double prob, average;
-    for (i = 0; i < maxQPower; i++) {
-        outputInt = (i & outputMask) >> outputStart;
-        prob = norm(nStateVec[i]);
-        average += prob * outputInt;
-    }
-    ResetStateVec(nStateVec);
-
-    return (unsigned char)(average + 0.5);
-}
 
 /** Add or Subtract based on an indexed load from classical memory */
 unsigned char QEngineOCL::OpSuperposeReg8(cl::Kernel *call, bitCapInt carryIn,
@@ -252,20 +230,6 @@ unsigned char QEngineOCL::OpSuperposeReg8(cl::Kernel *call, bitCapInt carryIn,
 
     // Return the expectation value.
     return (unsigned char)(average + 0.5);
-}
-
-/** Add based on an indexed load from classical memory */
-unsigned char QEngineOCL::AdcSuperposeReg8(
-    bitLenInt inputStart, bitLenInt outputStart, bitLenInt carryIndex, unsigned char* values)
-{
-    return OpSuperposeReg8(clObj->GetADC8Ptr(), 0, inputStart, outputStart, carryIndex, values);
-}
-
-/** Subtract based on an indexed load from classical memory */
-unsigned char QEngineOCL::SbcSuperposeReg8(
-    bitLenInt inputStart, bitLenInt outputStart, bitLenInt carryIndex, unsigned char* values)
-{
-    return OpSuperposeReg8(clObj->GetSBC8Ptr(), 1, inputStart, outputStart, carryIndex, values);
 }
 
 } // namespace Qrack

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -763,43 +763,30 @@ void QUnit::PhaseFlip()
     }
 }
 
-unsigned char QUnit::SuperposeReg8(bitLenInt inputStart, bitLenInt outputStart, unsigned char* values)
+unsigned char QUnit::IndexedLDA(bitLenInt indexStart, bitLenInt indexLength, bitLenInt valueStart, bitLenInt valueLength, unsigned char* values)
 {
-    const bitLenInt length = 8;
-    EntangleRange(inputStart, length, outputStart, length);
-    OrderContiguous(shards[inputStart].unit);
+    EntangleRange(indexStart, indexLength, valueStart, valueLength);
+    OrderContiguous(shards[indexStart].unit);
 
-    return shards[inputStart].unit->SuperposeReg8(shards[inputStart].mapped, shards[outputStart].mapped, values);
+    return shards[indexStart].unit->IndexedLDA(shards[indexStart].mapped, indexLength, shards[valueStart].mapped, valueLength, values);
 }
 
-unsigned char QUnit::AdcSuperposeReg8(
-    bitLenInt inputStart, bitLenInt outputStart, bitLenInt carryIndex, unsigned char* values)
+unsigned char QUnit::IndexedADC(bitLenInt indexStart, bitLenInt indexLength, bitLenInt valueStart, bitLenInt valueLength, bitLenInt carryIndex, unsigned char* values)
 {
-    const bitLenInt length = 8;
-    EntangleRange(inputStart, length, outputStart, length);
-    OrderContiguous(shards[inputStart].unit);
-    unsigned char result = 0;
+    EntangleRange(indexStart, indexLength, valueStart, valueLength);
+    EntangleRange(indexStart, 1, carryIndex, 1);
+    OrderContiguous(shards[indexStart].unit);
 
-    EntangleAndCall([&](QInterfacePtr unit, bitLenInt b1, bitLenInt b2, bitLenInt b3) {
-            result = unit->AdcSuperposeReg8(b1, b2, b3, values);
-        }, inputStart, outputStart, carryIndex);
-
-    return result;
+    return shards[indexStart].unit->IndexedADC(shards[indexStart].mapped, indexLength, shards[valueStart].mapped, valueLength, carryIndex, values);
 }
 
-unsigned char QUnit::SbcSuperposeReg8(
-    bitLenInt inputStart, bitLenInt outputStart, bitLenInt carryIndex, unsigned char* values)
+unsigned char QUnit::IndexedSBC(bitLenInt indexStart, bitLenInt indexLength, bitLenInt valueStart, bitLenInt valueLength, bitLenInt carryIndex, unsigned char* values)
 {
-    const bitLenInt length = 8;
-    EntangleRange(inputStart, length, outputStart, length);
-    OrderContiguous(shards[inputStart].unit);
-    unsigned char result = 0;
+    EntangleRange(indexStart, indexLength, valueStart, valueLength);
+    EntangleRange(indexStart, 1, carryIndex, 1);
+    OrderContiguous(shards[indexStart].unit);
 
-    EntangleAndCall([&](QInterfacePtr unit, bitLenInt b1, bitLenInt b2, bitLenInt b3) {
-            result = unit->SbcSuperposeReg8(b1, b2, b3, values);
-        }, inputStart, outputStart, carryIndex);
-
-    return result;
+    return shards[indexStart].unit->IndexedSBC(shards[indexStart].mapped, indexLength, shards[valueStart].mapped, valueLength, carryIndex, values);
 }
 
 } // namespace Qrack

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -205,7 +205,7 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_superposition_reg")
     for (j = 0; j < 256; j++) {
         testPage[j] = j;
     }
-    unsigned char expectation = qftReg->SuperposeReg8(0, 8, testPage);
+    unsigned char expectation = qftReg->IndexedLDA(0, 8, 8, 8, testPage);
     REQUIRE_THAT(qftReg, HasProbability(0, 16, 0x303));
 }
 
@@ -222,12 +222,12 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_adc_superposition_reg")
         testPage[j] = j;
     }
 
-    qftReg->SuperposeReg8(8, 0, testPage);
+    qftReg->IndexedLDA(8, 8, 0, 8, testPage);
 
     for (j = 0; j < 256; j++) {
         testPage[j] = 255 - j;
     }
-    unsigned char expectation = qftReg->AdcSuperposeReg8(8, 0, 16, testPage);
+    unsigned char expectation = qftReg->IndexedADC(8, 8, 0, 8, 16, testPage);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0xff));
     REQUIRE(expectation == 0xff);
 }
@@ -244,9 +244,9 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_sbc_superposition_reg")
     for (j = 0; j < 256; j++) {
         testPage[j] = j;
     }
-    qftReg->SuperposeReg8(8, 0, testPage);
+    qftReg->IndexedLDA(8, 8, 0, 8, testPage);
 
-    unsigned char expectation = qftReg->SbcSuperposeReg8(8, 0, 16, testPage);
+    unsigned char expectation = qftReg->IndexedSBC(8, 8, 0, 8, 16, testPage);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 1 << 16));
     REQUIRE(expectation == 0x00);
 }
@@ -548,7 +548,7 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_grover_lookup")
     // Our input to the subroutine "oracle" is 8 bits.
     qftReg->SetPermutation(0);
     qftReg->H(8, 8);
-    qftReg->SuperposeReg8(8, 0, toLoad);
+    qftReg->IndexedLDA(8, 8, 0, 8, toLoad);
 
     // std::cout << "Iterations:" << std::endl;
     // Twelve iterations maximizes the probablity for 256 searched elements.
@@ -559,13 +559,13 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_grover_lookup")
         qftReg->INC(100, 0, 8);
         // This ends the "oracle."
         qftReg->X(16);
-        qftReg->SbcSuperposeReg8(8, 0, 16, toLoad);
+        qftReg->IndexedSBC(8, 8, 0, 8, 16, toLoad);
         qftReg->X(16);
         qftReg->H(8, 8);
         qftReg->ZeroPhaseFlip(8, 8);
         qftReg->H(8, 8);
         qftReg->PhaseFlip();
-        qftReg->AdcSuperposeReg8(8, 0, 16, toLoad);
+        qftReg->IndexedADC(8, 8, 0, 8, 16, toLoad);
         // std::cout << "\t" << std::setw(2) << i << "> chance of match:" << qftReg->ProbAll(TARGET_PROB) << std::endl;
     }
 
@@ -598,7 +598,7 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_basis_change")
     // Divide qftReg into two registers of 8 bits each
     qftReg->SetPermutation(0);
     qftReg->H(8, 8);
-    qftReg->SuperposeReg8(8, 0, toSearch);
+    qftReg->IndexedLDA(8, 8, 0, 8, toSearch);
     qftReg->H(8, 8);
 
     REQUIRE_THAT(qftReg, HasProbability(0, 16, 100));


### PR DESCRIPTION
This generalizes LDA/ADC/SBC to accept indices and values of any length. Previously, the API only allowed 8 bit indices and 8 bit values. Also, the names of these methods have been refactored to more appropriately reflect that they are "indexed" operations. "Superposed" was a vague description.