### PR TITLE
Moving preprocessors defines into header

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,9 @@ if (ENABLE_COMPLEX_X2 AND NOT ENABLE_COMPLEX8)
     set(QRACK_COMPILE_OPTS -mavx)
 endif (ENABLE_COMPLEX_X2 AND NOT ENABLE_COMPLEX8)
 
+configure_file(include/qrack_defines.hpp.in include/qrack_defines.hpp @ONLY)
+include_directories(${CMAKE_CURRENT_BINARY_DIR}/include)
+
 enable_testing()
 
 # Run the unittest executable on 'make test'
@@ -75,7 +78,7 @@ if (APPLE)
     set(TEST_COMPILE_OPTS -Wno-inconsistent-missing-override)
 endif (APPLE)
 
-target_compile_options (qrack PUBLIC -O3 -std=c++11 -Wall -Werror ${QRACK_COMPILE_OPTS} -DCATCH_CONFIG_FAST_COMPILE -DPSTRIDE=${PSTRIDE})
+target_compile_options (qrack PUBLIC -O3 -std=c++11 -Wall -Werror ${QRACK_COMPILE_OPTS} -DCATCH_CONFIG_FAST_COMPILE)
 target_compile_options (unittest PUBLIC -O3 -std=c++11 -Wall -Werror ${TEST_COMPILE_OPTS} -DCATCH_CONFIG_FAST_COMPILE)
 target_compile_options (benchmarks PUBLIC -O3 -std=c++11 -Wall -Werror ${TEST_COMPILE_OPTS} -DCATCH_CONFIG_FAST_COMPILE)
 
@@ -85,22 +88,20 @@ set_target_properties (qrack PROPERTIES
 
 # Install common headers
 install (FILES
-    include/common/complex16simd.hpp
-    include/common/complex16x2simd.hpp
-    include/common/complex8x2simd.hpp
-    include/common/oclengine.hpp
-    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/qrack/common
-    )
-
-# Install qrack library headers
-install (FILES 
-    include/qengine_cpu.hpp
-    include/qunit.hpp
     include/common/oclengine.hpp
     include/common/complex16simd.hpp
     include/common/complex16x2simd.hpp
     include/common/complex8x2simd.hpp
     include/common/parallel_for.hpp
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/qrack/common
+    )
+
+# Install qrack library headers
+install (FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/include/qrack_defines.hpp
+    include/qfactory.hpp
+    include/qengine_cpu.hpp
+    include/qunit.hpp
     include/qengine_opencl.hpp
     include/qengine_opencl_multi.hpp
     include/qinterface.hpp

--- a/cmake/Complex8.cmake
+++ b/cmake/Complex8.cmake
@@ -1,6 +1,2 @@
 option (ENABLE_COMPLEX8 "Use 32 bit float accuracy instead of 64 bit float accuracy")
 message ("Single accuracy is: ${ENABLE_COMPLEX8}")
-
-if (ENABLE_COMPLEX8)
-    target_compile_definitions (qrack PUBLIC ENABLE_COMPLEX8=1)
-endif (ENABLE_COMPLEX8)

--- a/cmake/Complex_x2.cmake
+++ b/cmake/Complex_x2.cmake
@@ -1,6 +1,2 @@
 option (ENABLE_COMPLEX_X2 "Use Complex type vector optimizations (including AVX)" ON)
 message ("Complex_x2/AVX Support is: ${ENABLE_COMPLEX_X2}")
-
-if (ENABLE_COMPLEX_X2)
-    target_compile_definitions (qrack PUBLIC ENABLE_COMPLEX_X2=1)
-endif (ENABLE_COMPLEX_X2)

--- a/cmake/OpenCL.cmake
+++ b/cmake/OpenCL.cmake
@@ -29,7 +29,6 @@ if (ENABLE_OPENCL)
 endif ()
 
 if (ENABLE_OPENCL)
-    target_compile_definitions (qrack PUBLIC ENABLE_OPENCL=1)
     target_compile_definitions (qrack PUBLIC CL_HPP_TARGET_OPENCL_VERSION=200)
     target_compile_definitions (qrack PUBLIC CL_HPP_MINIMUM_OPENCL_VERSION=100)
 

--- a/include/common/oclengine.hpp
+++ b/include/common/oclengine.hpp
@@ -12,6 +12,8 @@
 
 #pragma once
 
+#include "qrack_defines.hpp"
+
 #if !ENABLE_OPENCL
 #error OpenCL has not been enabled
 #endif

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -22,6 +22,8 @@
 #define bitCapInt uint64_t
 #define bitsInByte 8
 
+#include "qrack_defines.hpp"
+
 #if ENABLE_COMPLEX8
 #include <complex>
 #define complex std::complex<float>

--- a/include/qrack_defines.hpp.in
+++ b/include/qrack_defines.hpp.in
@@ -1,0 +1,4 @@
+#cmakedefine ENABLE_OPENCL 1
+#cmakedefine ENABLE_COMPLEX_X2 1
+#cmakedefine ENABLE_COMPLEX8 1
+#cmakedefine PSTRIDE @PSTRIDE@


### PR DESCRIPTION
This removes the dependence of any build on command line preprocessor definitions.