### PR TITLE
Remove usedevicemem

### DIFF
--- a/include/common/oclengine.hpp
+++ b/include/common/oclengine.hpp
@@ -109,7 +109,6 @@ public:
     cl::CommandQueue queue;
 
 protected:
-    unsigned char totalQubitCount;
     std::recursive_mutex mutex;
     std::map<OCLAPI, cl::Kernel> calls;
 
@@ -119,31 +118,12 @@ public:
         , device(d)
         , context(c)
         , context_id(cntxt_id)
-        , totalQubitCount(0)
         , mutex()
     {
         queue = cl::CommandQueue(context, d);
     }
     OCLDeviceCall Reserve(OCLAPI call) { return OCLDeviceCall(mutex, calls[call]); }
     friend class OCLEngine;
-
-    void AddQubits(unsigned char toAdd)
-    {
-        if (totalQubitCount > (255U - toAdd)) {
-            totalQubitCount = 255U;
-        } else {
-            totalQubitCount += toAdd;
-        }
-    }
-    void SubtractQubits(unsigned char toSub)
-    {
-        if (toSub >= totalQubitCount) {
-            totalQubitCount = 0;
-        } else {
-            totalQubitCount -= toSub;
-        }
-    }
-    unsigned char GetQubitCount() { return totalQubitCount; }
 };
 
 /** "Qrack::OCLEngine" manages the single OpenCL context. */

--- a/include/qengine_opencl.hpp
+++ b/include/qengine_opencl.hpp
@@ -47,11 +47,6 @@ protected:
     size_t nrmGroupSize;
     size_t maxWorkItems;
     unsigned int procElemCount;
-    long unsigned int maxAllocMem;
-    long unsigned int maxDevMem;
-    bool useDeviceMem;
-    bool syncWrite;
-    bitLenInt totalDeviceQubits;
 
     virtual void ApplyM(bitCapInt qPower, bool result, complex nrm);
 

--- a/include/qengine_opencl.hpp
+++ b/include/qengine_opencl.hpp
@@ -73,13 +73,11 @@ public:
     QEngineOCL(QEngineOCLPtr toCopy);
     ~QEngineOCL()
     {
-        device_context->SubtractQubits(qubitCount);
         delete[] stateVec;
         delete[] nrmArray;
     }
 
     virtual void SetQubitCount(bitLenInt qb);
-    virtual void Resize(bool doResizeBuffers);
 
     virtual void EnableNormalize(bool doN) { doNormalize = doN; }
     virtual real1 GetNorm(bool update = true)

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -106,7 +106,8 @@ void QEngineOCL::CopyState(QInterfacePtr orig)
     SetQubitCount(orig->GetQubitCount());
 
     complex* nStateVec = AllocStateVec(maxQPower);
-    BufferPtr nStateBuffer = std::make_shared<cl::Buffer>(context, CL_MEM_USE_HOST_PTR | CL_MEM_READ_WRITE, sizeof(complex) * maxQPower, nStateVec);
+    BufferPtr nStateBuffer = std::make_shared<cl::Buffer>(
+        context, CL_MEM_USE_HOST_PTR | CL_MEM_READ_WRITE, sizeof(complex) * maxQPower, nStateVec);
     ResetStateVec(nStateVec, nStateBuffer);
 
     QEngineOCLPtr src = std::dynamic_pointer_cast<QEngineOCL>(orig);
@@ -190,7 +191,7 @@ void QEngineOCL::SetDevice(const int& dID, const bool& forceReInit)
 
     // create buffers on device (allocate space on GPU)
     stateBuffer = std::make_shared<cl::Buffer>(
-            context, CL_MEM_USE_HOST_PTR | CL_MEM_READ_WRITE, sizeof(complex) * maxQPower, stateVec);
+        context, CL_MEM_USE_HOST_PTR | CL_MEM_READ_WRITE, sizeof(complex) * maxQPower, stateVec);
     cmplxBuffer = cl::Buffer(context, CL_MEM_READ_ONLY, sizeof(complex) * CMPLX_NORM_LEN);
     ulongBuffer = cl::Buffer(context, CL_MEM_READ_ONLY, sizeof(bitCapInt) * BCI_ARG_LEN);
     nrmBuffer = cl::Buffer(context, CL_MEM_USE_HOST_PTR | CL_MEM_READ_WRITE, sizeof(real1) * nrmGroupCount, nrmArray);
@@ -236,7 +237,8 @@ void QEngineOCL::DispatchCall(
 
     /* Allocate a temporary nStateVec, or use the one supplied. */
     complex* nStateVec = AllocStateVec(maxQPower);
-    BufferPtr nStateBuffer = std::make_shared<cl::Buffer>(context, CL_MEM_USE_HOST_PTR | CL_MEM_READ_WRITE, sizeof(complex) * maxQPower, nStateVec);
+    BufferPtr nStateBuffer = std::make_shared<cl::Buffer>(
+        context, CL_MEM_USE_HOST_PTR | CL_MEM_READ_WRITE, sizeof(complex) * maxQPower, nStateVec);
     queue.enqueueFillBuffer(*nStateBuffer, complex(0.0, 0.0), 0, sizeof(complex) * maxQPower);
     queue.flush();
 
@@ -374,7 +376,8 @@ bitLenInt QEngineOCL::Cohere(QEngineOCLPtr toCopy)
     size_t ngs = FixGroupSize(ngc, nrmGroupSize);
 
     complex* nStateVec = AllocStateVec(maxQPower);
-    BufferPtr nStateBuffer = std::make_shared<cl::Buffer>(context, CL_MEM_USE_HOST_PTR | CL_MEM_READ_WRITE, sizeof(complex) * maxQPower, nStateVec);
+    BufferPtr nStateBuffer = std::make_shared<cl::Buffer>(
+        context, CL_MEM_USE_HOST_PTR | CL_MEM_READ_WRITE, sizeof(complex) * maxQPower, nStateVec);
 
     OCLDeviceCall ocl = device_context->Reserve(OCL_API_COHERE);
     queue.finish();
@@ -510,7 +513,8 @@ void QEngineOCL::DecohereDispose(bitLenInt start, bitLenInt length, QEngineOCLPt
     ngs = FixGroupSize(ngc, nrmGroupSize);
 
     complex* nStateVec = AllocStateVec(maxQPower);
-    BufferPtr nStateBuffer = std::make_shared<cl::Buffer>(context, CL_MEM_USE_HOST_PTR | CL_MEM_READ_WRITE, sizeof(complex) * maxQPower, nStateVec);
+    BufferPtr nStateBuffer = std::make_shared<cl::Buffer>(
+        context, CL_MEM_USE_HOST_PTR | CL_MEM_READ_WRITE, sizeof(complex) * maxQPower, nStateVec);
 
     queue.finish();
     amp_call.call.setArg(0, probBuffer1);


### PR DESCRIPTION
Simplifies code without hurting performance. (Attempt at manually using device global memory might be redundant with OpenCL compilation.)