### PR TITLE
QUnit bug fix and Inverse Quantum Fourier Transform

### DIFF
--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -1015,6 +1015,9 @@ public:
     /** Quantum Fourier Transform - Apply the quantum Fourier transform to the register. */
     virtual void QFT(bitLenInt start, bitLenInt length);
 
+    /** Inverse Quantum Fourier Transform - Apply the inverse quantum Fourier transform to the register. */
+    virtual void IQFT(bitLenInt start, bitLenInt length);
+
     /** Reverse the phase of the state where the register equals zero. */
     virtual void ZeroPhaseFlip(bitLenInt start, bitLenInt length) = 0;
 

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -203,6 +203,7 @@ protected:
 
     template <typename F, typename... B> void EntangleAndCallMember(F fn, B... bits);
     template <typename F, typename... B> void EntangleAndCall(F fn, B... bits);
+    template <typename F, typename... B> void EntangleAndCallMemberRot(F fn, real1 radians, B... bits);
 
     void OrderContiguous(QInterfacePtr unit);
 

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -196,6 +196,8 @@ protected:
     QInterfacePtr Entangle(std::initializer_list<bitLenInt*> bits);
     QInterfacePtr EntangleRange(bitLenInt start, bitLenInt length);
     QInterfacePtr EntangleRange(bitLenInt start, bitLenInt length, bitLenInt start2, bitLenInt length2);
+    QInterfacePtr EntangleRange(
+        bitLenInt start, bitLenInt length, bitLenInt start2, bitLenInt length2, bitLenInt start3, bitLenInt length3);
 
     template <class It> QInterfacePtr EntangleIterator(It first, It last);
 

--- a/src/qinterface/qinterface.cpp
+++ b/src/qinterface/qinterface.cpp
@@ -208,6 +208,21 @@ void QInterface::QFT(bitLenInt start, bitLenInt length)
     }
 }
 
+/// Inverse Quantum Fourier Transform - Apply the inverse quantum Fourier transform to the register
+void QInterface::IQFT(bitLenInt start, bitLenInt length)
+{
+    if (length > 0) {
+        int end = start + length - 1;
+        int i, j;
+        for (i = end; i >= start; i--) {
+            for (j = (end - i); j > 0; j--) {
+                CRTDyad(-1, j, i + j, i);
+            }
+            H(i);
+        }
+    }
+}
+
 /// Set register bits to given permutation
 void QInterface::SetReg(bitLenInt start, bitLenInt length, bitCapInt value)
 {

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -278,6 +278,12 @@ template <typename F, typename... B> void QUnit::EntangleAndCall(F fn, B... bits
     fn(qbits, bits...);
 }
 
+template <typename F, typename... B> void QUnit::EntangleAndCallMemberRot(F fn, real1 radians, B... bits)
+{
+    auto qbits = Entangle({ &bits... });
+    ((*qbits).*fn)(radians, bits...);
+}
+
 void QUnit::OrderContiguous(QInterfacePtr unit)
 {
     if (unit->GetQubitCount() == 1) {
@@ -452,6 +458,7 @@ void QUnit::Swap(bitLenInt qubit1, bitLenInt qubit2)
 /* Unfortunately, many methods are overloaded, which prevents using just the address-to-member. */
 #define PTR3(OP) (void (QInterface::*)(bitLenInt, bitLenInt, bitLenInt)) & QInterface::OP
 #define PTR2(OP) (void (QInterface::*)(bitLenInt, bitLenInt)) & QInterface::OP
+#define PTR2A(OP) (void (QInterface::*)(real1, bitLenInt, bitLenInt)) & QInterface::OP
 
 void QUnit::AND(bitLenInt inputBit1, bitLenInt inputBit2, bitLenInt outputBit)
 {
@@ -517,10 +524,7 @@ void QUnit::CY(bitLenInt control, bitLenInt target) { EntangleAndCallMember(PTR2
 
 void QUnit::CZ(bitLenInt control, bitLenInt target) { EntangleAndCallMember(PTR2(CZ), control, target); }
 
-void QUnit::RT(real1 radians, bitLenInt qubit)
-{
-    EntangleAndCall([&](QInterfacePtr unit, bitLenInt q) { unit->RT(radians, q); }, qubit);
-}
+void QUnit::RT(real1 radians, bitLenInt qubit) { shards[qubit].unit->RT(radians, shards[qubit].mapped); }
 
 void QUnit::RX(real1 radians, bitLenInt qubit) { shards[qubit].unit->RX(radians, shards[qubit].mapped); }
 
@@ -538,26 +542,22 @@ void QUnit::ExpZ(real1 radians, bitLenInt qubit) { shards[qubit].unit->ExpZ(radi
 
 void QUnit::CRT(real1 radians, bitLenInt control, bitLenInt target)
 {
-    EntangleAndCall(
-        [&](QInterfacePtr unit, bitLenInt b1, bitLenInt b2) { unit->CRT(radians, b1, b2); }, control, target);
+    EntangleAndCallMemberRot(PTR2A(CRT), radians, control, target);
 }
 
 void QUnit::CRX(real1 radians, bitLenInt control, bitLenInt target)
 {
-    EntangleAndCall(
-        [&](QInterfacePtr unit, bitLenInt b1, bitLenInt b2) { unit->CRX(radians, b1, b2); }, control, target);
+    EntangleAndCallMemberRot(PTR2A(CRX), radians, control, target);
 }
 
 void QUnit::CRY(real1 radians, bitLenInt control, bitLenInt target)
 {
-    EntangleAndCall(
-        [&](QInterfacePtr unit, bitLenInt b1, bitLenInt b2) { unit->CRY(radians, b1, b2); }, control, target);
+    EntangleAndCallMemberRot(PTR2A(CRY), radians, control, target);
 }
 
 void QUnit::CRZ(real1 radians, bitLenInt control, bitLenInt target)
 {
-    EntangleAndCall(
-        [&](QInterfacePtr unit, bitLenInt b1, bitLenInt b2) { unit->CRZ(radians, b1, b2); }, control, target);
+    EntangleAndCallMemberRot(PTR2A(CRZ), radians, control, target);
 }
 
 void QUnit::AND(bitLenInt inputStart1, bitLenInt inputStart2, bitLenInt outputStart, bitLenInt length)

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -1647,28 +1647,6 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_expmod")
     REQUIRE_THAT(qftReg, HasProbability(0, baseLen, 25));
 }
 
-TEST_CASE_METHOD(QInterfaceTestFixture, "test_phase_est")
-{
-    bitLenInt baseLen = 6;
-    bitLenInt expLen = 2;
-    bitCapInt res;
-    bool check;
-    
-    qftReg->SetPermutation(1);
-    // Last bits are exponent:
-    qftReg->H(20 - expLen, expLen);
-    ExpMod(qftReg, 31, 0, baseLen, 20 - expLen, expLen, 2 * baseLen);
-
-    qftReg->IQFT(20 - expLen, expLen);
-    qftReg->MReg(20 - expLen, expLen);
-    res = qftReg->MReg(0, baseLen);
-
-    //These are the two eigenvectors in the available set, with eigenvalue phase of "n," an integer.
-    check = (res == 31) || (res == 1);
-
-    REQUIRE(check);
-}
-
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_set_reg")
 {
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0));

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -1289,28 +1289,19 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_qft_h")
 
     int i, j;
 
-    // std::cout << "Quantum Fourier transform of 85 (1+4+16+64), with 1 bits first passed through Hadamard gates:"
-    //           << std::endl;
+    for (i = 0; i < 8; i += 2) {
+        qftReg->H(i);
+    }
+
+    qftReg->QFT(0, 8);
+
+    qftReg->IQFT(0, 8);
 
     for (i = 0; i < 8; i += 2) {
         qftReg->H(i);
     }
 
-    // std::cout << "Initial:" << std::endl;
-    // for (i = 0; i < 8; i++) {
-    //     std::cout << "Bit " << i << ", Chance of 1:" << qftReg->Prob(i) << std::endl;
-    // }
-
-    qftReg->QFT(0, 8);
-
-    // std::cout << "Final:" << std::endl;
-    // for (i = 0; i < 8; i++) {
-    //    qftProbs[i] = qftReg->Prob(i);
-    //    std::cout << "Bit " << i << ", Chance of 1:" << qftProbs[i] << std::endl;
-    //}
-
-    // TODO: Without the cout statements, this provides no verification, except that the method doesn't throw an
-    // exception.
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 85));
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_zero_phase_flip")
@@ -1619,7 +1610,9 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_grover_lookup")
     free(toLoad);
 }
 
-void ExpMod(QInterfacePtr qftReg, bitCapInt base, bitLenInt baseStart, bitLenInt baseLen, bitLenInt expStart, bitLenInt expLen, bitLenInt carryStart) {
+void ExpMod(QInterfacePtr qftReg, bitCapInt base, bitLenInt baseStart, bitLenInt baseLen, bitLenInt expStart,
+    bitLenInt expLen, bitLenInt carryStart)
+{
     bitCapInt workingPower = base;
     bitLenInt regStart1, regStart2;
     bitLenInt i;
@@ -1639,30 +1632,41 @@ void ExpMod(QInterfacePtr qftReg, bitCapInt base, bitLenInt baseStart, bitLenInt
     }
     if (i & 1) {
         qftReg->CNOT(carryStart, baseStart, baseLen);
+        qftReg->SetReg(carryStart, baseLen, 0);
     }
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_expmod")
 {
-    bitLenInt baseLen = 6;
+    bitLenInt baseLen = 4;
     bitLenInt expLen = 2;
     qftReg->SetPermutation(1);
     // Last bits are exponent:
     qftReg->SetReg(20 - expLen, expLen, 2);
-    ExpMod(qftReg, 5, 0, baseLen, 20 - expLen, expLen, 2 * baseLen);  
+    ExpMod(qftReg, 5, 0, baseLen, 20 - expLen, expLen, 2 * baseLen);
     REQUIRE_THAT(qftReg, HasProbability(0, baseLen, 25));
 }
 
-TEST_CASE_METHOD(QInterfaceTestFixture, "test_discretelog")
+TEST_CASE_METHOD(QInterfaceTestFixture, "test_phase_est")
 {
     bitLenInt baseLen = 6;
     bitLenInt expLen = 2;
+    bitCapInt res;
+    bool check;
+    
     qftReg->SetPermutation(1);
     // Last bits are exponent:
     qftReg->H(20 - expLen, expLen);
-    ExpMod(qftReg, 5, 0, baseLen, 20 - expLen, expLen, 2 * baseLen);  
-    qftReg->QFT(0, baseLen);
-    REQUIRE_THAT(qftReg, HasProbability(20 - expLen, expLen, 4));
+    ExpMod(qftReg, 31, 0, baseLen, 20 - expLen, expLen, 2 * baseLen);
+
+    qftReg->IQFT(20 - expLen, expLen);
+    qftReg->MReg(20 - expLen, expLen);
+    res = qftReg->MReg(0, baseLen);
+
+    //These are the two eigenvectors in the available set, with eigenvalue phase of "n," an integer.
+    check = (res == 31) || (res == 1);
+
+    REQUIRE(check);
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_set_reg")


### PR DESCRIPTION
This fixes a bug found in QUnit while implementing a modulo exponentiation example. For convenience, it also adds an inverse "QFT" method.