### PR TITLE
Reverse Complex2 components

### DIFF
--- a/include/common/complex8x2simd.hpp
+++ b/include/common/complex8x2simd.hpp
@@ -27,7 +27,7 @@ struct Complex8x2Simd {
     inline Complex8x2Simd(const __m128& v2) { _val2 = v2; }
     inline Complex8x2Simd(const float& r1, const float& i1, const float& r2, const float& i2)
     {
-        _val2 = _mm_set_ps(i1, r1, i2, r2);
+        _val2 = _mm_set_ps(i2, r2, i1, r1);
     }
     inline Complex8x2Simd operator+(const Complex8x2Simd& other) const { return _mm_add_ps(_val2, other._val2); }
     inline Complex8x2Simd operator+=(const Complex8x2Simd& other)

--- a/src/qengine/state.cpp
+++ b/src/qengine/state.cpp
@@ -140,7 +140,7 @@ union ComplexUnion {
     inline ComplexUnion(){};
     inline ComplexUnion(const complex& cmplx0, const complex& cmplx1)
     {
-        cmplx2 = complex2(real(cmplx1), imag(cmplx1), real(cmplx0), imag(cmplx0));
+        cmplx2 = complex2(real(cmplx0), imag(cmplx0), real(cmplx1), imag(cmplx1));
     }
 };
 #else

--- a/src/qengine/state.cpp
+++ b/src/qengine/state.cpp
@@ -130,7 +130,6 @@ void QEngineCPU::GetQuantumState(complex* outputState)
      * A fundamental operation used by almost all gates.
      */
 
-/*
 #if ENABLE_COMPLEX_X2
 
 #if ENABLE_COMPLEX8
@@ -141,7 +140,7 @@ union ComplexUnion {
     inline ComplexUnion(){};
     inline ComplexUnion(const complex& cmplx0, const complex& cmplx1)
     {
-        cmplx2 = complex2(real(cmplx0), imag(cmplx0), real(cmplx1), imag(cmplx1));
+        cmplx2 = complex2(real(cmplx1), imag(cmplx1), real(cmplx0), imag(cmplx0));
     }
 };
 #else
@@ -156,7 +155,6 @@ union ComplexUnion {
         cmplx[1] = cmplx1;
     }
 };
-#endif
 #endif
 
 void QEngineCPU::Apply2x2(bitCapInt offset1, bitCapInt offset2, const complex* mtrx, const bitLenInt bitCount,
@@ -208,7 +206,7 @@ void QEngineCPU::Apply2x2(bitCapInt offset1, bitCapInt offset2, const complex* m
     }
 }
 #else
-*/
+
 void QEngineCPU::Apply2x2(bitCapInt offset1, bitCapInt offset2, const complex* mtrx, const bitLenInt bitCount,
     const bitCapInt* qPowersSorted, bool doCalcNorm)
 {
@@ -254,7 +252,7 @@ void QEngineCPU::Apply2x2(bitCapInt offset1, bitCapInt offset2, const complex* m
         }
     }
 }
-//#endif
+#endif
 
 /**
  * Combine (a copy of) another QEngineCPU with this one, after the last bit

--- a/src/qengine/state.cpp
+++ b/src/qengine/state.cpp
@@ -206,7 +206,6 @@ void QEngineCPU::Apply2x2(bitCapInt offset1, bitCapInt offset2, const complex* m
     }
 }
 #else
-
 void QEngineCPU::Apply2x2(bitCapInt offset1, bitCapInt offset2, const complex* mtrx, const bitLenInt bitCount,
     const bitCapInt* qPowersSorted, bool doCalcNorm)
 {


### PR DESCRIPTION
Reversing the initialization components of ComplexUnion gives parity with all other implementations, for effective order of input matrices.