### PR TITLE
QFusion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ add_library (qrack STATIC
     src/qengine/operators.cpp
     src/qengine/gates.cpp
     src/qengine/state.cpp
+    src/qfusion.cpp
     src/qunit.cpp
     )
 
@@ -104,6 +105,7 @@ install (FILES
     include/qfactory.hpp
     include/qengine.hpp
     include/qengine_cpu.hpp
+    include/qfusion.hpp
     include/qunit.hpp
     include/qunitmulti.hpp
     include/qengine_opencl.hpp

--- a/include/qengine.hpp
+++ b/include/qengine.hpp
@@ -33,8 +33,6 @@ public:
     virtual ~QEngine(){};
 
     virtual bool ForceM(bitLenInt qubitIndex, bool result, bool doForce = true, real1 nrmlzr = 1.0);
-    using QInterface::M;
-    virtual bool M(bitLenInt qubit);
     virtual bitCapInt ForceM(const bitLenInt* bits, const bitLenInt& length, const bool* values);
     virtual bitCapInt ForceMReg(bitLenInt start, bitLenInt length, bitCapInt result, bool doForce = true);
 

--- a/include/qfactory.hpp
+++ b/include/qfactory.hpp
@@ -26,7 +26,8 @@ namespace Qrack {
 
 /** Factory method to create specific engine implementations. */
 template <typename... Ts>
-QInterfacePtr CreateQuantumInterface(QInterfaceEngine engine, QInterfaceEngine subengine1, QInterfaceEngine subengine2, Ts... args)
+QInterfacePtr CreateQuantumInterface(
+    QInterfaceEngine engine, QInterfaceEngine subengine1, QInterfaceEngine subengine2, Ts... args)
 {
     switch (engine) {
     case QINTERFACE_CPU:

--- a/include/qfactory.hpp
+++ b/include/qfactory.hpp
@@ -13,6 +13,7 @@
 #pragma once
 
 #include "qengine_cpu.hpp"
+#include "qfusion.hpp"
 
 #if ENABLE_OPENCL
 #include "qengine_opencl.hpp"
@@ -25,6 +26,27 @@ namespace Qrack {
 
 /** Factory method to create specific engine implementations. */
 template <typename... Ts>
+QInterfacePtr CreateQuantumInterface(QInterfaceEngine engine, QInterfaceEngine subengine1, QInterfaceEngine subengine2, Ts... args)
+{
+    switch (engine) {
+    case QINTERFACE_CPU:
+        return std::make_shared<QEngineCPU>(args...);
+#if ENABLE_OPENCL
+    case QINTERFACE_OPENCL:
+        return std::make_shared<QEngineOCL>(args...);
+    case QINTERFACE_QUNITMULTI:
+        return std::make_shared<QUnitMulti>(args...);
+#endif
+    case QINTERFACE_QFUSION:
+        return std::make_shared<QFusion>(subengine1, args...);
+    case QINTERFACE_QUNIT:
+        return std::make_shared<QUnit>(subengine1, subengine2, args...);
+    default:
+        return NULL;
+    }
+}
+
+template <typename... Ts>
 QInterfacePtr CreateQuantumInterface(QInterfaceEngine engine, QInterfaceEngine subengine, Ts... args)
 {
     switch (engine) {
@@ -36,8 +58,24 @@ QInterfacePtr CreateQuantumInterface(QInterfaceEngine engine, QInterfaceEngine s
     case QINTERFACE_QUNITMULTI:
         return std::make_shared<QUnitMulti>(args...);
 #endif
+    case QINTERFACE_QFUSION:
+        return std::make_shared<QFusion>(subengine, args...);
     case QINTERFACE_QUNIT:
         return std::make_shared<QUnit>(subengine, args...);
+    default:
+        return NULL;
+    }
+}
+
+template <typename... Ts> QInterfacePtr CreateQuantumInterface(QInterfaceEngine engine, Ts... args)
+{
+    switch (engine) {
+    case QINTERFACE_CPU:
+        return std::make_shared<QEngineCPU>(args...);
+#if ENABLE_OPENCL
+    case QINTERFACE_OPENCL:
+        return std::make_shared<QEngineOCL>(args...);
+#endif
     default:
         return NULL;
     }

--- a/include/qfusion.hpp
+++ b/include/qfusion.hpp
@@ -35,8 +35,9 @@ protected:
         bitBuffers.resize(qb);
     }
 
-    virtual void NormalizeState(real1 nrm = -999.0) {
-        //Intentionally left blank
+    virtual void NormalizeState(real1 nrm = -999.0)
+    {
+        // Intentionally left blank
     }
 
 public:
@@ -51,7 +52,10 @@ public:
     using QInterface::Cohere;
     virtual bitLenInt Cohere(QInterfacePtr toCopy) { return Cohere(std::dynamic_pointer_cast<QFusion>(toCopy)); }
     virtual bitLenInt Cohere(QFusionPtr toCopy);
-    virtual void Decohere(bitLenInt start, bitLenInt length, QInterfacePtr dest) { Decohere(start, length, std::dynamic_pointer_cast<QFusion>(dest)); }
+    virtual void Decohere(bitLenInt start, bitLenInt length, QInterfacePtr dest)
+    {
+        Decohere(start, length, std::dynamic_pointer_cast<QFusion>(dest));
+    }
     virtual void Decohere(bitLenInt start, bitLenInt length, QFusionPtr dest);
     virtual void Dispose(bitLenInt start, bitLenInt length);
     virtual void ApplySingleBit(const complex* mtrx, bool doCalcNorm, bitLenInt qubitIndex);
@@ -117,7 +121,7 @@ public:
     virtual void SqrtSwap(bitLenInt qubitIndex1, bitLenInt qubitIndex2);
     virtual void ISqrtSwap(bitLenInt qubitIndex1, bitLenInt qubitIndex2);
 
-    virtual void CopyState(QInterfacePtr orig) { return CopyState(std::dynamic_pointer_cast<QFusion>(orig)); } 
+    virtual void CopyState(QInterfacePtr orig) { return CopyState(std::dynamic_pointer_cast<QFusion>(orig)); }
     virtual void CopyState(QFusionPtr orig);
     virtual bool IsPhaseSeparable(bool forceCheck = false);
     virtual real1 Prob(bitLenInt qubitIndex);

--- a/include/qfusion.hpp
+++ b/include/qfusion.hpp
@@ -27,14 +27,95 @@ protected:
 
     std::vector<std::shared_ptr<complex[4]>> bitBuffers;
 
+    virtual void NormalizeState(real1 nrm = -999.0);
+
 public:
-    QFusion(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState = 0,
+    QFusion(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState,
         std::shared_ptr<std::default_random_engine> rgp = nullptr);
 
-    void ApplySingleBit(const complex* mtrx, bool doCalcNorm, bitLenInt qubitIndex);
+    virtual void SetQuantumState(complex* inputState);
+    virtual void GetQuantumState(complex* outputState);
+    virtual complex GetAmplitude(bitCapInt perm);
+    virtual void SetPermutation(bitCapInt perm);
+    virtual bitLenInt Cohere(QInterfacePtr toCopy);
+    virtual std::map<QInterfacePtr, bitLenInt> Cohere(std::vector<QInterfacePtr> toCopy);
+    virtual void Decohere(bitLenInt start, bitLenInt length, QInterfacePtr dest);
+    virtual void Dispose(bitLenInt start, bitLenInt length);
+    virtual void ApplySingleBit(const complex* mtrx, bool doCalcNorm, bitLenInt qubitIndex);
+    virtual void ApplyControlledSingleBit(
+        const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& target, const complex* mtrx);
+    virtual void ApplyAntiControlledSingleBit(
+        const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& target, const complex* mtrx);
+    virtual void CSwap(
+        const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& qubit1, const bitLenInt& qubit2);
+    virtual void AntiCSwap(
+        const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& qubit1, const bitLenInt& qubit2);
+    virtual void CSqrtSwap(
+        const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& qubit1, const bitLenInt& qubit2);
+    virtual void AntiCSqrtSwap(
+        const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& qubit1, const bitLenInt& qubit2);
+    virtual void CISqrtSwap(
+        const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& qubit1, const bitLenInt& qubit2);
+    virtual void AntiCISqrtSwap(
+        const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& qubit1, const bitLenInt& qubit2);
+    virtual bool ForceM(bitLenInt qubit, bool result, bool doForce = true, real1 nrmlzr = ONE_R1);
+
+    virtual void INC(bitCapInt toAdd, bitLenInt start, bitLenInt length);
+    virtual void CINC(
+        bitCapInt toAdd, bitLenInt inOutStart, bitLenInt length, bitLenInt* controls, bitLenInt controlLen);
+    virtual void INCC(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt carryIndex);
+    virtual void INCS(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt overflowIndex);
+    virtual void INCSC(
+        bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt overflowIndex, bitLenInt carryIndex);
+    virtual void INCSC(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt carryIndex);
+    virtual void INCBCD(bitCapInt toAdd, bitLenInt start, bitLenInt length);
+    virtual void INCBCDC(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt carryIndex);
+    virtual void DEC(bitCapInt toSub, bitLenInt start, bitLenInt length);
+    virtual void CDEC(
+        bitCapInt toSub, bitLenInt inOutStart, bitLenInt length, bitLenInt* controls, bitLenInt controlLen);
+    virtual void DECC(bitCapInt toSub, bitLenInt start, bitLenInt length, bitLenInt carryIndex);
+    virtual void DECS(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt overflowIndex);
+    virtual void DECSC(
+        bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt overflowIndex, bitLenInt carryIndex);
+    virtual void DECSC(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt carryIndex);
+    virtual void DECBCD(bitCapInt toAdd, bitLenInt start, bitLenInt length);
+    virtual void DECBCDC(bitCapInt toSub, bitLenInt start, bitLenInt length, bitLenInt carryIndex);
+    virtual void MUL(bitCapInt toMul, bitLenInt inOutStart, bitLenInt carryStart, bitLenInt length);
+    virtual void DIV(bitCapInt toDiv, bitLenInt inOutStart, bitLenInt carryStart, bitLenInt length);
+    virtual void CMUL(bitCapInt toMul, bitLenInt inOutStart, bitLenInt carryStart, bitLenInt length,
+        bitLenInt* controls, bitLenInt controlLen);
+    virtual void CDIV(bitCapInt toDiv, bitLenInt inOutStart, bitLenInt carryStart, bitLenInt length,
+        bitLenInt* controls, bitLenInt controlLen);
+
+    virtual void ZeroPhaseFlip(bitLenInt start, bitLenInt length);
+    virtual void CPhaseFlipIfLess(bitCapInt greaterPerm, bitLenInt start, bitLenInt length, bitLenInt flagIndex);
+    virtual void PhaseFlipIfLess(bitCapInt greaterPerm, bitLenInt start, bitLenInt length);
+    virtual void PhaseFlip();
+
+    virtual bitCapInt IndexedLDA(bitLenInt indexStart, bitLenInt indexLength, bitLenInt valueStart,
+        bitLenInt valueLength, unsigned char* values);
+    virtual bitCapInt IndexedADC(bitLenInt indexStart, bitLenInt indexLength, bitLenInt valueStart,
+        bitLenInt valueLength, bitLenInt carryIndex, unsigned char* values);
+    virtual bitCapInt IndexedSBC(bitLenInt indexStart, bitLenInt indexLength, bitLenInt valueStart,
+        bitLenInt valueLength, bitLenInt carryIndex, unsigned char* values);
+
+    virtual void Swap(bitLenInt qubitIndex1, bitLenInt qubitIndex2);
+    virtual void SqrtSwap(bitLenInt qubitIndex1, bitLenInt qubitIndex2);
+    virtual void ISqrtSwap(bitLenInt qubitIndex1, bitLenInt qubitIndex2);
+
+    virtual void CopyState(QInterfacePtr orig);
+    virtual bool IsPhaseSeparable(bool forceCheck = false);
+    virtual real1 Prob(bitLenInt qubitIndex);
+    virtual real1 ProbAll(bitCapInt fullRegister);
+
 
 protected:
-    inline void FlushBit(bitLenInt qubitIndex) { if (bitBuffers[qubitIndex]) qReg->ApplySingleBit(bitBuffers[qubitIndex].get(), true, qubitIndex); }
+    inline void FlushBit(bitLenInt qubitIndex) { 
+        if (bitBuffers[qubitIndex]) {
+            qReg->ApplySingleBit(bitBuffers[qubitIndex].get(), true, qubitIndex);
+            bitBuffers[qubitIndex] = NULL;
+        }
+    }
     inline void FlushReg(const bitLenInt& start, const bitLenInt& length);
 };
 }

--- a/include/qfusion.hpp
+++ b/include/qfusion.hpp
@@ -23,7 +23,6 @@ class QFusion : public QInterface {
 protected:
     static const bitLenInt MIN_FUSION_BITS = 3U;
     QInterfacePtr qReg;
-    QInterfaceEngine engineType;
     std::shared_ptr<std::default_random_engine> rand_generator;
 
     std::vector<std::shared_ptr<complex[4]>> bitBuffers;

--- a/include/qfusion.hpp
+++ b/include/qfusion.hpp
@@ -21,6 +21,7 @@ typedef std::shared_ptr<QFusion> QFusionPtr;
 
 class QFusion : public QInterface {
 protected:
+    static const bitLenInt MIN_FUSION_BITS = 3U;
     QInterfacePtr qReg;
     QInterfaceEngine engineType;
     std::shared_ptr<std::default_random_engine> rand_generator;

--- a/include/qfusion.hpp
+++ b/include/qfusion.hpp
@@ -47,12 +47,12 @@ public:
     virtual void GetQuantumState(complex* outputState);
     virtual complex GetAmplitude(bitCapInt perm);
     virtual void SetPermutation(bitCapInt perm);
+    virtual void SetReg(bitLenInt start, bitLenInt length, bitCapInt value);
+    using QInterface::Cohere;
+    virtual bitLenInt Cohere(QInterfacePtr toCopy) { return Cohere(std::dynamic_pointer_cast<QFusion>(toCopy)); }
     virtual bitLenInt Cohere(QFusionPtr toCopy);
-    virtual std::map<QInterfacePtr, bitLenInt> Cohere(std::vector<QFusionPtr> toCopy);
-    virtual bitLenInt Cohere(QInterfacePtr toCopy);
-    virtual std::map<QInterfacePtr, bitLenInt> Cohere(std::vector<QInterfacePtr> toCopy);
+    virtual void Decohere(bitLenInt start, bitLenInt length, QInterfacePtr dest) { Decohere(start, length, std::dynamic_pointer_cast<QFusion>(dest)); }
     virtual void Decohere(bitLenInt start, bitLenInt length, QFusionPtr dest);
-    virtual void Decohere(bitLenInt start, bitLenInt length, QInterfacePtr dest);
     virtual void Dispose(bitLenInt start, bitLenInt length);
     virtual void ApplySingleBit(const complex* mtrx, bool doCalcNorm, bitLenInt qubitIndex);
     virtual void ApplyControlledSingleBit(
@@ -72,6 +72,7 @@ public:
     virtual void AntiCISqrtSwap(
         const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& qubit1, const bitLenInt& qubit2);
     virtual bool ForceM(bitLenInt qubit, bool result, bool doForce = true, real1 nrmlzr = ONE_R1);
+    virtual bitCapInt ForceMReg(bitLenInt start, bitLenInt length, bitCapInt result, bool doForce = true);
 
     virtual void INC(bitCapInt toAdd, bitLenInt start, bitLenInt length);
     virtual void CINC(
@@ -116,10 +117,11 @@ public:
     virtual void SqrtSwap(bitLenInt qubitIndex1, bitLenInt qubitIndex2);
     virtual void ISqrtSwap(bitLenInt qubitIndex1, bitLenInt qubitIndex2);
 
+    virtual void CopyState(QInterfacePtr orig) { return CopyState(std::dynamic_pointer_cast<QFusion>(orig)); } 
     virtual void CopyState(QFusionPtr orig);
-    virtual void CopyState(QInterfacePtr orig);
     virtual bool IsPhaseSeparable(bool forceCheck = false);
     virtual real1 Prob(bitLenInt qubitIndex);
+    virtual real1 ProbReg(const bitLenInt& start, const bitLenInt& length, const bitCapInt& permutation);
     virtual real1 ProbAll(bitCapInt fullRegister);
 
 protected:

--- a/include/qfusion.hpp
+++ b/include/qfusion.hpp
@@ -1,0 +1,40 @@
+//////////////////////////////////////////////////////////////////////////////////////
+//
+// (C) Daniel Strano and the Qrack contributors 2017, 2018. All rights reserved.
+//
+// QUnit maintains explicit separability of qubits as an optimization on a QEngine.
+// See https://arxiv.org/abs/1710.05867
+// (The makers of Qrack have no affiliation with the authors of that paper.)
+//
+// Licensed under the GNU Lesser General Public License V3.
+// See LICENSE.md in the project root or https://www.gnu.org/licenses/lgpl-3.0.en.html
+// for details.
+
+#pragma once
+
+#include "qinterface.hpp"
+
+namespace Qrack {
+
+class QFusion;
+typedef std::shared_ptr<QFusion> QFusionPtr;
+
+class QFusion : public QInterface {
+protected:
+    QInterfacePtr qReg;
+    QInterfaceEngine engineType;
+    std::shared_ptr<std::default_random_engine> rand_generator;
+
+    std::vector<std::shared_ptr<complex[4]>> bitBuffers;
+
+public:
+    QFusion(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState = 0,
+        std::shared_ptr<std::default_random_engine> rgp = nullptr);
+
+    void ApplySingleBit(const complex* mtrx, bool doCalcNorm, bitLenInt qubitIndex);
+
+protected:
+    inline void FlushBit(bitLenInt qubitIndex) { if (bitBuffers[qubitIndex]) qReg->ApplySingleBit(bitBuffers[qubitIndex].get(), true, qubitIndex); }
+    inline void FlushReg(const bitLenInt& start, const bitLenInt& length);
+};
+}

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -63,7 +63,8 @@ enum QInterfaceEngine {
      * Create a QUnit, which utilizes other QInterface classes to minimize the amount of work that's needed for any
      * given operation based on the entanglement of the bits involved.
      *
-     * This, combined with QINTERFACE_QFUSION and QINTERFACE_OPTIMAL, is the recommended object to use as a library consumer.
+     * This, combined with QINTERFACE_QFUSION and QINTERFACE_OPTIMAL, is the recommended object to use as a library
+     * consumer.
      */
     QINTERFACE_QUNIT,
 

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -55,10 +55,15 @@ enum QInterfaceEngine {
     QINTERFACE_OPENCL_MULTI,
 
     /**
+     * Create a QFusion, which is a gate fusion layer between a QEngine and its public interface.
+     */
+    QINTERFACE_QFUSION,
+
+    /**
      * Create a QUnit, which utilizes other QInterface classes to minimize the amount of work that's needed for any
      * given operation based on the entanglement of the bits involved.
      *
-     * This, combined with QINTERFACE_OPTIMAL, is the recommended object to use as a library consumer.
+     * This, combined with QINTERFACE_QFUSION and QINTERFACE_OPTIMAL, is the recommended object to use as a library consumer.
      */
     QINTERFACE_QUNIT,
 

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -86,6 +86,7 @@ public:
     virtual void AntiCISqrtSwap(
         const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& qubit1, const bitLenInt& qubit2);
     virtual void H(bitLenInt qubit);
+    using QInterface::ForceM;
     virtual bool ForceM(bitLenInt qubitIndex, bool result, bool doForce = true, real1 nrmlzr = 1.0);
     virtual void X(bitLenInt qubit);
     virtual void Y(bitLenInt qubit);

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -37,6 +37,7 @@ typedef std::shared_ptr<QUnit> QUnitPtr;
 class QUnit : public QInterface {
 protected:
     QInterfaceEngine engine;
+    QInterfaceEngine subengine;
     std::vector<QEngineShard> shards;
 
     std::shared_ptr<std::default_random_engine> rand_generator;
@@ -48,6 +49,8 @@ protected:
     }
 
 public:
+    QUnit(QInterfaceEngine eng, QInterfaceEngine subEng, bitLenInt qBitCount, bitCapInt initState = 0,
+        std::shared_ptr<std::default_random_engine> rgp = nullptr);
     QUnit(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState = 0,
         std::shared_ptr<std::default_random_engine> rgp = nullptr);
 

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -85,10 +85,6 @@ public:
         const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& qubit1, const bitLenInt& qubit2);
     virtual void AntiCISqrtSwap(
         const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& qubit1, const bitLenInt& qubit2);
-    virtual void CCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target);
-    virtual void AntiCCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target);
-    virtual void CNOT(bitLenInt control, bitLenInt target);
-    virtual void AntiCNOT(bitLenInt control, bitLenInt target);
     virtual void H(bitLenInt qubit);
     virtual bool ForceM(bitLenInt qubitIndex, bool result, bool doForce = true, real1 nrmlzr = 1.0);
     virtual void X(bitLenInt qubit);

--- a/src/qengine/qengine.cpp
+++ b/src/qengine/qengine.cpp
@@ -86,13 +86,13 @@ bitCapInt QEngine::ForceM(const bitLenInt* bits, const bitLenInt& length, const 
             if (M(bits[0])) {
                 return (1U << bits[0]);
             } else {
-                return 0;
+                return 0U;
             }
         } else {
             if (ForceM(bits[0], values[0])) {
                 return (1U << bits[0]);
             } else {
-                return 0;
+                return 0U;
             }
         }
     }
@@ -565,9 +565,9 @@ bitCapInt QEngine::ForceMReg(bitLenInt start, bitLenInt length, bitCapInt result
     // Single bit operations are better optimized for this special case:
     if (length == 1U) {
         if (ForceM(start, result & 1U, doForce)) {
-            return 1U << start;
+            return 1U;
         } else {
-            return 0;
+            return 0U;
         }
     }
 

--- a/src/qengine/qengine.cpp
+++ b/src/qengine/qengine.cpp
@@ -48,6 +48,13 @@ bool QEngine::ForceM(bitLenInt qubit, bool result, bool doForce, real1 nrmlzr)
         NormalizeState();
     }
 
+    // Measurement introduces an overall phase shift. Since it is applied to every state, this will not change the
+    // status of our cached knowledge of phase separability. However, measurement could set some amplitudes to zero,
+    // meaning the relative amplitude phases might only become separable in the process if they are not already.
+    if (knowIsPhaseSeparable && (!isPhaseSeparable)) {
+        knowIsPhaseSeparable = false;
+    }
+
     if (!doForce) {
         real1 prob = Rand();
         real1 oneChance = Prob(qubit);
@@ -70,28 +77,9 @@ bool QEngine::ForceM(bitLenInt qubit, bool result, bool doForce, real1 nrmlzr)
     return result;
 }
 
-/// Measurement gate
-bool QEngine::M(bitLenInt qubit)
-{
-    // Measurement introduces an overall phase shift. Since it is applied to every state, this will not change the
-    // status of our cached knowledge of phase separability. However, measurement could set some amplitudes to zero,
-    // meaning the relative amplitude phases might only become separable in the process if they are not already.
-    if (knowIsPhaseSeparable && (!isPhaseSeparable)) {
-        knowIsPhaseSeparable = false;
-    }
-    return ForceM(qubit, false, false);
-}
-
 /// Measure permutation state of a register
 bitCapInt QEngine::ForceM(const bitLenInt* bits, const bitLenInt& length, const bool* values)
 {
-    // Measurement introduces an overall phase shift. Since it is applied to every state, this will not change the
-    // status of our cached knowledge of phase separability. However, measurement could set some amplitudes to zero,
-    // meaning the relative amplitude phases might only become separable in the process if they are not already.
-    if (knowIsPhaseSeparable && (!isPhaseSeparable)) {
-        knowIsPhaseSeparable = false;
-    }
-
     // Single bit operations are better optimized for this special case:
     if (length == 1) {
         if (values == NULL) {
@@ -107,6 +95,13 @@ bitCapInt QEngine::ForceM(const bitLenInt* bits, const bitLenInt& length, const 
                 return 0;
             }
         }
+    }
+
+    // Measurement introduces an overall phase shift. Since it is applied to every state, this will not change the
+    // status of our cached knowledge of phase separability. However, measurement could set some amplitudes to zero,
+    // meaning the relative amplitude phases might only become separable in the process if they are not already.
+    if (knowIsPhaseSeparable && (!isPhaseSeparable)) {
+        knowIsPhaseSeparable = false;
     }
 
     if (runningNorm != ONE_R1) {
@@ -567,20 +562,20 @@ void QEngine::ProbMaskAll(const bitCapInt& mask, real1* probsArray)
 /// Measure permutation state of a register
 bitCapInt QEngine::ForceMReg(bitLenInt start, bitLenInt length, bitCapInt result, bool doForce)
 {
+    // Single bit operations are better optimized for this special case:
+    if (length == 1U) {
+        if (ForceM(start, result & 1U, doForce)) {
+            return 1U << start;
+        } else {
+            return 0;
+        }
+    }
+
     // Measurement introduces an overall phase shift. Since it is applied to every state, this will not change the
     // status of our cached knowledge of phase separability. However, measurement could set some amplitudes to zero,
     // meaning the relative amplitude phases might only become separable in the process if they are not already.
     if (knowIsPhaseSeparable && (!isPhaseSeparable)) {
         knowIsPhaseSeparable = false;
-    }
-
-    // Single bit operations are better optimized for this special case:
-    if (length == 1) {
-        if (M(start)) {
-            return 1;
-        } else {
-            return 0;
-        }
     }
 
     if (runningNorm != ONE_R1) {

--- a/src/qfusion.cpp
+++ b/src/qfusion.cpp
@@ -11,8 +11,8 @@
 // See LICENSE.md in the project root or https://www.gnu.org/licenses/lgpl-3.0.en.html
 // for details.
 
-#include <future>
 #include <ctime>
+#include <future>
 #include <initializer_list>
 #include <map>
 
@@ -21,7 +21,8 @@
 
 namespace Qrack {
 
-QFusion::QFusion(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState, std::shared_ptr<std::default_random_engine> rgp)
+QFusion::QFusion(
+    QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState, std::shared_ptr<std::default_random_engine> rgp)
     : QInterface(qBitCount)
     , engineType(eng)
     , bitBuffers(qBitCount)
@@ -232,7 +233,8 @@ bool QFusion::ForceM(bitLenInt qubit, bool result, bool doForce, real1 nrmlzr)
     return qReg->ForceM(qubit, result, doForce, nrmlzr);
 }
 
-bitCapInt QFusion::ForceMReg(bitLenInt start, bitLenInt length, bitCapInt result, bool doForce) {
+bitCapInt QFusion::ForceMReg(bitLenInt start, bitLenInt length, bitCapInt result, bool doForce)
+{
     FlushReg(start, length);
     return qReg->ForceMReg(start, length, result, doForce);
 }
@@ -398,8 +400,9 @@ void QFusion::PhaseFlipIfLess(bitCapInt greaterPerm, bitLenInt start, bitLenInt 
     qReg->PhaseFlipIfLess(greaterPerm, start, length);
 }
 
-void QFusion::PhaseFlip() {
-    FlushAll(); 
+void QFusion::PhaseFlip()
+{
+    FlushAll();
     qReg->PhaseFlip();
 }
 
@@ -468,7 +471,8 @@ real1 QFusion::Prob(bitLenInt qubitIndex)
     return qReg->Prob(qubitIndex);
 }
 
-real1 QFusion::ProbReg(const bitLenInt& start, const bitLenInt& length, const bitCapInt& permutation) {
+real1 QFusion::ProbReg(const bitLenInt& start, const bitLenInt& length, const bitCapInt& permutation)
+{
     FlushReg(start, length);
     return qReg->ProbReg(start, length, permutation);
 }

--- a/src/qfusion.cpp
+++ b/src/qfusion.cpp
@@ -2,10 +2,9 @@
 //
 // (C) Daniel Strano and the Qrack contributors 2017, 2018. All rights reserved.
 //
-// QUnitMulti is a multiprocessor variant of QUnit.
-// QUnit maintains explicit separability of qubits as an optimization on a QEngine.
-// See https://arxiv.org/abs/1710.05867
-// (The makers of Qrack have no affiliation with the authors of that paper.)
+// QFusion adds an optional "gate fusion" layer on top of a QEngine or QUnit.
+// Single bit gates are buffered in per-bit 2x2 complex matrices, to reduce the cost
+// of successive application of single bit gates to the same bit.
 //
 // Licensed under the GNU Lesser General Public License VMIN_FUSION_BITS.
 // See LICENSE.md in the project root or https://www.gnu.org/licenses/lgpl-3.0.en.html
@@ -38,13 +37,43 @@ QFusion::QFusion(
     qReg = CreateQuantumInterface(engineType, qBitCount, initState, rand_generator);
 }
 
+/**
+ * All buffering operations happen in ApplySingleBit, which underlies the application of all 2x2 complex element matrix
+ * operators, such as H, X, Y, Z, RX, etc..
+ *
+ * Without a QFusion layer, ApplySingleBit applies the Kroenecker product of a 2x2 complex element matrix operator to a
+ * state vector of 2^N elements for N bits. With tensor slicing, this implies a complexity that scales as approximately
+ * 2^(N+1) complex multiplications for each single bit gate application. However, the succesive application of single
+ * bit gate "A" followed by single bit gate "B" is equal to a single application of their matrix product, "B*A". (Note
+ * that B and A do not necessarily "commute," that "B*A" is not generally equal to "A*B," without additional
+ * constraints.)
+ *
+ * Composing two single bit gates into one gate requires a constant 8 complex multiplications. Adding any additional
+ * number of gates requires an additional 8 complex multiplications per gate, independent of the number of qubits in the
+ * composed state vector. Ultimately applying the buffered, composed gate with tensor slicing requires 2^(N+1) complex
+ * multiplications, once. Hence, if a QEngine has at least 3 qubits, the successive application of at least 2 gates on
+ * the same bit is cheaper with "gate fusion," (M-1)*8+2^(N+1) multiplications for M gates instead of 2^(M+N+1)
+ * multiplications.
+ *
+ * QFusion must flush these buffers, applying them to the state vector, when an operation is applied that can't be
+ * buffered (and doesn't "commute") and before output from qubits. The rest of the engine simply wraps the other public
+ * methods of QInterface to flush or discard the buffers as necessary.
+ */
 void QFusion::ApplySingleBit(const complex* mtrx, bool doCalcNorm, bitLenInt qubitIndex)
 {
+    // MIN_FUSION_BITS might be 3 qubits, or more. If there are only 1 or 2 qubits in a QEngine, buffering is definitely
+    // more expensive than directly applying the gates.
     if (qubitCount < MIN_FUSION_BITS) {
+        // Directly apply the gate and return.
         qReg->ApplySingleBit(mtrx, doCalcNorm, qubitIndex);
         return;
     }
 
+    // If we pass the threshold number of qubits for buffering, we just do 2x2 complex matrix multiplication.
+    // We parallelize this, since we can.
+    // If a matrix component is very close to zero, we assume it's floating-point-error on a composition that has an
+    // exactly 0 component, number theoretically. (If it's not exactly 0 by number theory, it's numerically negligible,
+    // and we're safe.)
     std::shared_ptr<complex[4]> outBuffer(new complex[4]);
     if (bitBuffers[qubitIndex]) {
         std::shared_ptr<complex[4]> inBuffer = bitBuffers[qubitIndex];
@@ -79,12 +108,100 @@ void QFusion::ApplySingleBit(const complex* mtrx, bool doCalcNorm, bitLenInt qub
             futures[i].get();
         }
     } else {
+        // Empty buffers are null pointers. If our buffer is empty, we can just copy the first operation into the buffer
+        // as-is.
         std::copy(mtrx, mtrx + 4, outBuffer.get());
     }
 
+    // Replace the buffer, either with a copy of the first gate, or the composition of the old buffer content with the
+    // new gate via "left multiplication" by the new gate.
     bitBuffers[qubitIndex] = outBuffer;
+
+    // Almost all additional methods just wrap operations with buffer flushes, or discard the buffers.
 }
 
+// "Cohere" will increase the cost of application of every currently buffered gate by a factor of 2 per "cohered" qubit,
+// so it's most likely cheaper just to FlushAll() immediately.
+bitLenInt QFusion::Cohere(QFusionPtr toCopy)
+{
+    FlushAll();
+    toCopy->FlushAll();
+    bitLenInt toRet = qReg->Cohere(toCopy->qReg);
+    SetQubitCount(qReg->GetQubitCount());
+    return toRet;
+}
+
+// "Decohere" will reduce the cost of application of every currently buffered gate a by a factor of 2 per "decohered"
+// qubit, so it's definitely cheaper to maintain our buffers until after the Decohere.
+void QFusion::Decohere(bitLenInt start, bitLenInt length, QFusionPtr dest)
+{
+    qReg->Decohere(start, length, dest->qReg);
+    dest->SetQubitCount(length);
+    for (bitLenInt i = 0; i < length; i++) {
+        dest->bitBuffers[i] = bitBuffers[start + i];
+        bitBuffers[start + i] = NULL;
+    }
+    if (length < qubitCount) {
+        bitBuffers.erase(bitBuffers.begin() + start, bitBuffers.begin() + start + length);
+    }
+    SetQubitCount(qReg->GetQubitCount());
+
+    // If the Decohere caused us to fall below the MIN_FUSION_BITS threshold, this is the cheapest buffer application
+    // gets:
+    if (qubitCount < MIN_FUSION_BITS) {
+        FlushAll();
+    }
+    if (dest->GetQubitCount() < MIN_FUSION_BITS) {
+        dest->FlushAll();
+    }
+}
+
+// "Dispose" will reduce the cost of application of every currently buffered gate a by a factor of 2 per "disposed"
+// qubit, so it's definitely cheaper to maintain our buffers until after the Dispose.
+void QFusion::Dispose(bitLenInt start, bitLenInt length)
+{
+    DiscardReg(start, length);
+    qReg->Dispose(start, length);
+
+    // Since we're disposing bits, (and since we assume that the programmer knows that they're separable before calling
+    // "Dispose,") we can just throw the corresponding buffers away:
+    if (length < qubitCount) {
+        bitBuffers.erase(bitBuffers.begin() + start, bitBuffers.begin() + start + length);
+    }
+
+    // If the Dispose caused us to fall below the MIN_FUSION_BITS threshold, this is the cheapest buffer application
+    // gets:
+    SetQubitCount(qReg->GetQubitCount());
+    if (qubitCount < MIN_FUSION_BITS) {
+        FlushAll();
+    }
+}
+
+// "PhaseFlip" can be buffered as a single bit operation to make it cheaper, (equivalent to the application of the gates
+// Z X Z X to any given bit, for example).
+void QFusion::PhaseFlip()
+{
+    // If we're below the buffering threshold, direct application is cheaper.
+    if (qubitCount < MIN_FUSION_BITS) {
+        qReg->PhaseFlip();
+        return;
+    }
+
+    complex pfm[4] = { complex(-ONE_R1, ZERO_R1), complex(ZERO_R1, ZERO_R1), complex(ZERO_R1, ZERO_R1),
+        complex(-ONE_R1, ZERO_R1) };
+    // Try to add this to an existing buffer:
+    for (bitLenInt i = 0; i < qubitCount; i++) {
+        if (bitBuffers[i]) {
+            ApplySingleBit(pfm, false, i);
+            return;
+        }
+    }
+
+    // If no buffer is active, put in the 0 bit:
+    ApplySingleBit(pfm, false, 0);
+}
+
+// Every other operation just wraps the QEngine with the appropriate buffer flushes.
 void QFusion::SetQuantumState(complex* inputState)
 {
     DiscardAll();
@@ -119,47 +236,6 @@ void QFusion::SetBit(bitLenInt qubitIndex, bool value)
 {
     DiscardBit(qubitIndex);
     qReg->SetBit(qubitIndex, value);
-}
-
-bitLenInt QFusion::Cohere(QFusionPtr toCopy)
-{
-    FlushAll();
-    toCopy->FlushAll();
-    bitLenInt toRet = qReg->Cohere(toCopy->qReg);
-    SetQubitCount(qReg->GetQubitCount());
-    return toRet;
-}
-
-void QFusion::Decohere(bitLenInt start, bitLenInt length, QFusionPtr dest)
-{
-    qReg->Decohere(start, length, dest->qReg);
-    dest->SetQubitCount(length);
-    for (bitLenInt i = 0; i < length; i++) {
-        dest->bitBuffers[i] = bitBuffers[start + i];
-        bitBuffers[start + i] = NULL;
-    }
-    if (length < qubitCount) {
-        bitBuffers.erase(bitBuffers.begin() + start, bitBuffers.begin() + start + length);
-    }
-    SetQubitCount(qReg->GetQubitCount());
-    if (qubitCount < MIN_FUSION_BITS) {
-        FlushAll();
-    }
-    if (dest->GetQubitCount() < MIN_FUSION_BITS) {
-        dest->FlushAll();
-    }
-}
-void QFusion::Dispose(bitLenInt start, bitLenInt length)
-{
-    DiscardReg(start, length);
-    qReg->Dispose(start, length);
-    if (length < qubitCount) {
-        bitBuffers.erase(bitBuffers.begin() + start, bitBuffers.begin() + start + length);
-    }
-    SetQubitCount(qReg->GetQubitCount());
-    if (qubitCount < MIN_FUSION_BITS) {
-        FlushAll();
-    }
 }
 
 void QFusion::ApplyControlledSingleBit(
@@ -433,27 +509,6 @@ void QFusion::PhaseFlipIfLess(bitCapInt greaterPerm, bitLenInt start, bitLenInt 
 {
     FlushReg(start, length);
     qReg->PhaseFlipIfLess(greaterPerm, start, length);
-}
-
-void QFusion::PhaseFlip()
-{
-    if (qubitCount < MIN_FUSION_BITS) {
-        qReg->PhaseFlip();
-        return;
-    }
-
-    complex pfm[4] = { complex(-ONE_R1, ZERO_R1), complex(ZERO_R1, ZERO_R1), complex(ZERO_R1, ZERO_R1),
-        complex(-ONE_R1, ZERO_R1) };
-    // Try to add this to an existing buffer:
-    for (bitLenInt i = 0; i < qubitCount; i++) {
-        if (bitBuffers[i]) {
-            ApplySingleBit(pfm, false, i);
-            return;
-        }
-    }
-
-    // If no buffer is active, put in the 0 bit:
-    ApplySingleBit(pfm, false, 0);
 }
 
 bitCapInt QFusion::IndexedLDA(

--- a/src/qfusion.cpp
+++ b/src/qfusion.cpp
@@ -258,19 +258,19 @@ void QFusion::AntiCISqrtSwap(
 
 bool QFusion::ForceM(bitLenInt qubit, bool result, bool doForce, real1 nrmlzr)
 {
-    FlushBit(qubit);
+    FlushAll();
     return qReg->ForceM(qubit, result, doForce, nrmlzr);
 }
 
 bitCapInt QFusion::ForceM(const bitLenInt* bits, const bitLenInt& length, const bool* values)
 {
-    FlushList(bits, length);
+    FlushAll();
     return qReg->ForceM(bits, length, values);
 }
 
 bitCapInt QFusion::ForceMReg(bitLenInt start, bitLenInt length, bitCapInt result, bool doForce)
 {
-    FlushReg(start, length);
+    FlushAll();
     return qReg->ForceMReg(start, length, result, doForce);
 }
 

--- a/src/qfusion.cpp
+++ b/src/qfusion.cpp
@@ -115,7 +115,8 @@ void QFusion::SetReg(bitLenInt start, bitLenInt length, bitCapInt value)
     qReg->SetReg(start, length, value);
 }
 
-void QFusion::SetBit(bitLenInt qubitIndex, bool value) {
+void QFusion::SetBit(bitLenInt qubitIndex, bool value)
+{
     DiscardBit(qubitIndex);
     qReg->SetBit(qubitIndex, value);
 }
@@ -237,7 +238,8 @@ bool QFusion::ForceM(bitLenInt qubit, bool result, bool doForce, real1 nrmlzr)
     return qReg->ForceM(qubit, result, doForce, nrmlzr);
 }
 
-bitCapInt QFusion::ForceM(const bitLenInt* bits, const bitLenInt& length, const bool* values) {
+bitCapInt QFusion::ForceM(const bitLenInt* bits, const bitLenInt& length, const bool* values)
+{
     FlushList(bits, length);
     return qReg->ForceM(bits, length, values);
 }
@@ -417,7 +419,8 @@ void QFusion::PhaseFlip()
         return;
     }
 
-    complex pfm[4] = { complex(-ONE_R1, ZERO_R1), complex(ZERO_R1, ZERO_R1), complex(ZERO_R1, ZERO_R1), complex(-ONE_R1, ZERO_R1) };
+    complex pfm[4] = { complex(-ONE_R1, ZERO_R1), complex(ZERO_R1, ZERO_R1), complex(ZERO_R1, ZERO_R1),
+        complex(-ONE_R1, ZERO_R1) };
     // Try to add this to an existing buffer:
     for (bitLenInt i = 0; i < qubitCount; i++) {
         if (bitBuffers[i]) {
@@ -501,7 +504,8 @@ real1 QFusion::ProbReg(const bitLenInt& start, const bitLenInt& length, const bi
     return qReg->ProbReg(start, length, permutation);
 }
 
-real1 QFusion::ProbMask(const bitCapInt& mask, const bitCapInt& permutation) {
+real1 QFusion::ProbMask(const bitCapInt& mask, const bitCapInt& permutation)
+{
     FlushMask(mask);
     return qReg->ProbMask(mask, permutation);
 }

--- a/src/qfusion.cpp
+++ b/src/qfusion.cpp
@@ -23,7 +23,6 @@ namespace Qrack {
 QFusion::QFusion(
     QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState, std::shared_ptr<std::default_random_engine> rgp)
     : QInterface(qBitCount)
-    , engineType(eng)
     , bitBuffers(qBitCount)
 {
     if (rgp == nullptr) {
@@ -34,7 +33,7 @@ QFusion::QFusion(
         rand_generator = rgp;
     }
 
-    qReg = CreateQuantumInterface(engineType, qBitCount, initState, rand_generator);
+    qReg = CreateQuantumInterface(eng, qBitCount, initState, rand_generator);
 }
 
 /**

--- a/src/qfusion.cpp
+++ b/src/qfusion.cpp
@@ -52,7 +52,7 @@ QFusion::QFusion(
  * number of gates requires an additional 8 complex multiplications per gate, independent of the number of qubits in the
  * composed state vector. Ultimately applying the buffered, composed gate with tensor slicing requires 2^(N+1) complex
  * multiplications, once. Hence, if a QEngine has at least 3 qubits, the successive application of at least 2 gates on
- * the same bit is cheaper with "gate fusion," (M-1)*8+2^(N+1) multiplications for M gates instead of 2^(M+N+1)
+ * the same bit is cheaper with "gate fusion," (M-1)*8+2^(N+1) multiplications for M gates instead of M*(2^(N+1))
  * multiplications.
  *
  * QFusion must flush these buffers, applying them to the state vector, when an operation is applied that can't be

--- a/src/qfusion.cpp
+++ b/src/qfusion.cpp
@@ -12,6 +12,9 @@
 // for details.
 
 #include <future>
+#include <ctime>
+#include <initializer_list>
+#include <map>
 
 #include "qfactory.hpp"
 #include "qfusion.hpp"
@@ -21,6 +24,7 @@ namespace Qrack {
 QFusion::QFusion(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState, std::shared_ptr<std::default_random_engine> rgp)
     : QInterface(qBitCount)
     , engineType(eng)
+    , bitBuffers(qBitCount)
 {
     if (rgp == nullptr) {
         /* Used to control the random seed for all allocated interfaces. */
@@ -31,40 +35,468 @@ QFusion::QFusion(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState,
     }
 
     qReg = CreateQuantumInterface(engineType, qBitCount, initState, rand_generator);
-
-    bitBuffers.resize(qBitCount);
 }
 
-void QFusion::ApplySingleBit(const complex* mtrx, bool doCalcNorm, bitLenInt qubitIndex) {
-     if (qubitCount < 3U) {
-         qReg->ApplySingleBit(mtrx, true, qubitIndex);
-         return;
-     }
+void QFusion::ApplySingleBit(const complex* mtrx, bool doCalcNorm, bitLenInt qubitIndex)
+{
+    if (qubitCount < 3U) {
+        qReg->ApplySingleBit(mtrx, true, qubitIndex);
+        return;
+    }
 
-     std::shared_ptr<complex[4]> outBuffer;
-     if (bitBuffers[qubitIndex]) {
-         std::shared_ptr<complex[4]> inBuffer = bitBuffers[qubitIndex];
-         std::vector<std::future<void>> futures(4);
+    std::shared_ptr<complex[4]> outBuffer;
+    if (bitBuffers[qubitIndex]) {
+        std::shared_ptr<complex[4]> inBuffer = bitBuffers[qubitIndex];
+        std::vector<std::future<void>> futures(4);
 
-         futures[0] = std::async(std::launch::async, [&]() { outBuffer[0] = (mtrx[0] * inBuffer[0]) + (mtrx[1] * inBuffer[2]); });
-         futures[1] = std::async(std::launch::async, [&]() { outBuffer[1] = (mtrx[0] * inBuffer[1]) + (mtrx[1] * inBuffer[3]); });
-         futures[2] = std::async(std::launch::async, [&]() { outBuffer[2] = (mtrx[2] * inBuffer[0]) + (mtrx[3] * inBuffer[2]); });
-         futures[3] = std::async(std::launch::async, [&]() { outBuffer[3] = (mtrx[2] * inBuffer[1]) + (mtrx[3] * inBuffer[3]); });
+        futures[0] = std::async(std::launch::async, [&]() {
+            outBuffer[0] = (mtrx[0] * inBuffer[0]) + (mtrx[1] * inBuffer[2]);
+            if (norm(outBuffer[0]) < min_norm) {
+                outBuffer[0] = complex(ZERO_R1, ZERO_R1);
+            }
+        });
+        futures[1] = std::async(std::launch::async, [&]() {
+            outBuffer[1] = (mtrx[0] * inBuffer[1]) + (mtrx[1] * inBuffer[3]);
+            if (norm(outBuffer[1]) < min_norm) {
+                outBuffer[1] = complex(ZERO_R1, ZERO_R1);
+            }
+        });
+        futures[2] = std::async(std::launch::async, [&]() {
+            outBuffer[2] = (mtrx[2] * inBuffer[0]) + (mtrx[3] * inBuffer[2]);
+            if (norm(outBuffer[2]) < min_norm) {
+                outBuffer[2] = complex(ZERO_R1, ZERO_R1);
+            }
+        });
+        futures[3] = std::async(std::launch::async, [&]() {
+            outBuffer[3] = (mtrx[2] * inBuffer[1]) + (mtrx[3] * inBuffer[3]);
+            if (norm(outBuffer[3]) < min_norm) {
+                outBuffer[3] = complex(ZERO_R1, ZERO_R1);
+            }
+        });
 
-         for (int i = 0; i < 4; i++) {
+        for (int i = 0; i < 4; i++) {
             futures[i].get();
-         }
+        }
 
-         bitBuffers[qubitIndex] = outBuffer;
-     } else {
-         std::copy(mtrx, mtrx + 4, outBuffer.get());
-         bitBuffers[qubitIndex] = outBuffer;
-     }
-}
-
-void QFusion::FlushReg(const bitLenInt& start, const bitLenInt& length) {
-    for (bitLenInt i = 0U; i < length; i++) {
-        FlushBit(start + i);
+        bitBuffers[qubitIndex] = outBuffer;
+    } else {
+        std::copy(mtrx, mtrx + 4, outBuffer.get());
+        bitBuffers[qubitIndex] = outBuffer;
     }
 }
+
+void QFusion::SetQuantumState(complex* inputState)
+{
+    DiscardAll();
+    qReg->SetQuantumState(inputState);
 }
+
+void QFusion::GetQuantumState(complex* outputState)
+{
+    FlushAll();
+    qReg->GetQuantumState(outputState);
+}
+
+complex QFusion::GetAmplitude(bitCapInt perm)
+{
+    FlushAll();
+    return qReg->GetAmplitude(perm);
+}
+
+void QFusion::SetPermutation(bitCapInt perm)
+{
+    DiscardAll();
+    qReg->SetPermutation(perm);
+}
+
+bitLenInt QFusion::Cohere(QFusionPtr toCopy)
+{
+    FlushAll();
+    toCopy->FlushAll();
+    bitLenInt toRet = qReg->Cohere(toCopy->qReg);
+    SetQubitCount(qReg->GetQubitCount());
+    return toRet;
+}
+
+std::map<QInterfacePtr, bitLenInt> QFusion::Cohere(std::vector<QFusionPtr> toCopy)
+{
+    std::vector<QInterfacePtr> tCI(toCopy.size());
+    FlushAll();
+    for (bitLenInt i = 0; i < toCopy.size(); i++) {
+        toCopy[i]->FlushAll();
+        tCI[i] = toCopy[i]->qReg;
+    }
+    std::map<QInterfacePtr, bitLenInt> toRet = qReg->Cohere(tCI);
+    SetQubitCount(qReg->GetQubitCount());
+    return toRet;
+}
+
+bitLenInt QFusion::Cohere(QInterfacePtr toCopy)
+{
+    FlushAll();
+    bitLenInt toRet = qReg->Cohere(toCopy);
+    SetQubitCount(qReg->GetQubitCount());
+    return toRet;
+}
+
+std::map<QInterfacePtr, bitLenInt> QFusion::Cohere(std::vector<QInterfacePtr> toCopy)
+{
+    FlushAll();
+    std::map<QInterfacePtr, bitLenInt> toRet = qReg->Cohere(toCopy);
+    SetQubitCount(qReg->GetQubitCount());
+    return toRet;
+}
+
+void QFusion::Decohere(bitLenInt start, bitLenInt length, QFusionPtr dest)
+{
+    FlushReg(start, length);
+    qReg->Decohere(start, length, dest->qReg);
+    dest->SetQubitCount(length);
+    for (bitLenInt i = 0; i < length; i++) {
+        dest->bitBuffers[i] = bitBuffers[start + i];
+    }
+    bitBuffers.erase(bitBuffers.begin() + start, bitBuffers.begin() + start + length);
+    SetQubitCount(qReg->GetQubitCount());
+    if (qubitCount < 3) {
+        FlushAll();
+    }
+}
+
+void QFusion::Decohere(bitLenInt start, bitLenInt length, QInterfacePtr dest)
+{
+    FlushReg(start, length);
+    qReg->Decohere(start, length, dest);
+    bitBuffers.erase(bitBuffers.begin() + start, bitBuffers.begin() + start + length);
+    SetQubitCount(qReg->GetQubitCount());
+    if (qubitCount < 3) {
+        FlushAll();
+    }
+}
+
+void QFusion::Dispose(bitLenInt start, bitLenInt length)
+{
+    DiscardReg(start, length);
+    qReg->Dispose(start, length);
+    bitBuffers.erase(bitBuffers.begin() + start, bitBuffers.begin() + start + length);
+    SetQubitCount(qReg->GetQubitCount());
+    if (qubitCount < 3) {
+        FlushAll();
+    }
+}
+
+void QFusion::ApplyControlledSingleBit(
+    const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& target, const complex* mtrx)
+{
+    FlushList(controls, controlLen);
+    FlushBit(target);
+    qReg->ApplyControlledSingleBit(controls, controlLen, target, mtrx);
+}
+
+void QFusion::ApplyAntiControlledSingleBit(
+    const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& target, const complex* mtrx)
+{
+    FlushList(controls, controlLen);
+    FlushBit(target);
+    qReg->ApplyAntiControlledSingleBit(controls, controlLen, target, mtrx);
+}
+
+void QFusion::CSwap(
+    const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& qubit1, const bitLenInt& qubit2)
+{
+    FlushList(controls, controlLen);
+    FlushBit(qubit1);
+    FlushBit(qubit2);
+    qReg->CSwap(controls, controlLen, qubit1, qubit2);
+}
+
+void QFusion::AntiCSwap(
+    const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& qubit1, const bitLenInt& qubit2)
+{
+    FlushList(controls, controlLen);
+    FlushBit(qubit1);
+    FlushBit(qubit2);
+    qReg->AntiCSwap(controls, controlLen, qubit1, qubit2);
+}
+
+void QFusion::CSqrtSwap(
+    const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& qubit1, const bitLenInt& qubit2)
+{
+    FlushList(controls, controlLen);
+    FlushBit(qubit1);
+    FlushBit(qubit2);
+    qReg->CSqrtSwap(controls, controlLen, qubit1, qubit2);
+}
+
+void QFusion::AntiCSqrtSwap(
+    const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& qubit1, const bitLenInt& qubit2)
+{
+    FlushList(controls, controlLen);
+    FlushBit(qubit1);
+    FlushBit(qubit2);
+    qReg->AntiCSqrtSwap(controls, controlLen, qubit1, qubit2);
+}
+
+void QFusion::CISqrtSwap(
+    const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& qubit1, const bitLenInt& qubit2)
+{
+    FlushList(controls, controlLen);
+    FlushBit(qubit1);
+    FlushBit(qubit2);
+    qReg->CISqrtSwap(controls, controlLen, qubit1, qubit2);
+}
+
+void QFusion::AntiCISqrtSwap(
+    const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& qubit1, const bitLenInt& qubit2)
+{
+    FlushList(controls, controlLen);
+    FlushBit(qubit1);
+    FlushBit(qubit2);
+    qReg->AntiCISqrtSwap(controls, controlLen, qubit1, qubit2);
+}
+
+bool QFusion::ForceM(bitLenInt qubit, bool result, bool doForce, real1 nrmlzr)
+{
+    FlushBit(qubit);
+    return qReg->ForceM(qubit, result, doForce, nrmlzr);
+}
+
+void QFusion::INC(bitCapInt toAdd, bitLenInt start, bitLenInt length)
+{
+    FlushReg(start, length);
+    qReg->INC(toAdd, start, length);
+}
+
+void QFusion::CINC(bitCapInt toAdd, bitLenInt inOutStart, bitLenInt length, bitLenInt* controls, bitLenInt controlLen)
+{
+    FlushList(controls, controlLen);
+    FlushReg(inOutStart, length);
+    qReg->CINC(toAdd, inOutStart, length, controls, controlLen);
+}
+
+void QFusion::INCC(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt carryIndex)
+{
+    FlushReg(start, length);
+    FlushBit(carryIndex);
+    qReg->INCC(toAdd, start, length, carryIndex);
+}
+
+void QFusion::INCS(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt overflowIndex)
+{
+    FlushReg(start, length);
+    FlushBit(overflowIndex);
+    qReg->INCS(toAdd, start, length, overflowIndex);
+}
+
+void QFusion::INCSC(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt overflowIndex, bitLenInt carryIndex)
+{
+    FlushReg(start, length);
+    FlushBit(overflowIndex);
+    FlushBit(carryIndex);
+    qReg->INCSC(toAdd, start, length, overflowIndex, carryIndex);
+}
+
+void QFusion::INCSC(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt carryIndex)
+{
+    FlushReg(start, length);
+    FlushBit(carryIndex);
+    qReg->INCSC(toAdd, start, length, carryIndex);
+}
+
+void QFusion::INCBCD(bitCapInt toAdd, bitLenInt start, bitLenInt length)
+{
+    FlushReg(start, length);
+    qReg->INCBCD(toAdd, start, length);
+}
+
+void QFusion::INCBCDC(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt carryIndex)
+{
+    FlushReg(start, length);
+    FlushBit(carryIndex);
+    qReg->INCBCDC(toAdd, start, length, carryIndex);
+}
+
+void QFusion::DEC(bitCapInt toSub, bitLenInt start, bitLenInt length)
+{
+    FlushReg(start, length);
+    qReg->DEC(toSub, start, length);
+}
+
+void QFusion::CDEC(bitCapInt toSub, bitLenInt inOutStart, bitLenInt length, bitLenInt* controls, bitLenInt controlLen)
+{
+    FlushList(controls, controlLen);
+    FlushReg(inOutStart, length);
+    qReg->CDEC(toSub, inOutStart, length, controls, controlLen);
+}
+
+void QFusion::DECC(bitCapInt toSub, bitLenInt start, bitLenInt length, bitLenInt carryIndex)
+{
+    FlushReg(start, length);
+    FlushBit(carryIndex);
+    qReg->DECC(toSub, start, length, carryIndex);
+}
+
+void QFusion::DECS(bitCapInt toSub, bitLenInt start, bitLenInt length, bitLenInt overflowIndex)
+{
+    FlushReg(start, length);
+    FlushBit(overflowIndex);
+    qReg->DECS(toSub, start, length, overflowIndex);
+}
+
+void QFusion::DECSC(bitCapInt toSub, bitLenInt start, bitLenInt length, bitLenInt overflowIndex, bitLenInt carryIndex)
+{
+    FlushReg(start, length);
+    FlushBit(overflowIndex);
+    FlushBit(carryIndex);
+    qReg->DECSC(toSub, start, length, overflowIndex, carryIndex);
+}
+
+void QFusion::DECSC(bitCapInt toSub, bitLenInt start, bitLenInt length, bitLenInt carryIndex)
+{
+    FlushReg(start, length);
+    FlushBit(carryIndex);
+    qReg->DECSC(toSub, start, length, carryIndex);
+}
+
+void QFusion::DECBCD(bitCapInt toSub, bitLenInt start, bitLenInt length)
+{
+    FlushReg(start, length);
+    qReg->DECBCD(toSub, start, length);
+}
+
+void QFusion::DECBCDC(bitCapInt toSub, bitLenInt start, bitLenInt length, bitLenInt carryIndex)
+{
+    FlushReg(start, length);
+    FlushBit(carryIndex);
+    qReg->DECBCDC(toSub, start, length, carryIndex);
+}
+
+void QFusion::MUL(bitCapInt toMul, bitLenInt inOutStart, bitLenInt carryStart, bitLenInt length)
+{
+    FlushReg(inOutStart, length);
+    FlushReg(carryStart, length);
+    qReg->MUL(toMul, inOutStart, carryStart, length);
+}
+
+void QFusion::DIV(bitCapInt toDiv, bitLenInt inOutStart, bitLenInt carryStart, bitLenInt length)
+{
+    FlushReg(inOutStart, length);
+    FlushReg(carryStart, length);
+    qReg->DIV(toDiv, inOutStart, carryStart, length);
+}
+
+void QFusion::CMUL(bitCapInt toMul, bitLenInt inOutStart, bitLenInt carryStart, bitLenInt length, bitLenInt* controls,
+    bitLenInt controlLen)
+{
+    FlushList(controls, controlLen);
+    FlushReg(inOutStart, length);
+    FlushReg(carryStart, length);
+    qReg->CMUL(toMul, inOutStart, carryStart, length, controls, controlLen);
+}
+
+void QFusion::CDIV(bitCapInt toDiv, bitLenInt inOutStart, bitLenInt carryStart, bitLenInt length, bitLenInt* controls,
+    bitLenInt controlLen)
+{
+    FlushList(controls, controlLen);
+    FlushReg(inOutStart, length);
+    FlushReg(carryStart, length);
+    qReg->CDIV(toDiv, inOutStart, carryStart, length, controls, controlLen);
+}
+
+void QFusion::ZeroPhaseFlip(bitLenInt start, bitLenInt length)
+{
+    FlushReg(start, length);
+    qReg->ZeroPhaseFlip(start, length);
+}
+
+void QFusion::CPhaseFlipIfLess(bitCapInt greaterPerm, bitLenInt start, bitLenInt length, bitLenInt flagIndex)
+{
+    FlushReg(start, length);
+    FlushBit(flagIndex);
+    qReg->CPhaseFlipIfLess(greaterPerm, start, length, flagIndex);
+}
+
+void QFusion::PhaseFlipIfLess(bitCapInt greaterPerm, bitLenInt start, bitLenInt length)
+{
+    FlushReg(start, length);
+    qReg->PhaseFlipIfLess(greaterPerm, start, length);
+}
+
+void QFusion::PhaseFlip() { qReg->PhaseFlip(); }
+
+bitCapInt QFusion::IndexedLDA(
+    bitLenInt indexStart, bitLenInt indexLength, bitLenInt valueStart, bitLenInt valueLength, unsigned char* values)
+{
+    FlushReg(indexStart, indexLength);
+    FlushReg(valueStart, valueLength);
+    return qReg->IndexedLDA(indexStart, indexLength, valueStart, valueLength, values);
+}
+
+bitCapInt QFusion::IndexedADC(bitLenInt indexStart, bitLenInt indexLength, bitLenInt valueStart, bitLenInt valueLength,
+    bitLenInt carryIndex, unsigned char* values)
+{
+    FlushReg(indexStart, indexLength);
+    FlushReg(valueStart, valueLength);
+    FlushBit(carryIndex);
+    return qReg->IndexedADC(indexStart, indexLength, valueStart, valueLength, carryIndex, values);
+}
+
+bitCapInt QFusion::IndexedSBC(bitLenInt indexStart, bitLenInt indexLength, bitLenInt valueStart, bitLenInt valueLength,
+    bitLenInt carryIndex, unsigned char* values)
+{
+    FlushReg(indexStart, indexLength);
+    FlushReg(valueStart, valueLength);
+    FlushBit(carryIndex);
+    return qReg->IndexedSBC(indexStart, indexLength, valueStart, valueLength, carryIndex, values);
+}
+
+void QFusion::Swap(bitLenInt qubitIndex1, bitLenInt qubitIndex2)
+{
+    std::swap(bitBuffers[qubitIndex1], bitBuffers[qubitIndex2]);
+    qReg->Swap(qubitIndex1, qubitIndex2);
+}
+
+void QFusion::SqrtSwap(bitLenInt qubitIndex1, bitLenInt qubitIndex2)
+{
+    FlushBit(qubitIndex1);
+    FlushBit(qubitIndex2);
+    qReg->SqrtSwap(qubitIndex1, qubitIndex2);
+}
+
+void QFusion::ISqrtSwap(bitLenInt qubitIndex1, bitLenInt qubitIndex2)
+{
+    FlushBit(qubitIndex1);
+    FlushBit(qubitIndex2);
+    qReg->ISqrtSwap(qubitIndex1, qubitIndex2);
+}
+
+void QFusion::CopyState(QFusionPtr orig)
+{
+    FlushAll();
+    orig->FlushAll();
+    qReg->CopyState(orig->qReg);
+}
+
+void QFusion::CopyState(QInterfacePtr orig)
+{
+    FlushAll();
+    qReg->CopyState(orig);
+}
+
+bool QFusion::IsPhaseSeparable(bool forceCheck)
+{
+    FlushAll();
+    return IsPhaseSeparable(forceCheck);
+}
+
+real1 QFusion::Prob(bitLenInt qubitIndex)
+{
+    FlushBit(qubitIndex);
+    return qReg->Prob(qubitIndex);
+}
+
+real1 QFusion::ProbAll(bitCapInt fullRegister)
+{
+    FlushAll();
+    return qReg->ProbAll(fullRegister);
+}
+} // namespace Qrack

--- a/src/qfusion.cpp
+++ b/src/qfusion.cpp
@@ -181,6 +181,10 @@ void QFusion::ApplyAntiControlledSingleBit(
 void QFusion::CSwap(
     const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& qubit1, const bitLenInt& qubit2)
 {
+    if (qubit1 == qubit2) {
+        return;
+    }
+
     FlushList(controls, controlLen);
     FlushBit(qubit1);
     FlushBit(qubit2);
@@ -190,6 +194,10 @@ void QFusion::CSwap(
 void QFusion::AntiCSwap(
     const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& qubit1, const bitLenInt& qubit2)
 {
+    if (qubit1 == qubit2) {
+        return;
+    }
+
     FlushList(controls, controlLen);
     FlushBit(qubit1);
     FlushBit(qubit2);
@@ -199,6 +207,10 @@ void QFusion::AntiCSwap(
 void QFusion::CSqrtSwap(
     const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& qubit1, const bitLenInt& qubit2)
 {
+    if (qubit1 == qubit2) {
+        return;
+    }
+
     FlushList(controls, controlLen);
     FlushBit(qubit1);
     FlushBit(qubit2);
@@ -208,6 +220,10 @@ void QFusion::CSqrtSwap(
 void QFusion::AntiCSqrtSwap(
     const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& qubit1, const bitLenInt& qubit2)
 {
+    if (qubit1 == qubit2) {
+        return;
+    }
+
     FlushList(controls, controlLen);
     FlushBit(qubit1);
     FlushBit(qubit2);
@@ -217,6 +233,10 @@ void QFusion::AntiCSqrtSwap(
 void QFusion::CISqrtSwap(
     const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& qubit1, const bitLenInt& qubit2)
 {
+    if (qubit1 == qubit2) {
+        return;
+    }
+
     FlushList(controls, controlLen);
     FlushBit(qubit1);
     FlushBit(qubit2);
@@ -226,6 +246,10 @@ void QFusion::CISqrtSwap(
 void QFusion::AntiCISqrtSwap(
     const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& qubit1, const bitLenInt& qubit2)
 {
+    if (qubit1 == qubit2) {
+        return;
+    }
+
     FlushList(controls, controlLen);
     FlushBit(qubit1);
     FlushBit(qubit2);
@@ -414,7 +438,6 @@ void QFusion::PhaseFlipIfLess(bitCapInt greaterPerm, bitLenInt start, bitLenInt 
 void QFusion::PhaseFlip()
 {
     if (qubitCount < MIN_FUSION_BITS) {
-        FlushAll();
         qReg->PhaseFlip();
         return;
     }

--- a/src/qfusion.cpp
+++ b/src/qfusion.cpp
@@ -1,0 +1,63 @@
+//////////////////////////////////////////////////////////////////////////////////////
+//
+// (C) Daniel Strano and the Qrack contributors 2017, 2018. All rights reserved.
+//
+// QUnitMulti is a multiprocessor variant of QUnit.
+// QUnit maintains explicit separability of qubits as an optimization on a QEngine.
+// See https://arxiv.org/abs/1710.05867
+// (The makers of Qrack have no affiliation with the authors of that paper.)
+//
+// Licensed under the GNU Lesser General Public License V3.
+// See LICENSE.md in the project root or https://www.gnu.org/licenses/lgpl-3.0.en.html
+// for details.
+
+#include "qfactory.hpp"
+#include "qfusion.hpp"
+
+namespace Qrack {
+
+QFusion::QFusion(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState, std::shared_ptr<std::default_random_engine> rgp)
+    : QInterface(qBitCount)
+    , engineType(eng)
+{
+    if (rgp == nullptr) {
+        /* Used to control the random seed for all allocated interfaces. */
+        rand_generator = std::make_shared<std::default_random_engine>();
+        rand_generator->seed(std::time(0));
+    } else {
+        rand_generator = rgp;
+    }
+
+    qReg = CreateQuantumInterface(engineType, qBitCount, initState, rand_generator);
+
+    bitBuffers.resize(qBitCount);
+}
+
+void QFusion::ApplySingleBit(const complex* mtrx, bool doCalcNorm, bitLenInt qubitIndex) {
+     if (qubitCount < 3U) {
+         qReg->ApplySingleBit(mtrx, true, qubitIndex);
+         return;
+     }
+
+     std::shared_ptr<complex[4]> outBuffer;
+     if (bitBuffers[qubitIndex]) {
+         std::shared_ptr<complex[4]> inBuffer = bitBuffers[qubitIndex];
+
+         outBuffer[0] = (mtrx[0] * inBuffer[0]) + (mtrx[1] * inBuffer[2]);
+         outBuffer[1] = (mtrx[0] * inBuffer[1]) + (mtrx[1] * inBuffer[3]);
+         outBuffer[2] = (mtrx[2] * inBuffer[0]) + (mtrx[3] * inBuffer[2]);
+         outBuffer[3] = (mtrx[2] * inBuffer[1]) + (mtrx[3] * inBuffer[3]);
+
+         bitBuffers[qubitIndex] = outBuffer;
+     } else {
+         std::copy(mtrx, mtrx + 4, outBuffer.get());
+         bitBuffers[qubitIndex] = outBuffer;
+     }
+}
+
+void QFusion::FlushReg(const bitLenInt& start, const bitLenInt& length) {
+    for (bitLenInt i = 0U; i < length; i++) {
+        FlushBit(start + i);
+    }
+}
+}

--- a/src/qinterface/qinterface.cpp
+++ b/src/qinterface/qinterface.cpp
@@ -753,9 +753,15 @@ bitCapInt QInterface::ForceM(const bitLenInt* bits, const bitLenInt& length, con
 // Returns probability of permutation of the register
 real1 QInterface::ProbReg(const bitLenInt& start, const bitLenInt& length, const bitCapInt& permutation)
 {
-    bitCapInt mask = ((1U << length) - 1) << start;
-    bitCapInt perm = permutation << start;
-    return ProbMask(mask, perm);
+    real1 prob = ONE_R1;
+    for (bitLenInt i = 0; i < length; i++) {
+        if (permutation & (1U << i)) {
+            prob *= Prob(start + i);
+        } else {
+            prob *= (ONE_R1 - Prob(start + i));
+        }
+    }
+    return prob;
 }
 
 // Returns probability of permutation of the mask

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -21,8 +21,16 @@ namespace Qrack {
 
 QUnit::QUnit(
     QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState, std::shared_ptr<std::default_random_engine> rgp)
+    : QUnit(eng, eng, qBitCount, initState, rgp)
+{
+    // Intentionally left blank
+}
+
+QUnit::QUnit(QInterfaceEngine eng, QInterfaceEngine subEng, bitLenInt qBitCount, bitCapInt initState,
+    std::shared_ptr<std::default_random_engine> rgp)
     : QInterface(qBitCount)
     , engine(eng)
+    , subengine(subEng)
 {
     if (rgp == nullptr) {
         /* Used to control the random seed for all allocated interfaces. */
@@ -35,7 +43,7 @@ QUnit::QUnit(
     shards.resize(qBitCount);
 
     for (bitLenInt i = 0; i < qBitCount; i++) {
-        shards[i].unit = CreateQuantumInterface(engine, engine, 1, ((1 << i) & initState) >> i, rand_generator);
+        shards[i].unit = CreateQuantumInterface(engine, subengine, 1, ((1 << i) & initState) >> i, rand_generator);
         shards[i].mapped = 0;
     }
 }
@@ -54,7 +62,7 @@ void QUnit::CopyState(QUnit* orig)
         QEngineShard shard;
         shard.mapped = otherShard.mapped;
         if (otherUnits.find(otherShard.unit) == otherUnits.end()) {
-            otherUnits[otherShard.unit] = CreateQuantumInterface(engine, engine, 1, 0, rand_generator);
+            otherUnits[otherShard.unit] = CreateQuantumInterface(engine, subengine, 1, 0, rand_generator);
             otherUnits[otherShard.unit]->CopyState(otherShard.unit);
         }
         shard.unit = otherUnits[otherShard.unit];
@@ -64,7 +72,7 @@ void QUnit::CopyState(QUnit* orig)
 
 void QUnit::CopyState(QInterfacePtr orig)
 {
-    QInterfacePtr unit = CreateQuantumInterface(engine, engine, orig->GetQubitCount(), 0, rand_generator);
+    QInterfacePtr unit = CreateQuantumInterface(engine, subengine, orig->GetQubitCount(), 0, rand_generator);
     unit->CopyState(orig);
 
     SetQubitCount(orig->GetQubitCount());
@@ -83,7 +91,7 @@ void QUnit::SetQuantumState(complex* inputState)
 {
     knowIsPhaseSeparable = false;
 
-    auto unit = CreateQuantumInterface(engine, engine, qubitCount, 0, rand_generator);
+    auto unit = CreateQuantumInterface(engine, subengine, qubitCount, 0, rand_generator);
     unit->SetQuantumState(inputState);
 
     int idx = 0;
@@ -574,7 +582,7 @@ bool QUnit::ForceM(bitLenInt qubit, bool res, bool doForce, real1 nrmlzr)
         return result;
     }
 
-    QInterfacePtr dest = CreateQuantumInterface(engine, engine, 1, result ? 1 : 0, rand_generator);
+    QInterfacePtr dest = CreateQuantumInterface(engine, subengine, 1, result ? 1 : 0, rand_generator);
     unit->Dispose(mapped, 1);
 
     /* Update the mappings. */

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -567,12 +567,7 @@ real1 QUnit::ProbAll(bitCapInt perm)
 
 bool QUnit::ForceM(bitLenInt qubit, bool res, bool doForce, real1 nrmlzr)
 {
-    bool result;
-    if (doForce) {
-        result = shards[qubit].unit->ForceM(shards[qubit].mapped, res, true, nrmlzr);
-    } else {
-        result = shards[qubit].unit->M(shards[qubit].mapped);
-    }
+    bool result = shards[qubit].unit->ForceM(shards[qubit].mapped, res, doForce, nrmlzr);
 
     QInterfacePtr unit = shards[qubit].unit;
     bitLenInt mapped = shards[qubit].mapped;
@@ -1127,9 +1122,7 @@ void QUnit::CPhaseFlipIfLess(bitCapInt greaterPerm, bitLenInt start, bitLenInt l
 
 void QUnit::PhaseFlip()
 {
-    for (auto&& shard : shards) {
-        shard.unit->PhaseFlip();
-    }
+    shards[0].unit->PhaseFlip();
 }
 
 bitCapInt QUnit::IndexedLDA(

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -107,7 +107,7 @@ void QUnit::SetQuantumState(complex* inputState)
 
 void QUnit::GetQuantumState(complex* outputState)
 {
-    QUnit qUnitCopy(engine, 1, 0);
+    QUnit qUnitCopy(engine, subengine, 1, 0);
     qUnitCopy.CopyState((QUnit*)this);
     qUnitCopy.EntangleAll()->GetQuantumState(outputState);
 }
@@ -781,75 +781,6 @@ void QUnit::ApplyEitherControlled(const bitLenInt* controls, const bitLenInt& co
     cfn(unit, controlsMapped);
 
     delete[] controlsMapped;
-}
-
-void QUnit::CCNOT(bitLenInt inputBit1, bitLenInt inputBit2, bitLenInt outputBit)
-{
-    if (((shards[inputBit1].unit) != (shards[outputBit].unit)) ||
-        ((shards[inputBit2].unit) != (shards[outputBit].unit))) {
-        real1 prob = Prob(inputBit1) * Prob(inputBit2);
-        if (prob <= REAL_CLAMP) {
-            return;
-        } else if (REAL_CLAMP >= (ONE_R1 - prob)) {
-            bool isClassical = true;
-            if (shards[inputBit1].unit->IsPhaseSeparable()) {
-                ForceM(inputBit1, true);
-            } else {
-                isClassical = false;
-            }
-            if (isClassical && (shards[inputBit2].unit->IsPhaseSeparable())) {
-                ForceM(inputBit2, true);
-            } else {
-                isClassical = false;
-            }
-            if (isClassical) {
-                X(outputBit);
-                return;
-            }
-        }
-    }
-
-    bitLenInt oCopy = outputBit;
-    EntangleAndCallMember(PTR3(CCNOT), inputBit1, inputBit2, outputBit);
-    TrySeparate({ oCopy });
-}
-
-void QUnit::AntiCCNOT(bitLenInt inputBit1, bitLenInt inputBit2, bitLenInt outputBit)
-{
-    if (((shards[inputBit1].unit) != (shards[outputBit].unit)) ||
-        ((shards[inputBit2].unit) != (shards[outputBit].unit))) {
-        real1 prob = (ONE_R1 - Prob(inputBit1)) * (ONE_R1 - Prob(inputBit2));
-        if (prob <= REAL_CLAMP) {
-            return;
-        } else if (REAL_CLAMP >= (ONE_R1 - prob)) {
-            bool isClassical = true;
-            if (shards[inputBit1].unit->IsPhaseSeparable()) {
-                ForceM(inputBit1, false);
-            } else {
-                isClassical = false;
-            }
-            if (isClassical && (shards[inputBit2].unit->IsPhaseSeparable())) {
-                ForceM(inputBit2, false);
-            } else {
-                isClassical = false;
-            }
-            if (isClassical) {
-                X(outputBit);
-                return;
-            }
-        }
-    }
-
-    bitLenInt oCopy = outputBit;
-    EntangleAndCallMember(PTR3(AntiCCNOT), inputBit1, inputBit2, outputBit);
-    TrySeparate({ oCopy });
-}
-
-void QUnit::CNOT(bitLenInt control, bitLenInt target) { ControlCallMember(PTR2(CNOT), PTR1(X), control, target); }
-
-void QUnit::AntiCNOT(bitLenInt control, bitLenInt target)
-{
-    ControlCallMember(PTR2(AntiCNOT), PTR1(X), control, target, true);
 }
 
 void QUnit::H(bitLenInt qubit) { shards[qubit].unit->H(shards[qubit].mapped); }

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1120,10 +1120,7 @@ void QUnit::CPhaseFlipIfLess(bitCapInt greaterPerm, bitLenInt start, bitLenInt l
         start, flagIndex);
 }
 
-void QUnit::PhaseFlip()
-{
-    shards[0].unit->PhaseFlip();
-}
+void QUnit::PhaseFlip() { shards[0].unit->PhaseFlip(); }
 
 bitCapInt QUnit::IndexedLDA(
     bitLenInt indexStart, bitLenInt indexLength, bitLenInt valueStart, bitLenInt valueLength, unsigned char* values)

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -141,23 +141,23 @@ int main(int argc, char* argv[])
 #endif
 
         if (num_failed == 0 && !disable_qfusion) {
-        testEngineType = QINTERFACE_QUNIT;
-        if (!disable_cpu && !disable_single) {
-            session.config().stream() << "############ QUnit -> QFusion -> CPU ############" << std::endl;
-            testSubEngineType = QINTERFACE_QFUSION;
-            testSubSubEngineType = QINTERFACE_CPU;
-            num_failed = session.run();
-        }
+            testEngineType = QINTERFACE_QUNIT;
+            if (!disable_cpu && !disable_single) {
+                session.config().stream() << "############ QUnit -> QFusion -> CPU ############" << std::endl;
+                testSubEngineType = QINTERFACE_QFUSION;
+                testSubSubEngineType = QINTERFACE_CPU;
+                num_failed = session.run();
+            }
 
 #if ENABLE_OPENCL
-        if (num_failed == 0 && !disable_opencl && !disable_single) {
-            session.config().stream() << "############ QUnit -> QFusion -> OpenCL ############" << std::endl; 
-            testSubEngineType = QINTERFACE_QFUSION;
-            testSubSubEngineType = QINTERFACE_OPENCL;
-            CreateQuantumInterface(testEngineType, testSubEngineType, 1, 0)
-                .reset(); /* Get the OpenCL banner out of the way. */
-            num_failed = session.run();
-        }
+            if (num_failed == 0 && !disable_opencl && !disable_single) {
+                session.config().stream() << "############ QUnit -> QFusion -> OpenCL ############" << std::endl;
+                testSubEngineType = QINTERFACE_QFUSION;
+                testSubSubEngineType = QINTERFACE_OPENCL;
+                CreateQuantumInterface(testEngineType, testSubEngineType, 1, 0)
+                    .reset(); /* Get the OpenCL banner out of the way. */
+                num_failed = session.run();
+            }
 #endif
         }
     }

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -84,6 +84,7 @@ int main(int argc, char* argv[])
             session.config().stream() << "############ QEngine -> OpenCL ############" << std::endl;
             testEngineType = QINTERFACE_OPENCL;
             testSubEngineType = QINTERFACE_OPENCL;
+            testSubSubEngineType = QINTERFACE_OPENCL;
             CreateQuantumInterface(testEngineType, testSubEngineType, 1, 0)
                 .reset(); /* Get the OpenCL banner out of the way. */
             num_failed = session.run();
@@ -94,6 +95,7 @@ int main(int argc, char* argv[])
     if (num_failed == 0 && !disable_qfusion) {
         testEngineType = QINTERFACE_QFUSION;
         testSubEngineType = QINTERFACE_CPU;
+        testSubSubEngineType = QINTERFACE_CPU;
         if (num_failed == 0 && !disable_cpu && !disable_single) {
             session.config().stream() << "############ QFusion -> CPU ############" << std::endl;
             num_failed = session.run();
@@ -104,6 +106,7 @@ int main(int argc, char* argv[])
             session.config().stream() << "############ QFusion -> OpenCL ############" << std::endl;
             testEngineType = QINTERFACE_QFUSION;
             testSubEngineType = QINTERFACE_OPENCL;
+            testSubSubEngineType = QINTERFACE_OPENCL;
             num_failed = session.run();
         }
 #endif
@@ -114,6 +117,7 @@ int main(int argc, char* argv[])
         if (!disable_cpu && !disable_single) {
             session.config().stream() << "############ QUnit -> QEngine -> CPU ############" << std::endl;
             testSubEngineType = QINTERFACE_CPU;
+            testSubEngineType = QINTERFACE_CPU;
             num_failed = session.run();
         }
 
@@ -121,6 +125,7 @@ int main(int argc, char* argv[])
         if (num_failed == 0 && !disable_opencl && !disable_single) {
             session.config().stream() << "############ QUnit -> QEngine -> OpenCL ############" << std::endl;
             testSubEngineType = QINTERFACE_OPENCL;
+            testSubSubEngineType = QINTERFACE_OPENCL;
             CreateQuantumInterface(testEngineType, testSubEngineType, 1, 0)
                 .reset(); /* Get the OpenCL banner out of the way. */
             num_failed = session.run();
@@ -130,6 +135,7 @@ int main(int argc, char* argv[])
             session.config().stream() << "############ QUnitMulti ############" << std::endl;
             testEngineType = QINTERFACE_QUNITMULTI;
             testSubEngineType = QINTERFACE_OPENCL;
+            testSubSubEngineType = QINTERFACE_OPENCL;
             num_failed = session.run();
         }
 #endif

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -1732,7 +1732,8 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_dispose")
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_cohere")
 {
     qftReg = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 4, 0x0b, rng);
-    QInterfacePtr qftReg2 = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 4, 0x02, rng);
+    QInterfacePtr qftReg2 =
+        CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 4, 0x02, rng);
     qftReg->Cohere(qftReg2);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x2b));
 }

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -1707,7 +1707,7 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_sbc_superposition_reg_long_index")
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_decohere")
 {
-    QInterfacePtr qftReg2 = CreateQuantumInterface(testSubEngineType, testSubEngineType, 4, 0, rng);
+    QInterfacePtr qftReg2 = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 4, 0, rng);
 
     qftReg->SetPermutation(0x2b);
     qftReg->Decohere(0, 4, qftReg2);
@@ -1731,8 +1731,8 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_dispose")
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_cohere")
 {
-    qftReg = CreateQuantumInterface(testEngineType, testSubEngineType, 4, 0x0b, rng);
-    QInterfacePtr qftReg2 = CreateQuantumInterface(testSubEngineType, testSubEngineType, 4, 0x02, rng);
+    qftReg = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 4, 0x0b, rng);
+    QInterfacePtr qftReg2 = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 4, 0x02, rng);
     qftReg->Cohere(qftReg2);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x2b));
 }
@@ -1762,7 +1762,7 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_getamplitude")
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_getquantumstate")
 {
     complex state[1U << 4U];
-    qftReg = CreateQuantumInterface(testEngineType, testSubEngineType, 4, 0x0b, rng);
+    qftReg = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 4, 0x0b, rng);
     qftReg->GetQuantumState(state);
     qftReg->SetQuantumState(state);
 }

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -1800,7 +1800,7 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_grover")
     // std::cout << "Full Result:    " << qftReg << std::endl;
     // std::cout << "Per Bit Result: " << std::showpoint << qftReg << std::endl;
 
-    //qftReg->MReg(0, 8);
+    // qftReg->MReg(0, 8);
 
     REQUIRE_THAT(qftReg, HasProbability(0, 16, TARGET_PROB));
 }

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -1800,7 +1800,7 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_grover")
     // std::cout << "Full Result:    " << qftReg << std::endl;
     // std::cout << "Per Bit Result: " << std::showpoint << qftReg << std::endl;
 
-    // qftReg->MReg(0, 8);
+    qftReg->MReg(0, 8);
 
     REQUIRE_THAT(qftReg, HasProbability(0, 16, TARGET_PROB));
 }

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -1800,7 +1800,7 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_grover")
     // std::cout << "Full Result:    " << qftReg << std::endl;
     // std::cout << "Per Bit Result: " << std::showpoint << qftReg << std::endl;
 
-    qftReg->MReg(0, 8);
+    //qftReg->MReg(0, 8);
 
     REQUIRE_THAT(qftReg, HasProbability(0, 16, TARGET_PROB));
 }

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -1899,7 +1899,7 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_quaternary_search")
     const bitLenInt valueLength = 6;
     const bitLenInt carryIndex = 19;
     const int TARGET_VALUE = 6;
-    const int TARGET_KEY = 5;
+    const int TARGET_KEY = 18;
 
     bool foundPerm = false;
 

--- a/test/tests.hpp
+++ b/test/tests.hpp
@@ -26,6 +26,7 @@
  */
 extern enum Qrack::QInterfaceEngine testEngineType;
 extern enum Qrack::QInterfaceEngine testSubEngineType;
+extern enum Qrack::QInterfaceEngine testSubSubEngineType;
 extern std::shared_ptr<std::default_random_engine> rng;
 
 /* Declare the stream-to-probability prior to including catch.hpp. */


### PR DESCRIPTION
This PR adds a (minimal) optional gate fusion layer to Qrack. Since Qrack is based entirely around controlled single bit gate operations, besides arithmetic, it's appropriate that gate fusion is only applied to single bit gates. Hopefully, keeping the standard of controlled single bit gates, we can expand this gate fusion layer to maintain M by 2 by 2 matrix operator buffers for M control bits, as opposed to (2^N) by (2^N) component buffers for N total involved bits.

This passes all unit tests.