### PR TITLE
QFusion semantics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,7 @@ install (FILES
     include/common/complex8x2simd.hpp
     include/common/oclengine.hpp
     include/common/parallel_for.hpp
+    include/common/bitbuffer.hpp
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/qrack/common
     )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ set(PSTRIDE "16" CACHE STRING "Stride of parallel for loops")
 # Declare the library
 add_library (qrack STATIC
     src/common/parallel_for.cpp
+    src/common/bitbuffer.cpp
     src/qinterface/qinterface.cpp
     src/qinterface/protected.cpp
     src/qinterface/operators.cpp

--- a/include/common/bitbuffer.hpp
+++ b/include/common/bitbuffer.hpp
@@ -13,7 +13,10 @@
 
 #pragma once
 
-#include <future>
+#include <vector>
+#include <algorithm>
+
+#include "qinterface.hpp"
 
 namespace Qrack {
 
@@ -31,16 +34,7 @@ struct BitBuffer {
     bool isArithmetic;
     std::vector<bitLenInt> controls;
 
-    BitBuffer(bool antiCtrl, const bitLenInt* cntrls, const bitLenInt& cntrlLen, bool isArith)
-        : anti(antiCtrl)
-        , isArithmetic(isArith)
-        , controls(cntrlLen)
-    {
-        if (cntrlLen > 0) {
-            std::copy(cntrls, cntrls + cntrlLen, controls.begin());
-            std::sort(controls.begin(), controls.end());
-        }
-    }
+    BitBuffer(bool antiCtrl, const bitLenInt* cntrls, const bitLenInt& cntrlLen, bool isArith);
 
     BitBuffer(BitBuffer* toCopy)
         : anti(toCopy->anti)
@@ -52,46 +46,13 @@ struct BitBuffer {
 
     virtual void Apply(QInterfacePtr qReg, const bitLenInt& qubitIndex, std::vector<BitBufferPtr>* bitBuffers) = 0;
 
-    virtual bool CompareControls(BitBufferPtr toCmp)
-    {
-        if (toCmp == NULL) {
-            // If a bit buffer is empty, it's fine to overwrite it.
-            return true;
-        }
-
-        // Otherwise, we return "false" if we need to flush, and true if we can keep buffering.
-
-        if (anti != toCmp->anti) {
-            return false;
-        }
-
-        if (isArithmetic != toCmp->isArithmetic) {
-            return false;
-        }
-
-        if (controls.size() != toCmp->controls.size()) {
-            return false;
-        }
-
-        for (bitLenInt i = 0; i < controls.size(); i++) {
-            if (controls[i] != toCmp->controls[i]) {
-                return false;
-            }
-        }
-
-        return true;
-    }
+    virtual bool Combinable(BitBufferPtr toCmp);
 };
 
 struct GateBuffer : public BitBuffer {
     BitOp matrix;
 
-    GateBuffer(bool antiCtrl, const bitLenInt* cntrls, const bitLenInt& cntrlLen, const complex* mtrx)
-        : BitBuffer(antiCtrl, cntrls, cntrlLen, false)
-        , matrix(new complex[4], std::default_delete<complex[]>())
-    {
-        std::copy(mtrx, mtrx + 4, matrix.get());
-    }
+    GateBuffer(bool antiCtrl, const bitLenInt* cntrls, const bitLenInt& cntrlLen, const complex* mtrx);
 
     GateBuffer(GateBuffer* toCopy, BitOp mtrx)
         : BitBuffer(toCopy)
@@ -100,75 +61,9 @@ struct GateBuffer : public BitBuffer {
         // Intentionally left blank.
     }
 
-    GateBufferPtr LeftMul(BitBufferPtr rightBuffer)
-    {
-        // If we pass the threshold number of qubits for buffering, we just do 2x2 complex matrix multiplication.
-        // We parallelize this, since we can.
-        // If a matrix component is very close to zero, we assume it's floating-point-error on a composition that has an
-        // exactly 0 component, number theoretically. (If it's not exactly 0 by number theory, it's numerically
-        // negligible, and we're safe.)
+    GateBufferPtr LeftMul(BitBufferPtr rightBuffer);
 
-        BitOp outBuffer(new complex[4], std::default_delete<complex[]>());
-
-        if (rightBuffer != NULL) {
-            GateBuffer* rightGate = dynamic_cast<GateBuffer*>(rightBuffer.get());
-            BitOp right = rightGate->matrix;
-
-            std::vector<std::future<void>> futures(4);
-
-            futures[0] = std::async(std::launch::async, [&]() {
-                outBuffer.get()[0] = (matrix.get()[0] * right.get()[0]) + (matrix.get()[1] * right.get()[2]);
-                if (norm(outBuffer.get()[0]) < min_norm) {
-                    outBuffer.get()[0] = complex(ZERO_R1, ZERO_R1);
-                }
-            });
-            futures[1] = std::async(std::launch::async, [&]() {
-                outBuffer.get()[1] = (matrix.get()[0] * right.get()[1]) + (matrix.get()[1] * right.get()[3]);
-                if (norm(outBuffer.get()[1]) < min_norm) {
-                    outBuffer.get()[1] = complex(ZERO_R1, ZERO_R1);
-                }
-            });
-            futures[2] = std::async(std::launch::async, [&]() {
-                outBuffer.get()[2] = (matrix.get()[2] * right.get()[0]) + (matrix.get()[3] * right.get()[2]);
-                if (norm(outBuffer.get()[2]) < min_norm) {
-                    outBuffer.get()[2] = complex(ZERO_R1, ZERO_R1);
-                }
-            });
-            futures[3] = std::async(std::launch::async, [&]() {
-                outBuffer.get()[3] = (matrix.get()[2] * right.get()[1]) + (matrix.get()[3] * right.get()[3]);
-                if (norm(outBuffer.get()[3]) < min_norm) {
-                    outBuffer.get()[3] = complex(ZERO_R1, ZERO_R1);
-                }
-            });
-
-            for (int i = 0; i < 4; i++) {
-                futures[i].get();
-            }
-        } else {
-            std::copy(matrix.get(), matrix.get() + 4, outBuffer.get());
-        }
-
-        return std::make_shared<GateBuffer>(this, outBuffer);
-    }
-
-    virtual void Apply(QInterfacePtr qReg, const bitLenInt& qubitIndex, std::vector<BitBufferPtr>* bitBuffers)
-    {
-        if (controls.size() == 0) {
-            qReg->ApplySingleBit(matrix.get(), true, qubitIndex);
-        } else {
-            bitLenInt* ctrls = new bitLenInt[controls.size()];
-            std::copy(controls.begin(), controls.end(), ctrls);
-
-            if (anti) {
-                qReg->ApplyAntiControlledSingleBit(ctrls, controls.size(), qubitIndex, matrix.get());
-            } else {
-                qReg->ApplyControlledSingleBit(ctrls, controls.size(), qubitIndex, matrix.get());
-            }
-
-            delete[] ctrls;
-        }
-        (*bitBuffers)[qubitIndex] = NULL;
-    }
+    virtual void Apply(QInterfacePtr qReg, const bitLenInt& qubitIndex, std::vector<BitBufferPtr>* bitBuffers);
 };
 
 struct ArithmeticBuffer : public BitBuffer {
@@ -186,52 +81,8 @@ struct ArithmeticBuffer : public BitBuffer {
         // Intentionally left blank.
     }
 
-    virtual bool CompareControls(BitBufferPtr toCmp)
-    {
-        if (toCmp == NULL) {
-            return true;
-        }
+    virtual bool Combinable(BitBufferPtr toCmp);
 
-        if (BitBuffer::CompareControls(toCmp) == false) {
-            return false;
-        }
-
-        ArithmeticBuffer* toCmpArith = dynamic_cast<ArithmeticBuffer*>(toCmp.get());
-        if (start != toCmpArith->start) {
-            return false;
-        }
-
-        if (length != toCmpArith->length) {
-            return false;
-        }
-
-        return true;
-    }
-
-    virtual void Apply(QInterfacePtr qReg, const bitLenInt& qubitIndex, std::vector<BitBufferPtr>* bitBuffers)
-    {
-        if (controls.size() == 0) {
-            if (toAdd > 0) {
-                qReg->INC(toAdd, start, length);
-            } else if (toAdd < 0) {
-                qReg->DEC(-toAdd, start, length);
-            }
-        } else {
-            bitLenInt* ctrls = new bitLenInt[controls.size()];
-            std::copy(controls.begin(), controls.end(), ctrls);
-
-            if (toAdd > 0) {
-                qReg->CINC(toAdd, start, length, ctrls, controls.size());
-            } else if (toAdd < 0) {
-                qReg->CDEC(-toAdd, start, length, ctrls, controls.size());
-            }
-
-            delete[] ctrls;
-        }
-
-        for (bitLenInt i = 0; i < length; i++) {
-            (*bitBuffers)[start + i] = NULL;
-        }
-    }
+    virtual void Apply(QInterfacePtr qReg, const bitLenInt& qubitIndex, std::vector<BitBufferPtr>* bitBuffers);
 };
 } // namespace Qrack

--- a/include/common/bitbuffer.hpp
+++ b/include/common/bitbuffer.hpp
@@ -1,0 +1,237 @@
+//////////////////////////////////////////////////////////////////////////////////////
+//
+// (C) Daniel Strano and the Qrack contributors 2017, 2018. All rights reserved.
+//
+// This header defines buffers for Qrack::QFusion.
+// QFusion adds an optional "gate fusion" layer on top of a QEngine or QUnit.
+// Single bit gates are buffered in per-bit 2x2 complex matrices, to reduce the cost
+// of successive application of single bit gates to the same bit.
+//
+// Licensed under the GNU Lesser General Public License V3.
+// See LICENSE.md in the project root or https://www.gnu.org/licenses/lgpl-3.0.en.html
+// for details.
+
+#pragma once
+
+#include <future>
+
+namespace Qrack {
+
+struct BitBuffer;
+struct GateBuffer;
+struct ArithmeticBuffer;
+typedef std::shared_ptr<BitBuffer> BitBufferPtr;
+typedef std::shared_ptr<GateBuffer> GateBufferPtr;
+typedef std::shared_ptr<ArithmeticBuffer> ArithmeticBufferPtr;
+typedef std::shared_ptr<complex> BitOp;
+
+// This is a buffer struct that's capable of representing controlled single bit gates and arithmetic, when subclassed.
+struct BitBuffer {
+    bool anti;
+    bool isArithmetic;
+    std::vector<bitLenInt> controls;
+
+    BitBuffer(bool antiCtrl, const bitLenInt* cntrls, const bitLenInt& cntrlLen, bool isArith)
+        : anti(antiCtrl)
+        , isArithmetic(isArith)
+        , controls(cntrlLen)
+    {
+        if (cntrlLen > 0) {
+            std::copy(cntrls, cntrls + cntrlLen, controls.begin());
+            std::sort(controls.begin(), controls.end());
+        }
+    }
+
+    BitBuffer(BitBuffer* toCopy)
+        : anti(toCopy->anti)
+        , isArithmetic(toCopy->isArithmetic)
+        , controls(toCopy->controls)
+    {
+        // Intentionally left blank.
+    }
+
+    virtual void Apply(QInterfacePtr qReg, const bitLenInt& qubitIndex, std::vector<BitBufferPtr>* bitBuffers) = 0;
+
+    virtual bool CompareControls(BitBufferPtr toCmp)
+    {
+        if (toCmp == NULL) {
+            // If a bit buffer is empty, it's fine to overwrite it.
+            return true;
+        }
+
+        // Otherwise, we return "false" if we need to flush, and true if we can keep buffering.
+
+        if (anti != toCmp->anti) {
+            return false;
+        }
+
+        if (isArithmetic != toCmp->isArithmetic) {
+            return false;
+        }
+
+        if (controls.size() != toCmp->controls.size()) {
+            return false;
+        }
+
+        for (bitLenInt i = 0; i < controls.size(); i++) {
+            if (controls[i] != toCmp->controls[i]) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+};
+
+struct GateBuffer : public BitBuffer {
+    BitOp matrix;
+
+    GateBuffer(bool antiCtrl, const bitLenInt* cntrls, const bitLenInt& cntrlLen, const complex* mtrx)
+        : BitBuffer(antiCtrl, cntrls, cntrlLen, false)
+        , matrix(new complex[4], std::default_delete<complex[]>())
+    {
+        std::copy(mtrx, mtrx + 4, matrix.get());
+    }
+
+    GateBuffer(GateBuffer* toCopy, BitOp mtrx)
+        : BitBuffer(toCopy)
+        , matrix(mtrx)
+    {
+        // Intentionally left blank.
+    }
+
+    GateBufferPtr LeftMul(BitBufferPtr rightBuffer)
+    {
+        // If we pass the threshold number of qubits for buffering, we just do 2x2 complex matrix multiplication.
+        // We parallelize this, since we can.
+        // If a matrix component is very close to zero, we assume it's floating-point-error on a composition that has an
+        // exactly 0 component, number theoretically. (If it's not exactly 0 by number theory, it's numerically
+        // negligible, and we're safe.)
+
+        BitOp outBuffer(new complex[4], std::default_delete<complex[]>());
+
+        if (rightBuffer != NULL) {
+            GateBuffer* rightGate = dynamic_cast<GateBuffer*>(rightBuffer.get());
+            BitOp right = rightGate->matrix;
+
+            std::vector<std::future<void>> futures(4);
+
+            futures[0] = std::async(std::launch::async, [&]() {
+                outBuffer.get()[0] = (matrix.get()[0] * right.get()[0]) + (matrix.get()[1] * right.get()[2]);
+                if (norm(outBuffer.get()[0]) < min_norm) {
+                    outBuffer.get()[0] = complex(ZERO_R1, ZERO_R1);
+                }
+            });
+            futures[1] = std::async(std::launch::async, [&]() {
+                outBuffer.get()[1] = (matrix.get()[0] * right.get()[1]) + (matrix.get()[1] * right.get()[3]);
+                if (norm(outBuffer.get()[1]) < min_norm) {
+                    outBuffer.get()[1] = complex(ZERO_R1, ZERO_R1);
+                }
+            });
+            futures[2] = std::async(std::launch::async, [&]() {
+                outBuffer.get()[2] = (matrix.get()[2] * right.get()[0]) + (matrix.get()[3] * right.get()[2]);
+                if (norm(outBuffer.get()[2]) < min_norm) {
+                    outBuffer.get()[2] = complex(ZERO_R1, ZERO_R1);
+                }
+            });
+            futures[3] = std::async(std::launch::async, [&]() {
+                outBuffer.get()[3] = (matrix.get()[2] * right.get()[1]) + (matrix.get()[3] * right.get()[3]);
+                if (norm(outBuffer.get()[3]) < min_norm) {
+                    outBuffer.get()[3] = complex(ZERO_R1, ZERO_R1);
+                }
+            });
+
+            for (int i = 0; i < 4; i++) {
+                futures[i].get();
+            }
+        } else {
+            std::copy(matrix.get(), matrix.get() + 4, outBuffer.get());
+        }
+
+        return std::make_shared<GateBuffer>(this, outBuffer);
+    }
+
+    virtual void Apply(QInterfacePtr qReg, const bitLenInt& qubitIndex, std::vector<BitBufferPtr>* bitBuffers)
+    {
+        if (controls.size() == 0) {
+            qReg->ApplySingleBit(matrix.get(), true, qubitIndex);
+        } else {
+            bitLenInt* ctrls = new bitLenInt[controls.size()];
+            std::copy(controls.begin(), controls.end(), ctrls);
+
+            if (anti) {
+                qReg->ApplyAntiControlledSingleBit(ctrls, controls.size(), qubitIndex, matrix.get());
+            } else {
+                qReg->ApplyControlledSingleBit(ctrls, controls.size(), qubitIndex, matrix.get());
+            }
+
+            delete[] ctrls;
+        }
+        (*bitBuffers)[qubitIndex] = NULL;
+    }
+};
+
+struct ArithmeticBuffer : public BitBuffer {
+    bitLenInt start;
+    bitLenInt length;
+    int toAdd;
+
+    ArithmeticBuffer(bool antiCtrl, const bitLenInt* cntrls, const bitLenInt& cntrlLen, const bitLenInt& strt,
+        const bitLenInt& len, int intToAdd)
+        : BitBuffer(antiCtrl, cntrls, cntrlLen, true)
+        , start(strt)
+        , length(len)
+        , toAdd(intToAdd)
+    {
+        // Intentionally left blank.
+    }
+
+    virtual bool CompareControls(BitBufferPtr toCmp)
+    {
+        if (toCmp == NULL) {
+            return true;
+        }
+
+        if (BitBuffer::CompareControls(toCmp) == false) {
+            return false;
+        }
+
+        ArithmeticBuffer* toCmpArith = dynamic_cast<ArithmeticBuffer*>(toCmp.get());
+        if (start != toCmpArith->start) {
+            return false;
+        }
+
+        if (length != toCmpArith->length) {
+            return false;
+        }
+
+        return true;
+    }
+
+    virtual void Apply(QInterfacePtr qReg, const bitLenInt& qubitIndex, std::vector<BitBufferPtr>* bitBuffers)
+    {
+        if (controls.size() == 0) {
+            if (toAdd > 0) {
+                qReg->INC(toAdd, start, length);
+            } else if (toAdd < 0) {
+                qReg->DEC(-toAdd, start, length);
+            }
+        } else {
+            bitLenInt* ctrls = new bitLenInt[controls.size()];
+            std::copy(controls.begin(), controls.end(), ctrls);
+
+            if (toAdd > 0) {
+                qReg->CINC(toAdd, start, length, ctrls, controls.size());
+            } else if (toAdd < 0) {
+                qReg->CDEC(-toAdd, start, length, ctrls, controls.size());
+            }
+
+            delete[] ctrls;
+        }
+
+        for (bitLenInt i = 0; i < length; i++) {
+            (*bitBuffers)[start + i] = NULL;
+        }
+    }
+};
+} // namespace Qrack

--- a/include/common/bitbuffer.hpp
+++ b/include/common/bitbuffer.hpp
@@ -13,8 +13,8 @@
 
 #pragma once
 
-#include <vector>
 #include <algorithm>
+#include <vector>
 
 #include "qinterface.hpp"
 
@@ -47,6 +47,8 @@ struct BitBuffer {
     virtual void Apply(QInterfacePtr qReg, const bitLenInt& qubitIndex, std::vector<BitBufferPtr>* bitBuffers) = 0;
 
     virtual bool Combinable(BitBufferPtr toCmp);
+
+    virtual BitBufferPtr LeftRightCompose(BitBufferPtr rightBuffer) = 0;
 };
 
 struct GateBuffer : public BitBuffer {
@@ -61,9 +63,9 @@ struct GateBuffer : public BitBuffer {
         // Intentionally left blank.
     }
 
-    GateBufferPtr LeftMul(BitBufferPtr rightBuffer);
-
     virtual void Apply(QInterfacePtr qReg, const bitLenInt& qubitIndex, std::vector<BitBufferPtr>* bitBuffers);
+
+    virtual BitBufferPtr LeftRightCompose(BitBufferPtr rightBuffer);
 };
 
 struct ArithmeticBuffer : public BitBuffer {
@@ -81,8 +83,19 @@ struct ArithmeticBuffer : public BitBuffer {
         // Intentionally left blank.
     }
 
+    ArithmeticBuffer(ArithmeticBuffer* toCopy, int add)
+        : BitBuffer(toCopy)
+        , start(toCopy->start)
+        , length(toCopy->length)
+        , toAdd(toCopy->toAdd + add)
+    {
+        // Intentionally left blank.
+    }
+
     virtual bool Combinable(BitBufferPtr toCmp);
 
     virtual void Apply(QInterfacePtr qReg, const bitLenInt& qubitIndex, std::vector<BitBufferPtr>* bitBuffers);
+
+    virtual BitBufferPtr LeftRightCompose(BitBufferPtr rightBuffer);
 };
 } // namespace Qrack

--- a/include/qfusion.hpp
+++ b/include/qfusion.hpp
@@ -12,97 +12,10 @@
 
 #pragma once
 
+#include "common/bitbuffer.hpp"
 #include "qinterface.hpp"
 
 namespace Qrack {
-
-struct BitBuffer;
-typedef std::shared_ptr<BitBuffer> BitBufferPtr;
-typedef std::shared_ptr<complex> BitOp;
-
-// This is a buffer struct that's capable of representing both single bit and controlled single bit gates.
-struct BitBuffer {
-    bool anti;
-    std::vector<bitLenInt> controls;
-    BitOp matrix;
-
-    // For arithmetic gates:
-    bool isArithmetic;
-    bitLenInt start;
-    bitLenInt length;
-    int toAdd;
-
-    BitBuffer(bool antiCtrl, const bitLenInt* cntrls, const bitLenInt& cntrlLen, const complex* mtrx)
-        : anti(antiCtrl)
-        , controls(cntrlLen)
-        , matrix(new complex[4], std::default_delete<complex[]>())
-        , isArithmetic(false)
-        , start(0)
-        , length(0)
-        , toAdd(0)
-    {
-        if (cntrlLen > 0) {
-            std::copy(cntrls, cntrls + cntrlLen, controls.begin());
-            std::sort(controls.begin(), controls.end());
-        }
-
-        std::copy(mtrx, mtrx + 4, matrix.get());
-    }
-
-    BitBuffer(bool antiCtrl, const bitLenInt* cntrls, const bitLenInt& cntrlLen, const bitLenInt& strt,
-        const bitLenInt& len, int intToAdd)
-        : anti(antiCtrl)
-        , controls(cntrlLen)
-        , matrix(NULL)
-        , isArithmetic(true)
-        , start(strt)
-        , length(len)
-        , toAdd(intToAdd)
-    {
-        if (cntrlLen > 0) {
-            std::copy(cntrls, cntrls + cntrlLen, controls.begin());
-            std::sort(controls.begin(), controls.end());
-        }
-    }
-
-    bool CompareControls(BitBufferPtr toCmp)
-    {
-        if (toCmp == NULL) {
-            // If a bit buffer is empty, it's fine to overwrite it.
-            return true;
-        }
-
-        // Otherwise, we return "false" if we need to flush, and true if we can keep buffering.
-
-        if (anti != toCmp->anti) {
-            return false;
-        }
-
-        if (isArithmetic != toCmp->isArithmetic) {
-            return false;
-        }
-
-        if (start != toCmp->start) {
-            return false;
-        }
-
-        if (length != toCmp->length) {
-            return false;
-        }
-
-        if (controls.size() != toCmp->controls.size()) {
-            return false;
-        }
-
-        for (bitLenInt i = 0; i < controls.size(); i++) {
-            if (controls[i] != toCmp->controls[i]) {
-                return false;
-            }
-        }
-
-        return true;
-    }
-};
 
 class QFusion;
 typedef std::shared_ptr<QFusion> QFusionPtr;
@@ -215,7 +128,7 @@ public:
     virtual real1 ProbMask(const bitCapInt& mask, const bitCapInt& permutation);
     virtual real1 ProbAll(bitCapInt fullRegister);
 
-    virtual QInterfacePtr ReturnEngine()
+    virtual QInterfacePtr ReleaseEngine()
     {
         FlushAll();
         QInterfacePtr toRet = qReg;
@@ -225,8 +138,6 @@ public:
     }
 
 protected:
-    BitOp Mul2x2(BitOp left, BitOp right);
-
     /** Buffer flush methods, to apply accumulated buffers when bits are checked for output or become involved in
      * nonbufferable operations */
 
@@ -276,5 +187,8 @@ protected:
     }
 
     inline void DiscardAll() { DiscardReg(0, qubitCount); }
+
+    /** Method to compose arithmetic gates */
+    void BufferArithmetic(bitLenInt* controls, bitLenInt controlLen, int toAdd, bitLenInt inOutStart, bitLenInt length);
 };
 } // namespace Qrack

--- a/include/qfusion.hpp
+++ b/include/qfusion.hpp
@@ -26,10 +26,20 @@ struct BitBuffer {
     std::vector<bitLenInt> controls;
     BitOp matrix;
 
+    // For arithmetic gates:
+    bool isArithmetic;
+    bitLenInt start;
+    bitLenInt length;
+    int toAdd;
+
     BitBuffer(bool antiCtrl, const bitLenInt* cntrls, const bitLenInt& cntrlLen, const complex* mtrx)
         : anti(antiCtrl)
         , controls(cntrlLen)
         , matrix(new complex[4], std::default_delete<complex[]>())
+        , isArithmetic(false)
+        , start(0)
+        , length(0)
+        , toAdd(0)
     {
         if (cntrlLen > 0) {
             std::copy(cntrls, cntrls + cntrlLen, controls.begin());
@@ -37,6 +47,22 @@ struct BitBuffer {
         }
 
         std::copy(mtrx, mtrx + 4, matrix.get());
+    }
+
+    BitBuffer(bool antiCtrl, const bitLenInt* cntrls, const bitLenInt& cntrlLen, const bitLenInt& strt,
+        const bitLenInt& len, int intToAdd)
+        : anti(antiCtrl)
+        , controls(cntrlLen)
+        , matrix(NULL)
+        , isArithmetic(true)
+        , start(strt)
+        , length(len)
+        , toAdd(intToAdd)
+    {
+        if (cntrlLen > 0) {
+            std::copy(cntrls, cntrls + cntrlLen, controls.begin());
+            std::sort(controls.begin(), controls.end());
+        }
     }
 
     bool CompareControls(BitBufferPtr toCmp)
@@ -49,6 +75,10 @@ struct BitBuffer {
         // Otherwise, we return "false" if we need to flush, and true if we can keep buffering.
 
         if (anti != toCmp->anti) {
+            return false;
+        }
+
+        if (isArithmetic != toCmp->isArithmetic) {
             return false;
         }
 

--- a/include/qfusion.hpp
+++ b/include/qfusion.hpp
@@ -82,6 +82,14 @@ struct BitBuffer {
             return false;
         }
 
+        if (start != toCmp->start) {
+            return false;
+        }
+
+        if (length != toCmp->length) {
+            return false;
+        }
+
         if (controls.size() != toCmp->controls.size()) {
             return false;
         }

--- a/include/qfusion.hpp
+++ b/include/qfusion.hpp
@@ -73,7 +73,6 @@ class QFusion : public QInterface {
 protected:
     static const bitLenInt MIN_FUSION_BITS = 3U;
     QInterfacePtr qReg;
-    std::shared_ptr<std::default_random_engine> rand_generator;
 
     std::vector<BitBufferPtr> bitBuffers;
     std::vector<std::vector<bitLenInt>> bitControls;
@@ -89,6 +88,7 @@ protected:
 public:
     QFusion(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState = 0,
         std::shared_ptr<std::default_random_engine> rgp = nullptr);
+    QFusion(QInterfacePtr target);
 
     virtual void SetQuantumState(complex* inputState);
     virtual void GetQuantumState(complex* outputState);
@@ -176,6 +176,15 @@ public:
     virtual real1 ProbReg(const bitLenInt& start, const bitLenInt& length, const bitCapInt& permutation);
     virtual real1 ProbMask(const bitCapInt& mask, const bitCapInt& permutation);
     virtual real1 ProbAll(bitCapInt fullRegister);
+
+    virtual QInterfacePtr ReturnEngine()
+    {
+        FlushAll();
+        QInterfacePtr toRet = qReg;
+        qReg = NULL;
+        SetQubitCount(0);
+        return toRet;
+    }
 
 protected:
     BitOp Mul2x2(BitOp left, BitOp right);

--- a/src/common/bitbuffer.cpp
+++ b/src/common/bitbuffer.cpp
@@ -1,0 +1,185 @@
+//////////////////////////////////////////////////////////////////////////////////////
+//
+// (C) Daniel Strano and the Qrack contributors 2017, 2018. All rights reserved.
+//
+// This header defines buffers for Qrack::QFusion.
+// QFusion adds an optional "gate fusion" layer on top of a QEngine or QUnit.
+// Single bit gates are buffered in per-bit 2x2 complex matrices, to reduce the cost
+// of successive application of single bit gates to the same bit.
+//
+// Licensed under the GNU Lesser General Public License V3.
+// See LICENSE.md in the project root or https://www.gnu.org/licenses/lgpl-3.0.en.html
+// for details.
+
+#include <future>
+
+#include "bitbuffer.hpp"
+
+namespace Qrack {
+
+BitBuffer::BitBuffer(bool antiCtrl, const bitLenInt* cntrls, const bitLenInt& cntrlLen, bool isArith)
+    : anti(antiCtrl)
+    , isArithmetic(isArith)
+    , controls(cntrlLen)
+{
+    if (cntrlLen > 0) {
+        std::copy(cntrls, cntrls + cntrlLen, controls.begin());
+        std::sort(controls.begin(), controls.end());
+    }
+}
+
+bool BitBuffer::Combinable(BitBufferPtr toCmp)
+{
+    if (toCmp == NULL) {
+        // If a bit buffer is empty, it's fine to overwrite it.
+        return true;
+    }
+
+    // Otherwise, we return "false" if we need to flush, and true if we can keep buffering.
+
+    if (anti != toCmp->anti) {
+        return false;
+    }
+
+    if (isArithmetic != toCmp->isArithmetic) {
+        return false;
+    }
+
+    if (controls.size() != toCmp->controls.size()) {
+        return false;
+    }
+
+    for (bitLenInt i = 0; i < controls.size(); i++) {
+        if (controls[i] != toCmp->controls[i]) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+GateBuffer::GateBuffer(bool antiCtrl, const bitLenInt* cntrls, const bitLenInt& cntrlLen, const complex* mtrx)
+    : BitBuffer(antiCtrl, cntrls, cntrlLen, false)
+    , matrix(new complex[4], std::default_delete<complex[]>())
+{
+    std::copy(mtrx, mtrx + 4, matrix.get());
+}
+
+GateBufferPtr GateBuffer::LeftMul(BitBufferPtr rightBuffer)
+{
+    // If we pass the threshold number of qubits for buffering, we just do 2x2 complex matrix multiplication.
+    // We parallelize this, since we can.
+    // If a matrix component is very close to zero, we assume it's floating-point-error on a composition that has an
+    // exactly 0 component, number theoretically. (If it's not exactly 0 by number theory, it's numerically
+    // negligible, and we're safe.)
+
+    BitOp outBuffer(new complex[4], std::default_delete<complex[]>());
+
+    if (rightBuffer != NULL) {
+        GateBuffer* rightGate = dynamic_cast<GateBuffer*>(rightBuffer.get());
+        BitOp right = rightGate->matrix;
+
+        std::vector<std::future<void>> futures(4);
+
+        futures[0] = std::async(std::launch::async, [&]() {
+            outBuffer.get()[0] = (matrix.get()[0] * right.get()[0]) + (matrix.get()[1] * right.get()[2]);
+            if (norm(outBuffer.get()[0]) < min_norm) {
+                outBuffer.get()[0] = complex(ZERO_R1, ZERO_R1);
+            }
+        });
+        futures[1] = std::async(std::launch::async, [&]() {
+            outBuffer.get()[1] = (matrix.get()[0] * right.get()[1]) + (matrix.get()[1] * right.get()[3]);
+            if (norm(outBuffer.get()[1]) < min_norm) {
+                outBuffer.get()[1] = complex(ZERO_R1, ZERO_R1);
+            }
+        });
+        futures[2] = std::async(std::launch::async, [&]() {
+            outBuffer.get()[2] = (matrix.get()[2] * right.get()[0]) + (matrix.get()[3] * right.get()[2]);
+            if (norm(outBuffer.get()[2]) < min_norm) {
+                outBuffer.get()[2] = complex(ZERO_R1, ZERO_R1);
+            }
+        });
+        futures[3] = std::async(std::launch::async, [&]() {
+            outBuffer.get()[3] = (matrix.get()[2] * right.get()[1]) + (matrix.get()[3] * right.get()[3]);
+            if (norm(outBuffer.get()[3]) < min_norm) {
+                outBuffer.get()[3] = complex(ZERO_R1, ZERO_R1);
+            }
+        });
+
+        for (int i = 0; i < 4; i++) {
+            futures[i].get();
+        }
+    } else {
+        std::copy(matrix.get(), matrix.get() + 4, outBuffer.get());
+    }
+
+    return std::make_shared<GateBuffer>(this, outBuffer);
+}
+
+void GateBuffer::Apply(QInterfacePtr qReg, const bitLenInt& qubitIndex, std::vector<BitBufferPtr>* bitBuffers)
+{
+    if (controls.size() == 0) {
+        qReg->ApplySingleBit(matrix.get(), true, qubitIndex);
+    } else {
+        bitLenInt* ctrls = new bitLenInt[controls.size()];
+        std::copy(controls.begin(), controls.end(), ctrls);
+
+        if (anti) {
+            qReg->ApplyAntiControlledSingleBit(ctrls, controls.size(), qubitIndex, matrix.get());
+        } else {
+            qReg->ApplyControlledSingleBit(ctrls, controls.size(), qubitIndex, matrix.get());
+        }
+
+        delete[] ctrls;
+    }
+    (*bitBuffers)[qubitIndex] = NULL;
+}
+
+bool ArithmeticBuffer::Combinable(BitBufferPtr toCmp)
+{
+    if (toCmp == NULL) {
+        return true;
+    }
+
+    if (BitBuffer::Combinable(toCmp) == false) {
+        return false;
+    }
+
+    ArithmeticBuffer* toCmpArith = dynamic_cast<ArithmeticBuffer*>(toCmp.get());
+    if (start != toCmpArith->start) {
+        return false;
+    }
+
+    if (length != toCmpArith->length) {
+        return false;
+    }
+
+    return true;
+}
+
+void ArithmeticBuffer::Apply(QInterfacePtr qReg, const bitLenInt& qubitIndex, std::vector<BitBufferPtr>* bitBuffers)
+{
+    if (controls.size() == 0) {
+        if (toAdd > 0) {
+            qReg->INC(toAdd, start, length);
+        } else if (toAdd < 0) {
+            qReg->DEC(-toAdd, start, length);
+        }
+    } else {
+        bitLenInt* ctrls = new bitLenInt[controls.size()];
+        std::copy(controls.begin(), controls.end(), ctrls);
+
+        if (toAdd > 0) {
+            qReg->CINC(toAdd, start, length, ctrls, controls.size());
+        } else if (toAdd < 0) {
+            qReg->CDEC(-toAdd, start, length, ctrls, controls.size());
+        }
+
+        delete[] ctrls;
+    }
+
+    for (bitLenInt i = 0; i < length; i++) {
+        (*bitBuffers)[start + i] = NULL;
+    }
+}
+} // namespace Qrack

--- a/src/common/bitbuffer.cpp
+++ b/src/common/bitbuffer.cpp
@@ -141,7 +141,7 @@ bool ArithmeticBuffer::Combinable(BitBufferPtr toCmp)
         return true;
     }
 
-    if (!(BitBuffer::Combinable(toCmp))) {
+    if (!BitBuffer::Combinable(toCmp)) {
         return false;
     }
 

--- a/src/qfusion.cpp
+++ b/src/qfusion.cpp
@@ -22,19 +22,19 @@ namespace Qrack {
 
 QFusion::QFusion(
     QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState, std::shared_ptr<std::default_random_engine> rgp)
-    : QInterface(qBitCount)
+    : QInterface(qBitCount, rgp)
     , bitBuffers(qBitCount)
     , bitControls(qBitCount)
 {
-    if (rgp == nullptr) {
-        /* Used to control the random seed for all allocated interfaces. */
-        rand_generator = std::make_shared<std::default_random_engine>();
-        rand_generator->seed(std::time(0));
-    } else {
-        rand_generator = rgp;
-    }
+    qReg = CreateQuantumInterface(eng, qBitCount, initState, rgp);
+}
 
-    qReg = CreateQuantumInterface(eng, qBitCount, initState, rand_generator);
+QFusion::QFusion(QInterfacePtr target)
+    : QInterface(target->GetQubitCount())
+    , bitBuffers(target->GetQubitCount())
+    , bitControls(target->GetQubitCount())
+{
+    qReg = target;
 }
 
 /**

--- a/src/qfusion.cpp
+++ b/src/qfusion.cpp
@@ -542,7 +542,7 @@ void QFusion::CINC(bitCapInt toAdd, bitLenInt inOutStart, bitLenInt length, bitL
     for (i = 0; i < controlLen; i++) {
         FlushBit(controls[i]);
     }
-    
+
     BitBufferPtr toCheck;
     BitBufferPtr bfr = std::make_shared<BitBuffer>(false, controls, controlLen, inOutStart, length, toAdd);
 

--- a/src/qfusion.cpp
+++ b/src/qfusion.cpp
@@ -77,7 +77,7 @@ void QFusion::ApplySingleBit(const complex* mtrx, bool doCalcNorm, bitLenInt qub
     }
 
     // Now, we're going to chain our buffered gates;
-    bitBuffers[qubitIndex] = bfr->LeftMul(bitBuffers[qubitIndex]);
+    bitBuffers[qubitIndex] = bfr->LeftRightCompose(bitBuffers[qubitIndex]);
 }
 
 // Almost all additional methods, besides controlled variants of this one, just wrap operations with buffer flushes, or
@@ -173,7 +173,7 @@ void QFusion::ApplyControlledSingleBit(
     }
 
     // Now, we're going to chain our buffered gates;
-    bitBuffers[target] = bfr->LeftMul(bitBuffers[target]);
+    bitBuffers[target] = bfr->LeftRightCompose(bitBuffers[target]);
 }
 
 void QFusion::ApplyAntiControlledSingleBit(
@@ -210,7 +210,7 @@ void QFusion::ApplyAntiControlledSingleBit(
     }
 
     // Now, we're going to chain our buffered gates;
-    bitBuffers[target] = bfr->LeftMul(bitBuffers[target]);
+    bitBuffers[target] = bfr->LeftRightCompose(bitBuffers[target]);
 }
 
 // "Cohere" will increase the cost of application of every currently buffered gate by a factor of 2 per "cohered" qubit,
@@ -444,17 +444,18 @@ void QFusion::BufferArithmetic(
     }
 
     toCheck = bitBuffers[inOutStart];
+
+    // After the buffers have been compared with "Combinable," it's safe to assume the old buffer is an
+    // ArithmeticBuffer.
+    BitBufferPtr nBfr = bfr->LeftRightCompose(toCheck);
+    for (i = 0; i < length; i++) {
+        bitBuffers[inOutStart + i] = nBfr;
+    }
+
     if (toCheck == NULL) {
-        for (i = 0; i < length; i++) {
-            bitBuffers[inOutStart + i] = bfr;
-        }
         for (i = 0; i < controlLen; i++) {
             bitControls[controls[i]].push_back(inOutStart);
         }
-    } else {
-        // After the buffers have been compared with "Combinable," it's safe to assume the old buffer is an
-        // ArithmeticBuffer.
-        dynamic_cast<ArithmeticBuffer*>(toCheck.get())->toAdd += toAdd;
     }
 }
 

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -2506,20 +2506,24 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_sqrtswap_reg")
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_qfusion_order")
 {
-    qftReg->SetPermutation(0);
-    qftReg->X(0);
-    qftReg->CNOT(0, 1);
-    qftReg->X(0);
-    qftReg->CNOT(0, 1);
-    qftReg->X(2);
-    qftReg->CNOT(2, 3);
-    qftReg->SetBit(3, false);
+    QFusion optimizer(qftReg);
 
-    qftReg->AntiCCNOT(4, 5, 6);
-    qftReg->CCNOT(4, 5, 7);
-    qftReg->X(6);
-    qftReg->AntiCCNOT(4, 5, 6);
-    qftReg->AntiCCNOT(4, 5, 7);
+    optimizer.SetPermutation(0);
+    optimizer.X(0);
+    optimizer.CNOT(0, 1);
+    optimizer.X(0);
+    optimizer.CNOT(0, 1);
+    optimizer.X(2);
+    optimizer.CNOT(2, 3);
+    optimizer.SetBit(3, false);
+
+    optimizer.AntiCCNOT(4, 5, 6);
+    optimizer.CCNOT(4, 5, 7);
+    optimizer.X(6);
+    optimizer.AntiCCNOT(4, 5, 6);
+    optimizer.AntiCCNOT(4, 5, 7);
+
+    qftReg = optimizer.ReturnEngine();
 
     REQUIRE_THAT(qftReg, HasProbability(0, 20, 0xC6));
 }

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -2523,7 +2523,7 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_qfusion_order")
     optimizer.AntiCCNOT(4, 5, 6);
     optimizer.AntiCCNOT(4, 5, 7);
 
-    qftReg = optimizer.ReturnEngine();
+    qftReg = optimizer.ReleaseEngine();
 
     REQUIRE_THAT(qftReg, HasProbability(0, 20, 0xC6));
 }


### PR DESCRIPTION
This PR lets QFusion be used, semantically, as a temporary optimizing buffer layer on top of any QInterface.