### PR TITLE
QFusion Optimization - Discard Buffered Identity Operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Qrack
 
-[![Qrack Build Status](https://api.travis-ci.org/vm6502q/qrack.svg?branch=master)](https://travis-ci.org/vm6502q/qrack/builds)
+[![Qrack Build Status](https://api.travis-ci.org/vm6502q/qrack.svg?branch=master)](https://travis-ci.org/vm6502q/qrack/builds) [![Mentioned in Awesome awesome-quantum-computing](https://awesome.re/mentioned-badge.svg)](https://github.com/desireevl/awesome-quantum-computing)
 
 This is a multithreaded framework for developing classically emulated virtual universal quantum processors. It has CPU, GPU, and multi-processor engine types.
 

--- a/include/common/bitbuffer.hpp
+++ b/include/common/bitbuffer.hpp
@@ -49,6 +49,8 @@ struct BitBuffer {
     virtual bool Combinable(BitBufferPtr toCmp);
 
     virtual BitBufferPtr LeftRightCompose(BitBufferPtr rightBuffer) = 0;
+
+    virtual bool IsIdentity() = 0;
 };
 
 struct GateBuffer : public BitBuffer {
@@ -66,6 +68,8 @@ struct GateBuffer : public BitBuffer {
     virtual void Apply(QInterfacePtr qReg, const bitLenInt& qubitIndex, std::vector<BitBufferPtr>* bitBuffers);
 
     virtual BitBufferPtr LeftRightCompose(BitBufferPtr rightBuffer);
+
+    virtual bool IsIdentity();
 };
 
 struct ArithmeticBuffer : public BitBuffer {
@@ -97,5 +101,7 @@ struct ArithmeticBuffer : public BitBuffer {
     virtual void Apply(QInterfacePtr qReg, const bitLenInt& qubitIndex, std::vector<BitBufferPtr>* bitBuffers);
 
     virtual BitBufferPtr LeftRightCompose(BitBufferPtr rightBuffer);
+
+    virtual bool IsIdentity();
 };
 } // namespace Qrack

--- a/include/qfusion.hpp
+++ b/include/qfusion.hpp
@@ -15,6 +15,12 @@
 #include "common/bitbuffer.hpp"
 #include "qinterface.hpp"
 
+// MODLEN returns "arg" modulo the capacity of "len" bits. We use it to check if an arithmetic "arg" is equivalent to
+// the identity operator. (That is, we check if [addend] % [maxInt] == 0, such that we are effectively adding or
+// subtracting 0.) If a method call is equivalent to the identity operator, it makes no difference, so we do not flush
+// for it or buffer it.
+#define MODLEN(arg, len) (arg & ((1U << len) - 1U))
+
 namespace Qrack {
 
 class QFusion;

--- a/src/qfusion.cpp
+++ b/src/qfusion.cpp
@@ -478,12 +478,16 @@ void QFusion::BufferArithmetic(
 
 void QFusion::INC(bitCapInt toAdd, bitLenInt start, bitLenInt length)
 {
-    BufferArithmetic(NULL, 0, toAdd, start, length);
+    if (toAdd & ((1U << length) - 1U)) {
+        BufferArithmetic(NULL, 0, toAdd, start, length);
+    }
 }
 
 void QFusion::CINC(bitCapInt toAdd, bitLenInt inOutStart, bitLenInt length, bitLenInt* controls, bitLenInt controlLen)
 {
-    BufferArithmetic(controls, controlLen, toAdd, inOutStart, length);
+    if (toAdd & ((1U << length) - 1U)) {
+        BufferArithmetic(controls, controlLen, toAdd, inOutStart, length);
+    }
 }
 
 void QFusion::INCC(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt carryIndex)
@@ -495,9 +499,11 @@ void QFusion::INCC(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt
 
 void QFusion::INCS(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt overflowIndex)
 {
-    FlushReg(start, length);
-    FlushBit(overflowIndex);
-    qReg->INCS(toAdd, start, length, overflowIndex);
+    if (toAdd & ((1U << length) - 1U)) {
+        FlushReg(start, length);
+        FlushBit(overflowIndex);
+        qReg->INCS(toAdd, start, length, overflowIndex);
+    }
 }
 
 void QFusion::INCSC(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt overflowIndex, bitLenInt carryIndex)
@@ -517,8 +523,10 @@ void QFusion::INCSC(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenIn
 
 void QFusion::INCBCD(bitCapInt toAdd, bitLenInt start, bitLenInt length)
 {
-    FlushReg(start, length);
-    qReg->INCBCD(toAdd, start, length);
+    if (toAdd & ((1U << length) - 1U)) {
+        FlushReg(start, length);
+        qReg->INCBCD(toAdd, start, length);
+    }
 }
 
 void QFusion::INCBCDC(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt carryIndex)
@@ -530,12 +538,16 @@ void QFusion::INCBCDC(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLen
 
 void QFusion::DEC(bitCapInt toSub, bitLenInt start, bitLenInt length)
 {
-    BufferArithmetic(NULL, 0, -toSub, start, length);
+    if (toSub & ((1U << length) - 1U)) {
+        BufferArithmetic(NULL, 0, -toSub, start, length);
+    }
 }
 
 void QFusion::CDEC(bitCapInt toSub, bitLenInt inOutStart, bitLenInt length, bitLenInt* controls, bitLenInt controlLen)
 {
-    BufferArithmetic(controls, controlLen, -toSub, inOutStart, length);
+    if (toSub & ((1U << length) - 1U)) {
+        BufferArithmetic(controls, controlLen, -toSub, inOutStart, length);
+    }
 }
 
 void QFusion::DECC(bitCapInt toSub, bitLenInt start, bitLenInt length, bitLenInt carryIndex)
@@ -547,9 +559,11 @@ void QFusion::DECC(bitCapInt toSub, bitLenInt start, bitLenInt length, bitLenInt
 
 void QFusion::DECS(bitCapInt toSub, bitLenInt start, bitLenInt length, bitLenInt overflowIndex)
 {
-    FlushReg(start, length);
-    FlushBit(overflowIndex);
-    qReg->DECS(toSub, start, length, overflowIndex);
+    if (toSub & ((1U << length) - 1U)) {
+        FlushReg(start, length);
+        FlushBit(overflowIndex);
+        qReg->DECS(toSub, start, length, overflowIndex);
+    }
 }
 
 void QFusion::DECSC(bitCapInt toSub, bitLenInt start, bitLenInt length, bitLenInt overflowIndex, bitLenInt carryIndex)
@@ -569,8 +583,10 @@ void QFusion::DECSC(bitCapInt toSub, bitLenInt start, bitLenInt length, bitLenIn
 
 void QFusion::DECBCD(bitCapInt toSub, bitLenInt start, bitLenInt length)
 {
-    FlushReg(start, length);
-    qReg->DECBCD(toSub, start, length);
+    if (toSub & ((1U << length) - 1U)) {
+        FlushReg(start, length);
+        qReg->DECBCD(toSub, start, length);
+    }
 }
 
 void QFusion::DECBCDC(bitCapInt toSub, bitLenInt start, bitLenInt length, bitLenInt carryIndex)
@@ -582,34 +598,45 @@ void QFusion::DECBCDC(bitCapInt toSub, bitLenInt start, bitLenInt length, bitLen
 
 void QFusion::MUL(bitCapInt toMul, bitLenInt inOutStart, bitLenInt carryStart, bitLenInt length)
 {
-    FlushReg(inOutStart, length);
-    FlushReg(carryStart, length);
-    qReg->MUL(toMul, inOutStart, carryStart, length);
+    if (toMul == 0U) {
+        SetReg(inOutStart, length, 0U);
+        SetReg(carryStart, length, 0U);
+    } else if (toMul > 1U) {
+        FlushReg(inOutStart, length);
+        FlushReg(carryStart, length);
+        qReg->MUL(toMul, inOutStart, carryStart, length);
+    }
 }
 
 void QFusion::DIV(bitCapInt toDiv, bitLenInt inOutStart, bitLenInt carryStart, bitLenInt length)
 {
-    FlushReg(inOutStart, length);
-    FlushReg(carryStart, length);
-    qReg->DIV(toDiv, inOutStart, carryStart, length);
+    if (toDiv != 1U) {
+        FlushReg(inOutStart, length);
+        FlushReg(carryStart, length);
+        qReg->DIV(toDiv, inOutStart, carryStart, length);
+    }
 }
 
 void QFusion::CMUL(bitCapInt toMul, bitLenInt inOutStart, bitLenInt carryStart, bitLenInt length, bitLenInt* controls,
     bitLenInt controlLen)
 {
-    FlushList(controls, controlLen);
-    FlushReg(inOutStart, length);
-    FlushReg(carryStart, length);
-    qReg->CMUL(toMul, inOutStart, carryStart, length, controls, controlLen);
+    if (toMul != 1U) {
+        FlushList(controls, controlLen);
+        FlushReg(inOutStart, length);
+        FlushReg(carryStart, length);
+        qReg->CMUL(toMul, inOutStart, carryStart, length, controls, controlLen);
+    }
 }
 
 void QFusion::CDIV(bitCapInt toDiv, bitLenInt inOutStart, bitLenInt carryStart, bitLenInt length, bitLenInt* controls,
     bitLenInt controlLen)
 {
-    FlushList(controls, controlLen);
-    FlushReg(inOutStart, length);
-    FlushReg(carryStart, length);
-    qReg->CDIV(toDiv, inOutStart, carryStart, length, controls, controlLen);
+    if (toDiv != 1U) {
+        FlushList(controls, controlLen);
+        FlushReg(inOutStart, length);
+        FlushReg(carryStart, length);
+        qReg->CDIV(toDiv, inOutStart, carryStart, length, controls, controlLen);
+    }
 }
 
 void QFusion::ZeroPhaseFlip(bitLenInt start, bitLenInt length)
@@ -659,22 +686,28 @@ bitCapInt QFusion::IndexedSBC(bitLenInt indexStart, bitLenInt indexLength, bitLe
 
 void QFusion::Swap(bitLenInt qubitIndex1, bitLenInt qubitIndex2)
 {
-    std::swap(bitBuffers[qubitIndex1], bitBuffers[qubitIndex2]);
-    qReg->Swap(qubitIndex1, qubitIndex2);
+    if (qubitIndex1 != qubitIndex2) {
+        std::swap(bitBuffers[qubitIndex1], bitBuffers[qubitIndex2]);
+        qReg->Swap(qubitIndex1, qubitIndex2);
+    }
 }
 
 void QFusion::SqrtSwap(bitLenInt qubitIndex1, bitLenInt qubitIndex2)
 {
-    FlushBit(qubitIndex1);
-    FlushBit(qubitIndex2);
-    qReg->SqrtSwap(qubitIndex1, qubitIndex2);
+    if (qubitIndex1 != qubitIndex2) {
+        FlushBit(qubitIndex1);
+        FlushBit(qubitIndex2);
+        qReg->SqrtSwap(qubitIndex1, qubitIndex2);
+    }
 }
 
 void QFusion::ISqrtSwap(bitLenInt qubitIndex1, bitLenInt qubitIndex2)
 {
-    FlushBit(qubitIndex1);
-    FlushBit(qubitIndex2);
-    qReg->ISqrtSwap(qubitIndex1, qubitIndex2);
+    if (qubitIndex1 != qubitIndex2) {
+        FlushBit(qubitIndex1);
+        FlushBit(qubitIndex2);
+        qReg->ISqrtSwap(qubitIndex1, qubitIndex2);
+    }
 }
 
 void QFusion::CopyState(QFusionPtr orig)

--- a/src/qfusion.cpp
+++ b/src/qfusion.cpp
@@ -478,14 +478,14 @@ void QFusion::BufferArithmetic(
 
 void QFusion::INC(bitCapInt toAdd, bitLenInt start, bitLenInt length)
 {
-    if (toAdd & ((1U << length) - 1U)) {
+    if (MODLEN(toAdd, length)) {
         BufferArithmetic(NULL, 0, toAdd, start, length);
     }
 }
 
 void QFusion::CINC(bitCapInt toAdd, bitLenInt inOutStart, bitLenInt length, bitLenInt* controls, bitLenInt controlLen)
 {
-    if (toAdd & ((1U << length) - 1U)) {
+    if (MODLEN(toAdd, length)) {
         BufferArithmetic(controls, controlLen, toAdd, inOutStart, length);
     }
 }
@@ -499,7 +499,7 @@ void QFusion::INCC(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt
 
 void QFusion::INCS(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt overflowIndex)
 {
-    if (toAdd & ((1U << length) - 1U)) {
+    if (MODLEN(toAdd, length)) {
         FlushReg(start, length);
         FlushBit(overflowIndex);
         qReg->INCS(toAdd, start, length, overflowIndex);
@@ -523,7 +523,7 @@ void QFusion::INCSC(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenIn
 
 void QFusion::INCBCD(bitCapInt toAdd, bitLenInt start, bitLenInt length)
 {
-    if (toAdd & ((1U << length) - 1U)) {
+    if (MODLEN(toAdd, length)) {
         FlushReg(start, length);
         qReg->INCBCD(toAdd, start, length);
     }
@@ -538,14 +538,14 @@ void QFusion::INCBCDC(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLen
 
 void QFusion::DEC(bitCapInt toSub, bitLenInt start, bitLenInt length)
 {
-    if (toSub & ((1U << length) - 1U)) {
+    if (MODLEN(toSub, length)) {
         BufferArithmetic(NULL, 0, -toSub, start, length);
     }
 }
 
 void QFusion::CDEC(bitCapInt toSub, bitLenInt inOutStart, bitLenInt length, bitLenInt* controls, bitLenInt controlLen)
 {
-    if (toSub & ((1U << length) - 1U)) {
+    if (MODLEN(toSub, length)) {
         BufferArithmetic(controls, controlLen, -toSub, inOutStart, length);
     }
 }
@@ -559,7 +559,7 @@ void QFusion::DECC(bitCapInt toSub, bitLenInt start, bitLenInt length, bitLenInt
 
 void QFusion::DECS(bitCapInt toSub, bitLenInt start, bitLenInt length, bitLenInt overflowIndex)
 {
-    if (toSub & ((1U << length) - 1U)) {
+    if (MODLEN(toSub, length)) {
         FlushReg(start, length);
         FlushBit(overflowIndex);
         qReg->DECS(toSub, start, length, overflowIndex);
@@ -583,7 +583,7 @@ void QFusion::DECSC(bitCapInt toSub, bitLenInt start, bitLenInt length, bitLenIn
 
 void QFusion::DECBCD(bitCapInt toSub, bitLenInt start, bitLenInt length)
 {
-    if (toSub & ((1U << length) - 1U)) {
+    if (MODLEN(toSub, length)) {
         FlushReg(start, length);
         qReg->DECBCD(toSub, start, length);
     }


### PR DESCRIPTION
QFusion might buffer multiple gates that should compose as the identity matrix. For example, two X gates on the same bit should buffer as (approximately or exactly) the identity matrix. If a buffer needs to be flushed after composing just two X gates, for example, the buffer gate need not be applied at all. This scenario might actually be relatively common.

In this PR, when we start a buffer flush, we check if the buffer is (approximately or exactly) equal to the identity. If it is, we simply discard the buffer instead of applying it, to give the same result. This works with single bit gates, arithmetic gates, and the controlled variants of both those types.