### PR TITLE
QUnitMulti Optimization

### DIFF
--- a/include/qengine_opencl.hpp
+++ b/include/qengine_opencl.hpp
@@ -160,6 +160,7 @@ public:
     virtual void PhaseFlipIfLess(bitCapInt greaterPerm, bitLenInt start, bitLenInt length);
 
     virtual void SetDevice(const int& dID, const bool& forceReInit = false);
+    virtual int GetDeviceID() { return deviceID; }
 
     virtual void SetQuantumState(complex* inputState);
     virtual void GetQuantumState(complex* outputState);

--- a/include/qunitmulti.hpp
+++ b/include/qunitmulti.hpp
@@ -36,7 +36,8 @@ struct QEngineInfo {
         // Intentionally left blank
     }
 
-    bool operator< (const QEngineInfo& other) {
+    bool operator<(const QEngineInfo& other)
+    {
         if (size == other.size) {
             return deviceID < other.deviceID;
         } else {

--- a/include/qunitmulti.hpp
+++ b/include/qunitmulti.hpp
@@ -26,6 +26,23 @@ namespace Qrack {
 struct QEngineInfo {
     bitCapInt size;
     bitLenInt deviceID;
+    QEngineOCL* unit;
+
+    QEngineInfo(bitCapInt sz, bitLenInt devID, QEngineOCL* u)
+        : size(sz)
+        , deviceID(devID)
+        , unit(u)
+    {
+        // Intentionally left blank
+    }
+
+    bool operator< (const QEngineInfo& other) {
+        if (size == other.size) {
+            return deviceID < other.deviceID;
+        } else {
+            return size < other.size;
+        }
+    }
 };
 
 class QUnitMulti;
@@ -36,7 +53,6 @@ class QUnitMulti : public QUnit, public ParallelFor {
 protected:
     int deviceCount;
     int defaultDeviceID;
-    std::vector<int> deviceIDs;
 
 public:
     QUnitMulti(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState = 0,

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -177,8 +177,8 @@ void QEngineOCL::SetDevice(const int& dID, const bool& forceReInit)
     }
 
     int oldDeviceID = deviceID;
-    deviceID = dID;
-    device_context = OCLEngine::Instance()->GetDeviceContextPtr(deviceID);
+    device_context = OCLEngine::Instance()->GetDeviceContextPtr(dID);
+    deviceID = device_context->context_id;
     context = device_context->context;
     cl::CommandQueue oldQueue = queue;
     queue = device_context->queue;

--- a/src/qunitmulti.cpp
+++ b/src/qunitmulti.cpp
@@ -55,7 +55,8 @@ void QUnitMulti::RedistributeQEngines()
 
     for (i = 0; i < qinfos.size(); i++) {
         devID = i;
-        // If a given device has 0 load, or if the engine adds negligible load, we can keep let any given unit keep its residency on this device.
+        // If a given device has 0 load, or if the engine adds negligible load, we can keep let any given unit keep its
+        // residency on this device.
         if (qinfos[i].size <= 2U) {
             break;
         }


### PR DESCRIPTION
Most of the additional overhead for QUnitMulti in the unit tests is redistribution of single bit engines. If we only redistribute large separable blocks, we might efficiently distribute to multiple devices, if we leave any small separable systems on the device they start out on.