### PR TITLE
Device-memory-only option for QEngineOCL

### DIFF
--- a/include/qengine_cpu.hpp
+++ b/include/qengine_cpu.hpp
@@ -38,7 +38,7 @@ protected:
 
 public:
     QEngineCPU(bitLenInt qBitCount, bitCapInt initState, std::shared_ptr<std::default_random_engine> rgp = nullptr,
-        complex phaseFac = complex(-999.0, -999.0), bool doNorm = true);
+        complex phaseFac = complex(-999.0, -999.0), bool doNorm = true, bool useHostMem = false);
     QEngineCPU(QEngineCPUPtr toCopy);
     ~QEngineCPU() { delete[] stateVec; }
 

--- a/include/qengine_cpu.hpp
+++ b/include/qengine_cpu.hpp
@@ -164,7 +164,7 @@ protected:
     virtual void Apply2x2(bitCapInt offset1, bitCapInt offset2, const complex* mtrx, const bitLenInt bitCount,
         const bitCapInt* qPowersSorted, bool doCalcNorm);
     virtual void UpdateRunningNorm();
-    virtual complex* AllocStateVec(bitCapInt elemCount, bool ovrride = false);
+    virtual complex* AllocStateVec(bitCapInt elemCount, bool doForceAlloc = false);
     virtual void ApplyM(bitCapInt mask, bitCapInt result, complex nrm);
 };
 } // namespace Qrack

--- a/include/qengine_cpu.hpp
+++ b/include/qengine_cpu.hpp
@@ -125,7 +125,7 @@ public:
     virtual void CPhaseFlipIfLess(bitCapInt greaterPerm, bitLenInt start, bitLenInt length, bitLenInt flagIndex);
     virtual void PhaseFlipIfLess(bitCapInt greaterPerm, bitLenInt start, bitLenInt length);
     virtual void PhaseFlip();
-    virtual void SetPermutation(bitCapInt perm);
+    virtual void SetPermutation(bitCapInt perm, complex phaseFac = complex(-999.0, -999.0));
     virtual bitCapInt IndexedLDA(bitLenInt indexStart, bitLenInt indexLength, bitLenInt valueStart,
         bitLenInt valueLength, unsigned char* values);
     virtual bitCapInt IndexedADC(bitLenInt indexStart, bitLenInt indexLength, bitLenInt valueStart,
@@ -164,7 +164,7 @@ protected:
     virtual void Apply2x2(bitCapInt offset1, bitCapInt offset2, const complex* mtrx, const bitLenInt bitCount,
         const bitCapInt* qPowersSorted, bool doCalcNorm);
     virtual void UpdateRunningNorm();
-    virtual complex* AllocStateVec(bitCapInt elemCount);
+    virtual complex* AllocStateVec(bitCapInt elemCount, bool ovrride = false);
     virtual void ApplyM(bitCapInt mask, bitCapInt result, complex nrm);
 };
 } // namespace Qrack

--- a/include/qengine_opencl.hpp
+++ b/include/qengine_opencl.hpp
@@ -78,7 +78,7 @@ public:
      * object to zero norm.
      *
      * "devID" is the index of an OpenCL device in the OCLEngine singleton, to select the device to run this engine on.
-     * If "useHostMem" is set false, (as by default,) the QEngineOCL will attempt to allocate the state vector object
+     * If "useHostMem" is set false, as by default, the QEngineOCL will attempt to allocate the state vector object
      * only on device memory. If "useHostMem" is set true, general host RAM will be used for the state vector buffers.
      * If the state vector is too large to allocate only on device memory, the QEngineOCL will attempt to fall back to
      * allocating it in general host RAM.
@@ -86,7 +86,7 @@ public:
      * \warning "useHostMem" is not conscious of allocation by other QEngineOCL instances on the same device. Attempting
      * to allocate too much device memory across too many QEngineOCL instances, for which each instance would have
      * sufficient device resources on its own, will probably cause the program to crash (and may lead to general system
-     * instability). For safety, "useHostMem" can be totally turned off.
+     * instability). For safety, "useHostMem" can be turned on.
      */
 
     QEngineOCL(bitLenInt qBitCount, bitCapInt initState, std::shared_ptr<std::default_random_engine> rgp = nullptr,

--- a/include/qengine_opencl.hpp
+++ b/include/qengine_opencl.hpp
@@ -66,6 +66,7 @@ protected:
     size_t nrmGroupSize;
     size_t maxWorkItems;
     unsigned int procElemCount;
+    bool useHostRam;
 
 public:
     /**
@@ -81,7 +82,7 @@ public:
      */
 
     QEngineOCL(bitLenInt qBitCount, bitCapInt initState, std::shared_ptr<std::default_random_engine> rgp = nullptr,
-        complex phaseFac = complex(-999.0, -999.0), bool doNorm = true, int devID = -1);
+        complex phaseFac = complex(-999.0, -999.0), bool doNorm = true, bool useHostMem = true, int devID = -1);
     QEngineOCL(QEngineOCLPtr toCopy);
     ~QEngineOCL()
     {
@@ -100,7 +101,7 @@ public:
 
     virtual void SetQubitCount(bitLenInt qb);
 
-    virtual void SetPermutation(bitCapInt perm);
+    virtual void SetPermutation(bitCapInt perm, complex phaseFac = complex(-999.0, -999.0));
     virtual void CopyState(QInterfacePtr orig);
     virtual real1 ProbAll(bitCapInt fullRegister);
 
@@ -199,7 +200,8 @@ protected:
 
     void InitOCL(int devID);
     void ResetStateVec(complex* nStateVec, BufferPtr nStateBuffer);
-    virtual complex* AllocStateVec(bitCapInt elemCount);
+    virtual complex* AllocStateVec(bitCapInt elemCount, bool ovrride = false);
+    virtual BufferPtr MakeStateVecBuffer(complex* nStateVec);
 
     real1 ParSum(real1* toSum, bitCapInt maxI);
 

--- a/include/qengine_opencl.hpp
+++ b/include/qengine_opencl.hpp
@@ -79,13 +79,19 @@ public:
      * object to zero norm.
      *
      * "devID" is the index of an OpenCL device in the OCLEngine singleton, to select the device to run this engine on.
-     * "partialInit" is usually only set to true when this object is one of several collected in a
-     * Qrack::QEngineOCLMulti object, in which case this Qrack::QEngineOCL object might not contain the amplitude of the
-     * overall permutation state of the combined object.
+     * If "useHostMem" is set false, (as by default,) the QEngineOCL will attempt to allocate the state vector object
+     * only on device memory. If "useHostMem" is set true, general host RAM will be used for the state vector buffers.
+     * If the state vector is too large to allocate only on device memory, the QEngineOCL will attempt to fall back to
+     * allocating it in general host RAM.
+     *
+     * \warning "useHostMem" is not conscious of allocation by other QEngineOCL instances on the same device. Attempting
+     * to allocate too much device memory across too many QEngineOCL instances, for which each instance would have
+     * sufficient device resources on its own, will probably cause the program to crash (and may lead to general system
+     * instability). For safety, "useHostMem" can be totally turned off.
      */
 
     QEngineOCL(bitLenInt qBitCount, bitCapInt initState, std::shared_ptr<std::default_random_engine> rgp = nullptr,
-        complex phaseFac = complex(-999.0, -999.0), bool doNorm = true, bool useHostMem = true, int devID = -1);
+        complex phaseFac = complex(-999.0, -999.0), bool doNorm = true, bool useHostMem = false, int devID = -1);
     QEngineOCL(QEngineOCLPtr toCopy);
     ~QEngineOCL()
     {

--- a/include/qengine_opencl.hpp
+++ b/include/qengine_opencl.hpp
@@ -209,7 +209,7 @@ protected:
 
     void InitOCL(int devID);
     void ResetStateVec(complex* nStateVec, BufferPtr nStateBuffer);
-    virtual complex* AllocStateVec(bitCapInt elemCount, bool ovrride = false);
+    virtual complex* AllocStateVec(bitCapInt elemCount, bool doForceAlloc = false);
     virtual BufferPtr MakeStateVecBuffer(complex* nStateVec);
 
     real1 ParSum(real1* toSum, bitCapInt maxI);

--- a/include/qengine_opencl.hpp
+++ b/include/qengine_opencl.hpp
@@ -69,7 +69,6 @@ protected:
     size_t maxAlloc;
     unsigned int procElemCount;
     bool useHostRam;
-    bool usingHostRam;
 
 public:
     /**

--- a/include/qengine_opencl.hpp
+++ b/include/qengine_opencl.hpp
@@ -65,8 +65,11 @@ protected:
     size_t nrmGroupCount;
     size_t nrmGroupSize;
     size_t maxWorkItems;
+    size_t maxMem;
+    size_t maxAlloc;
     unsigned int procElemCount;
     bool useHostRam;
+    bool usingHostRam;
 
 public:
     /**

--- a/include/qfusion.hpp
+++ b/include/qfusion.hpp
@@ -47,7 +47,7 @@ protected:
 public:
     QFusion(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState = 0,
         std::shared_ptr<std::default_random_engine> rgp = nullptr, complex phaseFac = complex(-999.0, -999.0),
-        bool doNorm = true);
+        bool doNorm = true, bool useHostMem = false);
     QFusion(QInterfacePtr target);
 
     virtual void SetQuantumState(complex* inputState);

--- a/include/qfusion.hpp
+++ b/include/qfusion.hpp
@@ -53,7 +53,7 @@ public:
     virtual void SetQuantumState(complex* inputState);
     virtual void GetQuantumState(complex* outputState);
     virtual complex GetAmplitude(bitCapInt perm);
-    virtual void SetPermutation(bitCapInt perm);
+    virtual void SetPermutation(bitCapInt perm, complex phaseFac = complex(-999.0, -999.0));
     virtual void SetReg(bitLenInt start, bitLenInt length, bitCapInt value);
     virtual void SetBit(bitLenInt qubitIndex, bool value);
     using QInterface::Cohere;

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -168,7 +168,7 @@ public:
     virtual complex GetAmplitude(bitCapInt perm) = 0;
 
     /** Set to a specific permutation */
-    virtual void SetPermutation(bitCapInt perm) = 0;
+    virtual void SetPermutation(bitCapInt perm, complex phaseFac = complex(-999.0, -999.0)) = 0;
 
     /**
      * Combine another QInterface with this one, after the last bit index of

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -56,7 +56,10 @@ public:
     virtual void SetQuantumState(complex* inputState);
     virtual void GetQuantumState(complex* outputState);
     virtual complex GetAmplitude(bitCapInt perm);
-    virtual void SetPermutation(bitCapInt perm) { SetReg(0, qubitCount, perm); }
+    virtual void SetPermutation(bitCapInt perm, complex phaseFac = complex(-999.0, -999.0))
+    {
+        SetReg(0, qubitCount, perm);
+    }
     using QInterface::Cohere;
     virtual bitLenInt Cohere(QInterfacePtr toCopy);
     virtual void Decohere(bitLenInt start, bitLenInt length, QInterfacePtr dest);

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -36,6 +36,7 @@ protected:
     std::vector<QEngineShard> shards;
     complex phaseFactor;
     bool doNormalize;
+    bool useHostRam;
 
     std::shared_ptr<std::default_random_engine> rand_generator;
 
@@ -48,10 +49,10 @@ protected:
 public:
     QUnit(QInterfaceEngine eng, QInterfaceEngine subEng, bitLenInt qBitCount, bitCapInt initState = 0,
         std::shared_ptr<std::default_random_engine> rgp = nullptr, complex phaseFac = complex(-999.0, -999.0),
-        bool doNorm = true);
+        bool doNorm = true, bool useHostMem = false);
     QUnit(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState = 0,
         std::shared_ptr<std::default_random_engine> rgp = nullptr, complex phaseFac = complex(-999.0, -999.0),
-        bool doNorm = true);
+        bool doNorm = true, bool useHostMem = false);
 
     virtual void SetQuantumState(complex* inputState);
     virtual void GetQuantumState(complex* outputState);

--- a/include/qunitmulti.hpp
+++ b/include/qunitmulti.hpp
@@ -58,13 +58,13 @@ protected:
 public:
     QUnitMulti(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState = 0,
         std::shared_ptr<std::default_random_engine> rgp = nullptr, complex phaseFac = complex(-999.0, -999.0),
-        bool doNorm = true)
-        : QUnitMulti(qBitCount, initState, rgp, phaseFac, doNorm)
+        bool doNorm = true, bool useHostMem = false)
+        : QUnitMulti(qBitCount, initState, rgp, phaseFac, doNorm, useHostMem)
     {
     }
 
     QUnitMulti(bitLenInt qBitCount, bitCapInt initState = 0, std::shared_ptr<std::default_random_engine> rgp = nullptr,
-        complex phaseFac = complex(-999.0, -999.0), bool doNorm = true);
+        complex phaseFac = complex(-999.0, -999.0), bool doNorm = true, bool useHostMem = false);
 
     virtual void SetReg(bitLenInt start, bitLenInt length, bitCapInt value);
     virtual bitCapInt MReg(bitLenInt start, bitLenInt length);

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -264,23 +264,27 @@ void QEngineOCL::SetDevice(const int& dID, const bool& forceReInit)
 
     // create buffers on device (allocate space on GPU)
     if (didInit) {
-        // In this branch, the QEngineOCL was previously allocated, and now we need to copy its memory to a buffer that's accessible in a new device. (The old buffer is definitely not accessible to the new device.)
+        // In this branch, the QEngineOCL was previously allocated, and now we need to copy its memory to a buffer
+        // that's accessible in a new device. (The old buffer is definitely not accessible to the new device.)
 
         if (!stateVec) {
-            // We did not have host allocation, so we definitely have to copy device-local memory to host memory, then to a new device.
+            // We did not have host allocation, so we definitely have to copy device-local memory to host memory, then
+            // to a new device.
             cl::CommandQueue nQueue = queue;
             queue = oldQueue;
 
             complex* nStateVec = AllocStateVec(maxQPower, true);
             BufferPtr nStateBuffer = MakeStateVecBuffer(nStateVec);
             cl::Event copyEvent;
-            oldQueue.enqueueCopyBuffer(*stateBuffer, *nStateBuffer, 0, 0, sizeof(complex) * maxQPower, NULL, &copyEvent);
+            oldQueue.enqueueCopyBuffer(
+                *stateBuffer, *nStateBuffer, 0, 0, sizeof(complex) * maxQPower, NULL, &copyEvent);
             copyEvent.wait();
 
             // Host RAM should now by synchronized.
             queue = nQueue;
             if (usingHostRam) {
-                // If we're using host RAM from here out, just create the buffer from the array pointer, in the context of the new device/queue.
+                // If we're using host RAM from here out, just create the buffer from the array pointer, in the context
+                // of the new device/queue.
                 stateBuffer = MakeStateVecBuffer(nStateVec);
                 stateVec = nStateVec;
             } else {
@@ -290,17 +294,20 @@ void QEngineOCL::SetDevice(const int& dID, const bool& forceReInit)
                 free(nStateVec);
             }
         } else if (!usingHostRam) {
-            // We had host allocation; we will no longer have it. Just copy the array pointer into a buffer in the new context.
+            // We had host allocation; we will no longer have it. Just copy the array pointer into a buffer in the new
+            // context.
             stateBuffer = MakeStateVecBuffer(NULL);
             queue.enqueueWriteBuffer(*stateBuffer, CL_TRUE, 0, sizeof(bitCapInt) * BCI_ARG_LEN, stateVec);
             free(stateVec);
             stateVec = NULL;
         } else {
-            // We had host allocation; we will continue to have it. Just make the array pointer a buffer in the new context.
+            // We had host allocation; we will continue to have it. Just make the array pointer a buffer in the new
+            // context.
             stateBuffer = MakeStateVecBuffer(stateVec);
         }
     } else {
-        // In this branch, the QEngineOCL is first being initialized, and no data needs to be copied between device contexts.
+        // In this branch, the QEngineOCL is first being initialized, and no data needs to be copied between device
+        // contexts.
         stateBuffer = MakeStateVecBuffer(stateVec);
     }
 

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -207,6 +207,7 @@ void QEngineOCL::SetDevice(const int& dID, const bool& forceReInit)
     bitCapInt oldNrmGroupCount = nrmGroupCount;
     nrmGroupSize = ocl.call.getWorkGroupInfo<CL_KERNEL_PREFERRED_WORK_GROUP_SIZE_MULTIPLE>(device_context->device);
     procElemCount = device_context->device.getInfo<CL_DEVICE_MAX_COMPUTE_UNITS>();
+
     // If the user wants to not use general host RAM, but we can't allocate enough on the device, fall back to host RAM
     // anyway.
     maxMem = device_context->device.getInfo<CL_DEVICE_GLOBAL_MEM_SIZE>();
@@ -218,6 +219,7 @@ void QEngineOCL::SetDevice(const int& dID, const bool& forceReInit)
     } else {
         usingHostRam = false;
     }
+
     // constrain to a power of two
     size_t procElemPow = 2;
     while (procElemPow < procElemCount) {

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -293,17 +293,17 @@ void QEngineOCL::SetDevice(const int& dID, const bool& forceReInit)
                 queue.enqueueWriteBuffer(*stateBuffer, CL_TRUE, 0, sizeof(bitCapInt) * BCI_ARG_LEN, nStateVec);
                 free(nStateVec);
             }
-        } else if (!usingHostRam) {
+        } else if (usingHostRam) {
+            // We had host allocation; we will continue to have it. Just make the array pointer a buffer in the new
+            // context.
+            stateBuffer = MakeStateVecBuffer(stateVec);
+        } else {
             // We had host allocation; we will no longer have it. Just copy the array pointer into a buffer in the new
             // context.
             stateBuffer = MakeStateVecBuffer(NULL);
             queue.enqueueWriteBuffer(*stateBuffer, CL_TRUE, 0, sizeof(bitCapInt) * BCI_ARG_LEN, stateVec);
             free(stateVec);
             stateVec = NULL;
-        } else {
-            // We had host allocation; we will continue to have it. Just make the array pointer a buffer in the new
-            // context.
-            stateBuffer = MakeStateVecBuffer(stateVec);
         }
     } else {
         // In this branch, the QEngineOCL is first being initialized, and no data needs to be copied between device

--- a/src/qengine/state.cpp
+++ b/src/qengine/state.cpp
@@ -30,11 +30,14 @@ namespace Qrack {
  * Initialize a coherent unit with qBitCount number of bits, to initState unsigned integer permutation state, with
  * a shared random number generator, with a specific phase.
  *
+ * (Note that "useHostMem" is required as a parameter to normalize constructors for use with the
+ * CreateQuantumInterface() factory, but it serves no function in QEngineCPU.)
+ *
  * \warning Overall phase is generally arbitrary and unknowable. Setting two QEngineCPU instances to the same
  * phase usually makes sense only if they are initialized at the same time.
  */
 QEngineCPU::QEngineCPU(bitLenInt qBitCount, bitCapInt initState, std::shared_ptr<std::default_random_engine> rgp,
-    complex phaseFac, bool doNorm)
+    complex phaseFac, bool doNorm, bool useHostMem)
     : QEngine(qBitCount, rgp, doNorm)
     , stateVec(NULL)
 {

--- a/src/qengine/state.cpp
+++ b/src/qengine/state.cpp
@@ -76,11 +76,18 @@ complex QEngineCPU::GetAmplitude(bitCapInt perm)
     return stateVec[perm];
 }
 
-void QEngineCPU::SetPermutation(bitCapInt perm)
+void QEngineCPU::SetPermutation(bitCapInt perm, complex phaseFac)
 {
     std::fill(stateVec, stateVec + maxQPower, complex(ZERO_R1, ZERO_R1));
-    real1 angle = Rand() * 2.0 * PI_R1;
-    stateVec[perm] = complex(cos(angle), sin(angle));
+
+    if (phaseFac == complex(-999.0, -999.0)) {
+        real1 angle = Rand() * 2.0 * PI_R1;
+        stateVec[perm] = complex(cos(angle), sin(angle));
+    } else {
+        real1 nrm = abs(phaseFac);
+        stateVec[perm] = phaseFac / nrm;
+    }
+
     runningNorm = ONE_R1;
 }
 
@@ -585,7 +592,7 @@ void QEngineCPU::NormalizeState(real1 nrm)
 
 void QEngineCPU::UpdateRunningNorm() { runningNorm = par_norm(maxQPower, stateVec); }
 
-complex* QEngineCPU::AllocStateVec(bitCapInt elemCount)
+complex* QEngineCPU::AllocStateVec(bitCapInt elemCount, bool ovrride)
 {
 // elemCount is always a power of two, but might be smaller than ALIGN_SIZE
 #ifdef __APPLE__

--- a/src/qfusion.cpp
+++ b/src/qfusion.cpp
@@ -324,10 +324,10 @@ complex QFusion::GetAmplitude(bitCapInt perm)
     return qReg->GetAmplitude(perm);
 }
 
-void QFusion::SetPermutation(bitCapInt perm)
+void QFusion::SetPermutation(bitCapInt perm, complex phaseFac)
 {
     DiscardAll();
-    qReg->SetPermutation(perm);
+    qReg->SetPermutation(perm, phaseFac);
 }
 
 void QFusion::SetReg(bitLenInt start, bitLenInt length, bitCapInt value)

--- a/src/qfusion.cpp
+++ b/src/qfusion.cpp
@@ -20,14 +20,14 @@
 namespace Qrack {
 
 QFusion::QFusion(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState,
-    std::shared_ptr<std::default_random_engine> rgp, complex phaseFac, bool doNorm)
+    std::shared_ptr<std::default_random_engine> rgp, complex phaseFac, bool doNorm, bool useHostMem)
     : QInterface(qBitCount, rgp)
     , phaseFactor(phaseFac)
     , doNormalize(doNorm)
     , bitBuffers(qBitCount)
     , bitControls(qBitCount)
 {
-    qReg = CreateQuantumInterface(eng, qBitCount, initState, rgp, phaseFactor, doNormalize);
+    qReg = CreateQuantumInterface(eng, qBitCount, initState, rgp, phaseFactor, doNormalize, useHostMem);
 }
 
 QFusion::QFusion(QInterfacePtr target)

--- a/src/qunitmulti.cpp
+++ b/src/qunitmulti.cpp
@@ -16,8 +16,8 @@
 namespace Qrack {
 
 QUnitMulti::QUnitMulti(bitLenInt qBitCount, bitCapInt initState, std::shared_ptr<std::default_random_engine> rgp,
-    complex phaseFac, bool doNorm)
-    : QUnit(QINTERFACE_OPENCL, qBitCount, initState, rgp, phaseFac, doNorm)
+    complex phaseFac, bool doNorm, bool useHostMem)
+    : QUnit(QINTERFACE_OPENCL, qBitCount, initState, rgp, phaseFac, doNorm, useHostMem)
 {
     // Notice that this constructor does not take an engine type parameter, and it always passes QINTERFACE_OPENCL to
     // the QUnit constructor. For QUnitMulti, the "shard" engines are therefore guaranteed to always be QEngineOCL

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -122,7 +122,7 @@ void benchmarkLoopVariable(std::function<void(QInterfacePtr, int)> fn, bitLenInt
 }
 
 void benchmarkLoop(std::function<void(QInterfacePtr, int)> fn) { benchmarkLoopVariable(fn, MaxQubits); }
-
+#if 0
 TEST_CASE("test_cnot_all")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->CNOT(0, n / 2, n / 2); });
@@ -343,7 +343,7 @@ TEST_CASE("test_qft_ideal_init")
         qftReg->MReg(0, qftReg->GetQubitCount());
     });
 }
-
+#endif
 TEST_CASE("test_qft")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->QFT(0, n); });

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -122,7 +122,7 @@ void benchmarkLoopVariable(std::function<void(QInterfacePtr, int)> fn, bitLenInt
 }
 
 void benchmarkLoop(std::function<void(QInterfacePtr, int)> fn) { benchmarkLoopVariable(fn, MaxQubits); }
-#if 0
+
 TEST_CASE("test_cnot_all")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->CNOT(0, n / 2, n / 2); });
@@ -343,7 +343,7 @@ TEST_CASE("test_qft_ideal_init")
         qftReg->MReg(0, qftReg->GetQubitCount());
     });
 }
-#endif
+
 TEST_CASE("test_qft")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->QFT(0, n); });


### PR DESCRIPTION
This branch gives the user the option to rely entirely on OpenCL device memory, for QEngineOCL. It gives a significant speed boost to the unit tests, to use only device memory. Additionally, it potentially frees GB of memory in general heap, as general RAM no longer needs to be used for state vector allocation.

The original behavior is entirely recovered by constructing the QEngineOCL with "useHostMem = true." Stability might become an issue at the limits of device RAM usage and processing workload, but then the option can simply be toggled with this Boolean. Device memory might be limited to 8GB or significantly less, but QEngineOCL falls back to host memory allocation if it cannot allocate a large enough segment of RAM, and, again, the original behavior can be entirely recovered with the Boolean parameter.