### PR TITLE
Separability debug

### DIFF
--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -244,6 +244,8 @@ protected:
     void ApplyEitherControlled(const bitLenInt* controls, const bitLenInt& controlLen,
         const std::vector<bitLenInt> targets, const bool& anti, CF cfn, F f);
 
+    bool DoesOperatorPhaseShift(const complex* mtrx);
+
     /* Debugging and diagnostic routines. */
     void DumpShards();
     QInterfacePtr GetUnit(bitLenInt bit) { return shards[bit].unit; }

--- a/src/qengine/qengine.cpp
+++ b/src/qengine/qengine.cpp
@@ -161,7 +161,7 @@ void QEngine::ApplyControlledSingleBit(
     if (controlLen == 0) {
         ApplySingleBit(mtrx, true, target);
     } else {
-        ApplyControlled2x2(controls, controlLen, target, mtrx, controlLen == 0);
+        ApplyControlled2x2(controls, controlLen, target, mtrx, false);
         if (doNormalize) {
             UpdateRunningNorm();
         }
@@ -171,10 +171,13 @@ void QEngine::ApplyControlledSingleBit(
 void QEngine::ApplyAntiControlledSingleBit(
     const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& target, const complex* mtrx)
 {
-    ApplyAntiControlled2x2(controls, controlLen, target, mtrx, controlLen == 0);
-
-    if (doNormalize && controlLen) {
-        UpdateRunningNorm();
+    if (controlLen == 0) {
+        ApplySingleBit(mtrx, true, target);
+    } else {
+        ApplyAntiControlled2x2(controls, controlLen, target, mtrx, false);
+        if (doNormalize) {
+            UpdateRunningNorm();
+        }
     }
 }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -647,6 +647,9 @@ void QUnit::ApplyControlledSingleBit(
             unit->ApplyControlledSingleBit(mappedControls, controlLen, shards[target].mapped, mtrx);
             if (DoesOperatorPhaseShift(mtrx)) {
                 shards[target].isPhaseDirty = true;
+                for (bitLenInt i = 0; i < controlLen; i++) {
+                    shards[controls[i]].isPhaseDirty = true;
+                }
             }
             return TrySeparate({ target });
         },
@@ -661,6 +664,9 @@ void QUnit::ApplyAntiControlledSingleBit(
             unit->ApplyAntiControlledSingleBit(mappedControls, controlLen, shards[target].mapped, mtrx);
             if (DoesOperatorPhaseShift(mtrx)) {
                 shards[target].isPhaseDirty = true;
+                for (bitLenInt i = 0; i < controlLen; i++) {
+                    shards[controls[i]].isPhaseDirty = true;
+                }
             }
             return TrySeparate({ target });
         },
@@ -697,6 +703,9 @@ void QUnit::CSqrtSwap(
             unit->CSqrtSwap(mappedControls, controlLen, shards[qubit1].mapped, shards[qubit2].mapped);
             shards[qubit1].isPhaseDirty = true;
             shards[qubit2].isPhaseDirty = true;
+            for (bitLenInt i = 0; i < controlLen; i++) {
+                shards[controls[i]].isPhaseDirty = true;
+            }
             return TrySeparate({ qubit1, qubit2 });
         },
         [&]() { SqrtSwap(qubit1, qubit2); });
@@ -710,6 +719,9 @@ void QUnit::AntiCSqrtSwap(
             unit->AntiCSqrtSwap(mappedControls, controlLen, shards[qubit1].mapped, shards[qubit2].mapped);
             shards[qubit1].isPhaseDirty = true;
             shards[qubit2].isPhaseDirty = true;
+            for (bitLenInt i = 0; i < controlLen; i++) {
+                shards[controls[i]].isPhaseDirty = true;
+            }
             return TrySeparate({ qubit1, qubit2 });
         },
         [&]() { SqrtSwap(qubit1, qubit2); });
@@ -723,6 +735,9 @@ void QUnit::CISqrtSwap(
             unit->CISqrtSwap(mappedControls, controlLen, shards[qubit1].mapped, shards[qubit2].mapped);
             shards[qubit1].isPhaseDirty = true;
             shards[qubit2].isPhaseDirty = true;
+            for (bitLenInt i = 0; i < controlLen; i++) {
+                shards[controls[i]].isPhaseDirty = true;
+            }
             return TrySeparate({ qubit1, qubit2 });
         },
         [&]() { ISqrtSwap(qubit1, qubit2); });
@@ -736,6 +751,9 @@ void QUnit::AntiCISqrtSwap(
             unit->AntiCISqrtSwap(mappedControls, controlLen, shards[qubit1].mapped, shards[qubit2].mapped);
             shards[qubit1].isPhaseDirty = true;
             shards[qubit2].isPhaseDirty = true;
+            for (bitLenInt i = 0; i < controlLen; i++) {
+                shards[controls[i]].isPhaseDirty = true;
+            }
             return TrySeparate({ qubit1, qubit2 });
         },
         [&]() { ISqrtSwap(qubit1, qubit2); });
@@ -760,12 +778,11 @@ void QUnit::ApplyEitherControlled(const bitLenInt* controls, const bitLenInt& co
     if (prob <= min_norm) {
         return;
     } else if (min_norm >= (ONE_R1 - prob)) {
-        // The following commented code block should be safe, theoretically but it isn't.
-        // for (i = 0; i < controlLen; i++) {
-        //    if (!shards[controls[i]].isPhaseDirty) {
-        //        ForceM(controls[i], !anti);
-        //    }
-        //}
+        for (i = 0; i < controlLen; i++) {
+            if (!shards[controls[i]].isPhaseDirty) {
+                ForceM(controls[i], !anti);
+            }
+        }
 
         fn();
         return;

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -388,7 +388,7 @@ bool QUnit::TrySeparate(std::vector<bitLenInt> bits)
 
                 if (shard.isPhaseDirty) {
                     complex amp0 = testBit->GetAmplitude(0);
-                    complex phase0;
+                    real1 phase0;
                     if (norm(amp0) < min_norm) {
                         shards[bits[i]].isPhaseDirty = false;
                         continue;

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -397,7 +397,7 @@ bool QUnit::TrySeparate(std::vector<bitLenInt> bits)
                     }
 
                     complex amp1 = testBit->GetAmplitude(1);
-                    complex phase1;
+                    real1 phase1;
                     if (norm(amp1) < min_norm) {
                         shards[bits[i]].isPhaseDirty = false;
                         continue;

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -122,7 +122,7 @@ void benchmarkLoopVariable(std::function<void(QInterfacePtr, int)> fn, bitLenInt
 }
 
 void benchmarkLoop(std::function<void(QInterfacePtr, int)> fn) { benchmarkLoopVariable(fn, MaxQubits); }
-
+#if 0
 TEST_CASE("test_cnot_all")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->CNOT(0, n / 2, n / 2); });
@@ -343,7 +343,7 @@ TEST_CASE("test_qft_ideal_init")
         qftReg->MReg(0, qftReg->GetQubitCount());
     });
 }
-
+#endif
 TEST_CASE("test_qft")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->QFT(0, n); });

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -122,7 +122,7 @@ void benchmarkLoopVariable(std::function<void(QInterfacePtr, int)> fn, bitLenInt
 }
 
 void benchmarkLoop(std::function<void(QInterfacePtr, int)> fn) { benchmarkLoopVariable(fn, MaxQubits); }
-#if 0
+
 TEST_CASE("test_cnot_all")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->CNOT(0, n / 2, n / 2); });
@@ -343,7 +343,7 @@ TEST_CASE("test_qft_ideal_init")
         qftReg->MReg(0, qftReg->GetQubitCount());
     });
 }
-#endif
+
 TEST_CASE("test_qft")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->QFT(0, n); });


### PR DESCRIPTION
This is a temporary-to-permanent fix for a sporadically failing CRT unit test, with variants of QEngineCPU. The test failed on very roughly 1 out of 100 trials on the test system, but it could be reliably reproduced by iterating the test 1000 times.

The deeper issue might be QEngineCPU's M() method. The commented code in QUnit's ApplyEitherControlled should be theoretically safe, but it fails seemingly specifically with QUnit, QEngineCPU variants. I also noticed that additional isPhaseDirty logic should be added. None of this hurts performance on QFT benchmarks.