### PR TITLE
Fixing QEngineOCL deconstructor

### DIFF
--- a/include/qengine_opencl.hpp
+++ b/include/qengine_opencl.hpp
@@ -95,8 +95,12 @@ public:
     ~QEngineOCL()
     {
         clFinish();
-        delete[] stateVec;
-        delete[] nrmArray;
+        if (stateVec) {
+            free(stateVec);
+        }
+        if (nrmArray) {
+            free(nrmArray);
+        }
     }
 
     /**


### PR DESCRIPTION
The deallocation in the QEngineOCL deconstructor has never been right. This fixes it, and it also anticipates moving the "normBuffer" into device memory.