### PR TITLE
WIP: Debugging for ProjectQ

### DIFF
--- a/include/qengine.hpp
+++ b/include/qengine.hpp
@@ -34,7 +34,7 @@ public:
         : QInterface(n, rgp, doNorm)
         , runningNorm(ONE_R1){};
 
-    virtual bool ForceM(bitLenInt qubitIndex, bool result, bool doForce = true, real1 nrmlzr = 1.0);
+    virtual bool ForceM(bitLenInt qubitIndex, bool result, bool doForce = true);
     virtual bitCapInt ForceM(const bitLenInt* bits, const bitLenInt& length, const bool* values);
     virtual bitCapInt ForceMReg(bitLenInt start, bitLenInt length, bitCapInt result, bool doForce = true);
 

--- a/include/qfusion.hpp
+++ b/include/qfusion.hpp
@@ -82,7 +82,7 @@ public:
         const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& qubit1, const bitLenInt& qubit2);
     virtual void AntiCISqrtSwap(
         const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& qubit1, const bitLenInt& qubit2);
-    virtual bool ForceM(bitLenInt qubit, bool result, bool doForce = true, real1 nrmlzr = ONE_R1);
+    virtual bool ForceM(bitLenInt qubit, bool result, bool doForce = true);
     virtual bitCapInt ForceM(const bitLenInt* bits, const bitLenInt& length, const bool* values);
     virtual bitCapInt ForceMReg(bitLenInt start, bitLenInt length, bitCapInt result, bool doForce = true);
 

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -455,14 +455,14 @@ public:
      * assumed to be in a known fixed state, like all |0>, ahead of time to
      * produce unitary logical comparison operations.)
      */
-    virtual bool M(bitLenInt qubitIndex) { return ForceM(qubitIndex, false, false, ONE_R1); };
+    virtual bool M(bitLenInt qubitIndex) { return ForceM(qubitIndex, false, false); };
 
     /**
      * Act as if is a measurement was applied, except force the (usually random) result
      *
      * \warning PSEUDO-QUANTUM
      */
-    virtual bool ForceM(bitLenInt qubit, bool result, bool doForce = true, real1 nrmlzr = ONE_R1) = 0;
+    virtual bool ForceM(bitLenInt qubit, bool result, bool doForce = true) = 0;
 
     /**
      * S gate

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -89,7 +89,7 @@ public:
     virtual void AntiCISqrtSwap(
         const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& qubit1, const bitLenInt& qubit2);
     using QInterface::ForceM;
-    virtual bool ForceM(bitLenInt qubitIndex, bool result, bool doForce = true, real1 nrmlzr = 1.0);
+    virtual bool ForceM(bitLenInt qubitIndex, bool result, bool doForce = true);
 
     /** @} */
 

--- a/src/common/qengine.cl
+++ b/src/common/qengine.cl
@@ -432,9 +432,7 @@ void kernel probmask(global cmplx* stateVec, constant bitCapInt* bitCapIntPtr, g
     cmplx amp;
     bitCapInt i, iHigh, iLow, p;
 
-    real1 nrm;
-
-    for (lcv = ID; lcv < maxI; lcv++) {
+    for (lcv = ID; lcv < maxI; lcv+=Nthreads) {
         iHigh = lcv;
         i = 0U;
         for (p = 0U; p < len; p++) {

--- a/src/common/qengine.cl
+++ b/src/common/qengine.cl
@@ -432,7 +432,9 @@ void kernel probmask(global cmplx* stateVec, constant bitCapInt* bitCapIntPtr, g
     cmplx amp;
     bitCapInt i, iHigh, iLow, p;
 
-    for (lcv = 0U; lcv < maxI; lcv++) {
+    real1 nrm;
+
+    for (lcv = ID; lcv < maxI; lcv++) {
         iHigh = lcv;
         i = 0U;
         for (p = 0U; p < len; p++) {

--- a/src/qengine/qengine.cpp
+++ b/src/qengine/qengine.cpp
@@ -15,30 +15,28 @@
 namespace Qrack {
 
 /// PSEUDO-QUANTUM - Acts like a measurement gate, except with a specified forced result.
-bool QEngine::ForceM(bitLenInt qubit, bool result, bool doForce, real1 nrmlzr)
+bool QEngine::ForceM(bitLenInt qubit, bool result, bool doForce)
 {
-    if (doNormalize && (runningNorm != ONE_R1)) {
+    if (doNormalize) {
         NormalizeState();
     }
 
+    real1 oneChance = Prob(qubit);
     if (!doForce) {
         real1 prob = Rand();
-        real1 oneChance = Prob(qubit);
         result = ((prob < oneChance) && (oneChance > ZERO_R1));
-        nrmlzr = ONE_R1;
-        if (result) {
-            nrmlzr = oneChance;
-        } else {
-            nrmlzr = ONE_R1 - oneChance;
-        }
     }
-    if (nrmlzr > min_norm) {
-        bitCapInt qPower = 1 << qubit;
-        real1 angle = Rand() * 2 * M_PI;
-        ApplyM(qPower, result, complex(cos(angle), sin(angle)) / (real1)(sqrt(nrmlzr)));
+
+    real1 nrmlzr;
+    if (result) {
+        nrmlzr = oneChance;
     } else {
-        NormalizeState(ZERO_R1);
+        nrmlzr = ONE_R1 - oneChance;
     }
+
+    bitCapInt qPower = 1 << qubit;
+    real1 angle = Rand() * 2 * M_PI;
+    ApplyM(qPower, result, complex(cos(angle), sin(angle)) / (real1)(sqrt(nrmlzr)));
 
     return result;
 }
@@ -63,7 +61,7 @@ bitCapInt QEngine::ForceM(const bitLenInt* bits, const bitLenInt& length, const 
         }
     }
 
-    if (runningNorm != ONE_R1) {
+    if (doNormalize) {
         NormalizeState();
     }
 
@@ -465,7 +463,7 @@ bitCapInt QEngine::ForceMReg(bitLenInt start, bitLenInt length, bitCapInt result
         }
     }
 
-    if (runningNorm != ONE_R1) {
+    if (doNormalize) {
         NormalizeState();
     }
 

--- a/src/qfusion.cpp
+++ b/src/qfusion.cpp
@@ -420,10 +420,10 @@ void QFusion::AntiCISqrtSwap(
     qReg->AntiCISqrtSwap(controls, controlLen, qubit1, qubit2);
 }
 
-bool QFusion::ForceM(bitLenInt qubit, bool result, bool doForce, real1 nrmlzr)
+bool QFusion::ForceM(bitLenInt qubit, bool result, bool doForce)
 {
     FlushAll();
-    return qReg->ForceM(qubit, result, doForce, nrmlzr);
+    return qReg->ForceM(qubit, result, doForce);
 }
 
 bitCapInt QFusion::ForceM(const bitLenInt* bits, const bitLenInt& length, const bool* values)

--- a/src/qinterface/gates.cpp
+++ b/src/qinterface/gates.cpp
@@ -27,8 +27,8 @@ void QInterface::H(bitLenInt qubit)
 {
     // if (qubit >= qubitCount) throw std::invalid_argument("operation on bit index greater than total
     // bits.");
-    const complex had[4] = { complex(M_SQRT1_2, ZERO_R1), complex(M_SQRT1_2, ZERO_R1),
-        complex(M_SQRT1_2, ZERO_R1), complex(-M_SQRT1_2, ZERO_R1) };
+    const complex had[4] = { complex(M_SQRT1_2, ZERO_R1), complex(M_SQRT1_2, ZERO_R1), complex(M_SQRT1_2, ZERO_R1),
+        complex(-M_SQRT1_2, ZERO_R1) };
     ApplySingleBit(had, true, qubit);
 }
 

--- a/src/qinterface/gates.cpp
+++ b/src/qinterface/gates.cpp
@@ -27,8 +27,8 @@ void QInterface::H(bitLenInt qubit)
 {
     // if (qubit >= qubitCount) throw std::invalid_argument("operation on bit index greater than total
     // bits.");
-    const complex had[4] = { complex(ONE_R1 / M_SQRT2, ZERO_R1), complex(ONE_R1 / M_SQRT2, ZERO_R1),
-        complex(ONE_R1 / M_SQRT2, ZERO_R1), complex(-ONE_R1 / M_SQRT2, ZERO_R1) };
+    const complex had[4] = { complex(M_SQRT1_2, ZERO_R1), complex(M_SQRT1_2, ZERO_R1),
+        complex(M_SQRT1_2, ZERO_R1), complex(-M_SQRT1_2, ZERO_R1) };
     ApplySingleBit(had, true, qubit);
 }
 
@@ -58,7 +58,7 @@ void QInterface::T(bitLenInt qubit)
     // if (qubit >= qubitCount)
     //     throw std::invalid_argument("operation on bit index greater than total bits.");
     const complex tOp[4] = { complex(ONE_R1, ZERO_R1), complex(ZERO_R1, ZERO_R1), complex(ZERO_R1, ZERO_R1),
-        complex(M_SQRT2, M_SQRT2) };
+        complex(M_SQRT1_2, M_SQRT1_2) };
     ApplySingleBit(tOp, false, qubit);
 }
 
@@ -68,7 +68,7 @@ void QInterface::IT(bitLenInt qubit)
     // if (qubit >= qubitCount)
     //     throw std::invalid_argument("operation on bit index greater than total bits.");
     const complex itOp[4] = { complex(ONE_R1, ZERO_R1), complex(ZERO_R1, ZERO_R1), complex(ZERO_R1, ZERO_R1),
-        complex(M_SQRT2, -M_SQRT2) };
+        complex(M_SQRT1_2, -M_SQRT1_2) };
     ApplySingleBit(itOp, false, qubit);
 }
 

--- a/src/qinterface/qinterface.cpp
+++ b/src/qinterface/qinterface.cpp
@@ -711,7 +711,7 @@ bitCapInt QInterface::ForceMReg(bitLenInt start, bitLenInt length, bitCapInt res
     bitCapInt power;
     for (bitLenInt bit = 0; bit < length; bit++) {
         power = 1U << bit;
-        res |= ForceM(start + bit, !(!(power & result)), doForce, ONE_R1) ? power : 0;
+        res |= ForceM(start + bit, !(!(power & result)), doForce) ? power : 0;
     }
     return res;
 }

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -520,11 +520,11 @@ real1 QUnit::ProbAll(bitCapInt perm)
     return result;
 }
 
-bool QUnit::ForceM(bitLenInt qubit, bool res, bool doForce, real1 nrmlzr)
+bool QUnit::ForceM(bitLenInt qubit, bool res, bool doForce)
 {
     shards[qubit].isPhaseDirty = false;
 
-    bool result = shards[qubit].unit->ForceM(shards[qubit].mapped, res, doForce, nrmlzr);
+    bool result = shards[qubit].unit->ForceM(shards[qubit].mapped, res, doForce);
 
     QInterfacePtr unit = shards[qubit].unit;
     bitLenInt mapped = shards[qubit].mapped;

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -32,7 +32,7 @@ using namespace Qrack;
         REQUIRE(__tmp_b > (__tmp_b - EPSILON));                                                                        \
     } while (0);
 
-const bitLenInt MaxQubits = 24;
+const bitLenInt MaxQubits = 28;
 
 void benchmarkLoopVariable(std::function<void(QInterfacePtr, int)> fn, bitLenInt mxQbts)
 {
@@ -127,7 +127,7 @@ TEST_CASE("test_cnot_all")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->CNOT(0, n / 2, n / 2); });
 }
-
+#if 0
 TEST_CASE("test_ccnot_all")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->CCNOT(0, n / 3, (2 * n) / 3, n / 3); });
@@ -137,12 +137,12 @@ TEST_CASE("test_swap_all")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->Swap(0, n / 2, n / 2); });
 }
-
+#endif
 TEST_CASE("test_x_all")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->X(0, n); });
 }
-
+#if 0
 TEST_CASE("test_and_all")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->AND(0, n / 3, (2 * n) / 3, n / 3); });
@@ -284,7 +284,7 @@ TEST_CASE("test_set_reg")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->SetReg(0, n, 1); });
 }
-
+#endif
 TEST_CASE("test_cnot_single")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->CNOT(0, 1, 1); });
@@ -294,12 +294,12 @@ TEST_CASE("test_x_single")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->X(0, 1); });
 }
-
+#if 0
 TEST_CASE("test_swap_single")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->Swap(0, 1); });
 }
-
+#endif
 TEST_CASE("test_grover")
 {
 
@@ -333,9 +333,9 @@ TEST_CASE("test_grover")
 
             qftReg->MReg(0, n);
         },
-        16);
+        20);
 }
-
+#if 0
 TEST_CASE("test_qft_ideal_init")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) {
@@ -343,7 +343,7 @@ TEST_CASE("test_qft_ideal_init")
         qftReg->MReg(0, qftReg->GetQubitCount());
     });
 }
-
+#endif
 TEST_CASE("test_qft")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->QFT(0, n); });

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -60,7 +60,7 @@ void benchmarkLoopVariable(std::function<void(QInterfacePtr, int)> fn, bitLenInt
 
     // Grover's search inverts the function of a black box subroutine.
     // Our subroutine returns true only for an input of 100.
-    for (numBits = 3; numBits <= mxQbts; numBits++) {
+    for (numBits = 4; numBits <= mxQbts; numBits++) {
         QInterfacePtr qftReg = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, numBits,
             0, rng, complex(ONE_R1, ZERO_R1), !disable_normalization);
         avgt = 0.0;
@@ -299,7 +299,7 @@ TEST_CASE("test_swap_single")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->Swap(0, 1); });
 }
-#endif
+
 TEST_CASE("test_grover")
 {
 
@@ -335,7 +335,7 @@ TEST_CASE("test_grover")
         },
         20);
 }
-#if 0
+
 TEST_CASE("test_qft_ideal_init")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) {
@@ -343,8 +343,9 @@ TEST_CASE("test_qft_ideal_init")
         qftReg->MReg(0, qftReg->GetQubitCount());
     });
 }
-#endif
+
 TEST_CASE("test_qft")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->QFT(0, n); });
 }
+#endif

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -199,7 +199,7 @@ QInterfaceTestFixture::QInterfaceTestFixture()
 
     if (disable_normalization) {
         qftReg = CreateQuantumInterface(
-            testEngineType, testSubEngineType, testSubSubEngineType, 20, 0, rng, complex(ONE_R1, ZERO_R1), true);
+            testEngineType, testSubEngineType, testSubSubEngineType, 20, 0, rng, complex(ONE_R1, ZERO_R1), false);
     } else {
         qftReg = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 20, 0, rng);
     }

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -1904,6 +1904,23 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_probmask")
     REQUIRE(qftReg->ProbMask(0xF0, 0x40) < 0.01);
 }
 
+TEST_CASE_METHOD(QInterfaceTestFixture, "test_forcem")
+{
+    qftReg->SetPermutation(0x0);
+    qftReg->H(0, 4);
+
+    REQUIRE_FLOAT(qftReg->ProbMask(0xF, 0xA), 0.0625);
+
+    bitLenInt bits[3] = { 0, 1, 2 };
+    bool results[3] = { 0, 1, 0 };
+
+    qftReg->ForceM(bits, 3, results);
+
+    REQUIRE(qftReg->ProbMask(0x7, 0x2) > 0.99);
+    REQUIRE_FLOAT(qftReg->ProbMask(0xF, 0xA), 0.5);
+}
+
+
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_getamplitude")
 {
     qftReg->SetPermutation(0x03);

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -1920,7 +1920,6 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_forcem")
     REQUIRE_FLOAT(qftReg->ProbMask(0xF, 0xA), 0.5);
 }
 
-
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_getamplitude")
 {
     qftReg->SetPermutation(0x03);

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -1909,7 +1909,8 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_forcem")
     qftReg->SetPermutation(0x0);
     qftReg->H(0, 4);
 
-    REQUIRE_FLOAT(qftReg->ProbMask(0xF, 0xA), 0.0625);
+    REQUIRE_FLOAT(qftReg->ProbMask(0xF, 0), 0.0625);
+    REQUIRE_FLOAT(qftReg->ProbMask(0x7, 0), 0.125);
 
     bitLenInt bits[3] = { 0, 1, 2 };
     bool results[3] = { 0, 1, 0 };
@@ -1917,7 +1918,7 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_forcem")
     qftReg->ForceM(bits, 3, results);
 
     REQUIRE(qftReg->ProbMask(0x7, 0x2) > 0.99);
-    REQUIRE_FLOAT(qftReg->ProbMask(0xF, 0xA), 0.5);
+    REQUIRE_FLOAT(qftReg->ProbMask(0xF, 0x2), 0.5);
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_getamplitude")


### PR DESCRIPTION
The branch, as it is, fixes a problem with the loop control variable initialization and increment of QEngineOCL's ProbMask. This issue was discovered in testing against ProjectQ unit tests, but a Qrack unit test was added that isolated it.

The branch might be done as-is. However, with that problem fixed, I'm trying to wrap TimeEvolve back into an interface in ProjectQ. TimeEvolve might be entirely correct, but I won't be sure until I've debugged the wrapper for ProjectQ. When that is debugged, this branch will either be done, as it is now, or more debugging will be done probably on TimeEvolve.