### PR TITLE
WIP: Adding logarithm of gate method

### DIFF
--- a/include/common/qrack_types.hpp
+++ b/include/common/qrack_types.hpp
@@ -12,6 +12,8 @@
 
 #pragma once
 
+#include <memory>
+
 #define bitLenInt uint8_t
 #define bitCapInt uint64_t
 #define bitsInByte 8
@@ -39,4 +41,7 @@
 
 namespace Qrack {
 typedef std::shared_ptr<complex> BitOp;
-}
+
+void exp(complex* matrix2x2, complex* outMatrix2x2);
+void log(complex* matrix2x2, complex* outMatrix2x2);
+} // namespace Qrack

--- a/include/common/qrack_types.hpp
+++ b/include/common/qrack_types.hpp
@@ -42,6 +42,7 @@
 namespace Qrack {
 typedef std::shared_ptr<complex> BitOp;
 
-void exp(complex* matrix2x2, complex* outMatrix2x2);
-void log(complex* matrix2x2, complex* outMatrix2x2);
+void mul2x2(complex* left, complex* right, complex* out);
+void exp2x2(complex* matrix2x2, complex* outMatrix2x2);
+void log2x2(complex* matrix2x2, complex* outMatrix2x2);
 } // namespace Qrack

--- a/include/hamiltonian.hpp
+++ b/include/hamiltonian.hpp
@@ -28,29 +28,43 @@ struct HamiltonianOp {
     bitLenInt* controls;
     bitLenInt controlLen;
     bool anti;
+    bool* toggles;
 
     HamiltonianOp(bitLenInt target, BitOp mtrx)
         : targetBit(target)
         , matrix(mtrx)
         , controls(NULL)
         , controlLen(0)
+        , anti(false)
+        , toggles(NULL)
     {
     }
 
-    HamiltonianOp(bitLenInt* ctrls, bitLenInt ctrlLen, bool antiCtrled, bitLenInt target, BitOp mtrx)
+    HamiltonianOp(bitLenInt* ctrls, bitLenInt ctrlLen, bitLenInt target, BitOp mtrx, bool antiCtrled = false,
+        bool* ctrlToggles = NULL)
         : targetBit(target)
         , matrix(mtrx)
         , controls(new bitLenInt[ctrlLen])
         , controlLen(ctrlLen)
         , anti(antiCtrled)
+        , toggles(NULL)
     {
         std::copy(ctrls, ctrls + ctrlLen, controls);
+
+        if (ctrlToggles) {
+            toggles = new bool[ctrlLen];
+            std::copy(ctrlToggles, ctrlToggles + ctrlLen, toggles);
+        }
     }
 
     ~HamiltonianOp()
     {
         if (controls) {
             delete[] controls;
+        }
+
+        if (toggles) {
+            delete[] toggles;
         }
     }
 };
@@ -59,7 +73,14 @@ struct HamiltonianOp {
  * To define a Hamiltonian, give a vector of controlled single bit gates ("HamiltonianOp" instances) that are
  * applied by left-multiplication in low-to-high vector index order on the state vector.
  *
- * \warning Hamiltonian components might not commute, and observe the component factor of 2 * pi.
+ * To specify Hamiltonians with interaction terms, arbitrary sets of control bits may be specified for each term, in
+ * which case the term is acted only if the (superposable) control bits are true. The "antiCtrled" bool flips the
+ * overall convention, such that the term is acted only if all control bits are false. Additionally, for a combination
+ * of control bits and "anti-control" bits, an array of booleans, "ctrlToggles," of length "ctrlLen" may be specified
+ * that flips the activation state for each control bit, (relative the global anti- on/off convention,) without altering
+ * the state of the control bits.
+ *
+ * \warning Hamiltonian components might not commute.
  *
  * As a general point of linear algebra, where A and B are linear operators, e^{i * (A + B) * t} = e^{i * A * t} *
  * e^{i * B * t} might NOT hold, if the operators A and B do not commute. As a rule of thumb, A will commute with B

--- a/include/hamiltonian.hpp
+++ b/include/hamiltonian.hpp
@@ -80,6 +80,11 @@ struct HamiltonianOp {
  * that flips the activation state for each control bit, (relative the global anti- on/off convention,) without altering
  * the state of the control bits.
  *
+ * The point of this "toggle" behavior is to allow enumeration of arbitrary local Hamiltonian terms with permutations of
+ * a set of control bits. For example, a Hamiltonian might represent an array of local electromagnetic potential wells.
+ * If there are 4 wells, each with independent potentials, control "toggles" could be used on two control bits, to
+ * enumerate all four permutations of two control bits with four different local Hamiltonian terms.
+ *
  * \warning Hamiltonian components might not commute.
  *
  * As a general point of linear algebra, where A and B are linear operators, e^{i * (A + B) * t} = e^{i * A * t} *

--- a/include/hamiltonian.hpp
+++ b/include/hamiltonian.hpp
@@ -27,6 +27,7 @@ struct HamiltonianOp {
     BitOp matrix;
     bitLenInt* controls;
     bitLenInt controlLen;
+    bool anti;
 
     HamiltonianOp(bitLenInt target, BitOp mtrx)
         : targetBit(target)
@@ -36,11 +37,12 @@ struct HamiltonianOp {
     {
     }
 
-    HamiltonianOp(bitLenInt* ctrls, bitLenInt ctrlLen, bitLenInt target, BitOp mtrx)
+    HamiltonianOp(bitLenInt* ctrls, bitLenInt ctrlLen, bool antiCtrled, bitLenInt target, BitOp mtrx)
         : targetBit(target)
         , matrix(mtrx)
         , controls(new bitLenInt[ctrlLen])
         , controlLen(ctrlLen)
+        , anti(antiCtrled)
     {
         std::copy(ctrls, ctrls + ctrlLen, controls);
     }

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -124,8 +124,6 @@ protected:
 
     template <typename GateFunc> void ControlledLoopFixture(bitLenInt length, GateFunc gate);
 
-    virtual void ExpLog(bitLenInt* controls, bitLenInt controlLen, bitLenInt qubit, complex* matrix2x2, bool isExp);
-
 public:
     QInterface(bitLenInt n, std::shared_ptr<std::default_random_engine> rgp = nullptr, bool doNorm = true)
         : rand_distribution(0.0, 1.0)

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -638,14 +638,14 @@ public:
      *
      * Applies \f$ e^{-i*Op} \f$, where "Op" is a 2x2 matrix, (with controls on the application of the gate).
      */
-    virtual void Exp(bitLenInt* controls, bitLenInt controlLen, bitLenInt qubit, complex* matrix2x2);
+    virtual void Exp(bitLenInt* controls, bitLenInt controlLen, bitLenInt qubit, complex* matrix2x2, bool antiCtrled = false);
 
     /**
      *  Logarithm of arbitrary 2x2 gate
      *
      * Applies \f$ log(Op) \f$, where "Op" is a 2x2 matrix, (with controls on the application of the gate).
      */
-    virtual void Log(bitLenInt* controls, bitLenInt controlLen, bitLenInt qubit, complex* matrix2x2);
+    virtual void Log(bitLenInt* controls, bitLenInt controlLen, bitLenInt qubit, complex* matrix2x2, bool antiCtrled = false);
 
     /**
      * Dyadic fraction (identity) exponentiation gate

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -638,14 +638,16 @@ public:
      *
      * Applies \f$ e^{-i*Op} \f$, where "Op" is a 2x2 matrix, (with controls on the application of the gate).
      */
-    virtual void Exp(bitLenInt* controls, bitLenInt controlLen, bitLenInt qubit, complex* matrix2x2, bool antiCtrled = false);
+    virtual void Exp(
+        bitLenInt* controls, bitLenInt controlLen, bitLenInt qubit, complex* matrix2x2, bool antiCtrled = false);
 
     /**
      *  Logarithm of arbitrary 2x2 gate
      *
      * Applies \f$ log(Op) \f$, where "Op" is a 2x2 matrix, (with controls on the application of the gate).
      */
-    virtual void Log(bitLenInt* controls, bitLenInt controlLen, bitLenInt qubit, complex* matrix2x2, bool antiCtrled = false);
+    virtual void Log(
+        bitLenInt* controls, bitLenInt controlLen, bitLenInt qubit, complex* matrix2x2, bool antiCtrled = false);
 
     /**
      * Dyadic fraction (identity) exponentiation gate

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -124,6 +124,8 @@ protected:
 
     template <typename GateFunc> void ControlledLoopFixture(bitLenInt length, GateFunc gate);
 
+    virtual void ExpLog(bitLenInt* controls, bitLenInt controlLen, bitLenInt qubit, complex* matrix2x2, bool isExp);
+
 public:
     QInterface(bitLenInt n, std::shared_ptr<std::default_random_engine> rgp = nullptr, bool doNorm = true)
         : rand_distribution(0.0, 1.0)
@@ -634,11 +636,18 @@ public:
     virtual void Exp(real1 radians, bitLenInt qubitIndex);
 
     /**
-     *  Exponentiation of arbitrary 2x2 gate
+     *  Imaginary exponentiation of arbitrary 2x2 gate
      *
-     * Applies \f$ e^{-i*Op*I} \f$, where "Op" is a 2x2 matrix, (with controls on the application of the gate).
+     * Applies \f$ e^{-i*Op} \f$, where "Op" is a 2x2 matrix, (with controls on the application of the gate).
      */
     virtual void Exp(bitLenInt* controls, bitLenInt controlLen, bitLenInt qubit, complex* matrix2x2);
+
+    /**
+     *  Logarithm of arbitrary 2x2 gate
+     *
+     * Applies \f$ log(Op) \f$, where "Op" is a 2x2 matrix, (with controls on the application of the gate).
+     */
+    virtual void Log(bitLenInt* controls, bitLenInt controlLen, bitLenInt qubit, complex* matrix2x2);
 
     /**
      * Dyadic fraction (identity) exponentiation gate

--- a/src/qinterface/operators.cpp
+++ b/src/qinterface/operators.cpp
@@ -171,7 +171,23 @@ void QInterface::TimeEvolve(Hamiltonian h, real1 timeDiff)
         for (int j = 0; j < 4; j++) {
             mtrx[j] = opMtrx[j] * (-timeDiff);
         }
+        if (op->toggles) {
+            for (bitLenInt j = 0; j < op->controlLen; j++) {
+                if (op->toggles[j]) {
+                    X(op->controls[j]);
+                }
+            }
+        }
+
         Exp(op->controls, op->controlLen, op->targetBit, mtrx, op->anti);
+
+        if (op->toggles) {
+            for (bitLenInt j = 0; j < op->controlLen; j++) {
+                if (op->toggles[j]) {
+                    X(op->controls[j]);
+                }
+            }
+        }
     }
 }
 } // namespace Qrack

--- a/src/qinterface/operators.cpp
+++ b/src/qinterface/operators.cpp
@@ -171,7 +171,7 @@ void QInterface::TimeEvolve(Hamiltonian h, real1 timeDiff)
         for (int j = 0; j < 4; j++) {
             mtrx[j] = opMtrx[j] * (-timeDiff);
         }
-        Exp(op->controls, op->controlLen, op->targetBit, mtrx);
+        Exp(op->controls, op->controlLen, op->targetBit, mtrx, op->anti);
     }
 }
 } // namespace Qrack

--- a/src/qinterface/protected.cpp
+++ b/src/qinterface/protected.cpp
@@ -36,7 +36,7 @@ void rotate(BidirectionalIterator first, BidirectionalIterator middle, Bidirecti
 
 template void rotate<complex*>(complex* first, complex* middle, complex* last, bitCapInt stride);
 
-void matrix2x2Mul(complex* left, complex* right, complex* out)
+void mul2x2(complex* left, complex* right, complex* out)
 {
     out[0] = (left[0] * right[0]) + (left[1] * right[2]);
     out[1] = (left[0] * right[1]) + (left[1] * right[3]);
@@ -44,7 +44,7 @@ void matrix2x2Mul(complex* left, complex* right, complex* out)
     out[3] = (left[2] * right[1]) + (left[3] * right[3]);
 }
 
-void _expLog(complex* matrix2x2, complex* outMatrix2x2, bool isExp)
+void _expLog2x2(complex* matrix2x2, complex* outMatrix2x2, bool isExp)
 {
     // Solve for the eigenvalues and eigenvectors of a 2x2 matrix, diagonalize, exponentiate, return to the original
     // basis, and apply.
@@ -99,8 +99,8 @@ void _expLog(complex* matrix2x2, complex* outMatrix2x2, bool isExp)
         inverseJacobian[2] = -jacobian[2] / determinant;
         inverseJacobian[3] = jacobian[0] / determinant;
 
-        matrix2x2Mul(matrix2x2, jacobian, tempMatrix2x2);
-        matrix2x2Mul(inverseJacobian, tempMatrix2x2, expOfGate);
+        mul2x2(matrix2x2, jacobian, tempMatrix2x2);
+        mul2x2(inverseJacobian, tempMatrix2x2, expOfGate);
     } else {
         std::copy(matrix2x2, matrix2x2 + 4, expOfGate);
     }
@@ -124,15 +124,15 @@ void _expLog(complex* matrix2x2, complex* outMatrix2x2, bool isExp)
     }
 
     if (!isDiag) {
-        matrix2x2Mul(expOfGate, inverseJacobian, tempMatrix2x2);
-        matrix2x2Mul(jacobian, tempMatrix2x2, expOfGate);
+        mul2x2(expOfGate, inverseJacobian, tempMatrix2x2);
+        mul2x2(jacobian, tempMatrix2x2, expOfGate);
     }
 
     std::copy(expOfGate, expOfGate + 4, outMatrix2x2);
 }
 
-void exp(complex* matrix2x2, complex* outMatrix2x2) { _expLog(matrix2x2, outMatrix2x2, true); }
+void exp2x2(complex* matrix2x2, complex* outMatrix2x2) { _expLog2x2(matrix2x2, outMatrix2x2, true); }
 
-void log(complex* matrix2x2, complex* outMatrix2x2) { _expLog(matrix2x2, outMatrix2x2, false); }
+void log2x2(complex* matrix2x2, complex* outMatrix2x2) { _expLog2x2(matrix2x2, outMatrix2x2, false); }
 
 } // namespace Qrack

--- a/src/qinterface/protected.cpp
+++ b/src/qinterface/protected.cpp
@@ -10,9 +10,9 @@
 // See LICENSE.md in the project root or https://www.gnu.org/licenses/lgpl-3.0.en.html
 // for details.
 
+#include "common/qrack_types.hpp"
 #include <algorithm>
-
-#include "qinterface.hpp"
+#include <cmath>
 
 namespace Qrack {
 
@@ -35,5 +35,104 @@ void rotate(BidirectionalIterator first, BidirectionalIterator middle, Bidirecti
 }
 
 template void rotate<complex*>(complex* first, complex* middle, complex* last, bitCapInt stride);
+
+void matrix2x2Mul(complex* left, complex* right, complex* out)
+{
+    out[0] = (left[0] * right[0]) + (left[1] * right[2]);
+    out[1] = (left[0] * right[1]) + (left[1] * right[3]);
+    out[2] = (left[2] * right[0]) + (left[3] * right[2]);
+    out[3] = (left[2] * right[1]) + (left[3] * right[3]);
+}
+
+void _expLog(complex* matrix2x2, complex* outMatrix2x2, bool isExp)
+{
+    // Solve for the eigenvalues and eigenvectors of a 2x2 matrix, diagonalize, exponentiate, return to the original
+    // basis, and apply.
+
+    // Diagonal matrices are a special case.
+    bool isDiag = true;
+    if (norm(matrix2x2[1]) > min_norm) {
+        isDiag = false;
+    } else if (norm(matrix2x2[2]) > min_norm) {
+        isDiag = false;
+    }
+
+    complex expOfGate[4];
+    complex jacobian[4];
+    complex inverseJacobian[4];
+    complex tempMatrix2x2[4];
+
+    // Diagonalize the matrix, if it is not already diagonal. Otherwise, copy it into the temporary matrix.
+    if (!isDiag) {
+        complex trace = matrix2x2[0] + matrix2x2[3];
+        complex determinant = (matrix2x2[0] * matrix2x2[3]) - (matrix2x2[1] * matrix2x2[2]);
+        complex quadraticRoot =
+            sqrt((matrix2x2[0] - matrix2x2[3]) * (matrix2x2[0] - matrix2x2[3]) - (real1)(4.0) * determinant);
+        complex eigenvalue1 = (trace + quadraticRoot) / (real1)2.0;
+        complex eigenvalue2 = (trace - quadraticRoot) / (real1)2.0;
+
+        if (norm(matrix2x2[1]) > min_norm) {
+            jacobian[0] = matrix2x2[1];
+            jacobian[2] = eigenvalue1 - matrix2x2[0];
+
+            jacobian[1] = matrix2x2[1];
+            jacobian[3] = eigenvalue2 - matrix2x2[0];
+        } else {
+            jacobian[0] = eigenvalue1 - matrix2x2[3];
+            jacobian[2] = matrix2x2[2];
+
+            jacobian[1] = eigenvalue2 - matrix2x2[3];
+            jacobian[3] = matrix2x2[2];
+        }
+
+        real1 nrm = std::sqrt(norm(jacobian[0]) + norm(jacobian[2]));
+        jacobian[0] /= nrm;
+        jacobian[2] /= nrm;
+
+        nrm = std::sqrt(norm(jacobian[1]) + norm(jacobian[3]));
+        jacobian[1] /= nrm;
+        jacobian[3] /= nrm;
+
+        determinant = (jacobian[0] * jacobian[3]) - (jacobian[1] * jacobian[2]);
+        inverseJacobian[0] = jacobian[3] / determinant;
+        inverseJacobian[1] = -jacobian[1] / determinant;
+        inverseJacobian[2] = -jacobian[2] / determinant;
+        inverseJacobian[3] = jacobian[0] / determinant;
+
+        matrix2x2Mul(matrix2x2, jacobian, tempMatrix2x2);
+        matrix2x2Mul(inverseJacobian, tempMatrix2x2, expOfGate);
+    } else {
+        std::copy(matrix2x2, matrix2x2 + 4, expOfGate);
+    }
+
+    if (isExp) {
+        // In this branch, we calculate e^(matrix2x2).
+
+        // Note: For a (2x2) hermitian input gate, this theoretically produces a unitary output transformation.
+        expOfGate[0] = ((real1)std::exp(real(expOfGate[0]))) *
+            complex((real1)cos(imag(expOfGate[0])), (real1)sin(imag(expOfGate[0])));
+        expOfGate[1] = complex(ZERO_R1, ZERO_R1);
+        expOfGate[2] = complex(ZERO_R1, ZERO_R1);
+        expOfGate[3] = ((real1)std::exp(real(expOfGate[3]))) *
+            complex((real1)cos(imag(expOfGate[3])), (real1)sin(imag(expOfGate[3])));
+    } else {
+        // In this branch, we calculate log(matrix2x2).
+        expOfGate[0] = complex(std::log(abs(expOfGate[0])), arg(expOfGate[0]));
+        expOfGate[1] = complex(ZERO_R1, ZERO_R1);
+        expOfGate[2] = complex(ZERO_R1, ZERO_R1);
+        expOfGate[3] = complex(std::log(abs(expOfGate[3])), arg(expOfGate[3]));
+    }
+
+    if (!isDiag) {
+        matrix2x2Mul(expOfGate, inverseJacobian, tempMatrix2x2);
+        matrix2x2Mul(jacobian, tempMatrix2x2, expOfGate);
+    }
+
+    std::copy(expOfGate, expOfGate + 4, outMatrix2x2);
+}
+
+void exp(complex* matrix2x2, complex* outMatrix2x2) { _expLog(matrix2x2, outMatrix2x2, true); }
+
+void log(complex* matrix2x2, complex* outMatrix2x2) { _expLog(matrix2x2, outMatrix2x2, false); }
 
 } // namespace Qrack

--- a/src/qinterface/rotational.cpp
+++ b/src/qinterface/rotational.cpp
@@ -72,7 +72,7 @@ void QInterface::Exp(bitLenInt* controls, bitLenInt controlLen, bitLenInt qubit,
     for (bitLenInt i = 0; i < 4; i++) {
         timesI[i] = complex(ZERO_R1, ONE_R1) * matrix2x2[i];
     }
-    Qrack::exp(timesI, toApply);
+    Qrack::exp2x2(timesI, toApply);
     if (antiCtrled) {
         ApplyAntiControlledSingleBit(controls, controlLen, qubit, toApply);
     } else {
@@ -84,7 +84,7 @@ void QInterface::Exp(bitLenInt* controls, bitLenInt controlLen, bitLenInt qubit,
 void QInterface::Log(bitLenInt* controls, bitLenInt controlLen, bitLenInt qubit, complex* matrix2x2, bool antiCtrled)
 {
     complex toApply[4];
-    Qrack::log(matrix2x2, toApply);
+    Qrack::log2x2(matrix2x2, toApply);
     if (antiCtrled) {
         ApplyAntiControlledSingleBit(controls, controlLen, qubit, toApply);
     } else {

--- a/src/qinterface/rotational.cpp
+++ b/src/qinterface/rotational.cpp
@@ -65,7 +65,7 @@ void QInterface::Exp(real1 radians, bitLenInt qubit)
 }
 
 /// Imaginary exponentiate of arbitrary single bit gate
-void QInterface::Exp(bitLenInt* controls, bitLenInt controlLen, bitLenInt qubit, complex* matrix2x2)
+void QInterface::Exp(bitLenInt* controls, bitLenInt controlLen, bitLenInt qubit, complex* matrix2x2, bool antiCtrled)
 {
     complex timesI[4];
     complex toApply[4];
@@ -73,15 +73,23 @@ void QInterface::Exp(bitLenInt* controls, bitLenInt controlLen, bitLenInt qubit,
         timesI[i] = complex(ZERO_R1, ONE_R1) * matrix2x2[i];
     }
     Qrack::exp(timesI, toApply);
-    ApplyControlledSingleBit(controls, controlLen, qubit, toApply);
+    if (antiCtrled) {
+        ApplyAntiControlledSingleBit(controls, controlLen, qubit, toApply);
+    } else {
+        ApplyControlledSingleBit(controls, controlLen, qubit, toApply);
+    }
 }
 
 /// Logarithm of arbitrary single bit gate
-void QInterface::Log(bitLenInt* controls, bitLenInt controlLen, bitLenInt qubit, complex* matrix2x2)
+void QInterface::Log(bitLenInt* controls, bitLenInt controlLen, bitLenInt qubit, complex* matrix2x2, bool antiCtrled)
 {
     complex toApply[4];
     Qrack::log(matrix2x2, toApply);
-    ApplyControlledSingleBit(controls, controlLen, qubit, toApply);
+    if (antiCtrled) {
+        ApplyAntiControlledSingleBit(controls, controlLen, qubit, toApply);
+    } else {
+        ApplyControlledSingleBit(controls, controlLen, qubit, toApply);
+    }
 }
 
 /// Exponentiate Pauli X operator

--- a/src/qinterface/rotational.cpp
+++ b/src/qinterface/rotational.cpp
@@ -67,8 +67,12 @@ void QInterface::Exp(real1 radians, bitLenInt qubit)
 /// Imaginary exponentiate of arbitrary single bit gate
 void QInterface::Exp(bitLenInt* controls, bitLenInt controlLen, bitLenInt qubit, complex* matrix2x2)
 {
+    complex timesI[4];
     complex toApply[4];
-    Qrack::exp(matrix2x2, toApply);
+    for (bitLenInt i = 0; i < 4; i++) {
+        timesI[i] = complex(ZERO_R1, ONE_R1) * matrix2x2[i];
+    }
+    Qrack::exp(timesI, toApply);
     ApplyControlledSingleBit(controls, controlLen, qubit, toApply);
 }
 

--- a/src/qinterface/rotational.cpp
+++ b/src/qinterface/rotational.cpp
@@ -64,111 +64,20 @@ void QInterface::Exp(real1 radians, bitLenInt qubit)
     ApplySingleBit(expIdentity, true, qubit);
 }
 
-void matrix2x2Mul(complex* left, complex* right, complex* out)
-{
-    out[0] = (left[0] * right[0]) + (left[1] * right[2]);
-    out[1] = (left[0] * right[1]) + (left[1] * right[3]);
-    out[2] = (left[2] * right[0]) + (left[3] * right[2]);
-    out[3] = (left[2] * right[1]) + (left[3] * right[3]);
-}
-
-void QInterface::ExpLog(bitLenInt* controls, bitLenInt controlLen, bitLenInt qubit, complex* matrix2x2, bool isExp)
-{
-    // Solve for the eigenvalues and eigenvectors of a 2x2 matrix, diagonalize, exponentiate, return to the original
-    // basis, and apply.
-
-    // Diagonal matrices are a special case.
-    bool isDiag = true;
-    if (norm(matrix2x2[1]) > min_norm) {
-        isDiag = false;
-    } else if (norm(matrix2x2[2]) > min_norm) {
-        isDiag = false;
-    }
-
-    complex expOfGate[4];
-    complex jacobian[4];
-    complex inverseJacobian[4];
-    complex tempMatrix2x2[4];
-
-    // Diagonalize the matrix, if it is not already diagonal. Otherwise, copy it into the temporary matrix.
-    if (!isDiag) {
-        complex trace = matrix2x2[0] + matrix2x2[3];
-        complex determinant = (matrix2x2[0] * matrix2x2[3]) - (matrix2x2[1] * matrix2x2[2]);
-        complex quadraticRoot =
-            sqrt((matrix2x2[0] - matrix2x2[3]) * (matrix2x2[0] - matrix2x2[3]) - (real1)(4.0) * determinant);
-        complex eigenvalue1 = (trace + quadraticRoot) / (real1)2.0;
-        complex eigenvalue2 = (trace - quadraticRoot) / (real1)2.0;
-
-        if (norm(matrix2x2[1]) > min_norm) {
-            jacobian[0] = matrix2x2[1];
-            jacobian[2] = eigenvalue1 - matrix2x2[0];
-
-            jacobian[1] = matrix2x2[1];
-            jacobian[3] = eigenvalue2 - matrix2x2[0];
-        } else {
-            jacobian[0] = eigenvalue1 - matrix2x2[3];
-            jacobian[2] = matrix2x2[2];
-
-            jacobian[1] = eigenvalue2 - matrix2x2[3];
-            jacobian[3] = matrix2x2[2];
-        }
-
-        real1 nrm = std::sqrt(norm(jacobian[0]) + norm(jacobian[2]));
-        jacobian[0] /= nrm;
-        jacobian[2] /= nrm;
-
-        nrm = std::sqrt(norm(jacobian[1]) + norm(jacobian[3]));
-        jacobian[1] /= nrm;
-        jacobian[3] /= nrm;
-
-        determinant = (jacobian[0] * jacobian[3]) - (jacobian[1] * jacobian[2]);
-        inverseJacobian[0] = jacobian[3] / determinant;
-        inverseJacobian[1] = -jacobian[1] / determinant;
-        inverseJacobian[2] = -jacobian[2] / determinant;
-        inverseJacobian[3] = jacobian[0] / determinant;
-
-        matrix2x2Mul(matrix2x2, jacobian, tempMatrix2x2);
-        matrix2x2Mul(inverseJacobian, tempMatrix2x2, expOfGate);
-    } else {
-        std::copy(matrix2x2, matrix2x2 + 4, expOfGate);
-    }
-
-    if (isExp) {
-        // In this branch, we calculate e^(i * matrix2x2).
-
-        // Note: For a (2x2) hermitian input gate, this theoretically produces a unitary output transformation.
-        expOfGate[0] =
-            ((real1)exp(-imag(expOfGate[0]))) * complex((real1)cos(real(expOfGate[0])), (real1)sin(real(expOfGate[0])));
-        expOfGate[1] = complex(ZERO_R1, ZERO_R1);
-        expOfGate[2] = complex(ZERO_R1, ZERO_R1);
-        expOfGate[3] =
-            ((real1)exp(-imag(expOfGate[3]))) * complex((real1)cos(real(expOfGate[3])), (real1)sin(real(expOfGate[3])));
-    } else {
-        // In this branch, we calculate log(matrix2x2).
-        expOfGate[0] = complex(log(abs(expOfGate[0])), arg(expOfGate[0]));
-        expOfGate[1] = complex(ZERO_R1, ZERO_R1);
-        expOfGate[2] = complex(ZERO_R1, ZERO_R1);
-        expOfGate[3] = complex(log(abs(expOfGate[3])), arg(expOfGate[3]));
-    }
-
-    if (!isDiag) {
-        matrix2x2Mul(expOfGate, inverseJacobian, tempMatrix2x2);
-        matrix2x2Mul(jacobian, tempMatrix2x2, expOfGate);
-    }
-
-    ApplyControlledSingleBit(controls, controlLen, qubit, expOfGate);
-}
-
 /// Imaginary exponentiate of arbitrary single bit gate
 void QInterface::Exp(bitLenInt* controls, bitLenInt controlLen, bitLenInt qubit, complex* matrix2x2)
 {
-    ExpLog(controls, controlLen, qubit, matrix2x2, true);
+    complex toApply[4];
+    Qrack::exp(matrix2x2, toApply);
+    ApplyControlledSingleBit(controls, controlLen, qubit, toApply);
 }
 
 /// Logarithm of arbitrary single bit gate
 void QInterface::Log(bitLenInt* controls, bitLenInt controlLen, bitLenInt qubit, complex* matrix2x2)
 {
-    ExpLog(controls, controlLen, qubit, matrix2x2, false);
+    complex toApply[4];
+    Qrack::log(matrix2x2, toApply);
+    ApplyControlledSingleBit(controls, controlLen, qubit, toApply);
 }
 
 /// Exponentiate Pauli X operator

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -2564,9 +2564,45 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_timeevolve")
     qftReg->SetPermutation(0);
     qftReg->TimeEvolve(h, tDiff);
 
-    // std::cout << qftReg->Prob(0) << std::endl;
-    // std::cout << sin(aParam * tDiff) * sin(aParam * tDiff) << std::endl;
-    // std::cout << abs(qftReg->Prob(0) - sin(aParam * tDiff) * sin(aParam * tDiff)) << std::endl;
+    REQUIRE_FLOAT(abs((ONE_R1 - qftReg->Prob(0)) - sin(aParam * tDiff) * sin(aParam * tDiff)), 0);
+    REQUIRE_FLOAT(abs(qftReg->Prob(0) - cos(aParam * tDiff) * cos(aParam * tDiff)), 0);
+
+    bitLenInt controls[1] = { 1 };
+    bool controlToggles[1] = { false };
+
+    HamiltonianOpPtr h1 = std::make_shared<HamiltonianOp>(controls, 1, 0, o2neg1, false, controlToggles);
+    h[0] = h1;
+
+    qftReg->SetPermutation(2);
+    qftReg->TimeEvolve(h, tDiff);
+
+    REQUIRE_FLOAT(abs((ONE_R1 - qftReg->Prob(0)) - sin(aParam * tDiff) * sin(aParam * tDiff)), 0);
+    REQUIRE_FLOAT(abs(qftReg->Prob(0) - cos(aParam * tDiff) * cos(aParam * tDiff)), 0);
+
+    controlToggles[0] = true;
+    HamiltonianOpPtr h2 = std::make_shared<HamiltonianOp>(controls, 1, 0, o2neg1, false, controlToggles);
+    h[0] = h2;
+
+    qftReg->SetPermutation(2);
+    qftReg->TimeEvolve(h, tDiff);
+
+    REQUIRE_FLOAT(qftReg->Prob(0), ZERO_R1);
+
+    controlToggles[0] = false;
+    HamiltonianOpPtr h3 = std::make_shared<HamiltonianOp>(controls, 1, 0, o2neg1, true, controlToggles);
+    h[0] = h3;
+
+    qftReg->SetPermutation(2);
+    qftReg->TimeEvolve(h, tDiff);
+
+    REQUIRE_FLOAT(qftReg->Prob(0), ZERO_R1);
+
+    controlToggles[0] = true;
+    HamiltonianOpPtr h4 = std::make_shared<HamiltonianOp>(controls, 1, 0, o2neg1, true, controlToggles);
+    h[0] = h4;
+
+    qftReg->SetPermutation(2);
+    qftReg->TimeEvolve(h, tDiff);
 
     REQUIRE_FLOAT(abs((ONE_R1 - qftReg->Prob(0)) - sin(aParam * tDiff) * sin(aParam * tDiff)), 0);
     REQUIRE_FLOAT(abs(qftReg->Prob(0) - cos(aParam * tDiff) * cos(aParam * tDiff)), 0);

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -2573,6 +2573,12 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_timeevolve")
     HamiltonianOpPtr h1 = std::make_shared<HamiltonianOp>(controls, 1, 0, o2neg1, false, controlToggles);
     h[0] = h1;
 
+    // The point of this "toggle" behavior is to allow enumeration of arbitrary local Hamiltonian terms with
+    // permutations of a set of control bits. For example, a Hamiltonian might represent an array of local
+    // electromagnetic potential wells. If there are 4 wells, each with independent potentials, control "toggles" could
+    // be used on two control bits, to enumerate all four permutations of two control bits with four different local
+    // Hamiltonian terms.
+
     qftReg->SetPermutation(2);
     qftReg->TimeEvolve(h, tDiff);
 


### PR DESCRIPTION
For generality of time evolution Hamiltonians, it is necessary to form exponentiations of the products of gates. This can done if a matrix logarithm gate is available. (The product of exponentiations of commuting gates otherwise can only be equivalent to the exponentiation of their sum, not their product.)

We get this logic "for free," after having already added gate exponentiation, but this still needs to be tested.