### PR TITLE
Compose(): useHostMem and cross-device debugging

### DIFF
--- a/include/common/qrack_types.hpp
+++ b/include/common/qrack_types.hpp
@@ -35,7 +35,7 @@
 // "true." When TrySeparate or TryDecohere is applied after the QFT followed by its inverse on a permutation, the sum of
 // square errors of probability is generally less than 10^-11, for float accuracy. (A small number of trials return many
 // orders larger error, but these cases should not be separated, as the code stands.)
-#define approxcompare_error 1e-11f
+#define approxcompare_error 1e-8f
 #define polar(A, B) std::polar(A, B)
 #else
 #include "complex16simd.hpp"

--- a/include/qengine_opencl.hpp
+++ b/include/qengine_opencl.hpp
@@ -68,6 +68,7 @@ protected:
     size_t maxMem;
     size_t maxAlloc;
     unsigned int procElemCount;
+    bool unlockHostMem;
 
 public:
     /**

--- a/src/common/qengine.cl
+++ b/src/common/qengine.cl
@@ -256,7 +256,7 @@ void kernel decomposeprob(global cmplx* stateVec, constant bitCapInt* bitCapIntP
         j |= (lcv ^ j) << len;
 
         partProb = ZERO_R1;
-        firstAngle = -16 * M_PI;
+        firstAngle = -16 * PI_R1;
 
         for (k = 0U; k < partPower; k++) {
             l = j | (k << start);
@@ -267,7 +267,7 @@ void kernel decomposeprob(global cmplx* stateVec, constant bitCapInt* bitCapIntP
 
             if (nrm > min_norm) {
                 currentAngle = arg(amp);
-                if (firstAngle < (-8 * M_PI)) {
+                if (firstAngle < (-8 * PI_R1)) {
                     firstAngle = currentAngle;
                 }
                 partStateAngle[k] = currentAngle - firstAngle;
@@ -281,7 +281,7 @@ void kernel decomposeprob(global cmplx* stateVec, constant bitCapInt* bitCapIntP
         j = lcv << start;
 
         partProb = ZERO_R1;
-        firstAngle = -16 * M_PI;
+        firstAngle = -16 * PI_R1;
 
         for (k = 0U; k < remainderPower; k++) {
             l = k & ((1U << start) - 1);
@@ -294,7 +294,7 @@ void kernel decomposeprob(global cmplx* stateVec, constant bitCapInt* bitCapIntP
 
             if (nrm > min_norm) {
                 currentAngle = arg(stateVec[l]);
-                if (firstAngle < (-8 * M_PI)) {
+                if (firstAngle < (-8 * PI_R1)) {
                     firstAngle = currentAngle;
                 }
                 remainderStateAngle[k] = currentAngle - firstAngle;

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -1894,9 +1894,9 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_dispose")
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_compose")
 {
-    qftReg = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 4, 0x0b, rng);
+    qftReg = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 4, 0x0b, rng, complex(ONE_R1, ZERO_R1), true, true, false, 1);
     QInterfacePtr qftReg2 =
-        CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 4, 0x02, rng);
+        CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 4, 0x02, rng, complex(ONE_R1, ZERO_R1), true, true, false, 0);
     qftReg->Compose(qftReg2);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x2b));
 }

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -1894,9 +1894,9 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_dispose")
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_compose")
 {
-    qftReg = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 4, 0x0b, rng, complex(ONE_R1, ZERO_R1), true, true, false, 1);
+    qftReg = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 4, 0x0b, rng);
     QInterfacePtr qftReg2 =
-        CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 4, 0x02, rng, complex(ONE_R1, ZERO_R1), true, true, false, 0);
+        CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 4, 0x02, rng);
     qftReg->Compose(qftReg2);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x2b));
 }


### PR DESCRIPTION
This fixes a couple of critical bugs identified while testing Compose/Decompose/Dispose/TryDecompose on systems with smaller device memory limits. This fixes edge cases, when the state vector changes from too large to fit on an OpenCL device to small enough and vice versa. It should also fix issues with cross-device calls to these methods, including memory leaks.