### PR TITLE
Wrong OCL flag in GetQuantumState

### DIFF
--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -1763,7 +1763,7 @@ void QEngineOCL::GetQuantumState(complex* outputState)
         NormalizeState();
     }
 
-    LockSync(CL_MAP_WRITE);
+    LockSync(CL_MAP_READ);
     std::copy(stateVec, stateVec + maxQPower, outputState);
     UnlockSync();
 }


### PR DESCRIPTION
GetQuantumState() reads from the state vector, rather than writing to it.

The OpenCL code is often fairly insensitive to these flags, in a lot of cases, but they are necessary to guarantee the expected behavior in total generality.