### PR TITLE
Abstracting out random engine, and replacing with Mersenne twistor

### DIFF
--- a/include/common/qrack_types.hpp
+++ b/include/common/qrack_types.hpp
@@ -13,10 +13,12 @@
 #pragma once
 
 #include <memory>
+#include <random>
 
 #define bitLenInt uint8_t
 #define bitCapInt uint64_t
 #define bitsInByte 8
+#define qrack_rand_gen std::mt19937_64
 
 #include "config.h"
 

--- a/include/common/qrack_types.hpp
+++ b/include/common/qrack_types.hpp
@@ -19,15 +19,16 @@
 #define bitCapInt uint64_t
 #define bitsInByte 8
 #define qrack_rand_gen std::mt19937_64
+#define qrack_rand_gen_ptr std::shared_ptr<std::mt19937_64>
 
 #include "config.h"
 
 #if ENABLE_COMPLEX8
 #include <complex>
 namespace Qrack {
-    typedef std::complex<float> complex;
-    typedef float real1;
-}
+typedef std::complex<float> complex;
+typedef float real1;
+} // namespace Qrack
 #define ZERO_R1 0.0f
 #define ONE_R1 1.0f
 #define PI_R1 (real1) M_PI
@@ -44,9 +45,9 @@ namespace Qrack {
 #else
 #include "complex16simd.hpp"
 namespace Qrack {
-    typedef Complex16Simd complex;
-    typedef double real1;
-}
+typedef Complex16Simd complex;
+typedef double real1;
+} // namespace Qrack
 #define ZERO_R1 0.0
 #define ONE_R1 1.0
 #define PI_R1 M_PI

--- a/include/qengine.hpp
+++ b/include/qengine.hpp
@@ -42,8 +42,8 @@ protected:
     }
 
 public:
-    QEngine(bitLenInt n, std::shared_ptr<qrack_rand_gen> rgp = nullptr, bool doNorm = true,
-        bool randomGlobalPhase = true, bool useHostMem = false)
+    QEngine(bitLenInt n, qrack_rand_gen_ptr rgp = nullptr, bool doNorm = true, bool randomGlobalPhase = true,
+        bool useHostMem = false)
         : QInterface(n, rgp, doNorm)
         , randGlobalPhase(randomGlobalPhase)
         , useHostRam(useHostMem)

--- a/include/qengine.hpp
+++ b/include/qengine.hpp
@@ -42,7 +42,7 @@ protected:
     }
 
 public:
-    QEngine(bitLenInt n, std::shared_ptr<std::default_random_engine> rgp = nullptr, bool doNorm = true,
+    QEngine(bitLenInt n, std::shared_ptr<qrack_rand_gen> rgp = nullptr, bool doNorm = true,
         bool randomGlobalPhase = true, bool useHostMem = false)
         : QInterface(n, rgp, doNorm)
         , randGlobalPhase(randomGlobalPhase)

--- a/include/qengine_cpu.hpp
+++ b/include/qengine_cpu.hpp
@@ -37,7 +37,7 @@ protected:
     complex* stateVec;
 
 public:
-    QEngineCPU(bitLenInt qBitCount, bitCapInt initState, std::shared_ptr<qrack_rand_gen> rgp = nullptr,
+    QEngineCPU(bitLenInt qBitCount, bitCapInt initState, qrack_rand_gen_ptr rgp = nullptr,
         complex phaseFac = complex(-999.0, -999.0), bool doNorm = true, bool randomGlobalPhase = true,
         bool ignored = false);
     QEngineCPU(QEngineCPUPtr toCopy);

--- a/include/qengine_cpu.hpp
+++ b/include/qengine_cpu.hpp
@@ -37,7 +37,7 @@ protected:
     complex* stateVec;
 
 public:
-    QEngineCPU(bitLenInt qBitCount, bitCapInt initState, std::shared_ptr<std::default_random_engine> rgp = nullptr,
+    QEngineCPU(bitLenInt qBitCount, bitCapInt initState, std::shared_ptr<qrack_rand_gen> rgp = nullptr,
         complex phaseFac = complex(-999.0, -999.0), bool doNorm = true, bool randomGlobalPhase = true,
         bool ignored = false);
     QEngineCPU(QEngineCPUPtr toCopy);

--- a/include/qengine_opencl.hpp
+++ b/include/qengine_opencl.hpp
@@ -89,7 +89,7 @@ public:
      * instability). For safety, "useHostMem" can be turned on.
      */
 
-    QEngineOCL(bitLenInt qBitCount, bitCapInt initState, std::shared_ptr<qrack_rand_gen> rgp = nullptr,
+    QEngineOCL(bitLenInt qBitCount, bitCapInt initState, qrack_rand_gen_ptr rgp = nullptr,
         complex phaseFac = complex(-999.0, -999.0), bool doNorm = true, bool randomGlobalPhase = true,
         bool useHostMem = false, int devID = -1);
     QEngineOCL(QEngineOCLPtr toCopy);

--- a/include/qengine_opencl.hpp
+++ b/include/qengine_opencl.hpp
@@ -89,7 +89,7 @@ public:
      * instability). For safety, "useHostMem" can be turned on.
      */
 
-    QEngineOCL(bitLenInt qBitCount, bitCapInt initState, std::shared_ptr<std::default_random_engine> rgp = nullptr,
+    QEngineOCL(bitLenInt qBitCount, bitCapInt initState, std::shared_ptr<qrack_rand_gen> rgp = nullptr,
         complex phaseFac = complex(-999.0, -999.0), bool doNorm = true, bool randomGlobalPhase = true,
         bool useHostMem = false, int devID = -1);
     QEngineOCL(QEngineOCLPtr toCopy);

--- a/include/qfusion.hpp
+++ b/include/qfusion.hpp
@@ -47,7 +47,7 @@ protected:
 
 public:
     QFusion(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState = 0,
-        std::shared_ptr<std::default_random_engine> rgp = nullptr, complex phaseFac = complex(-999.0, -999.0),
+        std::shared_ptr<qrack_rand_gen> rgp = nullptr, complex phaseFac = complex(-999.0, -999.0),
         bool doNorm = true, bool randomGlobalPhase = true, bool useHostMem = false);
     QFusion(QInterfacePtr target);
 

--- a/include/qfusion.hpp
+++ b/include/qfusion.hpp
@@ -46,9 +46,9 @@ protected:
     }
 
 public:
-    QFusion(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState = 0,
-        std::shared_ptr<qrack_rand_gen> rgp = nullptr, complex phaseFac = complex(-999.0, -999.0),
-        bool doNorm = true, bool randomGlobalPhase = true, bool useHostMem = false);
+    QFusion(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState = 0, qrack_rand_gen_ptr rgp = nullptr,
+        complex phaseFac = complex(-999.0, -999.0), bool doNorm = true, bool randomGlobalPhase = true,
+        bool useHostMem = false);
     QFusion(QInterfacePtr target);
 
     virtual void SetQuantumState(complex* inputState);

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -90,7 +90,7 @@ protected:
     bitLenInt qubitCount;
     bitCapInt maxQPower;
     uint32_t randomSeed;
-    std::shared_ptr<qrack_rand_gen> rand_generator;
+    qrack_rand_gen_ptr rand_generator;
     std::uniform_real_distribution<real1> rand_distribution;
     bool doNormalize;
 
@@ -116,7 +116,7 @@ protected:
     template <typename GateFunc> void ControlledLoopFixture(bitLenInt length, GateFunc gate);
 
 public:
-    QInterface(bitLenInt n, std::shared_ptr<qrack_rand_gen> rgp = nullptr, bool doNorm = true)
+    QInterface(bitLenInt n, qrack_rand_gen_ptr rgp = nullptr, bool doNorm = true)
         : rand_distribution(0.0, 1.0)
         , doNormalize(doNorm)
     {

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -16,7 +16,6 @@
 #include <map>
 #include <math.h>
 #include <memory>
-#include <random>
 #include <vector>
 
 #include "common/parallel_for.hpp"
@@ -91,7 +90,7 @@ protected:
     bitLenInt qubitCount;
     bitCapInt maxQPower;
     uint32_t randomSeed;
-    std::shared_ptr<std::default_random_engine> rand_generator;
+    std::shared_ptr<qrack_rand_gen> rand_generator;
     std::uniform_real_distribution<real1> rand_distribution;
     bool doNormalize;
 
@@ -117,14 +116,14 @@ protected:
     template <typename GateFunc> void ControlledLoopFixture(bitLenInt length, GateFunc gate);
 
 public:
-    QInterface(bitLenInt n, std::shared_ptr<std::default_random_engine> rgp = nullptr, bool doNorm = true)
+    QInterface(bitLenInt n, std::shared_ptr<qrack_rand_gen> rgp = nullptr, bool doNorm = true)
         : rand_distribution(0.0, 1.0)
         , doNormalize(doNorm)
     {
         SetQubitCount(n);
 
         if (rgp == NULL) {
-            rand_generator = std::make_shared<std::default_random_engine>();
+            rand_generator = std::make_shared<qrack_rand_gen>();
             randomSeed = std::time(0);
             SetRandomSeed(randomSeed);
         } else {

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -40,7 +40,7 @@ protected:
     bool randGlobalPhase;
     bool useHostRam;
 
-    std::shared_ptr<std::default_random_engine> rand_generator;
+    std::shared_ptr<qrack_rand_gen> rand_generator;
 
     virtual void SetQubitCount(bitLenInt qb)
     {
@@ -50,10 +50,10 @@ protected:
 
 public:
     QUnit(QInterfaceEngine eng, QInterfaceEngine subEng, bitLenInt qBitCount, bitCapInt initState = 0,
-        std::shared_ptr<std::default_random_engine> rgp = nullptr, complex phaseFac = complex(-999.0, -999.0),
+        std::shared_ptr<qrack_rand_gen> rgp = nullptr, complex phaseFac = complex(-999.0, -999.0),
         bool doNorm = true, bool randomGlobalPhase = true, bool useHostMem = true);
     QUnit(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState = 0,
-        std::shared_ptr<std::default_random_engine> rgp = nullptr, complex phaseFac = complex(-999.0, -999.0),
+        std::shared_ptr<qrack_rand_gen> rgp = nullptr, complex phaseFac = complex(-999.0, -999.0),
         bool doNorm = true, bool randomGlobalPhase = true, bool useHostMem = true);
 
     virtual void SetQuantumState(complex* inputState);

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -40,7 +40,7 @@ protected:
     bool randGlobalPhase;
     bool useHostRam;
 
-    std::shared_ptr<qrack_rand_gen> rand_generator;
+    qrack_rand_gen_ptr rand_generator;
 
     virtual void SetQubitCount(bitLenInt qb)
     {
@@ -50,11 +50,11 @@ protected:
 
 public:
     QUnit(QInterfaceEngine eng, QInterfaceEngine subEng, bitLenInt qBitCount, bitCapInt initState = 0,
-        std::shared_ptr<qrack_rand_gen> rgp = nullptr, complex phaseFac = complex(-999.0, -999.0),
-        bool doNorm = true, bool randomGlobalPhase = true, bool useHostMem = true);
-    QUnit(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState = 0,
-        std::shared_ptr<qrack_rand_gen> rgp = nullptr, complex phaseFac = complex(-999.0, -999.0),
-        bool doNorm = true, bool randomGlobalPhase = true, bool useHostMem = true);
+        qrack_rand_gen_ptr rgp = nullptr, complex phaseFac = complex(-999.0, -999.0), bool doNorm = true,
+        bool randomGlobalPhase = true, bool useHostMem = true);
+    QUnit(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState = 0, qrack_rand_gen_ptr rgp = nullptr,
+        complex phaseFac = complex(-999.0, -999.0), bool doNorm = true, bool randomGlobalPhase = true,
+        bool useHostMem = true);
 
     virtual void SetQuantumState(complex* inputState);
     virtual void GetQuantumState(complex* outputState);

--- a/include/qunitmulti.hpp
+++ b/include/qunitmulti.hpp
@@ -57,13 +57,13 @@ protected:
 
 public:
     QUnitMulti(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState = 0,
-        std::shared_ptr<std::default_random_engine> rgp = nullptr, complex phaseFac = complex(-999.0, -999.0),
+        std::shared_ptr<qrack_rand_gen> rgp = nullptr, complex phaseFac = complex(-999.0, -999.0),
         bool doNorm = true, bool randomGlobalPhase = true, bool useHostMem = true)
         : QUnitMulti(qBitCount, initState, rgp, phaseFac, doNorm, randomGlobalPhase, useHostMem)
     {
     }
 
-    QUnitMulti(bitLenInt qBitCount, bitCapInt initState = 0, std::shared_ptr<std::default_random_engine> rgp = nullptr,
+    QUnitMulti(bitLenInt qBitCount, bitCapInt initState = 0, std::shared_ptr<qrack_rand_gen> rgp = nullptr,
         complex phaseFac = complex(-999.0, -999.0), bool doNorm = true, bool randomGlobalPhase = true,
         bool useHostMem = true);
 

--- a/include/qunitmulti.hpp
+++ b/include/qunitmulti.hpp
@@ -56,14 +56,14 @@ protected:
     int defaultDeviceID;
 
 public:
-    QUnitMulti(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState = 0,
-        std::shared_ptr<qrack_rand_gen> rgp = nullptr, complex phaseFac = complex(-999.0, -999.0),
-        bool doNorm = true, bool randomGlobalPhase = true, bool useHostMem = true)
+    QUnitMulti(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState = 0, qrack_rand_gen_ptr rgp = nullptr,
+        complex phaseFac = complex(-999.0, -999.0), bool doNorm = true, bool randomGlobalPhase = true,
+        bool useHostMem = true)
         : QUnitMulti(qBitCount, initState, rgp, phaseFac, doNorm, randomGlobalPhase, useHostMem)
     {
     }
 
-    QUnitMulti(bitLenInt qBitCount, bitCapInt initState = 0, std::shared_ptr<qrack_rand_gen> rgp = nullptr,
+    QUnitMulti(bitLenInt qBitCount, bitCapInt initState = 0, qrack_rand_gen_ptr rgp = nullptr,
         complex phaseFac = complex(-999.0, -999.0), bool doNorm = true, bool randomGlobalPhase = true,
         bool useHostMem = true);
 

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -53,8 +53,8 @@ namespace Qrack {
     device_context->wait_events.emplace_back();                                                                        \
     queue.enqueueUnmapMemObject(buff, array, NULL, &(device_context->wait_events.back()))
 
-QEngineOCL::QEngineOCL(bitLenInt qBitCount, bitCapInt initState, std::shared_ptr<qrack_rand_gen> rgp,
-    complex phaseFac, bool doNorm, bool randomGlobalPhase, bool useHostMem, int devID)
+QEngineOCL::QEngineOCL(bitLenInt qBitCount, bitCapInt initState, qrack_rand_gen_ptr rgp, complex phaseFac, bool doNorm,
+    bool randomGlobalPhase, bool useHostMem, int devID)
     : QEngine(qBitCount, rgp, doNorm, randomGlobalPhase, useHostMem)
     , stateVec(NULL)
     , deviceID(devID)
@@ -607,14 +607,13 @@ void QEngineOCL::UniformlyControlledSingleBit(
     cl::Event writeArgsEvent;
     DISPATCH_TEMP_WRITE(&waitVec, *ulongBuffer, sizeof(bitCapInt) * 3, bciArgs, writeArgsEvent);
 
-    BufferPtr nrmInBuffer =
-        std::make_shared<cl::Buffer>(context, CL_MEM_READ_ONLY, sizeof(real1));
+    BufferPtr nrmInBuffer = std::make_shared<cl::Buffer>(context, CL_MEM_READ_ONLY, sizeof(real1));
 
     cl::Event writeNormEvent;
     DISPATCH_TEMP_WRITE(&waitVec, *nrmInBuffer, sizeof(real1), &runningNorm, writeNormEvent);
 
-    BufferPtr uniformBuffer = std::make_shared<cl::Buffer>(
-        context, CL_MEM_READ_ONLY, sizeof(complex) * 4 * (1U << controlLen));
+    BufferPtr uniformBuffer =
+        std::make_shared<cl::Buffer>(context, CL_MEM_READ_ONLY, sizeof(complex) * 4 * (1U << controlLen));
 
     cl::Event writeMatricesEvent;
     DISPATCH_TEMP_WRITE(&waitVec, *uniformBuffer, sizeof(complex) * 4 * (1U << controlLen), mtrxs, writeMatricesEvent);

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -53,7 +53,7 @@ namespace Qrack {
     device_context->wait_events.emplace_back();                                                                        \
     queue.enqueueUnmapMemObject(buff, array, NULL, &(device_context->wait_events.back()))
 
-QEngineOCL::QEngineOCL(bitLenInt qBitCount, bitCapInt initState, std::shared_ptr<std::default_random_engine> rgp,
+QEngineOCL::QEngineOCL(bitLenInt qBitCount, bitCapInt initState, std::shared_ptr<qrack_rand_gen> rgp,
     complex phaseFac, bool doNorm, bool randomGlobalPhase, bool useHostMem, int devID)
     : QEngine(qBitCount, rgp, doNorm, randomGlobalPhase, useHostMem)
     , stateVec(NULL)

--- a/src/qengine/state.cpp
+++ b/src/qengine/state.cpp
@@ -36,7 +36,7 @@ namespace Qrack {
  * \warning Overall phase is generally arbitrary and unknowable. Setting two QEngineCPU instances to the same
  * phase usually makes sense only if they are initialized at the same time.
  */
-QEngineCPU::QEngineCPU(bitLenInt qBitCount, bitCapInt initState, std::shared_ptr<std::default_random_engine> rgp,
+QEngineCPU::QEngineCPU(bitLenInt qBitCount, bitCapInt initState, std::shared_ptr<qrack_rand_gen> rgp,
     complex phaseFac, bool doNorm, bool randomGlobalPhase, bool useHostMem)
     : QEngine(qBitCount, rgp, doNorm, randomGlobalPhase, true)
     , stateVec(NULL)

--- a/src/qengine/state.cpp
+++ b/src/qengine/state.cpp
@@ -36,8 +36,8 @@ namespace Qrack {
  * \warning Overall phase is generally arbitrary and unknowable. Setting two QEngineCPU instances to the same
  * phase usually makes sense only if they are initialized at the same time.
  */
-QEngineCPU::QEngineCPU(bitLenInt qBitCount, bitCapInt initState, std::shared_ptr<qrack_rand_gen> rgp,
-    complex phaseFac, bool doNorm, bool randomGlobalPhase, bool useHostMem)
+QEngineCPU::QEngineCPU(bitLenInt qBitCount, bitCapInt initState, qrack_rand_gen_ptr rgp, complex phaseFac, bool doNorm,
+    bool randomGlobalPhase, bool useHostMem)
     : QEngine(qBitCount, rgp, doNorm, randomGlobalPhase, true)
     , stateVec(NULL)
 {

--- a/src/qfusion.cpp
+++ b/src/qfusion.cpp
@@ -20,7 +20,7 @@
 namespace Qrack {
 
 QFusion::QFusion(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState,
-    std::shared_ptr<std::default_random_engine> rgp, complex phaseFac, bool doNorm, bool randomGlobalPhase,
+    std::shared_ptr<qrack_rand_gen> rgp, complex phaseFac, bool doNorm, bool randomGlobalPhase,
     bool useHostMem)
     : QInterface(qBitCount, rgp)
     , phaseFactor(phaseFac)

--- a/src/qfusion.cpp
+++ b/src/qfusion.cpp
@@ -19,9 +19,8 @@
 
 namespace Qrack {
 
-QFusion::QFusion(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState,
-    std::shared_ptr<qrack_rand_gen> rgp, complex phaseFac, bool doNorm, bool randomGlobalPhase,
-    bool useHostMem)
+QFusion::QFusion(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState, qrack_rand_gen_ptr rgp,
+    complex phaseFac, bool doNorm, bool randomGlobalPhase, bool useHostMem)
     : QInterface(qBitCount, rgp)
     , phaseFactor(phaseFac)
     , doNormalize(doNorm)

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -19,17 +19,15 @@
 
 namespace Qrack {
 
-QUnit::QUnit(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState,
-    std::shared_ptr<qrack_rand_gen> rgp, complex phaseFac, bool doNorm, bool randomGlobalPhase,
-    bool useHostMem)
+QUnit::QUnit(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState, qrack_rand_gen_ptr rgp, complex phaseFac,
+    bool doNorm, bool randomGlobalPhase, bool useHostMem)
     : QUnit(eng, eng, qBitCount, initState, rgp, phaseFac, doNorm, randomGlobalPhase, useHostMem)
 {
     // Intentionally left blank
 }
 
 QUnit::QUnit(QInterfaceEngine eng, QInterfaceEngine subEng, bitLenInt qBitCount, bitCapInt initState,
-    std::shared_ptr<qrack_rand_gen> rgp, complex phaseFac, bool doNorm, bool randomGlobalPhase,
-    bool useHostMem)
+    qrack_rand_gen_ptr rgp, complex phaseFac, bool doNorm, bool randomGlobalPhase, bool useHostMem)
     : QInterface(qBitCount, rgp, doNorm)
     , engine(eng)
     , subengine(subEng)

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -20,7 +20,7 @@
 namespace Qrack {
 
 QUnit::QUnit(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState,
-    std::shared_ptr<std::default_random_engine> rgp, complex phaseFac, bool doNorm, bool randomGlobalPhase,
+    std::shared_ptr<qrack_rand_gen> rgp, complex phaseFac, bool doNorm, bool randomGlobalPhase,
     bool useHostMem)
     : QUnit(eng, eng, qBitCount, initState, rgp, phaseFac, doNorm, randomGlobalPhase, useHostMem)
 {
@@ -28,7 +28,7 @@ QUnit::QUnit(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState,
 }
 
 QUnit::QUnit(QInterfaceEngine eng, QInterfaceEngine subEng, bitLenInt qBitCount, bitCapInt initState,
-    std::shared_ptr<std::default_random_engine> rgp, complex phaseFac, bool doNorm, bool randomGlobalPhase,
+    std::shared_ptr<qrack_rand_gen> rgp, complex phaseFac, bool doNorm, bool randomGlobalPhase,
     bool useHostMem)
     : QInterface(qBitCount, rgp, doNorm)
     , engine(eng)

--- a/src/qunitmulti.cpp
+++ b/src/qunitmulti.cpp
@@ -15,7 +15,7 @@
 
 namespace Qrack {
 
-QUnitMulti::QUnitMulti(bitLenInt qBitCount, bitCapInt initState, std::shared_ptr<std::default_random_engine> rgp,
+QUnitMulti::QUnitMulti(bitLenInt qBitCount, bitCapInt initState, std::shared_ptr<qrack_rand_gen> rgp,
     complex phaseFac, bool doNorm, bool randomGlobalPhase, bool useHostMem)
     : QUnit(QINTERFACE_OPENCL, qBitCount, initState, rgp, phaseFac, doNorm, randomGlobalPhase, useHostMem)
 {

--- a/src/qunitmulti.cpp
+++ b/src/qunitmulti.cpp
@@ -15,8 +15,8 @@
 
 namespace Qrack {
 
-QUnitMulti::QUnitMulti(bitLenInt qBitCount, bitCapInt initState, std::shared_ptr<qrack_rand_gen> rgp,
-    complex phaseFac, bool doNorm, bool randomGlobalPhase, bool useHostMem)
+QUnitMulti::QUnitMulti(bitLenInt qBitCount, bitCapInt initState, qrack_rand_gen_ptr rgp, complex phaseFac, bool doNorm,
+    bool randomGlobalPhase, bool useHostMem)
     : QUnit(QINTERFACE_OPENCL, qBitCount, initState, rgp, phaseFac, doNorm, randomGlobalPhase, useHostMem)
 {
     // Notice that this constructor does not take an engine type parameter, and it always passes QINTERFACE_OPENCL to

--- a/test/accuracy_main.cpp
+++ b/test/accuracy_main.cpp
@@ -25,7 +25,7 @@ using namespace Qrack;
 enum QInterfaceEngine testEngineType = QINTERFACE_CPU;
 enum QInterfaceEngine testSubEngineType = QINTERFACE_CPU;
 enum QInterfaceEngine testSubSubEngineType = QINTERFACE_CPU;
-std::shared_ptr<qrack_rand_gen> rng;
+qrack_rand_gen_ptr rng;
 bool disable_normalization = false;
 bool async_time = false;
 
@@ -196,7 +196,7 @@ QInterfaceTestFixture::QInterfaceTestFixture()
         rngSeed = std::time(0);
     }
 
-    std::shared_ptr<qrack_rand_gen> rng = std::make_shared<qrack_rand_gen>();
+    qrack_rand_gen_ptr rng = std::make_shared<qrack_rand_gen>();
     rng->seed(rngSeed);
 
     if (disable_normalization) {

--- a/test/accuracy_main.cpp
+++ b/test/accuracy_main.cpp
@@ -25,7 +25,7 @@ using namespace Qrack;
 enum QInterfaceEngine testEngineType = QINTERFACE_CPU;
 enum QInterfaceEngine testSubEngineType = QINTERFACE_CPU;
 enum QInterfaceEngine testSubSubEngineType = QINTERFACE_CPU;
-std::shared_ptr<std::default_random_engine> rng;
+std::shared_ptr<qrack_rand_gen> rng;
 bool disable_normalization = false;
 bool async_time = false;
 
@@ -196,7 +196,7 @@ QInterfaceTestFixture::QInterfaceTestFixture()
         rngSeed = std::time(0);
     }
 
-    std::shared_ptr<std::default_random_engine> rng = std::make_shared<std::default_random_engine>();
+    std::shared_ptr<qrack_rand_gen> rng = std::make_shared<qrack_rand_gen>();
     rng->seed(rngSeed);
 
     if (disable_normalization) {

--- a/test/benchmarks_main.cpp
+++ b/test/benchmarks_main.cpp
@@ -25,7 +25,7 @@ using namespace Qrack;
 enum QInterfaceEngine testEngineType = QINTERFACE_CPU;
 enum QInterfaceEngine testSubEngineType = QINTERFACE_CPU;
 enum QInterfaceEngine testSubSubEngineType = QINTERFACE_CPU;
-std::shared_ptr<std::default_random_engine> rng;
+std::shared_ptr<qrack_rand_gen> rng;
 bool disable_normalization = false;
 bool async_time = false;
 
@@ -199,6 +199,6 @@ QInterfaceTestFixture::QInterfaceTestFixture()
         rngSeed = std::time(0);
     }
 
-    std::shared_ptr<std::default_random_engine> rng = std::make_shared<std::default_random_engine>();
+    std::shared_ptr<qrack_rand_gen> rng = std::make_shared<qrack_rand_gen>();
     rng->seed(rngSeed);
 }

--- a/test/benchmarks_main.cpp
+++ b/test/benchmarks_main.cpp
@@ -25,7 +25,7 @@ using namespace Qrack;
 enum QInterfaceEngine testEngineType = QINTERFACE_CPU;
 enum QInterfaceEngine testSubEngineType = QINTERFACE_CPU;
 enum QInterfaceEngine testSubSubEngineType = QINTERFACE_CPU;
-std::shared_ptr<qrack_rand_gen> rng;
+qrack_rand_gen_ptr rng;
 bool disable_normalization = false;
 bool async_time = false;
 
@@ -199,6 +199,6 @@ QInterfaceTestFixture::QInterfaceTestFixture()
         rngSeed = std::time(0);
     }
 
-    std::shared_ptr<qrack_rand_gen> rng = std::make_shared<qrack_rand_gen>();
+    qrack_rand_gen_ptr rng = std::make_shared<qrack_rand_gen>();
     rng->seed(rngSeed);
 }

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -25,7 +25,7 @@ using namespace Qrack;
 enum QInterfaceEngine testEngineType = QINTERFACE_CPU;
 enum QInterfaceEngine testSubEngineType = QINTERFACE_CPU;
 enum QInterfaceEngine testSubSubEngineType = QINTERFACE_CPU;
-std::shared_ptr<qrack_rand_gen> rng;
+qrack_rand_gen_ptr rng;
 bool disable_normalization = false;
 bool async_time = false;
 
@@ -196,7 +196,7 @@ QInterfaceTestFixture::QInterfaceTestFixture()
         rngSeed = std::time(0);
     }
 
-    std::shared_ptr<qrack_rand_gen> rng = std::make_shared<qrack_rand_gen>();
+    qrack_rand_gen_ptr rng = std::make_shared<qrack_rand_gen>();
     rng->seed(rngSeed);
 
     if (disable_normalization) {

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -25,7 +25,7 @@ using namespace Qrack;
 enum QInterfaceEngine testEngineType = QINTERFACE_CPU;
 enum QInterfaceEngine testSubEngineType = QINTERFACE_CPU;
 enum QInterfaceEngine testSubSubEngineType = QINTERFACE_CPU;
-std::shared_ptr<std::default_random_engine> rng;
+std::shared_ptr<qrack_rand_gen> rng;
 bool disable_normalization = false;
 bool async_time = false;
 
@@ -196,7 +196,7 @@ QInterfaceTestFixture::QInterfaceTestFixture()
         rngSeed = std::time(0);
     }
 
-    std::shared_ptr<std::default_random_engine> rng = std::make_shared<std::default_random_engine>();
+    std::shared_ptr<qrack_rand_gen> rng = std::make_shared<qrack_rand_gen>();
     rng->seed(rngSeed);
 
     if (disable_normalization) {

--- a/test/tests.hpp
+++ b/test/tests.hpp
@@ -27,7 +27,7 @@
 extern enum Qrack::QInterfaceEngine testEngineType;
 extern enum Qrack::QInterfaceEngine testSubEngineType;
 extern enum Qrack::QInterfaceEngine testSubSubEngineType;
-extern std::shared_ptr<qrack_rand_gen> rng;
+extern qrack_rand_gen_ptr rng;
 extern bool disable_normalization;
 extern bool async_time;
 

--- a/test/tests.hpp
+++ b/test/tests.hpp
@@ -27,7 +27,7 @@
 extern enum Qrack::QInterfaceEngine testEngineType;
 extern enum Qrack::QInterfaceEngine testSubEngineType;
 extern enum Qrack::QInterfaceEngine testSubSubEngineType;
-extern std::shared_ptr<std::default_random_engine> rng;
+extern std::shared_ptr<qrack_rand_gen> rng;
 extern bool disable_normalization;
 extern bool async_time;
 


### PR DESCRIPTION
There should be an easy way to switch the random number generator engine, at will. With this branch, the user can change the definition of "qrack_rand_gen" in a single header and replace the random number generator everywhere. While we're at it, the Mersenne twistor generator is probably a better engine to use by default.

I have tested that this passes all unit tests.