### PR TITLE
Replacing cl.hpp with cl2.hpp

### DIFF
--- a/include/common/oclengine.hpp
+++ b/include/common/oclengine.hpp
@@ -24,7 +24,7 @@
 
 #ifdef __APPLE__
 #define CL_SILENCE_DEPRECATION
-#include <OpenCL/cl2.hpp>
+#include <OpenCL/cl.hpp>
 #else
 #include <CL/cl2.hpp>
 #endif

--- a/include/common/oclengine.hpp
+++ b/include/common/oclengine.hpp
@@ -24,9 +24,9 @@
 
 #ifdef __APPLE__
 #define CL_SILENCE_DEPRECATION
-#include <OpenCL/cl.hpp>
+#include <OpenCL/cl2.hpp>
 #else
-#include <CL/cl.hpp>
+#include <CL/cl2.hpp>
 #endif
 
 namespace Qrack {


### PR DESCRIPTION
The OpenCL 2.x headers should be used. However, this already compiles on my Ubuntu 18.04 system. See #134 .