### PR TITLE
QFusion buffering threshold bug

### DIFF
--- a/cmake/Examples.cmake
+++ b/cmake/Examples.cmake
@@ -20,5 +20,18 @@ target_link_libraries (grovers_lookup
     pthread
     )
 
+add_executable (ordered_list_search
+    examples/ordered_list_search.cpp
+    )
+
+set_target_properties(ordered_list_search PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/examples")
+
+target_link_libraries (ordered_list_search
+    qrack
+    pthread
+    )
+
+
 target_compile_options (grovers PUBLIC -O3 -std=c++11 -Wall -Werror ${TEST_COMPILE_OPTS} -DCATCH_CONFIG_FAST_COMPILE)
 target_compile_options (grovers_lookup PUBLIC -O3 -std=c++11 -Wall -Werror ${TEST_COMPILE_OPTS} -DCATCH_CONFIG_FAST_COMPILE)
+target_compile_options (ordered_list_search PUBLIC -O3 -std=c++11 -Wall -Werror ${TEST_COMPILE_OPTS} -DCATCH_CONFIG_FAST_COMPILE)

--- a/cmake/OpenCL.cmake
+++ b/cmake/OpenCL.cmake
@@ -40,6 +40,7 @@ if (ENABLE_OPENCL)
     target_link_libraries (accuracy ${LIB_OPENCL})
     target_link_libraries (grovers ${LIB_OPENCL})
     target_link_libraries (grovers_lookup ${LIB_OPENCL})
+    target_link_libraries (ordered_list_search ${LIB_OPENCL})
 
 
     # Build the OpenCL command files

--- a/doxygen.config
+++ b/doxygen.config
@@ -38,7 +38,7 @@ PROJECT_NAME           = "Qrack"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 2.0
+PROJECT_NUMBER         = 3.1
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/examples/ordered_list_search.cpp
+++ b/examples/ordered_list_search.cpp
@@ -1,0 +1,250 @@
+//////////////////////////////////////////////////////////////////////////////////////
+//
+// (C) Daniel Strano and the Qrack contributors 2017-2019. All rights reserved.
+//
+// This example demonstrates Grover's search, applied for the purpose of finding a value in a ordered list. (This relies
+// on the IndexedLDA/IndexedADC/IndexedSBC methods of Qrack. IndexedADC and IndexedSBC can be shown to be unitary
+// operations, while IndexedLDA is unitary up to the requirement that the "value register" is set to zero before
+// applying the operation.)
+//
+// Licensed under the GNU Lesser General Public License V3.
+// See LICENSE.md in the project root or https://www.gnu.org/licenses/lgpl-3.0.en.html
+// for details.
+
+#include <iomanip> // For setw
+#include <iostream> // For cout
+
+// "qfactory.hpp" pulls in all headers needed to create any type of "Qrack::QInterface."
+#include "qfactory.hpp"
+
+using namespace Qrack;
+
+// We align our "classical" cache to 64 bit boundaries, for optimal OpenCL performance.
+#define ALIGN_SIZE 64
+unsigned char* cl_alloc(size_t ucharCount)
+{
+#ifdef __APPLE__
+    void* toRet;
+    posix_memalign(&toRet, ALIGN_SIZE,
+        ((sizeof(unsigned char) * ucharCount) < ALIGN_SIZE) ? ALIGN_SIZE : (sizeof(unsigned char) * ucharCount));
+    return (unsigned char*)toRet;
+#else
+    return (unsigned char*)aligned_alloc(ALIGN_SIZE,
+        ((sizeof(unsigned char) * ucharCount) < ALIGN_SIZE) ? ALIGN_SIZE : (sizeof(unsigned char) * ucharCount));
+#endif
+}
+
+int main()
+{
+    // *** (Variant of) Grover's search to find a value in an ordered list. ***
+    // The oracle is made with integer subtraction/addition and a doubly controlled phase flip.
+
+    // Grover's algorithm ideally returns a 100% probable correct result in the case of choosing one of four distinct
+    // items that match our search criteria. With an ordered list, we can leverage this for a "quaternary" search akin
+    // to a classical "binary search." (The complexity order of this search does not outperform that of the binary
+    // search, but this program is still an example of a simple quantum program.)
+
+    // At each step of the search, we select the quadrant with bounds that could contain our value. In an ideal
+    // noiseless quantum computer, this search should be deterministic.
+
+    int i, j;
+    bitLenInt partStart;
+    bitLenInt partLength;
+
+    // Both CPU and GPU types share the QInterface API.
+#if ENABLE_OPENCL
+    QInterfacePtr qReg = CreateQuantumInterface(QINTERFACE_OPENCL, 20, 0);
+#else
+    QInterfacePtr qReg = CreateQuantumInterface(QINTERFACE_CPU, 20, 0);
+#endif
+
+    const bitLenInt indexLength = 6;
+    const bitLenInt valueLength = 6;
+    const bitLenInt carryIndex = 19;
+    const int TARGET_VALUE = 6;
+    const int TARGET_KEY = 5;
+
+    bool foundPerm = false;
+
+    unsigned char* toLoad = cl_alloc(1 << indexLength);
+    for (i = 0; i < TARGET_KEY; i++) {
+        toLoad[i] = 2;
+    }
+    toLoad[TARGET_KEY] = TARGET_VALUE;
+    for (i = (TARGET_KEY + 1); i < (1 << indexLength); i++) {
+        toLoad[i] = 7;
+    }
+
+    qReg->SetPermutation(0);
+    partLength = indexLength;
+
+    for (i = 0; i < (indexLength / 2); i++) {
+        // We're in an exact permutation basis state, at this point after every iteration of the loop, unless more than
+        // one quadrant contained a match for our search target on the previous iteration. We can check the quadrant
+        // boundaries, without disturbing the state. If there was more than one match, we either collapse into a valid
+        // state, so that we can continue as expected for one matching quadrant, or we collapse into an identifiably
+        // invalid set of bounds that cannot contain our match, which can be identified by checking two values and
+        // proceeding with special case logic.
+
+        bitLenInt fixedLength = i * 2;
+        bitLenInt unfixedLength = indexLength - fixedLength;
+        bitCapInt fixedLengthMask = ((1 << fixedLength) - 1) << unfixedLength;
+        bitCapInt unfixedMask = (1 << unfixedLength) - 1;
+        bitCapInt key = (qReg->MReg(2 * valueLength, indexLength)) & (fixedLengthMask);
+
+        // (We could either manipulate the quantum bits directly to check the bounds, or rely on auxiliary classical
+        // computing components, as need and efficiency dictate).
+        bitCapInt lowBound = toLoad[key];
+        bitCapInt highBound = toLoad[key | unfixedMask];
+
+        if (lowBound == TARGET_VALUE) {
+            // We've found our match, and the key register already contains the correct value.
+            std::cout << "Is low bound";
+            foundPerm = true;
+            break;
+        } else if (highBound == TARGET_VALUE) {
+            // We've found our match, but our key register points to the opposite bound.
+            std::cout << "Is high bound";
+            qReg->X(2 * valueLength, partLength);
+            foundPerm = true;
+            break;
+        } else if (((lowBound < TARGET_VALUE) && (highBound < TARGET_VALUE)) ||
+            ((lowBound > TARGET_VALUE) && (highBound > TARGET_VALUE))) {
+            // If we measure the key as a quadrant that doesn't contain our value, then either there is more than one
+            // quadrant with bounds that match our target value, or there is no match to our target in the list.
+            foundPerm = false;
+            break;
+        }
+
+        // Prepare partial index superposition, of two most significant qubits that have not yet been fixed:
+        partLength = indexLength - ((i + 1) * 2);
+        partStart = (2 * valueLength) + partLength;
+        qReg->H(partStart, 2);
+
+        // Load lower bound of quadrants:
+        qReg->IndexedADC(2 * valueLength, indexLength, 0, valueLength - 1, carryIndex, toLoad);
+
+        if (partLength > 0) {
+            // In this branch, our quadrant is "degenerate," (we mean, having more than one key/value pair).
+
+            // Load upper bound of quadrants:
+            qReg->X(2 * valueLength, partLength);
+            qReg->IndexedADC(2 * valueLength, indexLength, valueLength, valueLength - 1, carryIndex, toLoad);
+
+            // This begins the "oracle." Our "oracle" is true if the target can be within the bounds of this quadrant,
+            // and false otherwise: Set value bits to borrow from:
+            qReg->X(valueLength - 1);
+            qReg->X(2 * valueLength - 1);
+            // Subtract from the value registers with the bits to borrow from:
+            qReg->DEC(TARGET_VALUE, 0, valueLength);
+            qReg->DEC(TARGET_VALUE, valueLength, valueLength);
+            // If both are higher, this is not the quadrant, and neither flips the borrow.
+            // If both are lower, this is not the quadrant, and both flip the borrow.
+            // If one is higher and one is lower, the low register borrow bit is flipped, and high register borrow is
+            // not.
+            qReg->X(valueLength - 1);
+            qReg->CCNOT(valueLength - 1, 2 * valueLength - 1, carryIndex);
+            // Flip the phase is the test bit is set:
+            qReg->Z(carryIndex);
+            // Reverse everything but the phase flip:
+            qReg->CCNOT(valueLength - 1, 2 * valueLength - 1, carryIndex);
+            qReg->X(valueLength - 1);
+            qReg->INC(TARGET_VALUE, valueLength, valueLength);
+            qReg->INC(TARGET_VALUE, 0, valueLength);
+            qReg->X(2 * valueLength - 1);
+            qReg->X(valueLength - 1);
+            // This ends the "oracle."
+        } else {
+            // In this branch, we have one key/value pair in each quadrant, so we can use our usual Grover's oracle.
+
+            // We map from input to output.
+            qReg->DEC(TARGET_VALUE, 0, valueLength - 1);
+            // Phase flip the target state.
+            qReg->ZeroPhaseFlip(0, valueLength - 1);
+            // We map back from outputs to inputs.
+            qReg->INC(TARGET_VALUE, 0, valueLength - 1);
+        }
+
+        // Now, we flip the phase of the input state:
+
+        // Reverse the operations we used to construct the state:
+        qReg->X(carryIndex);
+        if (partLength > 0) {
+            qReg->IndexedSBC(2 * valueLength, indexLength, valueLength, valueLength - 1, carryIndex, toLoad);
+            qReg->X(2 * valueLength, partLength);
+        }
+        qReg->IndexedSBC(2 * valueLength, indexLength, 0, valueLength - 1, carryIndex, toLoad);
+        qReg->X(carryIndex);
+        qReg->H(partStart, 2);
+
+        // Flip the phase of the input state at the beginning of the iteration. Only in a quaternary Grover's search,
+        // we have an exact result at the end of each Grover's iteration, so we consider this an exact input for the
+        // next iteration. (See the beginning of the loop, for what happens if we have more than one matching quadrant.
+        qReg->ZeroPhaseFlip(partStart, 2);
+        qReg->H(partStart, 2);
+        // qReg->PhaseFlip();
+
+        std::cout << "Partial search result key: ";
+        for (j = indexLength - 1; j >= 0; j--) {
+            if (key & (1U << j)) {
+                std::cout << "1";
+            } else {
+                std::cout << "0";
+            }
+        }
+        std::cout << std::endl;
+    }
+
+    if (!foundPerm && (i == (indexLength / 2))) {
+        // Here, we hit the maximum iterations, but there might be no match in the array, or there might be more than
+        // one match.
+        bitCapInt key = qReg->MReg(2 * valueLength, indexLength);
+        if (toLoad[key] == TARGET_VALUE) {
+            foundPerm = true;
+        }
+    }
+    if (!foundPerm && (i > 0)) {
+        // If we measured an invalid value in fewer than the full iterations, or if we returned an invalid value on the
+        // last iteration, we back the index up one iteration, 2 index qubits. We check the 8 boundary values. If we
+        // have more than one match in the ordered list, one of our 8 boundary values is necessarily a match, since the
+        // match repetitions must cross the boundary between two quadrants. If none of the 8 match, a match necessarily
+        // does not exist in the ordered list.
+        // This can only happen on the first iteration if the single highest and lowest values in the list cannot bound
+        // the match, in which case we know a match does not exist in the list.
+        bitLenInt fixedLength = i * 2;
+        bitLenInt unfixedLength = indexLength - fixedLength;
+        bitCapInt fixedLengthMask = ((1 << fixedLength) - 1) << unfixedLength;
+        bitCapInt checkIncrement = 1 << (unfixedLength - 2);
+        bitCapInt key = (qReg->MReg(2 * valueLength, indexLength)) & (fixedLengthMask);
+        for (i = 0; i < 4; i++) {
+            // (We could either manipulate the quantum bits directly to check this, or rely on auxiliary classical
+            // computing components, as need and efficiency dictate).
+            if (toLoad[key | (i * checkIncrement)] == TARGET_VALUE) {
+                foundPerm = true;
+                qReg->SetReg(2 * valueLength, indexLength, key | (i * checkIncrement));
+                break;
+            }
+        }
+    }
+
+    if (!foundPerm) {
+        std::cout << "Value is not in array.";
+    } else {
+        qReg->IndexedADC(2 * valueLength, indexLength, 0, valueLength - 1, carryIndex, toLoad);
+        // (If we have more than one match, this REQUIRE_THAT needs to instead check that any of the matches are
+        // returned. This could be done by only requiring a match to the value register, but we want to show here that
+        // the index is correct.)
+    }
+    free(toLoad);
+
+    std::cout << "Full index/value pair:";
+    bitCapInt endState = qReg->MReg(0, 20);
+    for (j = 19; j >= 0; j--) {
+        if (endState & (1U << j)) {
+            std::cout << "1";
+        } else {
+            std::cout << "0";
+        }
+    }
+    std::cout << std::endl;
+}

--- a/include/common/qrack_types.hpp
+++ b/include/common/qrack_types.hpp
@@ -19,7 +19,8 @@
 #define bitCapInt uint64_t
 #define bitsInByte 8
 #define qrack_rand_gen std::mt19937_64
-#define qrack_rand_gen_ptr std::shared_ptr<std::mt19937_64>
+#define qrack_rand_gen_ptr std::shared_ptr<qrack_rand_gen>
+#define ALIGN_SIZE 64
 
 #include "config.h"
 

--- a/include/qfusion.hpp
+++ b/include/qfusion.hpp
@@ -28,11 +28,7 @@ typedef std::shared_ptr<QFusion> QFusionPtr;
 
 class QFusion : public QInterface {
 protected:
-
-    // This value should reasonably be set to 3, where buffering becomes efficient by complexity order.
-    // However, there is a bug that has not yet been completely isolated around the buffering threshold.
-    // Testing shows it is safe to buffer either everything or nothing.
-    static const bitLenInt MIN_FUSION_BITS = 0U;
+    static const bitLenInt MIN_FUSION_BITS = 3U;
     QInterfacePtr qReg;
     complex phaseFactor;
     bool doNormalize;

--- a/include/qfusion.hpp
+++ b/include/qfusion.hpp
@@ -28,7 +28,11 @@ typedef std::shared_ptr<QFusion> QFusionPtr;
 
 class QFusion : public QInterface {
 protected:
-    static const bitLenInt MIN_FUSION_BITS = 3U;
+
+    // This value should reasonably be set to 3, where buffering becomes efficient by complexity order.
+    // However, there is a bug that has not yet been completely isolated around the buffering threshold.
+    // Testing shows it is safe to buffer either everything or nothing.
+    static const bitLenInt MIN_FUSION_BITS = 0U;
     QInterfacePtr qReg;
     complex phaseFactor;
     bool doNormalize;

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -22,11 +22,13 @@
 #include "common/qrack_types.hpp"
 #include "hamiltonian.hpp"
 
-// The state vector must be an aligned piece of RAM, to be used by OpenCL.
-// We align to an ALIGN_SIZE byte boundary.
-#define ALIGN_SIZE 64
-
 namespace Qrack {
+
+// These are utility functions defined in qinterface/protected.cpp:
+unsigned char* qrack_alloc(size_t ucharCount);
+void mul2x2(complex* left, complex* right, complex* out);
+void exp2x2(complex* matrix2x2, complex* outMatrix2x2);
+void log2x2(complex* matrix2x2, complex* outMatrix2x2);
 
 class QInterface;
 typedef std::shared_ptr<QInterface> QInterfacePtr;

--- a/src/qfusion.cpp
+++ b/src/qfusion.cpp
@@ -78,7 +78,7 @@ void QFusion::ApplySingleBit(const complex* mtrx, bool doCalcNorm, bitLenInt qub
 
     // If we pass the threshold number of qubits for buffering, we just do 2x2 complex matrix multiplication.
     GateBufferPtr bfr = std::make_shared<GateBuffer>(false, (const bitLenInt*)NULL, 0, mtrx);
-    if ((bitControls[qubitIndex].size() > 0) || !(bfr->Combinable(bitBuffers[qubitIndex]))) {
+    if (!(bfr->Combinable(bitBuffers[qubitIndex]))) {
         // Flush the old buffer, if the buffered control bits don't match.
         FlushBit(qubitIndex);
     }
@@ -176,15 +176,12 @@ void QFusion::ApplyControlledSingleBit(
         return;
     }
 
-    // If we pass the threshold number of qubits for buffering, we track the buffered control bits, and we do 2x2
-    // complex matrix multiplication.
-
     for (bitLenInt i = 0; i < controlLen; i++) {
         FlushBit(controls[i]);
     }
 
     GateBufferPtr bfr = std::make_shared<GateBuffer>(false, controls, controlLen, mtrx);
-    if ((bitControls[target].size() > 0) || !(bfr->Combinable(bitBuffers[target]))) {
+    if (!(bfr->Combinable(bitBuffers[target]))) {
         // Flush the old buffer, if the buffered control bits don't match.
         FlushBit(target);
     }
@@ -213,15 +210,12 @@ void QFusion::ApplyAntiControlledSingleBit(
         return;
     }
 
-    // If we pass the threshold number of qubits for buffering, we track the buffered control bits, and we do 2x2
-    // complex matrix multiplication.
-
     for (bitLenInt i = 0; i < controlLen; i++) {
         FlushBit(controls[i]);
     }
 
     GateBufferPtr bfr = std::make_shared<GateBuffer>(true, controls, controlLen, mtrx);
-    if ((bitControls[target].size() > 0) || !(bfr->Combinable(bitBuffers[target]))) {
+    if (!(bfr->Combinable(bitBuffers[target]))) {
         // Flush the old buffer, if the buffered control bits don't match.
         FlushBit(target);
     }

--- a/src/qfusion.cpp
+++ b/src/qfusion.cpp
@@ -799,10 +799,7 @@ bool QFusion::ApproxCompare(QFusionPtr toCompare)
 }
 
 // Avoid calling this, when a QFusion layer is being used:
-void QFusion::UpdateRunningNorm() {
-    FlushAll();
-    qReg->UpdateRunningNorm();
-}
+void QFusion::UpdateRunningNorm() { qReg->UpdateRunningNorm(); }
 
 bool QFusion::TrySeparate(bitLenInt start, bitLenInt length)
 {

--- a/src/qinterface/protected.cpp
+++ b/src/qinterface/protected.cpp
@@ -16,6 +16,20 @@
 
 namespace Qrack {
 
+unsigned char* qrack_alloc(size_t ucharCount)
+{
+// ALIGN_SIZE is defined in common/qrack_types.hpp
+#ifdef __APPLE__
+    void* toRet;
+    posix_memalign(&toRet, ALIGN_SIZE,
+        ((sizeof(unsigned char) * ucharCount) < ALIGN_SIZE) ? ALIGN_SIZE : (sizeof(unsigned char) * ucharCount));
+    return (unsigned char*)toRet;
+#else
+    return (unsigned char*)aligned_alloc(ALIGN_SIZE,
+        ((sizeof(unsigned char) * ucharCount) < ALIGN_SIZE) ? ALIGN_SIZE : (sizeof(unsigned char) * ucharCount));
+#endif
+}
+
 template <class BidirectionalIterator>
 void reverse(BidirectionalIterator first, BidirectionalIterator last, bitCapInt stride)
 {

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -2790,3 +2790,47 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_timeevolve")
     REQUIRE_FLOAT(abs((ONE_R1 - qftReg->Prob(0)) - sin(aParam * tDiff) * sin(aParam * tDiff)), 0);
     REQUIRE_FLOAT(abs(qftReg->Prob(0) - cos(aParam * tDiff) * cos(aParam * tDiff)), 0);
 }
+
+void slow_ucry_implementation(
+    QInterfacePtr qReg, real1* angles, bitLenInt* control_qubits, bitLenInt controlLen, bitLenInt target_qubit)
+{
+    real1 cosine, sine;
+    complex pauliRY[4];
+
+    for (bitLenInt index = 0; index < (1 << controlLen); index++) {
+        for (bitLenInt bit_pos = 0; bit_pos < controlLen; bit_pos++) {
+            if (!((index >> bit_pos) & 1)) {
+                qReg->X(control_qubits[bit_pos]);
+            }
+        }
+
+        cosine = cos(angles[index] / 2.0);
+        sine = sin(angles[index] / 2.0);
+        pauliRY[0] = complex(cosine, ZERO_R1);
+        pauliRY[1] = complex(-sine, ZERO_R1);
+        pauliRY[2] = complex(sine, ZERO_R1);
+        pauliRY[3] = complex(cosine, ZERO_R1);
+
+        qReg->ApplyControlledSingleBit(control_qubits, controlLen, target_qubit, pauliRY);
+
+        for (bitLenInt bit_pos = 0; bit_pos < controlLen; bit_pos++) {
+            if (!((index >> bit_pos) & 1)) {
+                qReg->X(control_qubits[bit_pos]);
+            }
+        }
+    }
+}
+
+TEST_CASE_METHOD(QInterfaceTestFixture, "test_qfusion_controlled")
+{
+    bitLenInt controls[2] = { 1, 2 };
+    real1 angles[4] = { 3.0, 0.8, 1.2, 0.7 };
+
+    qftReg->SetPermutation(2);
+    QInterfacePtr qftReg2 = qftReg->Clone();
+
+    qftReg->UniformlyControlledRY(controls, 2, 0, angles);
+    slow_ucry_implementation(qftReg2, angles, controls, 2, 0);
+
+    REQUIRE(qftReg->ApproxCompare(qftReg2));
+}

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -2826,7 +2826,9 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_qfusion_controlled")
     bitLenInt controls[2] = { 1, 2 };
     real1 angles[4] = { 3.0, 0.8, 1.2, 0.7 };
 
-    complex amps[8] = { complex(ZERO_R1, ZERO_R1), complex(ZERO_R1, ZERO_R1), complex(ONE_R1, ZERO_R1), complex(ZERO_R1, ZERO_R1), complex(ZERO_R1, ZERO_R1), complex(ZERO_R1, ZERO_R1), complex(ZERO_R1, ZERO_R1), complex(ZERO_R1, ZERO_R1)};
+    complex amps[8] = { complex(ZERO_R1, ZERO_R1), complex(ZERO_R1, ZERO_R1), complex(ONE_R1, ZERO_R1),
+        complex(ZERO_R1, ZERO_R1), complex(ZERO_R1, ZERO_R1), complex(ZERO_R1, ZERO_R1), complex(ZERO_R1, ZERO_R1),
+        complex(ZERO_R1, ZERO_R1) };
 
     qftReg = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 3, 0, rng);
     qftReg->SetPermutation(2);

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -2826,11 +2826,20 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_qfusion_controlled")
     bitLenInt controls[2] = { 1, 2 };
     real1 angles[4] = { 3.0, 0.8, 1.2, 0.7 };
 
+    complex amps[8] = { complex(ZERO_R1, ZERO_R1), complex(ZERO_R1, ZERO_R1), complex(ONE_R1, ZERO_R1), complex(ZERO_R1, ZERO_R1), complex(ZERO_R1, ZERO_R1), complex(ZERO_R1, ZERO_R1), complex(ZERO_R1, ZERO_R1), complex(ZERO_R1, ZERO_R1)};
+
+    qftReg = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 3, 0, rng);
     qftReg->SetPermutation(2);
     QInterfacePtr qftReg2 = qftReg->Clone();
 
     qftReg->UniformlyControlledRY(controls, 2, 0, angles);
     slow_ucry_implementation(qftReg2, angles, controls, 2, 0);
 
-    REQUIRE(qftReg->ApproxCompare(qftReg2));
+    complex a, b;
+    for (bitCapInt i = 0; i < 8; i++) {
+        a = qftReg->GetAmplitude(i);
+        b = qftReg2->GetAmplitude(i);
+        REQUIRE_FLOAT(real(a), real(b));
+        REQUIRE_FLOAT(imag(a), imag(b));
+    }
 }

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -988,6 +988,36 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_crydyad_reg")
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x36));
 }
 
+void slow_ucry_implementation(
+    QInterfacePtr qReg, real1* angles, bitLenInt* control_qubits, bitLenInt controlLen, bitLenInt target_qubit)
+{
+    real1 cosine, sine;
+    complex pauliRY[4];
+
+    for (bitLenInt index = 0; index < (1 << controlLen); index++) {
+        for (bitLenInt bit_pos = 0; bit_pos < controlLen; bit_pos++) {
+            if (!((index >> bit_pos) & 1)) {
+                qReg->X(control_qubits[bit_pos]);
+            }
+        }
+
+        cosine = cos(angles[index] / 2.0);
+        sine = sin(angles[index] / 2.0);
+        pauliRY[0] = complex(cosine, ZERO_R1);
+        pauliRY[1] = complex(-sine, ZERO_R1);
+        pauliRY[2] = complex(sine, ZERO_R1);
+        pauliRY[3] = complex(cosine, ZERO_R1);
+
+        qReg->ApplyControlledSingleBit(control_qubits, controlLen, target_qubit, pauliRY);
+
+        for (bitLenInt bit_pos = 0; bit_pos < controlLen; bit_pos++) {
+            if (!((index >> bit_pos) & 1)) {
+                qReg->X(control_qubits[bit_pos]);
+            }
+        }
+    }
+}
+
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_uniform_cry")
 {
     bitLenInt controls[2] = { 4, 5 };
@@ -1041,28 +1071,7 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_uniform_cry")
     REQUIRE_THAT(qftReg2, HasProbability(0, 8, 0x02));
 
     qftReg->UniformlyControlledRY(controls, 2, 0, angles);
-
-    for (i = 0; i < 4; i++) {
-        for (j = 0; j < 2; j++) {
-            if (!(i & (1U << j))) {
-                qftReg2->X(controls[j]);
-            }
-        }
-
-        cosine = cos(angles[i] / 2);
-        sine = sin(angles[i] / 2);
-        pauliRY[0] = complex(cosine, ZERO_R1);
-        pauliRY[1] = complex(-sine, ZERO_R1);
-        pauliRY[2] = complex(sine, ZERO_R1);
-        pauliRY[3] = complex(cosine, ZERO_R1);
-        qftReg2->ApplyControlledSingleBit(controls, 2, 0, pauliRY);
-
-        for (j = 0; j < 2; j++) {
-            if (!(i & (1U << j))) {
-                qftReg2->X(controls[j]);
-            }
-        }
-    }
+    slow_ucry_implementation(qftReg2, angles, controls, 2, 0);
 
     REQUIRE(qftReg->ApproxCompare(qftReg2));
 }
@@ -2789,36 +2798,6 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_timeevolve")
 
     REQUIRE_FLOAT(abs((ONE_R1 - qftReg->Prob(0)) - sin(aParam * tDiff) * sin(aParam * tDiff)), 0);
     REQUIRE_FLOAT(abs(qftReg->Prob(0) - cos(aParam * tDiff) * cos(aParam * tDiff)), 0);
-}
-
-void slow_ucry_implementation(
-    QInterfacePtr qReg, real1* angles, bitLenInt* control_qubits, bitLenInt controlLen, bitLenInt target_qubit)
-{
-    real1 cosine, sine;
-    complex pauliRY[4];
-
-    for (bitLenInt index = 0; index < (1 << controlLen); index++) {
-        for (bitLenInt bit_pos = 0; bit_pos < controlLen; bit_pos++) {
-            if (!((index >> bit_pos) & 1)) {
-                qReg->X(control_qubits[bit_pos]);
-            }
-        }
-
-        cosine = cos(angles[index] / 2.0);
-        sine = sin(angles[index] / 2.0);
-        pauliRY[0] = complex(cosine, ZERO_R1);
-        pauliRY[1] = complex(-sine, ZERO_R1);
-        pauliRY[2] = complex(sine, ZERO_R1);
-        pauliRY[3] = complex(cosine, ZERO_R1);
-
-        qReg->ApplyControlledSingleBit(control_qubits, controlLen, target_qubit, pauliRY);
-
-        for (bitLenInt bit_pos = 0; bit_pos < controlLen; bit_pos++) {
-            if (!((index >> bit_pos) & 1)) {
-                qReg->X(control_qubits[bit_pos]);
-            }
-        }
-    }
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_qfusion_controlled")


### PR DESCRIPTION
(This branch was intended to tie up small loose ends for version 3.1, but I identified a large bug in QFusion the process. Apologies for the combined PR, but please tolerate it. Additionally, our CI just failed on pulling Ubuntu firmware packages, it looks like. We can talk about how to clean this up.)

In preparation for the 3.1 release, a critical bug has been fixed at the buffering threshold in QFusion, per #137 . Additionally, the ordered list search unit test ("quaternary search") has been pulled out into an example, and the Doxygen release number has been updated.