### PR TITLE
Locksync bug (#2)

### DIFF
--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -108,19 +108,12 @@ void QEngineOCL::UnlockSync()
     std::vector<cl::Event> waitVec = device_context->ResetWaitEvents();
     cl::Event unmapEvent;
     queue.enqueueUnmapMemObject(*stateBuffer, stateVec, &waitVec, &unmapEvent);
+    unmapEvent.wait();
 
-    if (unlockHostMem) {
-        device_context->wait_events.push_back(unmapEvent);
-        clFinish();
-    } else {
+    if (!unlockHostMem) {
         BufferPtr nStateBuffer = MakeStateVecBuffer(NULL);
-        cl::Event copyEvent;
-
-        unmapEvent.wait();
 
         WAIT_COPY(*stateBuffer, *nStateBuffer, sizeof(complex) * maxQPower);
-
-        clFinish();
 
         stateBuffer = nStateBuffer;
         free(stateVec);

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -111,6 +111,7 @@ void QEngineOCL::UnlockSync()
 
     if (unlockHostMem) {
         device_context->wait_events.push_back(unmapEvent);
+        clFinish();
     } else {
         BufferPtr nStateBuffer = MakeStateVecBuffer(NULL);
         cl::Event copyEvent;
@@ -118,6 +119,8 @@ void QEngineOCL::UnlockSync()
         unmapEvent.wait();
 
         WAIT_COPY(*stateBuffer, *nStateBuffer, sizeof(complex) * maxQPower);
+
+        clFinish();
 
         stateBuffer = nStateBuffer;
         free(stateVec);


### PR DESCRIPTION
It is not safe for a LockSync()/UnlockSync() block to return before mapped buffers are finished copying and being unmapped. Retaining a mapped buffer potentially leads to further operations being ignored, until the unmapping returns. (This bug was noticed in the context of writing amplitudes directly to the state vector in the context of ProjectQ.)