### PR TITLE
Default UniformlyControlledSingleBit

### DIFF
--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -337,7 +337,7 @@ public:
      * such as Qrack::ApplySingleBit.)
      */
     virtual void UniformlyControlledSingleBit(
-        const bitLenInt* controls, const bitLenInt& controlLen, bitLenInt qubitIndex, const complex* mtrxs) = 0;
+        const bitLenInt* controls, const bitLenInt& controlLen, bitLenInt qubitIndex, const complex* mtrxs);
 
     /**
      * To define a Hamiltonian, give a vector of controlled single bit gates ("HamiltonianOp" instances) that are

--- a/src/qinterface/gates.cpp
+++ b/src/qinterface/gates.cpp
@@ -195,4 +195,32 @@ void QInterface::CZ(bitLenInt control, bitLenInt target)
     ApplyControlledSingleBit(controls, 1, target, pauliZ);
 }
 
+void QInterface::UniformlyControlledSingleBit(const bitLenInt* controls, const bitLenInt& controlLen, bitLenInt qubitIndex, const complex* mtrxs)
+{
+    complex mtrx[4];
+    bitCapInt offset;
+
+    for (bitLenInt index = 0; index < (1 << controlLen); index++) {
+        for (bitLenInt bit_pos = 0; bit_pos < controlLen; bit_pos++) {
+            if (!((index >> bit_pos) & 1)) {
+                X(controls[bit_pos]);
+            }
+        }
+
+        offset = index * 4;
+        mtrx[0] = mtrxs[offset];
+        mtrx[1] = mtrxs[1 + offset];
+        mtrx[2] = mtrxs[2 + offset];
+        mtrx[3] = mtrxs[3 + offset];
+
+        ApplyControlledSingleBit(controls, controlLen, qubitIndex, mtrx);
+
+        for (bitLenInt bit_pos = 0; bit_pos < controlLen; bit_pos++) {
+            if (!((index >> bit_pos) & 1)) {
+                X(controls[bit_pos]);
+            }
+        }
+    }
+}
+
 } // namespace Qrack

--- a/src/qinterface/gates.cpp
+++ b/src/qinterface/gates.cpp
@@ -197,9 +197,6 @@ void QInterface::CZ(bitLenInt control, bitLenInt target)
 
 void QInterface::UniformlyControlledSingleBit(const bitLenInt* controls, const bitLenInt& controlLen, bitLenInt qubitIndex, const complex* mtrxs)
 {
-    complex mtrx[4];
-    bitCapInt offset;
-
     for (bitLenInt index = 0; index < (1 << controlLen); index++) {
         for (bitLenInt bit_pos = 0; bit_pos < controlLen; bit_pos++) {
             if (!((index >> bit_pos) & 1)) {
@@ -207,13 +204,7 @@ void QInterface::UniformlyControlledSingleBit(const bitLenInt* controls, const b
             }
         }
 
-        offset = index * 4;
-        mtrx[0] = mtrxs[offset];
-        mtrx[1] = mtrxs[1 + offset];
-        mtrx[2] = mtrxs[2 + offset];
-        mtrx[3] = mtrxs[3 + offset];
-
-        ApplyControlledSingleBit(controls, controlLen, qubitIndex, mtrx);
+        ApplyControlledSingleBit(controls, controlLen, qubitIndex, &(mtrxs[index * 4]));
 
         for (bitLenInt bit_pos = 0; bit_pos < controlLen; bit_pos++) {
             if (!((index >> bit_pos) & 1)) {


### PR DESCRIPTION
This adds a default implementation for `UniformlyControlledSingleBit()` to QInterface.

Default implementations like these (all of which rely only on calls back into other parts of the public interface) ease the process of adding new engine types and debugging optimized reimplementations of methods.

(This implementation has been used to test a bug in the ProjectQ integration. Relying on this default, it seems that the optimized implementations of `UniformlyControlledSingleBit` do not significantly differ from this decomposition in numerical result. The reason for the ProjectQ bug has not been identified, but this helps rule out bad optimized implementations, as the culprit.)