### PR TITLE
Wait events debug

### DIFF
--- a/include/common/oclengine.hpp
+++ b/include/common/oclengine.hpp
@@ -144,10 +144,10 @@ public:
 
     OCLDeviceCall Reserve(OCLAPI call) { return OCLDeviceCall(mutex, calls[call]); }
 
-    std::vector<cl::Event> ResetWaitEvents()
+    std::vector<cl::Event>& ResetWaitEvents()
     {
-        std::vector<cl::Event> waitVec = wait_events;
-        wait_events.clear();
+        std::vector<cl::Event>& waitVec = wait_events;
+        wait_events = std::vector<cl::Event>();
         return waitVec;
     }
 

--- a/include/qengine_cpu.hpp
+++ b/include/qengine_cpu.hpp
@@ -41,7 +41,7 @@ public:
         complex phaseFac = complex(-999.0, -999.0), bool doNorm = true, bool randomGlobalPhase = true,
         bool ignored = false);
     QEngineCPU(QEngineCPUPtr toCopy);
-    ~QEngineCPU() { free(stateVec); }
+    ~QEngineCPU() { FreeStateVec(); }
 
     virtual void SetQuantumState(complex* inputState);
     virtual void GetQuantumState(complex* outputState);
@@ -167,13 +167,19 @@ public:
 
 protected:
     virtual void ResetStateVec(complex* nStateVec);
+    virtual complex* AllocStateVec(bitCapInt elemCount, bool doForceAlloc = false);
+    virtual void FreeStateVec() {
+        if (stateVec) {
+            free(stateVec);
+        }
+    }
+
     virtual void DecomposeDispose(bitLenInt start, bitLenInt length, QEngineCPUPtr dest);
     virtual void Apply2x2(bitCapInt offset1, bitCapInt offset2, const complex* mtrx, const bitLenInt bitCount,
         const bitCapInt* qPowersSorted, bool doCalcNorm);
     virtual void UniformlyControlledSingleBit(
         const bitLenInt* controls, const bitLenInt& controlLen, bitLenInt qubitIndex, const complex* mtrxs);
     virtual void UpdateRunningNorm();
-    virtual complex* AllocStateVec(bitCapInt elemCount, bool doForceAlloc = false);
     virtual void ApplyM(bitCapInt mask, bitCapInt result, complex nrm);
 };
 } // namespace Qrack

--- a/include/qengine_cpu.hpp
+++ b/include/qengine_cpu.hpp
@@ -41,7 +41,7 @@ public:
         complex phaseFac = complex(-999.0, -999.0), bool doNorm = true, bool randomGlobalPhase = true,
         bool ignored = false);
     QEngineCPU(QEngineCPUPtr toCopy);
-    ~QEngineCPU() { delete[] stateVec; }
+    ~QEngineCPU() { free(stateVec); }
 
     virtual void SetQuantumState(complex* inputState);
     virtual void GetQuantumState(complex* outputState);

--- a/include/qengine_opencl.hpp
+++ b/include/qengine_opencl.hpp
@@ -96,9 +96,9 @@ public:
     ~QEngineOCL()
     {
         clFinish();
-        if (stateVec) {
-            free(stateVec);
-        }
+
+        FreeStateVec();
+
         if (nrmArray) {
             free(nrmArray);
         }
@@ -204,6 +204,11 @@ protected:
     void InitOCL(int devID);
     void ResetStateVec(complex* nStateVec, BufferPtr nStateBuffer);
     virtual complex* AllocStateVec(bitCapInt elemCount, bool doForceAlloc = false);
+    virtual void FreeStateVec() {
+        if (stateVec) {
+            free(stateVec);
+        }
+    }
     virtual BufferPtr MakeStateVecBuffer(complex* nStateVec);
 
     real1 ParSum(real1* toSum, bitCapInt maxI);

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -434,10 +434,9 @@ void QEngineOCL::SetPermutation(bitCapInt perm, complex phaseFac)
 
     fillEvent1.wait();
 
-    cl::Event fillEvent2;
-    queue.enqueueFillBuffer(*stateBuffer, amp, sizeof(complex) * perm, sizeof(complex), NULL, &fillEvent2);
+    device_context->wait_events.emplace_back();
+    queue.enqueueFillBuffer(*stateBuffer, amp, sizeof(complex) * perm, sizeof(complex), NULL, &(device_context->wait_events.back()));
     queue.flush();
-    device_context->wait_events.push_back(fillEvent2);
 
     runningNorm = ONE_R1;
 }

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -23,8 +23,7 @@ namespace Qrack {
 // These are commonly used emplace patterns, for OpenCL buffer I/O.
 #define DISPATCH_TEMP_WRITE(waitVec, buff, size, array, clEvent)                                                       \
     queue.enqueueWriteBuffer(buff, CL_FALSE, 0, size, array, waitVec, &clEvent);                                       \
-    queue.flush();                                                                                                     \
-    device_context->wait_events.push_back(clEvent)
+    queue.flush();
 
 #define DISPATCH_WRITE(waitVec, buff, size, array)                                                                     \
     device_context->wait_events.emplace_back();                                                                        \
@@ -194,11 +193,6 @@ cl::Event QEngineOCL::QueueCall(
         ocl.call.setArg(args.size(), cl::Local(localBuffSize));
     }
 
-#if ENABLE_VC4CL
-    // See issue VC4CL#55
-    clFinish();
-#endif
-
     // Dispatch the primary kernel, to apply the gate.
     cl::Event kernelEvent;
     std::vector<cl::Event> kernelWaitVec = device_context->ResetWaitEvents();
@@ -209,11 +203,6 @@ cl::Event QEngineOCL::QueueCall(
         &kernelEvent); // handle to wait for the kernel
 
     queue.flush();
-
-#if ENABLE_VC4CL
-    // See issue VC4CL#55
-    clFinish();
-#endif
 
     return kernelEvent;
 }
@@ -558,6 +547,11 @@ void QEngineOCL::Apply2x2(bitCapInt offset1, bitCapInt offset2, const complex* m
         }
     }
 
+    // Wait for buffer write from limited lifetime objects
+    writeArgsEvent.wait();
+    writeGateEvent.wait();
+    writeControlsEvent.wait();
+
     if (doCalcNorm) {
         device_context->wait_events.push_back(QueueCall(api_call, ngc, ngs,
             { stateBuffer, cmplxBuffer, ulongBuffer, powersBuffer, nrmBuffer }, sizeof(real1) * ngs));
@@ -585,11 +579,6 @@ void QEngineOCL::Apply2x2(bitCapInt offset1, bitCapInt offset2, const complex* m
         // "runningNorm" variable.
         DISPATCH_READ(&waitVec2, *nrmBuffer, sizeof(real1), &runningNorm);
     }
-
-    // Wait for buffer write from limited lifetime objects
-    writeArgsEvent.wait();
-    writeGateEvent.wait();
-    writeControlsEvent.wait();
 }
 
 void QEngineOCL::UniformlyControlledSingleBit(
@@ -637,6 +626,12 @@ void QEngineOCL::UniformlyControlledSingleBit(
     cl::Event writeControlsEvent;
     DISPATCH_TEMP_WRITE(&waitVec, *powersBuffer, sizeof(bitCapInt) * controlLen, qPowers, writeControlsEvent);
 
+    // Wait for buffer write from limited lifetime objects
+    writeNormEvent.wait();
+    writeMatricesEvent.wait();
+    writeArgsEvent.wait();
+    writeControlsEvent.wait();
+
     // We call the kernel, with global buffers and one local buffer.
     device_context->wait_events.push_back(QueueCall(OCL_API_UNIFORMLYCONTROLLED, ngc, ngs,
         { stateBuffer, ulongBuffer, powersBuffer, uniformBuffer, nrmInBuffer, nrmBuffer }, sizeof(real1) * ngs));
@@ -659,12 +654,6 @@ void QEngineOCL::UniformlyControlledSingleBit(
     // "runningNorm" variable.
     DISPATCH_READ(&waitVec2, *nrmBuffer, sizeof(real1), &runningNorm);
 
-    // Wait for buffer write from limited lifetime objects
-    writeNormEvent.wait();
-    writeMatricesEvent.wait();
-    writeArgsEvent.wait();
-    writeControlsEvent.wait();
-
     delete[] qPowers;
 }
 
@@ -679,10 +668,10 @@ void QEngineOCL::ApplyMx(OCLAPI api_call, bitCapInt* bciArgs, complex nrm)
     size_t ngc = FixWorkItemCount(bciArgs[0], nrmGroupCount);
     size_t ngs = FixGroupSize(ngc, nrmGroupSize);
 
-    device_context->wait_events.push_back(QueueCall(api_call, ngc, ngs, { stateBuffer, ulongBuffer, cmplxBuffer }));
-
     // Wait for buffer write from limited lifetime objects
     writeArgsEvent.wait();
+
+    device_context->wait_events.push_back(QueueCall(api_call, ngc, ngs, { stateBuffer, ulongBuffer, cmplxBuffer }));
 }
 
 void QEngineOCL::ApplyM(bitCapInt qPower, bool result, complex nrm)
@@ -1815,10 +1804,10 @@ void QEngineOCL::PhaseFlipX(OCLAPI api_call, bitCapInt* bciArgs)
     size_t ngc = FixWorkItemCount(bciArgs[0], nrmGroupCount);
     size_t ngs = FixGroupSize(ngc, nrmGroupSize);
 
-    device_context->wait_events.push_back(QueueCall(api_call, ngc, ngs, { stateBuffer, ulongBuffer }));
-
     // Wait for buffer write from limited lifetime objects
     writeArgsEvent.wait();
+
+    device_context->wait_events.push_back(QueueCall(api_call, ngc, ngs, { stateBuffer, ulongBuffer }));
 }
 
 void QEngineOCL::PhaseFlip()
@@ -1984,18 +1973,13 @@ void QEngineOCL::NormalizeState(real1 nrm)
     size_t ngc = FixWorkItemCount(bciArgs[0], nrmGroupCount);
     size_t ngs = FixGroupSize(ngc, nrmGroupSize);
 
+    // Wait for buffer write from limited lifetime objects
+    writeArgsEvent.wait();
+
     device_context->wait_events.push_back(
         QueueCall(OCL_API_NORMALIZE, ngc, ngs, { stateBuffer, ulongBuffer, argsBuffer }));
 
     runningNorm = ONE_R1;
-
-    // Wait for buffer write from limited lifetime objects
-    writeArgsEvent.wait();
-
-#if ENABLE_VC4CL
-    // See issue VC4CL#55
-    clFinish();
-#endif
 }
 
 void QEngineOCL::UpdateRunningNorm()
@@ -2010,6 +1994,9 @@ void QEngineOCL::UpdateRunningNorm()
 
     cl::Event writeArgsEvent;
     DISPATCH_TEMP_WRITE(&waitVec, *ulongBuffer, sizeof(bitCapInt), bciArgs, writeArgsEvent);
+
+    // Wait for buffer write from limited lifetime objects
+    writeArgsEvent.wait();
 
     device_context->wait_events.push_back(QueueCall(OCL_API_UPDATENORM, nrmGroupCount, nrmGroupSize,
         { stateBuffer, ulongBuffer, nrmBuffer }, sizeof(real1) * nrmGroupSize));
@@ -2028,14 +2015,6 @@ void QEngineOCL::UpdateRunningNorm()
     std::vector<cl::Event> waitVec2 = device_context->ResetWaitEvents();
 
     DISPATCH_WRITE(&waitVec2, *nrmBuffer, sizeof(real1), &runningNorm);
-
-    // Wait for buffer write from limited lifetime objects
-    writeArgsEvent.wait();
-
-#if ENABLE_VC4CL
-    // See issue VC4CL#55
-    clFinish();
-#endif
 }
 
 complex* QEngineOCL::AllocStateVec(bitCapInt elemCount, bool doForceAlloc)


### PR DESCRIPTION
This addresses the findings of https://github.com/doe300/VC4CL/issues/55:

1. QEngineCPU used the wrong deallocator for its state vector (`delete[]` instead of `free()`).
2. `cl::Event` objects should be treated as unique references and not duplicated between our "soft queue" and stack instances.
3. `clear()` should not be called on our running queue of `cl::Event` objects as a `std::vector`, to avoid invoking the destructor on each event prematurely.

Addressing these three issues, it seems that the VC4CL build for Raspberry Pi works without build-specific `clFinish()` calls.