### PR TITLE
Debugging on Raspberry Pi

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,9 +105,9 @@ This option is needed for certain older or simpler hardware. This removes all us
 ```
 $ cmake -DENABLE_VC4CL=ON ..
 ```
-This option sets `-DENABLE_PURE32=ON` and additionally branches certain code, in order to support execution on the VideoCore GPU of the Raspberry Pi 3 with the VC4CL OpenCL compiler. Currently, only `Qrack::QEngineOCL` (and specifically not `Qrack::QUnit`) has been successfully built and tested on the Raspberry Pi 3.
+This option sets `-DENABLE_PURE32=ON` and additionally branches certain code, in order to support execution on the VideoCore GPU of the Raspberry Pi 3 with the VC4CL OpenCL compiler.
 
-This option is probably temporary, due to issues currently being diagnosed and resolved in cooperation with VC4CL. (See VC4CL issues [#54](https://github.com/doe300/VC4CL/issues/54) and [#55](https://github.com/doe300/VC4CL/issues/55).) When those are addressed, -DENABLE_PURE32=ON should be necessary and sufficient to support VC4CL with the Raspberry Pi 3.
+This option is probably temporary, due to a known issue being resolved by the VC4CL team. (See VC4CL issue [#54](https://github.com/doe300/VC4CL/issues/54).) When that is addressed, -DENABLE_PURE32=ON should be necessary and sufficient to support VC4CL with the Raspberry Pi 3.
 
 ## Copyright and License
 

--- a/include/qengine_opencl.hpp
+++ b/include/qengine_opencl.hpp
@@ -58,6 +58,7 @@ protected:
     // QEngineOCL itself, specifically by QEngineOCLMulti.
     BufferPtr stateBuffer;
     BufferPtr cmplxBuffer;
+    BufferPtr realBuffer;
     BufferPtr ulongBuffer;
     BufferPtr nrmBuffer;
     BufferPtr powersBuffer;

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -631,9 +631,18 @@ void QEngineOCL::UniformlyControlledSingleBit(
     writeArgsEvent.wait();
     writeControlsEvent.wait();
 
+#if ENABLE_VC4CL
+    // 2^n different parallel gates for n control bits might be too much to queue at once, on a Raspberry Pi.
+    clFinish();
+#endif
+
     // We call the kernel, with global buffers and one local buffer.
     device_context->wait_events.push_back(QueueCall(OCL_API_UNIFORMLYCONTROLLED, ngc, ngs,
         { stateBuffer, ulongBuffer, powersBuffer, uniformBuffer, nrmInBuffer, nrmBuffer }, sizeof(real1) * ngs));
+
+#if ENABLE_VC4CL
+    clFinish();
+#endif
 
     // If we have calculated the norm of the state vector in this call, we need to sum the buffer of partial norm
     // values into a single normalization constant. We want to do this in a non-blocking, asynchronous way.

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -662,15 +662,16 @@ void QEngineOCL::ApplyMx(OCLAPI api_call, bitCapInt* bciArgs, complex nrm)
 {
     std::vector<cl::Event> waitVec = device_context->ResetWaitEvents();
 
-    cl::Event writeArgsEvent;
+    cl::Event writeArgsEvent, writeNormEvent;
     DISPATCH_TEMP_WRITE(&waitVec, *ulongBuffer, sizeof(bitCapInt) * 3, bciArgs, writeArgsEvent);
-    DISPATCH_WRITE(&waitVec, *cmplxBuffer, sizeof(complex), &nrm);
+    DISPATCH_TEMP_WRITE(&waitVec, *cmplxBuffer, sizeof(complex), &nrm, writeNormEvent);
 
     size_t ngc = FixWorkItemCount(bciArgs[0], nrmGroupCount);
     size_t ngs = FixGroupSize(ngc, nrmGroupSize);
 
     // Wait for buffer write from limited lifetime objects
     writeArgsEvent.wait();
+    writeNormEvent.wait();
 
     device_context->wait_events.push_back(QueueCall(api_call, ngc, ngs, { stateBuffer, ulongBuffer, cmplxBuffer }));
 }

--- a/src/qinterface/protected.cpp
+++ b/src/qinterface/protected.cpp
@@ -81,23 +81,20 @@ void _expLog2x2(complex* matrix2x2, complex* outMatrix2x2, bool isExp)
         complex trace = matrix2x2[0] + matrix2x2[3];
         complex determinant = (matrix2x2[0] * matrix2x2[3]) - (matrix2x2[1] * matrix2x2[2]);
         complex quadraticRoot =
-            sqrt((matrix2x2[0] - matrix2x2[3]) * (matrix2x2[0] - matrix2x2[3]) - (real1)(4.0) * determinant);
+            sqrt(trace * trace - (real1)(4.0) * determinant);
         complex eigenvalue1 = (trace + quadraticRoot) / (real1)2.0;
         complex eigenvalue2 = (trace - quadraticRoot) / (real1)2.0;
 
-        if (norm(matrix2x2[1]) > min_norm) {
-            jacobian[0] = matrix2x2[1];
-            jacobian[2] = eigenvalue1 - matrix2x2[0];
+        jacobian[0] = matrix2x2[0] - eigenvalue1;
+        jacobian[2] = matrix2x2[2];
 
-            jacobian[1] = matrix2x2[1];
-            jacobian[3] = eigenvalue2 - matrix2x2[0];
-        } else {
-            jacobian[0] = eigenvalue1 - matrix2x2[3];
-            jacobian[2] = matrix2x2[2];
+        jacobian[1] = matrix2x2[1];
+        jacobian[3] = matrix2x2[3] - eigenvalue2;
 
-            jacobian[1] = eigenvalue2 - matrix2x2[3];
-            jacobian[3] = matrix2x2[2];
-        }
+        expOfGate[0] = eigenvalue1;
+        expOfGate[1] = ZERO_R1;
+        expOfGate[2] = ZERO_R1;
+        expOfGate[3] = eigenvalue2;
 
         real1 nrm = std::sqrt(norm(jacobian[0]) + norm(jacobian[2]));
         jacobian[0] /= nrm;
@@ -112,9 +109,6 @@ void _expLog2x2(complex* matrix2x2, complex* outMatrix2x2, bool isExp)
         inverseJacobian[1] = -jacobian[1] / determinant;
         inverseJacobian[2] = -jacobian[2] / determinant;
         inverseJacobian[3] = jacobian[0] / determinant;
-
-        mul2x2(matrix2x2, jacobian, tempMatrix2x2);
-        mul2x2(inverseJacobian, tempMatrix2x2, expOfGate);
     } else {
         std::copy(matrix2x2, matrix2x2 + 4, expOfGate);
     }

--- a/src/qinterface/protected.cpp
+++ b/src/qinterface/protected.cpp
@@ -92,8 +92,8 @@ void _expLog2x2(complex* matrix2x2, complex* outMatrix2x2, bool isExp)
         jacobian[3] = matrix2x2[3] - eigenvalue2;
 
         expOfGate[0] = eigenvalue1;
-        expOfGate[1] = ZERO_R1;
-        expOfGate[2] = ZERO_R1;
+        expOfGate[1] = complex(ZERO_R1, ZERO_R1);
+        expOfGate[2] = complex(ZERO_R1, ZERO_R1);
         expOfGate[3] = eigenvalue2;
 
         real1 nrm = std::sqrt(norm(jacobian[0]) + norm(jacobian[2]));

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -2750,8 +2750,8 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_timeevolve")
     qftReg->SetPermutation(0);
     qftReg->TimeEvolve(h, tDiff);
 
-    REQUIRE_FLOAT(abs((ONE_R1 - qftReg->Prob(0)) - sin(aParam * tDiff) * sin(aParam * tDiff)), 0);
-    REQUIRE_FLOAT(abs(qftReg->Prob(0) - cos(aParam * tDiff) * cos(aParam * tDiff)), 0);
+    REQUIRE_FLOAT(abs(qftReg->Prob(0) - sin(aParam * tDiff) * sin(aParam * tDiff)), 0);
+    REQUIRE_FLOAT(abs((ONE_R1 - qftReg->Prob(0)) - cos(aParam * tDiff) * cos(aParam * tDiff)), 0);
 
     bitLenInt controls[1] = { 1 };
     bool controlToggles[1] = { false };
@@ -2768,8 +2768,8 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_timeevolve")
     qftReg->SetPermutation(2);
     qftReg->TimeEvolve(h, tDiff);
 
-    REQUIRE_FLOAT(abs((ONE_R1 - qftReg->Prob(0)) - sin(aParam * tDiff) * sin(aParam * tDiff)), 0);
-    REQUIRE_FLOAT(abs(qftReg->Prob(0) - cos(aParam * tDiff) * cos(aParam * tDiff)), 0);
+    REQUIRE_FLOAT(abs(qftReg->Prob(0) - sin(aParam * tDiff) * sin(aParam * tDiff)), 0);
+    REQUIRE_FLOAT(abs((ONE_R1 - qftReg->Prob(0)) - cos(aParam * tDiff) * cos(aParam * tDiff)), 0);
 
     controlToggles[0] = true;
     HamiltonianOpPtr h2 = std::make_shared<HamiltonianOp>(controls, 1, 0, o2neg1, false, controlToggles);
@@ -2796,8 +2796,8 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_timeevolve")
     qftReg->SetPermutation(2);
     qftReg->TimeEvolve(h, tDiff);
 
-    REQUIRE_FLOAT(abs((ONE_R1 - qftReg->Prob(0)) - sin(aParam * tDiff) * sin(aParam * tDiff)), 0);
-    REQUIRE_FLOAT(abs(qftReg->Prob(0) - cos(aParam * tDiff) * cos(aParam * tDiff)), 0);
+    REQUIRE_FLOAT(abs(qftReg->Prob(0) - sin(aParam * tDiff) * sin(aParam * tDiff)), 0);
+    REQUIRE_FLOAT(abs((ONE_R1 - qftReg->Prob(0)) - cos(aParam * tDiff) * cos(aParam * tDiff)), 0);
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_qfusion_controlled")


### PR DESCRIPTION
Uniformly controlled gates hang for an indefinite amount of time, on the Raspberry Pi 3. I will continue to profile this, but this might simply be at the limits of the hardware. For `n` control bits, these operation are equivalent to `2^n` parallel gates, which is extreme. If just the uniformly controlled gates are made to wait on finishing the queue, before and after kernel dispatch, this behavior resolves.