### PR TITLE
Debugging on Mac

### DIFF
--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -184,7 +184,7 @@ size_t QEngineOCL::FixGroupSize(size_t wic, size_t gs)
 
 EventVecPtr QEngineOCL::ResetWaitEvents()
 {
-    wait_refs.emplace_back(std::move(device_context->ResetWaitEvents()));
+    wait_refs.emplace_back(device_context->ResetWaitEvents());
     return wait_refs.back();
 }
 

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -79,14 +79,19 @@ QEngineOCL::QEngineOCL(QEngineOCLPtr toCopy)
     : QEngine(
           toCopy->qubitCount, toCopy->rand_generator, toCopy->doNormalize, toCopy->randGlobalPhase, toCopy->useHostRam)
     , stateVec(NULL)
-    , deviceID(-1)
+    , deviceID(toCopy->deviceID)
     , wait_refs()
     , nrmArray(NULL)
     , unlockHostMem(false)
 {
-    CopyState(toCopy);
+    runningNorm = ONE_R1;
+    SetQubitCount(toCopy->qubitCount);
+    
+    toCopy->Finish();
 
     InitOCL(toCopy->deviceID);
+    
+    CopyState(toCopy);
 }
 
 void QEngineOCL::LockSync(cl_int flags)
@@ -398,7 +403,7 @@ void QEngineOCL::SetDevice(const int& dID, const bool& forceReInit)
 
     if ((!didInit) || (oldDeviceID != deviceID) || (nrmGroupCount != oldNrmGroupCount)) {
         nrmBuffer = std::make_shared<cl::Buffer>(
-            context, CL_MEM_USE_HOST_PTR | CL_MEM_READ_WRITE, sizeof(real1) * nrmGroupCount, nrmArray);
+            context, CL_MEM_USE_HOST_PTR | CL_MEM_READ_WRITE, nrmVecAlignSize, nrmArray);
         EventVecPtr waitVec = ResetWaitEvents();
         // GPUs can't always tolerate uninitialized host memory, even if they're not reading from it
         DISPATCH_FILL(waitVec, *nrmBuffer, sizeof(real1) * nrmGroupCount, ZERO_R1);
@@ -422,7 +427,7 @@ real1 QEngineOCL::ParSum(real1* toSum, bitCapInt maxI)
     return totNorm;
 }
 
-void QEngineOCL::InitOCL(int devID) { SetDevice(devID); }
+void QEngineOCL::InitOCL(int devID) { SetDevice(devID, true); }
 
 void QEngineOCL::ResetStateVec(complex* nStateVec, BufferPtr nStateBuffer)
 {
@@ -584,21 +589,9 @@ void QEngineOCL::Apply2x2(bitCapInt offset1, bitCapInt offset2, const complex* m
 
     if (doCalcNorm) {
         // If we have calculated the norm of the state vector in this call, we need to sum the buffer of partial norm
-        // values into a single normalization constant. We want to do this in a non-blocking, asynchronous way.
-
-        // Until a norm calculation returns, don't change the stateVec length.
-        runningNorm = ONE_R1;
-
-        // This kernel is run on a single work group, but it lets us continue asynchronously.
-        if (ngc / ngs > 1) {
-            QueueCall(OCL_API_NORMSUM, ngc / ngs, ngc / ngs, { nrmBuffer }, sizeof(real1) * ngc / ngs);
-        }
-
+        // values into a single normalization constant.
         EventVecPtr waitVec2 = ResetWaitEvents();
-
-        // Asynchronously, whenever the normalization result is ready, it will be placed in this QEngineOCL's
-        // "runningNorm" variable.
-        DISPATCH_READ(waitVec2, *nrmBuffer, sizeof(real1), &runningNorm);
+        WAIT_REAL1_SUM(waitVec2, *nrmBuffer, ngc / ngs, nrmArray, &runningNorm);
     }
 }
 
@@ -647,21 +640,9 @@ void QEngineOCL::UniformlyControlledSingleBit(
         { stateBuffer, ulongBuffer, powersBuffer, uniformBuffer, nrmInBuffer, nrmBuffer }, sizeof(real1) * ngs);
 
     // If we have calculated the norm of the state vector in this call, we need to sum the buffer of partial norm
-    // values into a single normalization constant. We want to do this in a non-blocking, asynchronous way.
-
-    // Until a norm calculation returns, don't change the stateVec length.
-    runningNorm = ONE_R1;
-
-    // This kernel is run on a single work group, but it lets us continue asynchronously.
-    if (ngc / ngs > 1) {
-        QueueCall(OCL_API_NORMSUM, ngc / ngs, ngc / ngs, { nrmBuffer }, sizeof(real1) * ngc / ngs);
-    }
-
+    // values into a single normalization constant.
     EventVecPtr waitVec2 = ResetWaitEvents();
-
-    // Asynchronously, whenever the normalization result is ready, it will be placed in this QEngineOCL's
-    // "runningNorm" variable.
-    DISPATCH_READ(waitVec2, *nrmBuffer, sizeof(real1), &runningNorm);
+    WAIT_REAL1_SUM(waitVec2, *nrmBuffer, ngc / ngs, nrmArray, &runningNorm);
 
     delete[] qPowers;
 }
@@ -2010,19 +1991,8 @@ void QEngineOCL::UpdateRunningNorm()
 
     QueueCall(OCL_API_UPDATENORM, nrmGroupCount, nrmGroupSize, { stateBuffer, ulongBuffer, nrmBuffer }, sizeof(real1) * nrmGroupSize);
 
-    unsigned int size = (nrmGroupCount / nrmGroupSize);
-    if (size == 0) {
-        size = 1;
-    }
-
-    // This kernel is run on a single work group, but it lets us continue asynchronously.
-    if (size > 1) {
-        QueueCall(OCL_API_NORMSUM, size, size, { nrmBuffer }, sizeof(real1) * size);
-    }
-
     EventVecPtr waitVec2 = ResetWaitEvents();
-
-    DISPATCH_READ(waitVec2, *nrmBuffer, sizeof(real1), &runningNorm);
+    WAIT_REAL1_SUM(waitVec2, *nrmBuffer, nrmGroupCount / nrmGroupSize, nrmArray, &runningNorm);
 }
 
 complex* QEngineOCL::AllocStateVec(bitCapInt elemCount, bool doForceAlloc)

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -2022,7 +2022,7 @@ void QEngineOCL::UpdateRunningNorm()
 
     EventVecPtr waitVec2 = ResetWaitEvents();
 
-    DISPATCH_WRITE(waitVec2, *nrmBuffer, sizeof(real1), &runningNorm);
+    DISPATCH_READ(waitVec2, *nrmBuffer, sizeof(real1), &runningNorm);
 }
 
 complex* QEngineOCL::AllocStateVec(bitCapInt elemCount, bool doForceAlloc)

--- a/src/qinterface/gates.cpp
+++ b/src/qinterface/gates.cpp
@@ -198,7 +198,7 @@ void QInterface::CZ(bitLenInt control, bitLenInt target)
 void QInterface::UniformlyControlledSingleBit(
     const bitLenInt* controls, const bitLenInt& controlLen, bitLenInt qubitIndex, const complex* mtrxs)
 {
-    for (bitLenInt index = 0; index < (1 << controlLen); index++) {
+    for (bitCapInt index = 0; index < (1 << controlLen); index++) {
         for (bitLenInt bit_pos = 0; bit_pos < controlLen; bit_pos++) {
             if (!((index >> bit_pos) & 1)) {
                 X(controls[bit_pos]);

--- a/src/qinterface/gates.cpp
+++ b/src/qinterface/gates.cpp
@@ -198,7 +198,7 @@ void QInterface::CZ(bitLenInt control, bitLenInt target)
 void QInterface::UniformlyControlledSingleBit(
     const bitLenInt* controls, const bitLenInt& controlLen, bitLenInt qubitIndex, const complex* mtrxs)
 {
-    for (bitCapInt index = 0; index < (1 << controlLen); index++) {
+    for (bitCapInt index = 0; index < (1U << controlLen); index++) {
         for (bitLenInt bit_pos = 0; bit_pos < controlLen; bit_pos++) {
             if (!((index >> bit_pos) & 1)) {
                 X(controls[bit_pos]);

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -988,36 +988,6 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_crydyad_reg")
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x36));
 }
 
-void slow_ucry_implementation(
-    QInterfacePtr qReg, real1* angles, bitLenInt* control_qubits, bitLenInt controlLen, bitLenInt target_qubit)
-{
-    real1 cosine, sine;
-    complex pauliRY[4];
-
-    for (bitLenInt index = 0; index < (1 << controlLen); index++) {
-        for (bitLenInt bit_pos = 0; bit_pos < controlLen; bit_pos++) {
-            if (!((index >> bit_pos) & 1)) {
-                qReg->X(control_qubits[bit_pos]);
-            }
-        }
-
-        cosine = cos(angles[index] / 2.0);
-        sine = sin(angles[index] / 2.0);
-        pauliRY[0] = complex(cosine, ZERO_R1);
-        pauliRY[1] = complex(-sine, ZERO_R1);
-        pauliRY[2] = complex(sine, ZERO_R1);
-        pauliRY[3] = complex(cosine, ZERO_R1);
-
-        qReg->ApplyControlledSingleBit(control_qubits, controlLen, target_qubit, pauliRY);
-
-        for (bitLenInt bit_pos = 0; bit_pos < controlLen; bit_pos++) {
-            if (!((index >> bit_pos) & 1)) {
-                qReg->X(control_qubits[bit_pos]);
-            }
-        }
-    }
-}
-
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_uniform_cry")
 {
     bitLenInt controls[2] = { 4, 5 };
@@ -1071,7 +1041,7 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_uniform_cry")
     REQUIRE_THAT(qftReg2, HasProbability(0, 8, 0x02));
 
     qftReg->UniformlyControlledRY(controls, 2, 0, angles);
-    slow_ucry_implementation(qftReg2, angles, controls, 2, 0);
+    qftReg2->QInterface::UniformlyControlledRY(controls, 2, 0, angles);
 
     REQUIRE(qftReg->ApproxCompare(qftReg2));
 }
@@ -2814,7 +2784,7 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_qfusion_controlled")
     QInterfacePtr qftReg2 = qftReg->Clone();
 
     qftReg->UniformlyControlledRY(controls, 2, 0, angles);
-    slow_ucry_implementation(qftReg2, angles, controls, 2, 0);
+    qftReg2->QInterface::UniformlyControlledRY(controls, 2, 0, angles);
 
     complex a, b;
     for (bitCapInt i = 0; i < 8; i++) {


### PR DESCRIPTION
I noticed that our Mac build stopped working, and, when the build was fixed, it failed a couple of unit tests. I diagnosed and addressed the issue, here. The build error was a warning (with `--Wall --pedantic`) that really isn't significant. The unit tests failures were slightly nasty, though.

`enqueueReadBuffer` throws an exception (sometimes) when trying to read from a buffer that is allocated host-side. Forcing the buffer to map to the allocated array, instead of reading into a different array, fixes the issue. This _might_ be a strict requirement of OpenCL host code with host-side allocated arrays, which we violated. Strangely, the same hardware does this just fine on the Linux boot side of its Mac/Linux dual boot, and it hasn't been an issue anywhere else.

There will be a small to significant performance degradation, due to this. However, there should also be an accuracy improvement, as the buffer of interest contains values for normalization. Further, this definitely improves stability across devices. We might be able to separate the use of the host-side allocated buffer from this particular application, but I think that should be in a future pull request, if we do it. This fixes the problem.