### PR TITLE
Debugging on Windows and cross-device

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,7 @@ else (MSVC)
 endif(MSVC)
 
 if (ENABLE_COMPLEX_X2 AND NOT ENABLE_COMPLEX8)
-    set(QRACK_COMPILE_OPTS "${QRACK_COMPILE_OPTS} -mavx")
+    set(QRACK_COMPILE_OPTS ${QRACK_COMPILE_OPTS} -mavx)
 endif (ENABLE_COMPLEX_X2 AND NOT ENABLE_COMPLEX8)
 
 configure_file(include/common/config.h.in include/common/config.h @ONLY)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,9 +103,15 @@ if (APPLE)
     set(TEST_COMPILE_OPTS -Wno-inconsistent-missing-override)
 endif (APPLE)
 
-target_compile_options (qrack PUBLIC -O3 -std=c++11 -Wall -Werror -fPIC ${QRACK_COMPILE_OPTS} -DCATCH_CONFIG_FAST_COMPILE)
-target_compile_options (unittest PUBLIC -O3 -std=c++11 -Wall -Werror ${TEST_COMPILE_OPTS} -DCATCH_CONFIG_FAST_COMPILE)
-target_compile_options (benchmarks PUBLIC -O3 -std=c++11 -Wall -Werror ${TEST_COMPILE_OPTS} -DCATCH_CONFIG_FAST_COMPILE)
+if (MSVC)
+    target_compile_options (qrack PUBLIC -std=c++11 -Wall -fPIC ${QRACK_COMPILE_OPTS} -DCATCH_CONFIG_FAST_COMPILE)
+    target_compile_options (unittest PUBLIC -std=c++11 -Wall ${TEST_COMPILE_OPTS} -DCATCH_CONFIG_FAST_COMPILE)
+    target_compile_options (benchmarks PUBLIC -std=c++11 -Wall ${TEST_COMPILE_OPTS} -DCATCH_CONFIG_FAST_COMPILE)
+else (MSVC)
+    target_compile_options (qrack PUBLIC -O3 -std=c++11 -Wall -Werror -fPIC ${QRACK_COMPILE_OPTS} -DCATCH_CONFIG_FAST_COMPILE)
+    target_compile_options (unittest PUBLIC -O3 -std=c++11 -Wall -Werror ${TEST_COMPILE_OPTS} -DCATCH_CONFIG_FAST_COMPILE)
+    target_compile_options (benchmarks PUBLIC -O3 -std=c++11 -Wall -Werror ${TEST_COMPILE_OPTS} -DCATCH_CONFIG_FAST_COMPILE)
+endif (MSVC)
 
 set_target_properties (qrack PROPERTIES
     VERSION ${PROJECT_VERSION}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,10 +34,16 @@ add_executable (unittest
     test/tests.cpp
     )
 
-target_link_libraries (unittest
-    qrack
-    pthread
-    )
+if (MSVC)
+    target_link_libraries (unittest
+        qrack
+        )
+else (MSVC)
+    target_link_libraries (unittest
+        qrack
+        pthread
+        )
+endif (MSVC)
 
 add_test (NAME qrack_tests
     COMMAND unittest
@@ -49,10 +55,16 @@ add_executable (benchmarks
     test/benchmarks.cpp
     )
 
-target_link_libraries (benchmarks
-    qrack
-    pthread
-    )
+if (MSVC)
+    target_link_libraries (benchmarks
+        qrack
+        )
+else (MSVC)
+    target_link_libraries (benchmarks
+        qrack
+        pthread
+        )
+endif (MSVC)
 
 add_test (NAME qrack_benchmarks
     COMMAND benchmarks
@@ -64,10 +76,16 @@ add_executable (accuracy
     test/accuracy.cpp
     )
 
-target_link_libraries (accuracy
-    qrack
-    pthread
-    )
+if (MSVC)
+    target_link_libraries (accuracy
+        qrack
+        )
+else (MSVC)
+    target_link_libraries (accuracy
+        qrack
+        pthread
+        )
+endif (MSVC)
 
 add_test (NAME qrack_accuracy
     COMMAND accuracy

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,22 +28,19 @@ add_library (qrack STATIC
     src/qunit.cpp
     )
 
+if (MSVC)
+    set(QRACK_LIBS qrack)
+else (MSVC)
+    set(QRACK_LIBS qrack pthread)
+endif (MSVC)
+
 # Declare the unittest executable
 add_executable (unittest
     test/test_main.cpp
     test/tests.cpp
     )
 
-if (MSVC)
-    target_link_libraries (unittest
-        qrack
-        )
-else (MSVC)
-    target_link_libraries (unittest
-        qrack
-        pthread
-        )
-endif (MSVC)
+target_link_libraries (unittest ${QRACK_LIBS})
 
 add_test (NAME qrack_tests
     COMMAND unittest
@@ -55,16 +52,7 @@ add_executable (benchmarks
     test/benchmarks.cpp
     )
 
-if (MSVC)
-    target_link_libraries (benchmarks
-        qrack
-        )
-else (MSVC)
-    target_link_libraries (benchmarks
-        qrack
-        pthread
-        )
-endif (MSVC)
+target_link_libraries (benchmarks ${QRACK_LIBS})
 
 add_test (NAME qrack_benchmarks
     COMMAND benchmarks
@@ -76,16 +64,7 @@ add_executable (accuracy
     test/accuracy.cpp
     )
 
-if (MSVC)
-    target_link_libraries (accuracy
-        qrack
-        )
-else (MSVC)
-    target_link_libraries (accuracy
-        qrack
-        pthread
-        )
-endif (MSVC)
+target_link_libraries (accuracy ${QRACK_LIBS})
 
 add_test (NAME qrack_accuracy
     COMMAND accuracy
@@ -103,8 +82,16 @@ message ("Pure 32-bit compilation is: ${ENABLE_PURE32}")
 message ("Single accuracy is: ${ENABLE_COMPLEX8}")
 message ("Complex_x2/AVX Support is: ${ENABLE_COMPLEX_X2}")
 
+if (MSVC)
+    set(QRACK_COMPILE_OPTS -std=c++11 -Wall)
+    set(TEST_COMPILE_OPTS -std=c++11 -Wall)
+else (MSVC)
+    set(QRACK_COMPILE_OPTS -O3 -std=c++11 -Wall -Werror -fPIC)
+    set(TEST_COMPILE_OPTS -O3 -std=c++11 -Wall -Werror)
+endif(MSVC)
+
 if (ENABLE_COMPLEX_X2 AND NOT ENABLE_COMPLEX8)
-    set(QRACK_COMPILE_OPTS -mavx)
+    set(QRACK_COMPILE_OPTS "${QRACK_COMPILE_OPTS} -mavx")
 endif (ENABLE_COMPLEX_X2 AND NOT ENABLE_COMPLEX8)
 
 configure_file(include/common/config.h.in include/common/config.h @ONLY)
@@ -121,15 +108,9 @@ if (APPLE)
     set(TEST_COMPILE_OPTS -Wno-inconsistent-missing-override)
 endif (APPLE)
 
-if (MSVC)
-    target_compile_options (qrack PUBLIC -std=c++11 -Wall -fPIC ${QRACK_COMPILE_OPTS} -DCATCH_CONFIG_FAST_COMPILE)
-    target_compile_options (unittest PUBLIC -std=c++11 -Wall ${TEST_COMPILE_OPTS} -DCATCH_CONFIG_FAST_COMPILE)
-    target_compile_options (benchmarks PUBLIC -std=c++11 -Wall ${TEST_COMPILE_OPTS} -DCATCH_CONFIG_FAST_COMPILE)
-else (MSVC)
-    target_compile_options (qrack PUBLIC -O3 -std=c++11 -Wall -Werror -fPIC ${QRACK_COMPILE_OPTS} -DCATCH_CONFIG_FAST_COMPILE)
-    target_compile_options (unittest PUBLIC -O3 -std=c++11 -Wall -Werror ${TEST_COMPILE_OPTS} -DCATCH_CONFIG_FAST_COMPILE)
-    target_compile_options (benchmarks PUBLIC -O3 -std=c++11 -Wall -Werror ${TEST_COMPILE_OPTS} -DCATCH_CONFIG_FAST_COMPILE)
-endif (MSVC)
+target_compile_options (qrack PUBLIC ${QRACK_COMPILE_OPTS} -DCATCH_CONFIG_FAST_COMPILE)
+target_compile_options (unittest PUBLIC ${TEST_COMPILE_OPTS} -DCATCH_CONFIG_FAST_COMPILE)
+target_compile_options (benchmarks PUBLIC ${TEST_COMPILE_OPTS} -DCATCH_CONFIG_FAST_COMPILE)
 
 set_target_properties (qrack PROPERTIES
     VERSION ${PROJECT_VERSION}

--- a/README.md
+++ b/README.md
@@ -67,6 +67,22 @@ While the OpenCL framework is available by default on most modern Macs, the C++ 
 
 https://www.khronos.org/registry/OpenCL/
 
+## Building and Installing Qrack on Windows
+
+Qrack supports building on Windows, but some special configuration is required. Windows 10 usually comes with default OpenCL libraries for Intel (or AMD) CPUs and their graphics coprocessors, but NVIDIA graphics card support might require the CUDA Toolkit. The CUDA Toolkit also provides an OpenCL development environment, which is generally necessary to build Qrack.
+
+Qrack requires the `xxd` command to convert its OpenCL kernel code into hexadecimal format for building. `xxd` is not natively available on Windows systems, but Windows executables for it are provided by sources including the [Vim editor Windows port](https://www.vim.org/download.php).
+
+CMake on Windows will set up a 32-bit Visual Studio project by default, (if using Visual Studio). Putting together all of the above considerations, after installing the CUDA Toolkit and Vim, a typical CMake command for Windows might look like this:
+
+```
+    $ mkdir _build
+	$ cd _build
+	$ cmake -DCMAKE_GENERATOR_PLATFORM=x64 -DXXD_BIN="C:/Program Files (x86)/Vim/vim81/xxd.exe" ..
+```
+
+After CMake, the project must be built in Visual Studio.
+
 ## Performing code coverage
 
 ```

--- a/cmake/Examples.cmake
+++ b/cmake/Examples.cmake
@@ -4,10 +4,16 @@ add_executable (grovers
 
 set_target_properties(grovers PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/examples")
 
-target_link_libraries (grovers
-    qrack
-    pthread
-    )
+if (MSVC)
+    target_link_libraries (grovers
+        qrack
+        )
+else (MSVC)
+    target_link_libraries (grovers
+        qrack
+        pthread
+        )
+endif (MSVC)
 
 add_executable (grovers_lookup
     examples/grovers_lookup.cpp
@@ -15,10 +21,16 @@ add_executable (grovers_lookup
 
 set_target_properties(grovers_lookup PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/examples")
 
-target_link_libraries (grovers_lookup
-    qrack
-    pthread
-    )
+if (MSVC)
+    target_link_libraries (grovers_lookup
+        qrack
+        )
+else (MSVC)
+    target_link_libraries (grovers_lookup
+        qrack
+        pthread
+        )
+endif (MSVC)
 
 add_executable (ordered_list_search
     examples/ordered_list_search.cpp
@@ -26,10 +38,16 @@ add_executable (ordered_list_search
 
 set_target_properties(ordered_list_search PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/examples")
 
-target_link_libraries (ordered_list_search
-    qrack
-    pthread
-    )
+if (MSVC)
+    target_link_libraries (ordered_list_search
+        qrack
+        )
+else (MSVC)
+    target_link_libraries (ordered_list_search
+        qrack
+        pthread
+        )
+endif (MSVC)
 
 if (MSVC)
     target_compile_options (grovers PUBLIC -std=c++11 -Wall ${TEST_COMPILE_OPTS} -DCATCH_CONFIG_FAST_COMPILE)

--- a/cmake/Examples.cmake
+++ b/cmake/Examples.cmake
@@ -4,16 +4,7 @@ add_executable (grovers
 
 set_target_properties(grovers PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/examples")
 
-if (MSVC)
-    target_link_libraries (grovers
-        qrack
-        )
-else (MSVC)
-    target_link_libraries (grovers
-        qrack
-        pthread
-        )
-endif (MSVC)
+target_link_libraries (grovers ${QRACK_LIBS})
 
 add_executable (grovers_lookup
     examples/grovers_lookup.cpp
@@ -21,16 +12,7 @@ add_executable (grovers_lookup
 
 set_target_properties(grovers_lookup PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/examples")
 
-if (MSVC)
-    target_link_libraries (grovers_lookup
-        qrack
-        )
-else (MSVC)
-    target_link_libraries (grovers_lookup
-        qrack
-        pthread
-        )
-endif (MSVC)
+target_link_libraries (grovers_lookup ${QRACK_LIBS})
 
 add_executable (ordered_list_search
     examples/ordered_list_search.cpp
@@ -38,23 +20,8 @@ add_executable (ordered_list_search
 
 set_target_properties(ordered_list_search PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/examples")
 
-if (MSVC)
-    target_link_libraries (ordered_list_search
-        qrack
-        )
-else (MSVC)
-    target_link_libraries (ordered_list_search
-        qrack
-        pthread
-        )
-endif (MSVC)
+target_link_libraries (ordered_list_search ${QRACK_LIBS})
 
-if (MSVC)
-    target_compile_options (grovers PUBLIC -std=c++11 -Wall ${TEST_COMPILE_OPTS} -DCATCH_CONFIG_FAST_COMPILE)
-    target_compile_options (grovers_lookup PUBLIC -std=c++11 -Wall ${TEST_COMPILE_OPTS} -DCATCH_CONFIG_FAST_COMPILE)
-    target_compile_options (ordered_list_search PUBLIC -std=c++11 -Wall ${TEST_COMPILE_OPTS} -DCATCH_CONFIG_FAST_COMPILE)
-else (MSVC)
-    target_compile_options (grovers PUBLIC -O3 -std=c++11 -Wall -Werror ${TEST_COMPILE_OPTS} -DCATCH_CONFIG_FAST_COMPILE)
-    target_compile_options (grovers_lookup PUBLIC -O3 -std=c++11 -Wall -Werror ${TEST_COMPILE_OPTS} -DCATCH_CONFIG_FAST_COMPILE)
-    target_compile_options (ordered_list_search PUBLIC -O3 -std=c++11 -Wall -Werror ${TEST_COMPILE_OPTS} -DCATCH_CONFIG_FAST_COMPILE)
-endif (MSVC)
+target_compile_options (grovers PUBLIC ${TEST_COMPILE_OPTS} -DCATCH_CONFIG_FAST_COMPILE)
+target_compile_options (grovers_lookup PUBLIC ${TEST_COMPILE_OPTS} -DCATCH_CONFIG_FAST_COMPILE)
+target_compile_options (ordered_list_search PUBLIC ${TEST_COMPILE_OPTS} -DCATCH_CONFIG_FAST_COMPILE)

--- a/cmake/Examples.cmake
+++ b/cmake/Examples.cmake
@@ -31,7 +31,12 @@ target_link_libraries (ordered_list_search
     pthread
     )
 
-
-target_compile_options (grovers PUBLIC -O3 -std=c++11 -Wall -Werror ${TEST_COMPILE_OPTS} -DCATCH_CONFIG_FAST_COMPILE)
-target_compile_options (grovers_lookup PUBLIC -O3 -std=c++11 -Wall -Werror ${TEST_COMPILE_OPTS} -DCATCH_CONFIG_FAST_COMPILE)
-target_compile_options (ordered_list_search PUBLIC -O3 -std=c++11 -Wall -Werror ${TEST_COMPILE_OPTS} -DCATCH_CONFIG_FAST_COMPILE)
+if (MSVC)
+    target_compile_options (grovers PUBLIC -std=c++11 -Wall ${TEST_COMPILE_OPTS} -DCATCH_CONFIG_FAST_COMPILE)
+    target_compile_options (grovers_lookup PUBLIC -std=c++11 -Wall ${TEST_COMPILE_OPTS} -DCATCH_CONFIG_FAST_COMPILE)
+    target_compile_options (ordered_list_search PUBLIC -std=c++11 -Wall ${TEST_COMPILE_OPTS} -DCATCH_CONFIG_FAST_COMPILE)
+else (MSVC)
+    target_compile_options (grovers PUBLIC -O3 -std=c++11 -Wall -Werror ${TEST_COMPILE_OPTS} -DCATCH_CONFIG_FAST_COMPILE)
+    target_compile_options (grovers_lookup PUBLIC -O3 -std=c++11 -Wall -Werror ${TEST_COMPILE_OPTS} -DCATCH_CONFIG_FAST_COMPILE)
+    target_compile_options (ordered_list_search PUBLIC -O3 -std=c++11 -Wall -Werror ${TEST_COMPILE_OPTS} -DCATCH_CONFIG_FAST_COMPILE)
+endif (MSVC)

--- a/cmake/OpenCL.cmake
+++ b/cmake/OpenCL.cmake
@@ -1,30 +1,19 @@
 option (ENABLE_OPENCL "Use OpenCL optimizations" ON)
 
 set (OPENCL_AMDSDK /opt/AMDAPPSDK-3.0 CACHE PATH "Installation path for the installed AMD OpenCL SDK, if used")
+set (OPENCL_NVIDIASDK "C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v10.0" "Installation path for the installed NVIDIA CUDA Toolkit, if used")
 
 # Options used when building the project
-find_library (LIB_OPENCL OpenCL)
-if (NOT LIB_OPENCL)
-    # Attempt with AMD's OpenCL SDK
-    find_library (LIB_OPENCL OpenCL PATHS ${OPENCL_AMDSDK}/lib/x86_64/)
-    if (NOT LIB_OPENCL)
-        set (ENABLE_OPENCL OFF)
-    else ()
-        # Found, set the required include path.
-        set (OPENCL_INCLUDE_PATH ${OPENCL_AMDSDK}/include CACHE PATH "AMD OpenCL SDK Header include path")
-        set (OPENCL_COMPILATION_OPTIONS
-            -Wno-ignored-attributes
-            -Wno-deprecated-declarations
-            CACHE STRING "AMD OpenCL SDK Compilation Option Requirements")
-        message ("OpenCL support found in the AMD SDK")
-    endif ()
+find_package (OpenCL)
+if (NOT OpenCL_FOUND)
+    set (ENABLE_OPENCL OFF)
 endif ()
 
 message ("OpenCL Support is: ${ENABLE_OPENCL}")
 
 if (ENABLE_OPENCL)
-    message ("    libOpenCL: ${LIB_OPENCL}")
-    message ("    Includes:  ${OPENCL_INCLUDE_PATH}")
+    message ("    libOpenCL: ${OpenCL_LIBRARIES}")
+    message ("    Includes:  ${OpenCL_INCLUDE_DIRS}")
     message ("    Options:   ${OPENCL_COMPILATION_OPTIONS}")
 endif ()
 
@@ -33,14 +22,14 @@ if (ENABLE_OPENCL)
     target_compile_definitions (qrack PUBLIC CL_HPP_MINIMUM_OPENCL_VERSION=100)
 
     # Include the necessary options and libraries to link against
-    target_include_directories (qrack PUBLIC ${PROJECT_BINARY_DIR} ${OPENCL_INCLUDE_PATH})
+    target_include_directories (qrack PUBLIC ${PROJECT_BINARY_DIR} ${OpenCL_INCLUDE_DIRS})
     target_compile_options (qrack PUBLIC ${OPENCL_COMPILATION_OPTIONS})
-    target_link_libraries (unittest ${LIB_OPENCL})
-    target_link_libraries (benchmarks ${LIB_OPENCL})
-    target_link_libraries (accuracy ${LIB_OPENCL})
-    target_link_libraries (grovers ${LIB_OPENCL})
-    target_link_libraries (grovers_lookup ${LIB_OPENCL})
-    target_link_libraries (ordered_list_search ${LIB_OPENCL})
+    target_link_libraries (unittest ${OpenCL_LIBRARIES})
+    target_link_libraries (benchmarks ${OpenCL_LIBRARIES})
+    target_link_libraries (accuracy ${OpenCL_LIBRARIES})
+    target_link_libraries (grovers ${OpenCL_LIBRARIES})
+    target_link_libraries (grovers_lookup ${OpenCL_LIBRARIES})
+    target_link_libraries (ordered_list_search ${OpenCL_LIBRARIES})
 
 
     # Build the OpenCL command files

--- a/cmake/OpenCL.cmake
+++ b/cmake/OpenCL.cmake
@@ -1,12 +1,23 @@
 option (ENABLE_OPENCL "Use OpenCL optimizations" ON)
 
 set (OPENCL_AMDSDK /opt/AMDAPPSDK-3.0 CACHE PATH "Installation path for the installed AMD OpenCL SDK, if used")
-set (OPENCL_NVIDIASDK "C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v10.0" "Installation path for the installed NVIDIA CUDA Toolkit, if used")
 
 # Options used when building the project
 find_package (OpenCL)
 if (NOT OpenCL_FOUND)
-    set (ENABLE_OPENCL OFF)
+    # Attempt with AMD's OpenCL SDK
+    find_library (LIB_OPENCL OpenCL PATHS ${OPENCL_AMDSDK}/lib/x86_64/)
+    if (NOT LIB_OPENCL)
+        set (ENABLE_OPENCL OFF)
+    else ()
+        # Found, set the required include path.
+        set (OpenCL_INCLUDE_DIRS ${OPENCL_AMDSDK}/include CACHE PATH "AMD OpenCL SDK Header include path")
+        set (OpenCL_COMPILATION_OPTIONS
+            -Wno-ignored-attributes
+            -Wno-deprecated-declarations
+            CACHE STRING "AMD OpenCL SDK Compilation Option Requirements")
+        message ("OpenCL support found in the AMD SDK")
+    endif()
 endif ()
 
 message ("OpenCL Support is: ${ENABLE_OPENCL}")
@@ -14,7 +25,7 @@ message ("OpenCL Support is: ${ENABLE_OPENCL}")
 if (ENABLE_OPENCL)
     message ("    libOpenCL: ${OpenCL_LIBRARIES}")
     message ("    Includes:  ${OpenCL_INCLUDE_DIRS}")
-    message ("    Options:   ${OPENCL_COMPILATION_OPTIONS}")
+    message ("    Options:   ${OpenCL_COMPILATION_OPTIONS}")
 endif ()
 
 if (ENABLE_OPENCL)
@@ -23,7 +34,7 @@ if (ENABLE_OPENCL)
 
     # Include the necessary options and libraries to link against
     target_include_directories (qrack PUBLIC ${PROJECT_BINARY_DIR} ${OpenCL_INCLUDE_DIRS})
-    target_compile_options (qrack PUBLIC ${OPENCL_COMPILATION_OPTIONS})
+    target_compile_options (qrack PUBLIC ${OpenCL_COMPILATION_OPTIONS})
     target_link_libraries (unittest ${OpenCL_LIBRARIES})
     target_link_libraries (benchmarks ${OpenCL_LIBRARIES})
     target_link_libraries (accuracy ${OpenCL_LIBRARIES})

--- a/include/common/complex16simd.hpp
+++ b/include/common/complex16simd.hpp
@@ -13,10 +13,13 @@
 #pragma once
 
 #include <cmath>
+#if defined(_WIN32)
+#include <intrin.h>
+#else
 #include <emmintrin.h>
-
 #if ENABLE_AVX
 #include <smmintrin.h>
+#endif
 #endif
 
 namespace Qrack {
@@ -85,7 +88,10 @@ struct Complex16Simd {
         _val = _mm_div_pd(_val, _mm_set1_pd(rhs));
         return _val;
     }
-    inline Complex16Simd operator-() const { return -_val; }
+    inline Complex16Simd operator-() const {
+		__m128d negOne = _mm_set1_pd(1.0);
+		return _mm_mul_pd(negOne, _val);
+	}
     inline Complex16Simd operator*=(const double& other)
     {
         _val = _mm_mul_pd(_val, _mm_set1_pd(other));

--- a/include/common/complex16simd.hpp
+++ b/include/common/complex16simd.hpp
@@ -88,10 +88,11 @@ struct Complex16Simd {
         _val = _mm_div_pd(_val, _mm_set1_pd(rhs));
         return _val;
     }
-    inline Complex16Simd operator-() const {
-		__m128d negOne = _mm_set1_pd(1.0);
-		return _mm_mul_pd(negOne, _val);
-	}
+    inline Complex16Simd operator-() const
+    {
+        __m128d negOne = _mm_set1_pd(1.0);
+        return _mm_mul_pd(negOne, _val);
+    }
     inline Complex16Simd operator*=(const double& other)
     {
         _val = _mm_mul_pd(_val, _mm_set1_pd(other));

--- a/include/common/complex16x2simd.hpp
+++ b/include/common/complex16x2simd.hpp
@@ -58,10 +58,11 @@ struct Complex16x2Simd {
         return _val2;
     }
     inline Complex16x2Simd operator*(const double rhs) const { return _mm256_mul_pd(_val2, _mm256_set1_pd(rhs)); }
-    inline Complex16x2Simd operator-() const {
-		__m256d negOne = _mm256_set1_pd(1.0);
-		return _mm256_mul_pd(negOne, _val2);
-	}
+    inline Complex16x2Simd operator-() const
+    {
+        __m256d negOne = _mm256_set1_pd(1.0);
+        return _mm256_mul_pd(negOne, _val2);
+    }
     inline Complex16x2Simd operator*=(const double& other)
     {
         _val2 = _mm256_mul_pd(_val2, _mm256_set1_pd(other));

--- a/include/common/complex16x2simd.hpp
+++ b/include/common/complex16x2simd.hpp
@@ -12,9 +12,13 @@
 
 #pragma once
 
+#if defined(_WIN32)
+#include <intrin.h>
+#else
 #include <emmintrin.h>
 #include <immintrin.h>
 #include <smmintrin.h>
+#endif
 
 namespace Qrack {
 
@@ -54,7 +58,10 @@ struct Complex16x2Simd {
         return _val2;
     }
     inline Complex16x2Simd operator*(const double rhs) const { return _mm256_mul_pd(_val2, _mm256_set1_pd(rhs)); }
-    inline Complex16x2Simd operator-() const { return -_val2; }
+    inline Complex16x2Simd operator-() const {
+		__m256d negOne = _mm256_set1_pd(1.0);
+		return _mm256_mul_pd(negOne, _val2);
+	}
     inline Complex16x2Simd operator*=(const double& other)
     {
         _val2 = _mm256_mul_pd(_val2, _mm256_set1_pd(other));

--- a/include/common/complex8x2simd.hpp
+++ b/include/common/complex8x2simd.hpp
@@ -59,10 +59,11 @@ struct Complex8x2Simd {
         return _val2;
     }
     inline Complex8x2Simd operator*(const float rhs) const { return _mm_mul_ps(_val2, _mm_set1_ps(rhs)); }
-    inline Complex8x2Simd operator-() const {
-		__m128 negOne = _mm_set1_ps(-1.0f);
-		return _mm_mul_ps(negOne, _val2);
-	}
+    inline Complex8x2Simd operator-() const
+    {
+        __m128 negOne = _mm_set1_ps(-1.0f);
+        return _mm_mul_ps(negOne, _val2);
+    }
     inline Complex8x2Simd operator*=(const float& other)
     {
         _val2 = _mm_mul_ps(_val2, _mm_set1_ps(other));

--- a/include/common/complex8x2simd.hpp
+++ b/include/common/complex8x2simd.hpp
@@ -12,7 +12,11 @@
 
 #pragma once
 
+#if defined(_WIN32)
+#include <intrin.h>
+#else
 #include <xmmintrin.h>
+#endif
 
 namespace Qrack {
 
@@ -55,7 +59,10 @@ struct Complex8x2Simd {
         return _val2;
     }
     inline Complex8x2Simd operator*(const float rhs) const { return _mm_mul_ps(_val2, _mm_set1_ps(rhs)); }
-    inline Complex8x2Simd operator-() const { return -_val2; }
+    inline Complex8x2Simd operator-() const {
+		__m128 negOne = _mm_set1_ps(-1.0f);
+		return _mm_mul_ps(negOne, _val2);
+	}
     inline Complex8x2Simd operator*=(const float& other)
     {
         _val2 = _mm_mul_ps(_val2, _mm_set1_ps(other));

--- a/include/common/oclengine.hpp
+++ b/include/common/oclengine.hpp
@@ -22,9 +22,11 @@
 #include <memory>
 #include <mutex>
 
-#ifdef __APPLE__
+#if defined(__APPLE__)
 #define CL_SILENCE_DEPRECATION
 #include <OpenCL/cl.hpp>
+#elif defined(_WIN32)
+#include <CL/cl.hpp>
 #else
 #include <CL/cl2.hpp>
 #endif

--- a/include/qengine_cpu.hpp
+++ b/include/qengine_cpu.hpp
@@ -171,8 +171,13 @@ protected:
     virtual void FreeStateVec()
     {
         if (stateVec) {
+#if defined(_WIN32)
+            _aligned_free(stateVec);
+#else 
             free(stateVec);
+#endif
         }
+        stateVec = NULL;
     }
 
     virtual void DecomposeDispose(bitLenInt start, bitLenInt length, QEngineCPUPtr dest);

--- a/include/qengine_cpu.hpp
+++ b/include/qengine_cpu.hpp
@@ -173,7 +173,7 @@ protected:
         if (stateVec) {
 #if defined(_WIN32)
             _aligned_free(stateVec);
-#else 
+#else
             free(stateVec);
 #endif
         }

--- a/include/qengine_opencl.hpp
+++ b/include/qengine_opencl.hpp
@@ -101,9 +101,7 @@ public:
 
         FreeStateVec();
 
-        if (nrmArray) {
-            free(nrmArray);
-        }
+        FreeAligned(nrmArray);
     }
 
     virtual void SetQubitCount(bitLenInt qb);
@@ -209,8 +207,13 @@ protected:
     virtual void FreeStateVec()
     {
         if (stateVec) {
+#if defined(_WIN32)
+            _aligned_free(stateVec);
+#else
             free(stateVec);
+#endif
         }
+        stateVec = NULL;
     }
     virtual BufferPtr MakeStateVecBuffer(complex* nStateVec);
 

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -119,6 +119,17 @@ protected:
 
     template <typename GateFunc> void ControlledLoopFixture(bitLenInt length, GateFunc gate);
 
+    void FreeAligned(void* toFree)
+    {
+        if (toFree) {
+#if defined(_WIN32)
+            _aligned_free(toFree);
+#else
+            free(toFree);
+#endif
+		}
+    }
+
 public:
     QInterface(bitLenInt n, qrack_rand_gen_ptr rgp = nullptr, bool doNorm = true)
         : rand_distribution(0.0, 1.0)

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -127,7 +127,7 @@ protected:
 #else
             free(toFree);
 #endif
-		}
+        }
     }
 
 public:

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -12,6 +12,8 @@
 
 #pragma once
 
+#define _USE_MATH_DEFINES
+
 #include <ctime>
 #include <map>
 #include <math.h>

--- a/src/common/parallel_for.cpp
+++ b/src/common/parallel_for.cpp
@@ -138,10 +138,10 @@ void ParallelFor::par_for_mask(
     }
 
     /* Pre-calculate the masks to simplify the increment function later. */
-	bitCapInt** masks = new bitCapInt*[maskLen];
-	for (int i = 0; i < maskLen; i++) {
-		masks[i] = new bitCapInt[2];
-	}
+    bitCapInt** masks = new bitCapInt*[maskLen];
+    for (int i = 0; i < maskLen; i++) {
+        masks[i] = new bitCapInt[2];
+    }
 
     bool onlyLow = true;
     for (int i = 0; i < maskLen; i++) {
@@ -166,11 +166,11 @@ void ParallelFor::par_for_mask(
 
         par_for_inc(begin, (end - begin) >> maskLen, incFn, fn);
     }
-	
-	for (int i = 0; i < maskLen; i++) {
-		delete[] masks[i];
-	}
-	delete[] masks;
+
+    for (int i = 0; i < maskLen; i++) {
+        delete[] masks[i];
+    }
+    delete[] masks;
 }
 
 real1 ParallelFor::par_norm(const bitCapInt maxQPower, const complex* stateArray)

--- a/src/common/parallel_for.cpp
+++ b/src/common/parallel_for.cpp
@@ -10,6 +10,8 @@
 // See LICENSE.md in the project root or https://www.gnu.org/licenses/lgpl-3.0.en.html
 // for details.
 
+#define _USE_MATH_DEFINES
+
 #include <atomic>
 #include <future>
 #include <math.h>
@@ -136,7 +138,10 @@ void ParallelFor::par_for_mask(
     }
 
     /* Pre-calculate the masks to simplify the increment function later. */
-    bitCapInt masks[maskLen][2];
+	bitCapInt** masks = new bitCapInt*[maskLen];
+	for (int i = 0; i < maskLen; i++) {
+		masks[i] = new bitCapInt[2];
+	}
 
     bool onlyLow = true;
     for (int i = 0; i < maskLen; i++) {
@@ -161,6 +166,11 @@ void ParallelFor::par_for_mask(
 
         par_for_inc(begin, (end - begin) >> maskLen, incFn, fn);
     }
+	
+	for (int i = 0; i < maskLen; i++) {
+		delete[] masks[i];
+	}
+	delete[] masks;
 }
 
 real1 ParallelFor::par_norm(const bitCapInt maxQPower, const complex* stateArray)

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -334,7 +334,7 @@ void QEngineOCL::SetDevice(const int& dID, const bool& forceReInit)
     if (!didInit) {
 #if defined(__APPLE__)
         posix_memalign((void**)&nrmArray, ALIGN_SIZE, nrmVecAlignSize);
-#elif defined(_WIN32) || !defined(__CYGWIN__)
+#elif defined(_WIN32) && !defined(__CYGWIN__)
         nrmArray = (real1*)_aligned_malloc(ALIGN_SIZE, nrmVecAlignSize);
 #else
         nrmArray = (real1*)aligned_alloc(ALIGN_SIZE, nrmVecAlignSize);
@@ -345,7 +345,7 @@ void QEngineOCL::SetDevice(const int& dID, const bool& forceReInit)
         nrmArray = NULL;
 #if defined(__APPLE__)
         posix_memalign((void**)&nrmArray, ALIGN_SIZE, nrmVecAlignSize);
-#elif defined(_WIN32) || !defined(__CYGWIN__)
+#elif defined(_WIN32) && !defined(__CYGWIN__)
         nrmArray = (real1*)_aligned_malloc(ALIGN_SIZE, nrmVecAlignSize);
 #else
         nrmArray = (real1*)aligned_alloc(ALIGN_SIZE, nrmVecAlignSize);
@@ -2015,7 +2015,7 @@ complex* QEngineOCL::AllocStateVec(bitCapInt elemCount, bool doForceAlloc)
     posix_memalign(
         &toRet, ALIGN_SIZE, ((sizeof(complex) * elemCount) < ALIGN_SIZE) ? ALIGN_SIZE : sizeof(complex) * elemCount);
     return (complex*)toRet;
-#elif defined(_WIN32) || !defined(__CYGWIN__)
+#elif defined(_WIN32) && !defined(__CYGWIN__)
     return (complex*)_aligned_malloc(
         ALIGN_SIZE, ((sizeof(complex) * elemCount) < ALIGN_SIZE) ? ALIGN_SIZE : sizeof(complex) * elemCount);
 #else

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -332,8 +332,11 @@ void QEngineOCL::SetDevice(const int& dID, const bool& forceReInit)
         ((sizeof(real1) * nrmGroupCount) < ALIGN_SIZE) ? ALIGN_SIZE : (sizeof(real1) * nrmGroupCount);
 
     if (!didInit) {
-#ifdef __APPLE__
+#if defined(__APPLE__)
         posix_memalign((void**)&nrmArray, ALIGN_SIZE, nrmVecAlignSize);
+#elif defined(_WIN32) || !defined(__CYGWIN__)
+        nrmArray = _aligned_malloc(
+            ALIGN_SIZE, ((sizeof(complex) * elemCount) < ALIGN_SIZE) ? ALIGN_SIZE : sizeof(complex) * elemCount);
 #else
         nrmArray = (real1*)aligned_alloc(ALIGN_SIZE, nrmVecAlignSize);
 #endif
@@ -341,8 +344,11 @@ void QEngineOCL::SetDevice(const int& dID, const bool& forceReInit)
         nrmBuffer = NULL;
         free(nrmArray);
         nrmArray = NULL;
-#ifdef __APPLE__
+#if defined(__APPLE__)
         posix_memalign((void**)&nrmArray, ALIGN_SIZE, nrmVecAlignSize);
+#elif defined(_WIN32) || !defined(__CYGWIN__)
+        nrmArray = _aligned_malloc(
+            ALIGN_SIZE, ((sizeof(complex) * elemCount) < ALIGN_SIZE) ? ALIGN_SIZE : sizeof(complex) * elemCount);
 #else
         nrmArray = (real1*)aligned_alloc(ALIGN_SIZE, nrmVecAlignSize);
 #endif
@@ -2003,11 +2009,14 @@ complex* QEngineOCL::AllocStateVec(bitCapInt elemCount, bool doForceAlloc)
     }
 
         // elemCount is always a power of two, but might be smaller than ALIGN_SIZE
-#ifdef __APPLE__
+#if defined(__APPLE__)
     void* toRet;
     posix_memalign(
         &toRet, ALIGN_SIZE, ((sizeof(complex) * elemCount) < ALIGN_SIZE) ? ALIGN_SIZE : sizeof(complex) * elemCount);
     return (complex*)toRet;
+#elif defined(_WIN32) || !defined(__CYGWIN__)
+    return (complex*)_aligned_malloc(
+        ALIGN_SIZE, ((sizeof(complex) * elemCount) < ALIGN_SIZE) ? ALIGN_SIZE : sizeof(complex) * elemCount);
 #else
     return (complex*)aligned_alloc(
         ALIGN_SIZE, ((sizeof(complex) * elemCount) < ALIGN_SIZE) ? ALIGN_SIZE : sizeof(complex) * elemCount);

--- a/src/qengine/state.cpp
+++ b/src/qengine/state.cpp
@@ -118,7 +118,7 @@ void QEngineCPU::CopyState(QInterfacePtr orig)
 
 void QEngineCPU::ResetStateVec(complex* nStateVec)
 {
-    free(stateVec);
+    FreeStateVec();
     stateVec = nStateVec;
 }
 

--- a/src/qengine/state.cpp
+++ b/src/qengine/state.cpp
@@ -764,8 +764,7 @@ complex* QEngineCPU::AllocStateVec(bitCapInt elemCount, bool ovrride)
         &toRet, ALIGN_SIZE, ((sizeof(complex) * elemCount) < ALIGN_SIZE) ? ALIGN_SIZE : sizeof(complex) * elemCount);
     return (complex*)toRet;
 #elif defined(_WIN32) && !defined(__CYGWIN__)
-    return (complex*)_aligned_malloc(
-        ALIGN_SIZE, ((sizeof(complex) * elemCount) < ALIGN_SIZE) ? ALIGN_SIZE : sizeof(complex) * elemCount);
+    return (complex*)_aligned_malloc(((sizeof(complex) * elemCount) < ALIGN_SIZE) ? ALIGN_SIZE : sizeof(complex) * elemCount, ALIGN_SIZE);
 #else
     return (complex*)aligned_alloc(
         ALIGN_SIZE, ((sizeof(complex) * elemCount) < ALIGN_SIZE) ? ALIGN_SIZE : sizeof(complex) * elemCount);

--- a/src/qengine/state.cpp
+++ b/src/qengine/state.cpp
@@ -763,7 +763,7 @@ complex* QEngineCPU::AllocStateVec(bitCapInt elemCount, bool ovrride)
     posix_memalign(
         &toRet, ALIGN_SIZE, ((sizeof(complex) * elemCount) < ALIGN_SIZE) ? ALIGN_SIZE : sizeof(complex) * elemCount);
     return (complex*)toRet;
-#elif defined(_WIN32) || !defined(__CYGWIN__)
+#elif defined(_WIN32) && !defined(__CYGWIN__)
     return (complex*)_aligned_malloc(
         ALIGN_SIZE, ((sizeof(complex) * elemCount) < ALIGN_SIZE) ? ALIGN_SIZE : sizeof(complex) * elemCount);
 #else

--- a/src/qengine/state.cpp
+++ b/src/qengine/state.cpp
@@ -758,11 +758,14 @@ void QEngineCPU::UpdateRunningNorm() { runningNorm = par_norm(maxQPower, stateVe
 complex* QEngineCPU::AllocStateVec(bitCapInt elemCount, bool ovrride)
 {
 // elemCount is always a power of two, but might be smaller than ALIGN_SIZE
-#ifdef __APPLE__
+#if defined(__APPLE__)
     void* toRet;
     posix_memalign(
         &toRet, ALIGN_SIZE, ((sizeof(complex) * elemCount) < ALIGN_SIZE) ? ALIGN_SIZE : sizeof(complex) * elemCount);
     return (complex*)toRet;
+#elif defined(_WIN32) || !defined(__CYGWIN__)
+    return (complex*)_aligned_malloc(
+        ALIGN_SIZE, ((sizeof(complex) * elemCount) < ALIGN_SIZE) ? ALIGN_SIZE : sizeof(complex) * elemCount);
 #else
     return (complex*)aligned_alloc(
         ALIGN_SIZE, ((sizeof(complex) * elemCount) < ALIGN_SIZE) ? ALIGN_SIZE : sizeof(complex) * elemCount);

--- a/src/qinterface/protected.cpp
+++ b/src/qinterface/protected.cpp
@@ -24,7 +24,7 @@ unsigned char* qrack_alloc(size_t ucharCount)
     posix_memalign(&toRet, ALIGN_SIZE,
         ((sizeof(unsigned char) * ucharCount) < ALIGN_SIZE) ? ALIGN_SIZE : (sizeof(unsigned char) * ucharCount));
     return (unsigned char*)toRet;
-#elif defined(_WIN32) || !defined(__CYGWIN__)
+#elif defined(_WIN32) && !defined(__CYGWIN__)
     return (unsigned char*)_aligned_malloc(ALIGN_SIZE,
         ((sizeof(unsigned char) * ucharCount) < ALIGN_SIZE) ? ALIGN_SIZE : (sizeof(unsigned char) * ucharCount));
 #else

--- a/src/qinterface/protected.cpp
+++ b/src/qinterface/protected.cpp
@@ -25,8 +25,7 @@ unsigned char* qrack_alloc(size_t ucharCount)
         ((sizeof(unsigned char) * ucharCount) < ALIGN_SIZE) ? ALIGN_SIZE : (sizeof(unsigned char) * ucharCount));
     return (unsigned char*)toRet;
 #elif defined(_WIN32) && !defined(__CYGWIN__)
-    return (unsigned char*)_aligned_malloc(ALIGN_SIZE,
-        ((sizeof(unsigned char) * ucharCount) < ALIGN_SIZE) ? ALIGN_SIZE : (sizeof(unsigned char) * ucharCount));
+    return (unsigned char*)_aligned_malloc(((sizeof(unsigned char) * ucharCount) < ALIGN_SIZE) ? ALIGN_SIZE : (sizeof(unsigned char) * ucharCount), ALIGN_SIZE);
 #else
     return (unsigned char*)aligned_alloc(ALIGN_SIZE,
         ((sizeof(unsigned char) * ucharCount) < ALIGN_SIZE) ? ALIGN_SIZE : (sizeof(unsigned char) * ucharCount));

--- a/src/qinterface/protected.cpp
+++ b/src/qinterface/protected.cpp
@@ -19,11 +19,14 @@ namespace Qrack {
 unsigned char* qrack_alloc(size_t ucharCount)
 {
 // ALIGN_SIZE is defined in common/qrack_types.hpp
-#ifdef __APPLE__
+#if defined(__APPLE__)
     void* toRet;
     posix_memalign(&toRet, ALIGN_SIZE,
         ((sizeof(unsigned char) * ucharCount) < ALIGN_SIZE) ? ALIGN_SIZE : (sizeof(unsigned char) * ucharCount));
     return (unsigned char*)toRet;
+#elif defined(_WIN32) || !defined(__CYGWIN__)
+    return (unsigned char*)_aligned_malloc(ALIGN_SIZE,
+        ((sizeof(unsigned char) * ucharCount) < ALIGN_SIZE) ? ALIGN_SIZE : (sizeof(unsigned char) * ucharCount));
 #else
     return (unsigned char*)aligned_alloc(ALIGN_SIZE,
         ((sizeof(unsigned char) * ucharCount) < ALIGN_SIZE) ? ALIGN_SIZE : (sizeof(unsigned char) * ucharCount));

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -54,8 +54,7 @@ unsigned char* cl_alloc(size_t ucharCount)
         ((sizeof(unsigned char) * ucharCount) < ALIGN_SIZE) ? ALIGN_SIZE : (sizeof(unsigned char) * ucharCount));
     return (unsigned char*)toRet;
 #elif defined(_WIN32) && !defined(__CYGWIN__)
-    return (unsigned char*)_aligned_malloc(ALIGN_SIZE,
-        ((sizeof(unsigned char) * ucharCount) < ALIGN_SIZE) ? ALIGN_SIZE : (sizeof(unsigned char) * ucharCount));
+    return (unsigned char*)_aligned_malloc(((sizeof(unsigned char) * ucharCount) < ALIGN_SIZE) ? ALIGN_SIZE : (sizeof(unsigned char) * ucharCount), ALIGN_SIZE);
 #else
     return (unsigned char*)aligned_alloc(ALIGN_SIZE,
         ((sizeof(unsigned char) * ucharCount) < ALIGN_SIZE) ? ALIGN_SIZE : (sizeof(unsigned char) * ucharCount));

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -131,7 +131,7 @@ TEST_CASE("test_qengine_cpu_par_for")
 {
     QEngineCPUPtr qengine = std::make_shared<QEngineCPU>(1, 0);
 
-    int NUM_ENTRIES = 2000;
+    const int NUM_ENTRIES = 2000;
     std::atomic_bool hit[NUM_ENTRIES];
     std::atomic_int calls;
 
@@ -159,8 +159,8 @@ TEST_CASE("test_qengine_cpu_par_for_skip")
 {
     QEngineCPUPtr qengine = std::make_shared<QEngineCPU>(1, 0);
 
-    int NUM_ENTRIES = 2000;
-    int NUM_CALLS = 1000;
+    const int NUM_ENTRIES = 2000;
+    const int NUM_CALLS = 1000;
 
     std::atomic_bool hit[NUM_ENTRIES];
     std::atomic_int calls;
@@ -189,8 +189,8 @@ TEST_CASE("test_qengine_cpu_par_for_skip_wide")
 {
     QEngineCPUPtr qengine = std::make_shared<QEngineCPU>(1, 0);
 
-    int NUM_ENTRIES = 2000;
-    int NUM_CALLS = 1000;
+    const int NUM_ENTRIES = 2000;
+    const int NUM_CALLS = 1000;
 
     std::atomic_bool hit[NUM_ENTRIES];
     std::atomic_int calls;
@@ -218,8 +218,8 @@ TEST_CASE("test_qengine_cpu_par_for_mask")
 {
     QEngineCPUPtr qengine = std::make_shared<QEngineCPU>(1, 0);
 
-    int NUM_ENTRIES = 2000;
-    int NUM_CALLS = 512; // 2048 >> 2, masked off so all bits are set.
+    const int NUM_ENTRIES = 2000;
+    const int NUM_CALLS = 512; // 2048 >> 2, masked off so all bits are set.
 
     std::atomic_bool hit[NUM_ENTRIES];
     std::atomic_int calls;

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -62,6 +62,17 @@ unsigned char* cl_alloc(size_t ucharCount)
 #endif
 }
 
+void cl_free(void* toFree)
+{
+    if (toFree) {
+#if defined(_WIN32)
+        _aligned_free(toFree);
+#else
+        free(toFree);
+#endif
+    }
+}
+
 TEST_CASE("test_complex")
 {
     bool test;
@@ -1865,7 +1876,7 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_superposition_reg")
     }
     qftReg->IndexedLDA(0, 8, 8, 8, testPage);
     REQUIRE_THAT(qftReg, HasProbability(0, 16, 0x303));
-    free(testPage);
+    cl_free(testPage);
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_adc_superposition_reg")
@@ -1889,7 +1900,7 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_adc_superposition_reg")
     qftReg->IndexedADC(8, 8, 0, 8, 16, testPage);
     qftReg->H(8, 8);
     REQUIRE_THAT(qftReg, HasProbability(0, 17, 0xff));
-    free(testPage);
+    cl_free(testPage);
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_sbc_superposition_reg")
@@ -1909,7 +1920,7 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_sbc_superposition_reg")
     qftReg->IndexedSBC(8, 8, 0, 8, 16, testPage);
     qftReg->H(8, 8);
     REQUIRE_THAT(qftReg, HasProbability(0, 17, 1 << 16));
-    free(testPage);
+    cl_free(testPage);
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_superposition_reg_long")
@@ -1926,7 +1937,7 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_superposition_reg_long")
     }
     qftReg->IndexedLDA(0, 9, 9, 9, testPage);
     REQUIRE_THAT(qftReg, HasProbability(0, 17, 0x603));
-    free(testPage);
+    cl_free(testPage);
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_adc_superposition_reg_long_index")
@@ -1951,7 +1962,7 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_adc_superposition_reg_long_index")
     }
     qftReg->IndexedADC(9, 9, 0, 9, 18, testPage);
     REQUIRE_THAT(qftReg, HasProbability(0, 9, 0x1ff));
-    free(testPage);
+    cl_free(testPage);
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_sbc_superposition_reg_long_index")
@@ -1972,7 +1983,7 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_sbc_superposition_reg_long_index")
     qftReg->IndexedSBC(9, 9, 0, 9, 18, testPage);
     qftReg->H(9, 9);
     REQUIRE_THAT(qftReg, HasProbability(0, 19, 1 << 18));
-    free(testPage);
+    cl_free(testPage);
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_clone")
@@ -2177,7 +2188,7 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_grover_lookup")
     }
 
     REQUIRE_THAT(qftReg, HasProbability(0, indexLength + valueLength, TARGET_VALUE | (TARGET_KEY << valueLength)));
-    free(toLoad);
+    cl_free(toLoad);
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_fast_grover")
@@ -2375,7 +2386,7 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_quaternary_search")
         REQUIRE_THAT(qftReg,
             HasProbability(0, (2 * valueLength) + indexLength, TARGET_VALUE | (TARGET_KEY << (2 * valueLength))));
     }
-    free(toLoad);
+    cl_free(toLoad);
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_quaternary_search_alt")
@@ -2555,7 +2566,7 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_quaternary_search_alt")
         REQUIRE_THAT(qftReg,
             HasProbability(0, (2 * valueLength) + indexLength, TARGET_VALUE | (TARGET_KEY << (2 * valueLength))));
     }
-    free(toLoad);
+    cl_free(toLoad);
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_set_reg")
@@ -2582,7 +2593,7 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_basis_change")
     qftReg->H(8, 8);
 
     REQUIRE_THAT(qftReg, HasProbability(0, 16, 100));
-    free(toSearch);
+    cl_free(toSearch);
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_entanglement")

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -48,11 +48,14 @@ void log(QInterfacePtr p) { std::cout << std::endl << std::showpoint << p << std
 
 unsigned char* cl_alloc(size_t ucharCount)
 {
-#ifdef __APPLE__
+#if defined(__APPLE__)
     void* toRet;
     posix_memalign(&toRet, ALIGN_SIZE,
         ((sizeof(unsigned char) * ucharCount) < ALIGN_SIZE) ? ALIGN_SIZE : (sizeof(unsigned char) * ucharCount));
     return (unsigned char*)toRet;
+#elif defined(_WIN32) || !defined(__CYGWIN__)
+    return (unsigned char*)_aligned_malloc(ALIGN_SIZE,
+        ((sizeof(unsigned char) * ucharCount) < ALIGN_SIZE) ? ALIGN_SIZE : (sizeof(unsigned char) * ucharCount));
 #else
     return (unsigned char*)aligned_alloc(ALIGN_SIZE,
         ((sizeof(unsigned char) * ucharCount) < ALIGN_SIZE) ? ALIGN_SIZE : (sizeof(unsigned char) * ucharCount));

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -53,7 +53,7 @@ unsigned char* cl_alloc(size_t ucharCount)
     posix_memalign(&toRet, ALIGN_SIZE,
         ((sizeof(unsigned char) * ucharCount) < ALIGN_SIZE) ? ALIGN_SIZE : (sizeof(unsigned char) * ucharCount));
     return (unsigned char*)toRet;
-#elif defined(_WIN32) || !defined(__CYGWIN__)
+#elif defined(_WIN32) && !defined(__CYGWIN__)
     return (unsigned char*)_aligned_malloc(ALIGN_SIZE,
         ((sizeof(unsigned char) * ucharCount) < ALIGN_SIZE) ? ALIGN_SIZE : (sizeof(unsigned char) * ucharCount));
 #else


### PR DESCRIPTION
In an effort to test this on a Windows machine with an AMD, I debugged our Windows build and unit tests. This passes all tests on the Windows partition of my primary development machine, except for the noted issue with `ApproxCompare()`. Windows 10 has OpenCL drivers for all of my devices, so this gave me an opportunity to test and debug a configuration with 3 devices on 2 platforms.