### PR TITLE
Fixing bug in QUnit ApproxCompare()

### DIFF
--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1330,7 +1330,7 @@ bool QUnit::ApproxCompare(QUnitPtr toCompare)
 
     QUnitPtr thatCopy = std::dynamic_pointer_cast<QUnit>(toCompare->Clone());
     thatCopy->EntangleAll();
-    thisCopy->OrderContiguous(thatCopy->shards[0].unit);
+    thatCopy->OrderContiguous(thatCopy->shards[0].unit);
 
     return thisCopy->shards[0].unit->ApproxCompare(thatCopy->shards[0].unit);
 }


### PR DESCRIPTION
This appears to have been the problem with ApproxCompare(). The problem and the fix are manifestly simple.