### PR TITLE
Unitarity check on gates

### DIFF
--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -313,7 +313,7 @@ public:
 
     /**
      * Apply an arbitrary single bit unitary transformation.
-     *const
+     *
      * If float rounding from the application of the matrix might change the state vector norm, "doCalcNorm" should be
      * set to true.
      *

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -316,6 +316,13 @@ public:
      *const
      * If float rounding from the application of the matrix might change the state vector norm, "doCalcNorm" should be
      * set to true.
+     *
+     * \warning Physically, besides measurement, all quantum gates are unitary. This means there is always exactly a
+100% chance
+-    * of finding a qubit in ANY STATE. A nonunitary gate besides measurement is nonphysical, at least because it
+-    * implies that the sum of qubit probability over all possible states could be not exactly 100%. We strongly
+discourage the use of nonunitary gates under all circumstances, because they will likely hinder porting software to
+genuine quantum hardware. If normalization is on, this method will throw an exception if a nonunitary gate is used.
      */
     virtual void ApplySingleBit(const complex* mtrx, bool doCalcNorm, bitLenInt qubitIndex) = 0;
 
@@ -1525,26 +1532,6 @@ public:
      *  Clone this QInterface
      */
     virtual QInterfacePtr Clone() = 0;
-
-    /**
-     *  Apply a single bit "nonunitary gate"
-     *
-     *  \warning PSEUDO-QUANTUM
-     *
-     *  Physically, besides measurement, all quantum gates are unitary. This means there is always exactly a 100% chance
-     * of finding a qubit in ANY STATE. A nonunitary gate besides measurement is nonphysical, at least because it
-     * implies that the sum of qubit probability over all possible states could be not exactly 100%. Hence, this
-     * operation should never be used. This method is added to Qrack only due to a demand for it by existing software
-     * Qrack might interface with; we strongly suggest developers of new software never use it. (We do not guarantee
-     * long term support for it.) This method will throw an exception, if normalization is on in this QInterface.
-     */
-    virtual void ApplyNonunitarySingleBit(const complex* mtrx, bool doCalcNorm, bitLenInt qubitIndex)
-    {
-        if (doNormalize) {
-            throw("Nonunitary gates and normalization cannot be used at the same time. (You probably shouldn't use "
-                  "nonunitary gates at all.)");
-        }
-    }
 
     /** @} */
 };

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -318,11 +318,10 @@ public:
      * set to true.
      *
      * \warning Physically, besides measurement, all quantum gates are unitary. This means there is always exactly a
-100% chance
--    * of finding a qubit in ANY STATE. A nonunitary gate besides measurement is nonphysical, at least because it
--    * implies that the sum of qubit probability over all possible states could be not exactly 100%. We strongly
-discourage the use of nonunitary gates under all circumstances, because they will likely hinder porting software to
-genuine quantum hardware. If normalization is on, this method will throw an exception if a nonunitary gate is used.
+100% chance of finding a qubit in ANY STATE. A nonunitary gate besides measurement is nonphysical, at least because it
+implies that the sum of qubit probability over all possible states could be not exactly 100%. We strongly discourage the
+use of nonunitary gates under all circumstances, because they will likely hinder porting software to genuine quantum
+hardware. If normalization is on, this method will throw an exception if a nonunitary gate is used.
      */
     virtual void ApplySingleBit(const complex* mtrx, bool doCalcNorm, bitLenInt qubitIndex) = 0;
 

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -31,6 +31,7 @@ unsigned char* qrack_alloc(size_t ucharCount);
 void mul2x2(complex* left, complex* right, complex* out);
 void exp2x2(complex* matrix2x2, complex* outMatrix2x2);
 void log2x2(complex* matrix2x2, complex* outMatrix2x2);
+bool isUnitary2x2(const complex* mtrx);
 
 class QInterface;
 typedef std::shared_ptr<QInterface> QInterfacePtr;
@@ -312,7 +313,7 @@ public:
 
     /**
      * Apply an arbitrary single bit unitary transformation.
-     *
+     *const
      * If float rounding from the application of the matrix might change the state vector norm, "doCalcNorm" should be
      * set to true.
      */
@@ -1524,6 +1525,26 @@ public:
      *  Clone this QInterface
      */
     virtual QInterfacePtr Clone() = 0;
+
+    /**
+     *  Apply a single bit "nonunitary gate"
+     *
+     *  \warning PSEUDO-QUANTUM
+     *
+     *  Physically, besides measurement, all quantum gates are unitary. This means there is always exactly a 100% chance
+     * of finding a qubit in ANY STATE. A nonunitary gate besides measurement is nonphysical, at least because it
+     * implies that the sum of qubit probability over all possible states could be not exactly 100%. Hence, this
+     * operation should never be used. This method is added to Qrack only due to a demand for it by existing software
+     * Qrack might interface with; we strongly suggest developers of new software never use it. (We do not guarantee
+     * long term support for it.) This method will throw an exception, if normalization is on in this QInterface.
+     */
+    virtual void ApplyNonunitarySingleBit(const complex* mtrx, bool doCalcNorm, bitLenInt qubitIndex)
+    {
+        if (doNormalize) {
+            throw("Nonunitary gates and normalization cannot be used at the same time. (You probably shouldn't use "
+                  "nonunitary gates at all.)");
+        }
+    }
 
     /** @} */
 };

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -159,9 +159,6 @@ public:
     /** Generate a random real number between 0 and 1 */
     virtual real1 Rand() { return rand_distribution(*rand_generator); }
 
-    virtual void SetDoNormalize(bool doN) { doNormalize = doN; }
-    virtual bool GetDoNormalize() { return doNormalize; }
-
     /** Set an arbitrary pure quantum state representation
      *
      * \warning PSEUDO-QUANTUM

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -159,6 +159,9 @@ public:
     /** Generate a random real number between 0 and 1 */
     virtual real1 Rand() { return rand_distribution(*rand_generator); }
 
+    virtual void SetDoNormalize(bool doN) { doNormalize = doN; }
+    virtual bool GetDoNormalize() { return doNormalize; }
+
     /** Set an arbitrary pure quantum state representation
      *
      * \warning PSEUDO-QUANTUM

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -331,11 +331,11 @@ void QEngineOCL::SetDevice(const int& dID, const bool& forceReInit)
     size_t nrmVecAlignSize =
         ((sizeof(real1) * nrmGroupCount) < ALIGN_SIZE) ? ALIGN_SIZE : (sizeof(real1) * nrmGroupCount);
 
-	if (didInit && (nrmGroupCount != oldNrmGroupCount)) {
+    if (didInit && (nrmGroupCount != oldNrmGroupCount)) {
         nrmBuffer = NULL;
         FreeAligned(nrmArray);
         nrmArray = NULL;
-	}
+    }
 
     if (!didInit || (nrmGroupCount != oldNrmGroupCount)) {
 #if defined(__APPLE__)
@@ -730,7 +730,8 @@ void QEngineOCL::Compose(OCLAPI apiCall, bitCapInt* bciArgs, QEngineOCLPtr toCop
         toCopy->LockSync(CL_MAP_READ);
         std::copy(toCopy->stateVec, toCopy->stateVec + toCopy->maxQPower, otherStateVec);
         toCopy->UnlockSync();
-        otherStateBuffer = std::make_shared<cl::Buffer>(context, CL_MEM_USE_HOST_PTR | CL_MEM_READ_WRITE, sizeof(complex) * toCopy->maxQPower, otherStateVec);
+        otherStateBuffer = std::make_shared<cl::Buffer>(
+            context, CL_MEM_USE_HOST_PTR | CL_MEM_READ_WRITE, sizeof(complex) * toCopy->maxQPower, otherStateVec);
     }
 
     runningNorm = ONE_R1;
@@ -904,7 +905,8 @@ void QEngineOCL::DecomposeDispose(bitLenInt start, bitLenInt length, QEngineOCLP
             otherStateBuffer = destination->stateBuffer;
         } else {
             otherStateVec = AllocStateVec(destination->maxQPower, true);
-            otherStateBuffer = std::make_shared<cl::Buffer>(context, CL_MEM_USE_HOST_PTR | CL_MEM_READ_WRITE, sizeof(complex) * destination->maxQPower, otherStateVec);
+            otherStateBuffer = std::make_shared<cl::Buffer>(context, CL_MEM_USE_HOST_PTR | CL_MEM_READ_WRITE,
+                sizeof(complex) * destination->maxQPower, otherStateVec);
 
             DISPATCH_FILL(
                 waitVec2, *otherStateBuffer, sizeof(complex) * destination->maxQPower, complex(ZERO_R1, ZERO_R1));
@@ -1900,7 +1902,8 @@ bool QEngineOCL::ApproxCompare(QEngineOCLPtr toCompare)
         toCompare->LockSync(CL_MAP_READ);
         std::copy(toCompare->stateVec, toCompare->stateVec + toCompare->maxQPower, otherStateVec);
         toCompare->UnlockSync();
-        otherStateBuffer = std::make_shared<cl::Buffer>(context, CL_MEM_USE_HOST_PTR | CL_MEM_READ_WRITE, sizeof(complex) * toCompare->maxQPower, otherStateVec);
+        otherStateBuffer = std::make_shared<cl::Buffer>(
+            context, CL_MEM_USE_HOST_PTR | CL_MEM_READ_WRITE, sizeof(complex) * toCompare->maxQPower, otherStateVec);
     }
 
     QueueCall(OCL_API_APPROXCOMPARE, nrmGroupCount, nrmGroupSize,
@@ -1923,12 +1926,12 @@ QInterfacePtr QEngineOCL::Clone()
     QEngineOCLPtr copyPtr = std::make_shared<QEngineOCL>(
         qubitCount, 0, rand_generator, complex(ONE_R1, ZERO_R1), doNormalize, randGlobalPhase, useHostRam, deviceID);
 
-	copyPtr->clFinish();
+    copyPtr->clFinish();
 
-	copyPtr->runningNorm = runningNorm;
-	//WAIT_COPY(*stateBuffer, *(copyPtr->stateBuffer), sizeof(complex) * maxQPower);
+    copyPtr->runningNorm = runningNorm;
+    // WAIT_COPY(*stateBuffer, *(copyPtr->stateBuffer), sizeof(complex) * maxQPower);
 
-	LockSync(CL_MAP_READ);
+    LockSync(CL_MAP_READ);
     copyPtr->LockSync(CL_MAP_WRITE);
     std::copy(stateVec, stateVec + maxQPower, copyPtr->stateVec);
     UnlockSync();
@@ -2015,7 +2018,8 @@ complex* QEngineOCL::AllocStateVec(bitCapInt elemCount, bool doForceAlloc)
         &toRet, ALIGN_SIZE, ((sizeof(complex) * elemCount) < ALIGN_SIZE) ? ALIGN_SIZE : sizeof(complex) * elemCount);
     return (complex*)toRet;
 #elif defined(_WIN32) && !defined(__CYGWIN__)
-    return (complex*)_aligned_malloc(((sizeof(complex) * elemCount) < ALIGN_SIZE) ? ALIGN_SIZE : sizeof(complex) * elemCount, ALIGN_SIZE);
+    return (complex*)_aligned_malloc(
+        ((sizeof(complex) * elemCount) < ALIGN_SIZE) ? ALIGN_SIZE : sizeof(complex) * elemCount, ALIGN_SIZE);
 #else
     return (complex*)aligned_alloc(
         ALIGN_SIZE, ((sizeof(complex) * elemCount) < ALIGN_SIZE) ? ALIGN_SIZE : sizeof(complex) * elemCount);

--- a/src/qengine/qengine.cpp
+++ b/src/qengine/qengine.cpp
@@ -145,6 +145,10 @@ bitCapInt QEngine::ForceM(const bitLenInt* bits, const bitLenInt& length, const 
 
 void QEngine::ApplySingleBit(const complex* mtrx, bool doCalcNorm, bitLenInt qubit)
 {
+    if (!isUnitary2x2(mtrx)) {
+        throw "ApplySingleBit gate matrix must be unitary.";
+    }
+
     bitCapInt qPowers[1];
     qPowers[0] = 1 << qubit;
     Apply2x2(0, qPowers[0], mtrx, 1, qPowers, doCalcNorm);
@@ -153,6 +157,10 @@ void QEngine::ApplySingleBit(const complex* mtrx, bool doCalcNorm, bitLenInt qub
 void QEngine::ApplyControlledSingleBit(
     const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& target, const complex* mtrx)
 {
+    if (!isUnitary2x2(mtrx)) {
+        throw "ApplyControlledSingleBit gate matrix must be unitary.";
+    }
+
     if (controlLen == 0) {
         ApplySingleBit(mtrx, true, target);
     } else {
@@ -166,6 +174,10 @@ void QEngine::ApplyControlledSingleBit(
 void QEngine::ApplyAntiControlledSingleBit(
     const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& target, const complex* mtrx)
 {
+    if (!isUnitary2x2(mtrx)) {
+        throw "ApplyAntiControlledSingleBit gate matrix must be unitary.";
+    }
+
     if (controlLen == 0) {
         ApplySingleBit(mtrx, true, target);
     } else {

--- a/src/qengine/qengine.cpp
+++ b/src/qengine/qengine.cpp
@@ -145,8 +145,9 @@ bitCapInt QEngine::ForceM(const bitLenInt* bits, const bitLenInt& length, const 
 
 void QEngine::ApplySingleBit(const complex* mtrx, bool doCalcNorm, bitLenInt qubit)
 {
-    if (!isUnitary2x2(mtrx)) {
-        throw "ApplySingleBit gate matrix must be unitary.";
+    if (doNormalize && !isUnitary2x2(mtrx)) {
+        throw("Nonunitary gates and normalization cannot be used at the same time. (You probably shouldn't use "
+              "nonunitary gates at all.)");
     }
 
     bitCapInt qPowers[1];
@@ -157,8 +158,9 @@ void QEngine::ApplySingleBit(const complex* mtrx, bool doCalcNorm, bitLenInt qub
 void QEngine::ApplyControlledSingleBit(
     const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& target, const complex* mtrx)
 {
-    if (!isUnitary2x2(mtrx)) {
-        throw "ApplyControlledSingleBit gate matrix must be unitary.";
+    if (doNormalize && !isUnitary2x2(mtrx)) {
+        throw("Nonunitary gates and normalization cannot be used at the same time. (You probably shouldn't use "
+              "nonunitary gates at all.)");
     }
 
     if (controlLen == 0) {
@@ -174,8 +176,9 @@ void QEngine::ApplyControlledSingleBit(
 void QEngine::ApplyAntiControlledSingleBit(
     const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& target, const complex* mtrx)
 {
-    if (!isUnitary2x2(mtrx)) {
-        throw "ApplyAntiControlledSingleBit gate matrix must be unitary.";
+    if (doNormalize && !isUnitary2x2(mtrx)) {
+        throw("Nonunitary gates and normalization cannot be used at the same time. (You probably shouldn't use "
+              "nonunitary gates at all.)");
     }
 
     if (controlLen == 0) {

--- a/src/qengine/state.cpp
+++ b/src/qengine/state.cpp
@@ -764,7 +764,8 @@ complex* QEngineCPU::AllocStateVec(bitCapInt elemCount, bool ovrride)
         &toRet, ALIGN_SIZE, ((sizeof(complex) * elemCount) < ALIGN_SIZE) ? ALIGN_SIZE : sizeof(complex) * elemCount);
     return (complex*)toRet;
 #elif defined(_WIN32) && !defined(__CYGWIN__)
-    return (complex*)_aligned_malloc(((sizeof(complex) * elemCount) < ALIGN_SIZE) ? ALIGN_SIZE : sizeof(complex) * elemCount, ALIGN_SIZE);
+    return (complex*)_aligned_malloc(
+        ((sizeof(complex) * elemCount) < ALIGN_SIZE) ? ALIGN_SIZE : sizeof(complex) * elemCount, ALIGN_SIZE);
 #else
     return (complex*)aligned_alloc(
         ALIGN_SIZE, ((sizeof(complex) * elemCount) < ALIGN_SIZE) ? ALIGN_SIZE : sizeof(complex) * elemCount);

--- a/src/qinterface/protected.cpp
+++ b/src/qinterface/protected.cpp
@@ -25,7 +25,9 @@ unsigned char* qrack_alloc(size_t ucharCount)
         ((sizeof(unsigned char) * ucharCount) < ALIGN_SIZE) ? ALIGN_SIZE : (sizeof(unsigned char) * ucharCount));
     return (unsigned char*)toRet;
 #elif defined(_WIN32) && !defined(__CYGWIN__)
-    return (unsigned char*)_aligned_malloc(((sizeof(unsigned char) * ucharCount) < ALIGN_SIZE) ? ALIGN_SIZE : (sizeof(unsigned char) * ucharCount), ALIGN_SIZE);
+    return (unsigned char*)_aligned_malloc(
+        ((sizeof(unsigned char) * ucharCount) < ALIGN_SIZE) ? ALIGN_SIZE : (sizeof(unsigned char) * ucharCount),
+        ALIGN_SIZE);
 #else
     return (unsigned char*)aligned_alloc(ALIGN_SIZE,
         ((sizeof(unsigned char) * ucharCount) < ALIGN_SIZE) ? ALIGN_SIZE : (sizeof(unsigned char) * ucharCount));
@@ -143,5 +145,42 @@ void _expLog2x2(complex* matrix2x2, complex* outMatrix2x2, bool isExp)
 void exp2x2(complex* matrix2x2, complex* outMatrix2x2) { _expLog2x2(matrix2x2, outMatrix2x2, true); }
 
 void log2x2(complex* matrix2x2, complex* outMatrix2x2) { _expLog2x2(matrix2x2, outMatrix2x2, false); }
+
+bool isUnitary2x2(const complex* mtrx)
+{
+    const real1 TOL = 1e-5;
+    complex conjTrans[4] = { conj(mtrx[0]), conj(mtrx[2]), conj(mtrx[1]), conj(mtrx[3]) };
+
+    complex testMtrx[4];
+
+    mul2x2(conjTrans, (complex*)mtrx, testMtrx);
+
+    if (!((real(testMtrx[0]) > (ONE_R1 - TOL)) && (real(testMtrx[0]) < (ONE_R1 + TOL)))) {
+        return false;
+    }
+    if (!((imag(testMtrx[0]) > (ZERO_R1 - TOL)) && (imag(testMtrx[0]) < (ZERO_R1 + TOL)))) {
+        return false;
+    }
+    if (!((real(testMtrx[1]) > (ZERO_R1 - TOL)) && (real(testMtrx[1]) < (ZERO_R1 + TOL)))) {
+        return false;
+    }
+    if (!((imag(testMtrx[1]) > (ZERO_R1 - TOL)) && (imag(testMtrx[1]) < (ZERO_R1 + TOL)))) {
+        return false;
+    }
+    if (!((real(testMtrx[2]) > (ZERO_R1 - TOL)) && (real(testMtrx[2]) < (ZERO_R1 + TOL)))) {
+        return false;
+    }
+    if (!((imag(testMtrx[2]) > (ZERO_R1 - TOL)) && (imag(testMtrx[2]) < (ZERO_R1 + TOL)))) {
+        return false;
+    }
+    if (!((real(testMtrx[3]) > (ONE_R1 - TOL)) && (real(testMtrx[3]) < (ONE_R1 + TOL)))) {
+        return false;
+    }
+    if (!((imag(testMtrx[3]) > (ZERO_R1 - TOL)) && (imag(testMtrx[3]) < (ZERO_R1 + TOL)))) {
+        return false;
+    }
+
+    return true;
+}
 
 } // namespace Qrack

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -54,7 +54,9 @@ unsigned char* cl_alloc(size_t ucharCount)
         ((sizeof(unsigned char) * ucharCount) < ALIGN_SIZE) ? ALIGN_SIZE : (sizeof(unsigned char) * ucharCount));
     return (unsigned char*)toRet;
 #elif defined(_WIN32) && !defined(__CYGWIN__)
-    return (unsigned char*)_aligned_malloc(((sizeof(unsigned char) * ucharCount) < ALIGN_SIZE) ? ALIGN_SIZE : (sizeof(unsigned char) * ucharCount), ALIGN_SIZE);
+    return (unsigned char*)_aligned_malloc(
+        ((sizeof(unsigned char) * ucharCount) < ALIGN_SIZE) ? ALIGN_SIZE : (sizeof(unsigned char) * ucharCount),
+        ALIGN_SIZE);
 #else
     return (unsigned char*)aligned_alloc(ALIGN_SIZE,
         ((sizeof(unsigned char) * ucharCount) < ALIGN_SIZE) ? ALIGN_SIZE : (sizeof(unsigned char) * ucharCount));


### PR DESCRIPTION
We have not officially supported "nonunitary gates," to date. I don't really want to, because I strongly think that relying on manipulation of the quantum state vector via nonphysical methods will only hurt the longevity and accuracy of new software, in a nascent field, when we seek to port it to genuine quantum hardware.

However, as I've found we need "nonunitary gates" to support other software, which does not support this point of our philosophy, I realized we can already perform them with `ApplySingleBit()` and related methods, if normalization is off.

This pull requests adds checks, to restrict the use of these nonphysical operations so that they are at least consistent with the normalization option.