### PR TITLE
Removing polar() macro

### DIFF
--- a/include/common/qrack_types.hpp
+++ b/include/common/qrack_types.hpp
@@ -24,7 +24,7 @@
 #define bitsInByte 8
 #define qrack_rand_gen std::mt19937_64
 #define qrack_rand_gen_ptr std::shared_ptr<qrack_rand_gen>
-#define ALIGN_SIZE 64
+#define QRACK_STATE_VEC_ALIGN_SIZE 64
 
 #include "config.h"
 

--- a/include/common/qrack_types.hpp
+++ b/include/common/qrack_types.hpp
@@ -29,7 +29,6 @@
 #include "config.h"
 
 #include <complex>
-#define polar(A, B) std::polar(A, B)
 
 #if ENABLE_COMPLEX8
 namespace Qrack {

--- a/include/common/qrack_types.hpp
+++ b/include/common/qrack_types.hpp
@@ -24,7 +24,7 @@
 #define bitsInByte 8
 #define qrack_rand_gen std::mt19937_64
 #define qrack_rand_gen_ptr std::shared_ptr<qrack_rand_gen>
-#define QRACK_STATE_VEC_ALIGN_SIZE 64
+#define QRACK_ALIGN_SIZE 64
 
 #include "config.h"
 

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -329,7 +329,7 @@ void QEngineOCL::SetDevice(const int& dID, const bool& forceReInit)
     }
 
     size_t nrmVecAlignSize =
-        ((sizeof(real1) * nrmGroupCount) < QRACK_STATE_VEC_ALIGN_SIZE) ? QRACK_STATE_VEC_ALIGN_SIZE : (sizeof(real1) * nrmGroupCount);
+        ((sizeof(real1) * nrmGroupCount) < QRACK_ALIGN_SIZE) ? QRACK_ALIGN_SIZE : (sizeof(real1) * nrmGroupCount);
 
     if (didInit && (nrmGroupCount != oldNrmGroupCount)) {
         nrmBuffer = NULL;
@@ -339,11 +339,11 @@ void QEngineOCL::SetDevice(const int& dID, const bool& forceReInit)
 
     if (!didInit || (nrmGroupCount != oldNrmGroupCount)) {
 #if defined(__APPLE__)
-        posix_memalign((void**)&nrmArray, QRACK_STATE_VEC_ALIGN_SIZE, nrmVecAlignSize);
+        posix_memalign((void**)&nrmArray, QRACK_ALIGN_SIZE, nrmVecAlignSize);
 #elif defined(_WIN32) && !defined(__CYGWIN__)
-        nrmArray = (real1*)_aligned_malloc(nrmVecAlignSize, QRACK_STATE_VEC_ALIGN_SIZE);
+        nrmArray = (real1*)_aligned_malloc(nrmVecAlignSize, QRACK_ALIGN_SIZE);
 #else
-        nrmArray = (real1*)aligned_alloc(QRACK_STATE_VEC_ALIGN_SIZE, nrmVecAlignSize);
+        nrmArray = (real1*)aligned_alloc(QRACK_ALIGN_SIZE, nrmVecAlignSize);
 #endif
     }
 
@@ -1969,18 +1969,18 @@ complex* QEngineOCL::AllocStateVec(bitCapInt elemCount, bool doForceAlloc)
         return NULL;
     }
 
-        // elemCount is always a power of two, but might be smaller than QRACK_STATE_VEC_ALIGN_SIZE
+        // elemCount is always a power of two, but might be smaller than QRACK_ALIGN_SIZE
 #if defined(__APPLE__)
     void* toRet;
     posix_memalign(
-        &toRet, QRACK_STATE_VEC_ALIGN_SIZE, ((sizeof(complex) * elemCount) < QRACK_STATE_VEC_ALIGN_SIZE) ? QRACK_STATE_VEC_ALIGN_SIZE : sizeof(complex) * elemCount);
+        &toRet, QRACK_ALIGN_SIZE, ((sizeof(complex) * elemCount) < QRACK_ALIGN_SIZE) ? QRACK_ALIGN_SIZE : sizeof(complex) * elemCount);
     return (complex*)toRet;
 #elif defined(_WIN32) && !defined(__CYGWIN__)
     return (complex*)_aligned_malloc(
-        ((sizeof(complex) * elemCount) < QRACK_STATE_VEC_ALIGN_SIZE) ? QRACK_STATE_VEC_ALIGN_SIZE : sizeof(complex) * elemCount, QRACK_STATE_VEC_ALIGN_SIZE);
+        ((sizeof(complex) * elemCount) < QRACK_ALIGN_SIZE) ? QRACK_ALIGN_SIZE : sizeof(complex) * elemCount, QRACK_ALIGN_SIZE);
 #else
     return (complex*)aligned_alloc(
-        QRACK_STATE_VEC_ALIGN_SIZE, ((sizeof(complex) * elemCount) < QRACK_STATE_VEC_ALIGN_SIZE) ? QRACK_STATE_VEC_ALIGN_SIZE : sizeof(complex) * elemCount);
+        QRACK_ALIGN_SIZE, ((sizeof(complex) * elemCount) < QRACK_ALIGN_SIZE) ? QRACK_ALIGN_SIZE : sizeof(complex) * elemCount);
 #endif
 }
 

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -329,7 +329,7 @@ void QEngineOCL::SetDevice(const int& dID, const bool& forceReInit)
     }
 
     size_t nrmVecAlignSize =
-        ((sizeof(real1) * nrmGroupCount) < ALIGN_SIZE) ? ALIGN_SIZE : (sizeof(real1) * nrmGroupCount);
+        ((sizeof(real1) * nrmGroupCount) < QRACK_STATE_VEC_ALIGN_SIZE) ? QRACK_STATE_VEC_ALIGN_SIZE : (sizeof(real1) * nrmGroupCount);
 
     if (didInit && (nrmGroupCount != oldNrmGroupCount)) {
         nrmBuffer = NULL;
@@ -339,11 +339,11 @@ void QEngineOCL::SetDevice(const int& dID, const bool& forceReInit)
 
     if (!didInit || (nrmGroupCount != oldNrmGroupCount)) {
 #if defined(__APPLE__)
-        posix_memalign((void**)&nrmArray, ALIGN_SIZE, nrmVecAlignSize);
+        posix_memalign((void**)&nrmArray, QRACK_STATE_VEC_ALIGN_SIZE, nrmVecAlignSize);
 #elif defined(_WIN32) && !defined(__CYGWIN__)
-        nrmArray = (real1*)_aligned_malloc(nrmVecAlignSize, ALIGN_SIZE);
+        nrmArray = (real1*)_aligned_malloc(nrmVecAlignSize, QRACK_STATE_VEC_ALIGN_SIZE);
 #else
-        nrmArray = (real1*)aligned_alloc(ALIGN_SIZE, nrmVecAlignSize);
+        nrmArray = (real1*)aligned_alloc(QRACK_STATE_VEC_ALIGN_SIZE, nrmVecAlignSize);
 #endif
     }
 
@@ -1969,18 +1969,18 @@ complex* QEngineOCL::AllocStateVec(bitCapInt elemCount, bool doForceAlloc)
         return NULL;
     }
 
-        // elemCount is always a power of two, but might be smaller than ALIGN_SIZE
+        // elemCount is always a power of two, but might be smaller than QRACK_STATE_VEC_ALIGN_SIZE
 #if defined(__APPLE__)
     void* toRet;
     posix_memalign(
-        &toRet, ALIGN_SIZE, ((sizeof(complex) * elemCount) < ALIGN_SIZE) ? ALIGN_SIZE : sizeof(complex) * elemCount);
+        &toRet, QRACK_STATE_VEC_ALIGN_SIZE, ((sizeof(complex) * elemCount) < QRACK_STATE_VEC_ALIGN_SIZE) ? QRACK_STATE_VEC_ALIGN_SIZE : sizeof(complex) * elemCount);
     return (complex*)toRet;
 #elif defined(_WIN32) && !defined(__CYGWIN__)
     return (complex*)_aligned_malloc(
-        ((sizeof(complex) * elemCount) < ALIGN_SIZE) ? ALIGN_SIZE : sizeof(complex) * elemCount, ALIGN_SIZE);
+        ((sizeof(complex) * elemCount) < QRACK_STATE_VEC_ALIGN_SIZE) ? QRACK_STATE_VEC_ALIGN_SIZE : sizeof(complex) * elemCount, QRACK_STATE_VEC_ALIGN_SIZE);
 #else
     return (complex*)aligned_alloc(
-        ALIGN_SIZE, ((sizeof(complex) * elemCount) < ALIGN_SIZE) ? ALIGN_SIZE : sizeof(complex) * elemCount);
+        QRACK_STATE_VEC_ALIGN_SIZE, ((sizeof(complex) * elemCount) < QRACK_STATE_VEC_ALIGN_SIZE) ? QRACK_STATE_VEC_ALIGN_SIZE : sizeof(complex) * elemCount);
 #endif
 }
 

--- a/src/qengine/state.cpp
+++ b/src/qengine/state.cpp
@@ -757,18 +757,18 @@ void QEngineCPU::UpdateRunningNorm() { runningNorm = par_norm(maxQPower, stateVe
 
 complex* QEngineCPU::AllocStateVec(bitCapInt elemCount, bool ovrride)
 {
-// elemCount is always a power of two, but might be smaller than QRACK_STATE_VEC_ALIGN_SIZE
+// elemCount is always a power of two, but might be smaller than QRACK_ALIGN_SIZE
 #if defined(__APPLE__)
     void* toRet;
     posix_memalign(
-        &toRet, QRACK_STATE_VEC_ALIGN_SIZE, ((sizeof(complex) * elemCount) < QRACK_STATE_VEC_ALIGN_SIZE) ? QRACK_STATE_VEC_ALIGN_SIZE : sizeof(complex) * elemCount);
+        &toRet, QRACK_ALIGN_SIZE, ((sizeof(complex) * elemCount) < QRACK_ALIGN_SIZE) ? QRACK_ALIGN_SIZE : sizeof(complex) * elemCount);
     return (complex*)toRet;
 #elif defined(_WIN32) && !defined(__CYGWIN__)
     return (complex*)_aligned_malloc(
-        ((sizeof(complex) * elemCount) < QRACK_STATE_VEC_ALIGN_SIZE) ? QRACK_STATE_VEC_ALIGN_SIZE : sizeof(complex) * elemCount, QRACK_STATE_VEC_ALIGN_SIZE);
+        ((sizeof(complex) * elemCount) < QRACK_ALIGN_SIZE) ? QRACK_ALIGN_SIZE : sizeof(complex) * elemCount, QRACK_ALIGN_SIZE);
 #else
     return (complex*)aligned_alloc(
-        QRACK_STATE_VEC_ALIGN_SIZE, ((sizeof(complex) * elemCount) < QRACK_STATE_VEC_ALIGN_SIZE) ? QRACK_STATE_VEC_ALIGN_SIZE : sizeof(complex) * elemCount);
+        QRACK_ALIGN_SIZE, ((sizeof(complex) * elemCount) < QRACK_ALIGN_SIZE) ? QRACK_ALIGN_SIZE : sizeof(complex) * elemCount);
 #endif
 }
 } // namespace Qrack

--- a/src/qengine/state.cpp
+++ b/src/qengine/state.cpp
@@ -757,18 +757,18 @@ void QEngineCPU::UpdateRunningNorm() { runningNorm = par_norm(maxQPower, stateVe
 
 complex* QEngineCPU::AllocStateVec(bitCapInt elemCount, bool ovrride)
 {
-// elemCount is always a power of two, but might be smaller than ALIGN_SIZE
+// elemCount is always a power of two, but might be smaller than QRACK_STATE_VEC_ALIGN_SIZE
 #if defined(__APPLE__)
     void* toRet;
     posix_memalign(
-        &toRet, ALIGN_SIZE, ((sizeof(complex) * elemCount) < ALIGN_SIZE) ? ALIGN_SIZE : sizeof(complex) * elemCount);
+        &toRet, QRACK_STATE_VEC_ALIGN_SIZE, ((sizeof(complex) * elemCount) < QRACK_STATE_VEC_ALIGN_SIZE) ? QRACK_STATE_VEC_ALIGN_SIZE : sizeof(complex) * elemCount);
     return (complex*)toRet;
 #elif defined(_WIN32) && !defined(__CYGWIN__)
     return (complex*)_aligned_malloc(
-        ((sizeof(complex) * elemCount) < ALIGN_SIZE) ? ALIGN_SIZE : sizeof(complex) * elemCount, ALIGN_SIZE);
+        ((sizeof(complex) * elemCount) < QRACK_STATE_VEC_ALIGN_SIZE) ? QRACK_STATE_VEC_ALIGN_SIZE : sizeof(complex) * elemCount, QRACK_STATE_VEC_ALIGN_SIZE);
 #else
     return (complex*)aligned_alloc(
-        ALIGN_SIZE, ((sizeof(complex) * elemCount) < ALIGN_SIZE) ? ALIGN_SIZE : sizeof(complex) * elemCount);
+        QRACK_STATE_VEC_ALIGN_SIZE, ((sizeof(complex) * elemCount) < QRACK_STATE_VEC_ALIGN_SIZE) ? QRACK_STATE_VEC_ALIGN_SIZE : sizeof(complex) * elemCount);
 #endif
 }
 } // namespace Qrack

--- a/src/qinterface/protected.cpp
+++ b/src/qinterface/protected.cpp
@@ -18,19 +18,19 @@ namespace Qrack {
 
 unsigned char* qrack_alloc(size_t ucharCount)
 {
-// QRACK_STATE_VEC_ALIGN_SIZE is defined in common/qrack_types.hpp
+// QRACK_ALIGN_SIZE is defined in common/qrack_types.hpp
 #if defined(__APPLE__)
     void* toRet;
-    posix_memalign(&toRet, QRACK_STATE_VEC_ALIGN_SIZE,
-        ((sizeof(unsigned char) * ucharCount) < QRACK_STATE_VEC_ALIGN_SIZE) ? QRACK_STATE_VEC_ALIGN_SIZE : (sizeof(unsigned char) * ucharCount));
+    posix_memalign(&toRet, QRACK_ALIGN_SIZE,
+        ((sizeof(unsigned char) * ucharCount) < QRACK_ALIGN_SIZE) ? QRACK_ALIGN_SIZE : (sizeof(unsigned char) * ucharCount));
     return (unsigned char*)toRet;
 #elif defined(_WIN32) && !defined(__CYGWIN__)
     return (unsigned char*)_aligned_malloc(
-        ((sizeof(unsigned char) * ucharCount) < QRACK_STATE_VEC_ALIGN_SIZE) ? QRACK_STATE_VEC_ALIGN_SIZE : (sizeof(unsigned char) * ucharCount),
-        QRACK_STATE_VEC_ALIGN_SIZE);
+        ((sizeof(unsigned char) * ucharCount) < QRACK_ALIGN_SIZE) ? QRACK_ALIGN_SIZE : (sizeof(unsigned char) * ucharCount),
+        QRACK_ALIGN_SIZE);
 #else
-    return (unsigned char*)aligned_alloc(QRACK_STATE_VEC_ALIGN_SIZE,
-        ((sizeof(unsigned char) * ucharCount) < QRACK_STATE_VEC_ALIGN_SIZE) ? QRACK_STATE_VEC_ALIGN_SIZE : (sizeof(unsigned char) * ucharCount));
+    return (unsigned char*)aligned_alloc(QRACK_ALIGN_SIZE,
+        ((sizeof(unsigned char) * ucharCount) < QRACK_ALIGN_SIZE) ? QRACK_ALIGN_SIZE : (sizeof(unsigned char) * ucharCount));
 #endif
 }
 

--- a/src/qinterface/protected.cpp
+++ b/src/qinterface/protected.cpp
@@ -18,19 +18,19 @@ namespace Qrack {
 
 unsigned char* qrack_alloc(size_t ucharCount)
 {
-// ALIGN_SIZE is defined in common/qrack_types.hpp
+// QRACK_STATE_VEC_ALIGN_SIZE is defined in common/qrack_types.hpp
 #if defined(__APPLE__)
     void* toRet;
-    posix_memalign(&toRet, ALIGN_SIZE,
-        ((sizeof(unsigned char) * ucharCount) < ALIGN_SIZE) ? ALIGN_SIZE : (sizeof(unsigned char) * ucharCount));
+    posix_memalign(&toRet, QRACK_STATE_VEC_ALIGN_SIZE,
+        ((sizeof(unsigned char) * ucharCount) < QRACK_STATE_VEC_ALIGN_SIZE) ? QRACK_STATE_VEC_ALIGN_SIZE : (sizeof(unsigned char) * ucharCount));
     return (unsigned char*)toRet;
 #elif defined(_WIN32) && !defined(__CYGWIN__)
     return (unsigned char*)_aligned_malloc(
-        ((sizeof(unsigned char) * ucharCount) < ALIGN_SIZE) ? ALIGN_SIZE : (sizeof(unsigned char) * ucharCount),
-        ALIGN_SIZE);
+        ((sizeof(unsigned char) * ucharCount) < QRACK_STATE_VEC_ALIGN_SIZE) ? QRACK_STATE_VEC_ALIGN_SIZE : (sizeof(unsigned char) * ucharCount),
+        QRACK_STATE_VEC_ALIGN_SIZE);
 #else
-    return (unsigned char*)aligned_alloc(ALIGN_SIZE,
-        ((sizeof(unsigned char) * ucharCount) < ALIGN_SIZE) ? ALIGN_SIZE : (sizeof(unsigned char) * ucharCount));
+    return (unsigned char*)aligned_alloc(QRACK_STATE_VEC_ALIGN_SIZE,
+        ((sizeof(unsigned char) * ucharCount) < QRACK_STATE_VEC_ALIGN_SIZE) ? QRACK_STATE_VEC_ALIGN_SIZE : (sizeof(unsigned char) * ucharCount));
 #endif
 }
 

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -89,7 +89,7 @@ TEST_CASE("test_complex")
     test = ((real1)abs(cmplx1) > (real1)(sqrt(2.0) - EPSILON)) && ((real1)abs(cmplx1) < (real1)(sqrt(2.0) + EPSILON));
     REQUIRE(test);
 
-    cmplx3 = polar(1.0, M_PI / 2.0);
+    cmplx3 = std::polar(1.0, M_PI / 2.0);
     test = (real(cmplx3) > (real1)(0.0 - EPSILON)) && (real(cmplx3) < (real1)(0.0 + EPSILON));
     REQUIRE(test);
     test = (imag(cmplx3) > (real1)(1.0 - EPSILON)) && (imag(cmplx3) < (real1)(1.0 + EPSILON));


### PR DESCRIPTION
I looked over the common types/macros, and this is the only one that worries me, at the current stage of development. We've dropped the custom double complex type, since it was bugged, since it only gave a benefit to QEngineCPU, and since the x2 vector type optimizations work just fine with the `std::complex` types. Given this, it's no longer necessary to have this macro. It only clutters up the space with a reserved symbol that I could see becoming a problem.

I'll invite other opinions, while we're on the topic, but I think all the other macro type definitions are specific enough to Qrack, and very unlikely to be otherwise desired for custom symbols, that they can (and should) remain as they are.