### PR TITLE
Optimizing and debugging QNeuron

### DIFF
--- a/include/qneuron.hpp
+++ b/include/qneuron.hpp
@@ -25,6 +25,7 @@ private:
     bitLenInt* inputIndices;
     bitLenInt inputCount;
     bitCapInt inputPower;
+    bitCapInt inputMask;
     bitLenInt outputIndex;
     real1* angles;
     real1 tolerance;
@@ -46,6 +47,11 @@ public:
 
         inputIndices = new bitLenInt[inputCount];
         std::copy(inputIndcs, inputIndcs + inputCount, inputIndices);
+
+        inputMask = 0;
+        for (bitLenInt i = 0; i < inputCount; i++) {
+            inputMask |= 1U << inputIndices[i];
+        }
 
         angles = new real1[inputPower];
         std::fill(angles, angles + inputPower, ZERO_R1);
@@ -135,7 +141,7 @@ public:
             return;
         }
 
-        bitCapInt perm = qReg->MReg(0, qReg->GetQubitCount());
+        bitCapInt perm = qReg->MReg(0, qReg->GetQubitCount()) & inputMask;
 
         origAngle = angles[perm];
         angles[perm] += eta * M_PI;

--- a/src/qinterface/rotational.cpp
+++ b/src/qinterface/rotational.cpp
@@ -55,7 +55,7 @@ void QInterface::UniformlyControlledRY(
     complex* pauliRYs = new complex[4 * permCount];
 
     real1 cosine, sine;
-    for (bitLenInt i = 0; i < permCount; i++) {
+    for (bitCapInt i = 0; i < permCount; i++) {
         cosine = cos(angles[i] / 2);
         sine = sin(angles[i] / 2);
 
@@ -89,7 +89,7 @@ void QInterface::UniformlyControlledRZ(
     complex* pauliRZs = new complex[4 * permCount];
 
     real1 cosine, sine;
-    for (bitLenInt i = 0; i < permCount; i++) {
+    for (bitCapInt i = 0; i < permCount; i++) {
         cosine = cos(angles[i] / 2);
         sine = sin(angles[i] / 2);
 

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -2838,7 +2838,7 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_qneuron")
         for (bitLenInt i = 0; i < OutputCount; i++) {
             qftReg->SetPermutation(perm);
             bit = comp & (1U << i);
-            outputLayer[i]->LearnPermutation(bit, eta);
+            outputLayer[i]->Learn(bit, eta);
         }
     }
 

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -2838,7 +2838,7 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_qneuron")
         for (bitLenInt i = 0; i < OutputCount; i++) {
             qftReg->SetPermutation(perm);
             bit = comp & (1U << i);
-            outputLayer[i]->Learn(bit, eta);
+            outputLayer[i]->LearnPermutation(bit, eta);
         }
     }
 


### PR DESCRIPTION
It is commonly not necessary to update every variational parameter in a `QNeuron` on a learning iteration--only one parameter, on a non-superposed permutation.

Additionally, a bug was discovered in uniformly controlled gates, where a `bitLenInt` type was used where the expected range required a `bitCapInt`.