### PR TITLE
QNeuron get/set angles

### DIFF
--- a/include/qneuron.hpp
+++ b/include/qneuron.hpp
@@ -70,6 +70,16 @@ public:
         delete[] angles;
     }
 
+    /** Set the angles of this QNeuron */
+    void SetAngles(real1* nAngles) {
+        std::copy(nAngles, nAngles + inputPower, angles);
+    }
+
+    /** Get the angles of this QNeuron */
+    void GetAngle(real1* oAngles) {
+        std::copy(angles, angles + inputPower, oAngles);
+    }
+
     /** Feed-forward from the inputs, loaded in "qReg", to a binary categorical distinction. "expected" flips the binary
      * categories, if false. */
     real1 Predict(bool expected = true)

--- a/include/qneuron.hpp
+++ b/include/qneuron.hpp
@@ -76,7 +76,7 @@ public:
     }
 
     /** Get the angles of this QNeuron */
-    void GetAngle(real1* oAngles) {
+    void GetAngles(real1* oAngles) {
         std::copy(angles, angles + inputPower, oAngles);
     }
 


### PR DESCRIPTION
It's useful to be able to get and set QNeuron angles (model parameters) in order output trained models and set the initial state for hybrid training.