### PR TITLE
Baseline of QNeuron output set to 0.5/0.5 superposition

### DIFF
--- a/examples/quantum_associative_memory.cpp
+++ b/examples/quantum_associative_memory.cpp
@@ -25,7 +25,7 @@ int main()
     const bitLenInt OutputCount = 4;
     const bitCapInt InputPower = 1U << InputCount;
     // const bitCapInt OutputPower = 1U << OutputCount;
-    const real1 eta = 1.0;
+    const real1 eta = 0.5;
 
     // QINTERFACE_OPTIMAL uses the (single-processor) OpenCL engine type, if available. Otherwise, it falls back to
     // QEngineCPU.
@@ -53,7 +53,7 @@ int main()
         for (bitLenInt i = 0; i < OutputCount; i++) {
             qReg->SetPermutation(perm);
             bit = comp & (1U << i);
-            outputLayer[i]->Learn(bit, eta);
+            outputLayer[i]->LearnPermutation(bit, eta);
         }
     }
 

--- a/examples/quantum_perceptron.cpp
+++ b/examples/quantum_perceptron.cpp
@@ -23,7 +23,7 @@ int main()
     const bitLenInt ControlCount = 4;
     const bitCapInt ControlPower = 1U << ControlCount;
     const bitLenInt ControlLog = 2;
-    const real1 eta = 1.0;
+    const real1 eta = 0.5;
 
     // QINTERFACE_OPTIMAL uses the (single-processor) OpenCL engine type, if available. Otherwise, it falls back to
     // QEngineCPU.
@@ -45,7 +45,7 @@ int main()
         std::cout << "Epoch " << (perm + 1U) << " out of " << ControlPower << std::endl;
         qReg->SetPermutation(perm);
         isPowerOf2 = ((perm != 0) && ((perm & (perm - 1U)) == 0));
-        qPerceptron->Learn(isPowerOf2, eta);
+        qPerceptron->LearnPermutation(isPowerOf2, eta);
     }
 
     std::cout << "Should be close to 1 for powers of two, and close to 0 for all else..." << std::endl;

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -111,7 +111,8 @@ protected:
         return pow;
     }
 
-    inline real1 ClampProb(real1 toClamp) {
+    inline real1 ClampProb(real1 toClamp)
+    {
         if (toClamp < ZERO_R1) {
             toClamp = ZERO_R1;
         }

--- a/include/qneuron.hpp
+++ b/include/qneuron.hpp
@@ -53,8 +53,7 @@ public:
             inputMask |= 1U << inputIndices[i];
         }
 
-        angles = new real1[inputPower];
-        std::fill(angles, angles + inputPower, ZERO_R1);
+        angles = new real1[inputPower]();
     }
 
     /** Create a new QNeuron which is an exact duplicate of another, including its learned state. */
@@ -85,6 +84,7 @@ public:
     real1 Predict(bool expected = true)
     {
         qReg->SetBit(outputIndex, false);
+        qReg->RY(M_PI / 2, outputIndex);
         qReg->UniformlyControlledRY(inputIndices, inputCount, outputIndex, angles);
         real1 prob = qReg->Prob(outputIndex);
         if (!expected) {

--- a/include/qneuron.hpp
+++ b/include/qneuron.hpp
@@ -70,14 +70,10 @@ public:
     }
 
     /** Set the angles of this QNeuron */
-    void SetAngles(real1* nAngles) {
-        std::copy(nAngles, nAngles + inputPower, angles);
-    }
+    void SetAngles(real1* nAngles) { std::copy(nAngles, nAngles + inputPower, angles); }
 
     /** Get the angles of this QNeuron */
-    void GetAngles(real1* oAngles) {
-        std::copy(angles, angles + inputPower, oAngles);
-    }
+    void GetAngles(real1* oAngles) { std::copy(angles, angles + inputPower, oAngles); }
 
     /** Feed-forward from the inputs, loaded in "qReg", to a binary categorical distinction. "expected" flips the binary
      * categories, if false. */
@@ -128,8 +124,10 @@ public:
 
         LearnInternal(expected, eta, perm, startProb);
     }
+
 protected:
-    real1 LearnInternal(bool expected, real1 eta, bitCapInt perm, real1 startProb) {
+    real1 LearnInternal(bool expected, real1 eta, bitCapInt perm, real1 startProb)
+    {
         real1 endProb;
         real1 origAngle;
 

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -1972,15 +1972,16 @@ complex* QEngineOCL::AllocStateVec(bitCapInt elemCount, bool doForceAlloc)
         // elemCount is always a power of two, but might be smaller than QRACK_ALIGN_SIZE
 #if defined(__APPLE__)
     void* toRet;
-    posix_memalign(
-        &toRet, QRACK_ALIGN_SIZE, ((sizeof(complex) * elemCount) < QRACK_ALIGN_SIZE) ? QRACK_ALIGN_SIZE : sizeof(complex) * elemCount);
+    posix_memalign(&toRet, QRACK_ALIGN_SIZE,
+        ((sizeof(complex) * elemCount) < QRACK_ALIGN_SIZE) ? QRACK_ALIGN_SIZE : sizeof(complex) * elemCount);
     return (complex*)toRet;
 #elif defined(_WIN32) && !defined(__CYGWIN__)
     return (complex*)_aligned_malloc(
-        ((sizeof(complex) * elemCount) < QRACK_ALIGN_SIZE) ? QRACK_ALIGN_SIZE : sizeof(complex) * elemCount, QRACK_ALIGN_SIZE);
+        ((sizeof(complex) * elemCount) < QRACK_ALIGN_SIZE) ? QRACK_ALIGN_SIZE : sizeof(complex) * elemCount,
+        QRACK_ALIGN_SIZE);
 #else
-    return (complex*)aligned_alloc(
-        QRACK_ALIGN_SIZE, ((sizeof(complex) * elemCount) < QRACK_ALIGN_SIZE) ? QRACK_ALIGN_SIZE : sizeof(complex) * elemCount);
+    return (complex*)aligned_alloc(QRACK_ALIGN_SIZE,
+        ((sizeof(complex) * elemCount) < QRACK_ALIGN_SIZE) ? QRACK_ALIGN_SIZE : sizeof(complex) * elemCount);
 #endif
 }
 

--- a/src/qengine/state.cpp
+++ b/src/qengine/state.cpp
@@ -760,15 +760,16 @@ complex* QEngineCPU::AllocStateVec(bitCapInt elemCount, bool ovrride)
 // elemCount is always a power of two, but might be smaller than QRACK_ALIGN_SIZE
 #if defined(__APPLE__)
     void* toRet;
-    posix_memalign(
-        &toRet, QRACK_ALIGN_SIZE, ((sizeof(complex) * elemCount) < QRACK_ALIGN_SIZE) ? QRACK_ALIGN_SIZE : sizeof(complex) * elemCount);
+    posix_memalign(&toRet, QRACK_ALIGN_SIZE,
+        ((sizeof(complex) * elemCount) < QRACK_ALIGN_SIZE) ? QRACK_ALIGN_SIZE : sizeof(complex) * elemCount);
     return (complex*)toRet;
 #elif defined(_WIN32) && !defined(__CYGWIN__)
     return (complex*)_aligned_malloc(
-        ((sizeof(complex) * elemCount) < QRACK_ALIGN_SIZE) ? QRACK_ALIGN_SIZE : sizeof(complex) * elemCount, QRACK_ALIGN_SIZE);
+        ((sizeof(complex) * elemCount) < QRACK_ALIGN_SIZE) ? QRACK_ALIGN_SIZE : sizeof(complex) * elemCount,
+        QRACK_ALIGN_SIZE);
 #else
-    return (complex*)aligned_alloc(
-        QRACK_ALIGN_SIZE, ((sizeof(complex) * elemCount) < QRACK_ALIGN_SIZE) ? QRACK_ALIGN_SIZE : sizeof(complex) * elemCount);
+    return (complex*)aligned_alloc(QRACK_ALIGN_SIZE,
+        ((sizeof(complex) * elemCount) < QRACK_ALIGN_SIZE) ? QRACK_ALIGN_SIZE : sizeof(complex) * elemCount);
 #endif
 }
 } // namespace Qrack

--- a/src/qinterface/protected.cpp
+++ b/src/qinterface/protected.cpp
@@ -22,15 +22,18 @@ unsigned char* qrack_alloc(size_t ucharCount)
 #if defined(__APPLE__)
     void* toRet;
     posix_memalign(&toRet, QRACK_ALIGN_SIZE,
-        ((sizeof(unsigned char) * ucharCount) < QRACK_ALIGN_SIZE) ? QRACK_ALIGN_SIZE : (sizeof(unsigned char) * ucharCount));
+        ((sizeof(unsigned char) * ucharCount) < QRACK_ALIGN_SIZE) ? QRACK_ALIGN_SIZE
+                                                                  : (sizeof(unsigned char) * ucharCount));
     return (unsigned char*)toRet;
 #elif defined(_WIN32) && !defined(__CYGWIN__)
-    return (unsigned char*)_aligned_malloc(
-        ((sizeof(unsigned char) * ucharCount) < QRACK_ALIGN_SIZE) ? QRACK_ALIGN_SIZE : (sizeof(unsigned char) * ucharCount),
+    return (unsigned char*)_aligned_malloc(((sizeof(unsigned char) * ucharCount) < QRACK_ALIGN_SIZE)
+            ? QRACK_ALIGN_SIZE
+            : (sizeof(unsigned char) * ucharCount),
         QRACK_ALIGN_SIZE);
 #else
     return (unsigned char*)aligned_alloc(QRACK_ALIGN_SIZE,
-        ((sizeof(unsigned char) * ucharCount) < QRACK_ALIGN_SIZE) ? QRACK_ALIGN_SIZE : (sizeof(unsigned char) * ucharCount));
+        ((sizeof(unsigned char) * ucharCount) < QRACK_ALIGN_SIZE) ? QRACK_ALIGN_SIZE
+                                                                  : (sizeof(unsigned char) * ucharCount));
 #endif
 }
 

--- a/test/benchmarks_main.cpp
+++ b/test/benchmarks_main.cpp
@@ -38,7 +38,7 @@ int main(int argc, char* argv[])
     bool qunit = false;
     bool qunit_qfusion = false;
     bool cpu = false;
-    bool opencl_single = false; 
+    bool opencl_single = false;
 
     using namespace Catch::clara;
 

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -2817,7 +2817,9 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_qneuron")
     const bitLenInt OutputCount = 4;
     const bitCapInt InputPower = 1U << InputCount;
     const bitCapInt OutputPower = 1U << OutputCount;
-    const real1 eta = 1.0;
+    const real1 eta = 0.5;
+
+    qftReg->Dispose(0, qftReg->GetQubitCount() - (InputCount + OutputCount));
 
     bitLenInt inputIndices[InputCount];
     for (bitLenInt i = 0; i < InputCount; i++) {
@@ -2830,19 +2832,17 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_qneuron")
     }
 
     // Train the network to associate powers of 2 with their log2()
-    bitCapInt perm;
-    bitCapInt comp;
+    bitCapInt perm, comp, test;
     bool bit;
     for (perm = 0; perm < InputPower; perm++) {
         comp = (~perm) + 1U;
         for (bitLenInt i = 0; i < OutputCount; i++) {
             qftReg->SetPermutation(perm);
             bit = comp & (1U << i);
-            outputLayer[i]->Learn(bit, eta);
+            outputLayer[i]->LearnPermutation(bit, eta);
         }
     }
 
-    bitCapInt test;
     for (perm = 0; perm < InputPower; perm++) {
         qftReg->SetPermutation(perm);
         for (bitLenInt i = 0; i < OutputCount; i++) {
@@ -2852,4 +2852,5 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_qneuron")
         test = ((~perm) + 1U) & (OutputPower - 1);
         REQUIRE(comp == test);
     }
+
 }


### PR DESCRIPTION
It seems to make more sense to start the default of any untrained QNeuron state as returning a 0.5/0.5 probability superposition of true and false. "Eta" will not be rescaled, since 0.5 still trains up to 0.5 probability in one step, which is full training, and 1.0 trains exactly 0 to exactly 1, or vice versa. `Learn()` (as opposed to `LearnPermutation()`) might find limited use, now, but it was already replaced for training on permutations, and it might still be appropriate in the case that training data is loaded in superposition.