### PR TITLE
QNeuron initial conditions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,4 @@ script:
   - mkdir _build && cd _build && cmake -DUSE_OPENCL=OFF -DENABLE_COMPLEX8=OFF .. && make -j 8 all
   - cd .. && rm -r _build
   - mkdir _build && cd _build && cmake -DUSE_OPENCL=OFF -DENABLE_COMPLEX8=ON .. && make -j 8 all
+  - ./unittest --proc-cpu

--- a/include/qneuron.hpp
+++ b/include/qneuron.hpp
@@ -36,7 +36,9 @@ public:
      * This is a simple "quantum neuron" or "quantum perceptron" class, for use of the Qrack library for machine
      * learning. See https://arxiv.org/abs/1711.11240 for the basis of this class' theoretical concept. (That paper does
      * not use the term "uniformly controlled rotation gate," but "conditioning on all controls" is computationally the
-     * same.) */
+     * same.)
+     *
+     * An untrained QNeuron (with all 0 variational parameters) will forward all inputs to 1/sqrt(2) * (|0> + |1>). The variational parameters are Pauli Y-axis rotation angles divided by 2 * Pi (such that a learning parameter of 0.5 will train from a default output of 0.5/0.5 probability to either 1.0 or 0.0 on one training input). */
     QNeuron(QInterfacePtr reg, bitLenInt* inputIndcs, bitLenInt inputCnt, bitLenInt outputIndx, real1 tol = 1e-6)
         : inputCount(inputCnt)
         , inputPower(1U << inputCnt)
@@ -76,10 +78,12 @@ public:
     void GetAngles(real1* oAngles) { std::copy(angles, angles + inputPower, oAngles); }
 
     /** Feed-forward from the inputs, loaded in "qReg", to a binary categorical distinction. "expected" flips the binary
-     * categories, if false. */
-    real1 Predict(bool expected = true)
+     * categories, if false. "resetInit," if true, resets the result qubit to 0 before proceeding to predict. */
+    real1 Predict(bool expected = true, bool resetInit = true)
     {
-        qReg->SetBit(outputIndex, false);
+        if (resetInit) {
+            qReg->SetBit(outputIndex, false);
+        }
         qReg->RY(M_PI / 2, outputIndex);
         qReg->UniformlyControlledRY(inputIndices, inputCount, outputIndex, angles);
         real1 prob = qReg->Prob(outputIndex);

--- a/include/qneuron.hpp
+++ b/include/qneuron.hpp
@@ -38,7 +38,9 @@ public:
      * not use the term "uniformly controlled rotation gate," but "conditioning on all controls" is computationally the
      * same.)
      *
-     * An untrained QNeuron (with all 0 variational parameters) will forward all inputs to 1/sqrt(2) * (|0> + |1>). The variational parameters are Pauli Y-axis rotation angles divided by 2 * Pi (such that a learning parameter of 0.5 will train from a default output of 0.5/0.5 probability to either 1.0 or 0.0 on one training input). */
+     * An untrained QNeuron (with all 0 variational parameters) will forward all inputs to 1/sqrt(2) * (|0> + |1>). The
+     * variational parameters are Pauli Y-axis rotation angles divided by 2 * Pi (such that a learning parameter of 0.5
+     * will train from a default output of 0.5/0.5 probability to either 1.0 or 0.0 on one training input). */
     QNeuron(QInterfacePtr reg, bitLenInt* inputIndcs, bitLenInt inputCnt, bitLenInt outputIndx, real1 tol = 1e-6)
         : inputCount(inputCnt)
         , inputPower(1U << inputCnt)
@@ -78,13 +80,14 @@ public:
     void GetAngles(real1* oAngles) { std::copy(angles, angles + inputPower, oAngles); }
 
     /** Feed-forward from the inputs, loaded in "qReg", to a binary categorical distinction. "expected" flips the binary
-     * categories, if false. "resetInit," if true, resets the result qubit to 0 before proceeding to predict. */
+     * categories, if false. "resetInit," if true, resets the result qubit to 0.5/0.5 |0>/|1> superposition before
+     * proceeding to predict. */
     real1 Predict(bool expected = true, bool resetInit = true)
     {
         if (resetInit) {
             qReg->SetBit(outputIndex, false);
+            qReg->RY(M_PI / 2, outputIndex);
         }
-        qReg->RY(M_PI / 2, outputIndex);
         qReg->UniformlyControlledRY(inputIndices, inputCount, outputIndex, angles);
         real1 prob = qReg->Prob(outputIndex);
         if (!expected) {

--- a/include/qneuron.hpp
+++ b/include/qneuron.hpp
@@ -93,7 +93,7 @@ public:
 
         if (inputCount == 0) {
             // If there are no controls, this "neuron" is actually just a bias.
-            qReg->RY(M_PI + 2 * M_PI * angles[0], outputIndex);
+            qReg->RY(angles[0], outputIndex);
         } else {
             // Otherwise, the action can always be represented as a uniformly controlled gate.
             qReg->UniformlyControlledRY(inputIndices, inputCount, outputIndex, angles);

--- a/include/qneuron.hpp
+++ b/include/qneuron.hpp
@@ -64,14 +64,16 @@ public:
 
     /** Create a new QNeuron which is an exact duplicate of another, including its learned state. */
     QNeuron(const QNeuron& toCopy)
-        : QNeuron(toCopy.qReg, toCopy.inputIndices, toCopy.inputCount, toCopy.outputIndex)
+        : QNeuron(toCopy.qReg, toCopy.inputIndices, toCopy.inputCount, toCopy.outputIndex, toCopy.tolerance)
     {
-        std::copy(toCopy.angles, toCopy.angles + inputPower, angles);
+        std::copy(toCopy.angles, toCopy.angles + toCopy.inputPower, angles);
     }
 
     ~QNeuron()
     {
-        delete[] inputIndices;
+        if (inputCount > 0) {
+            delete[] inputIndices;
+        }
         delete[] angles;
     }
 
@@ -112,7 +114,7 @@ public:
      */
     void Learn(bool expected, real1 eta)
     {
-        real1 startProb = Predict(expected, false);
+        real1 startProb = Predict(expected);
         if (startProb > (ONE_R1 - tolerance)) {
             return;
         }
@@ -131,7 +133,7 @@ public:
      */
     void LearnPermutation(bool expected, real1 eta)
     {
-        real1 startProb = Predict(expected, false);
+        real1 startProb = Predict(expected);
         if (startProb > (ONE_R1 - tolerance)) {
             return;
         }
@@ -150,7 +152,7 @@ protected:
         origAngle = angles[perm];
         angles[perm] += eta * M_PI;
 
-        endProb = Predict(expected, false);
+        endProb = Predict(expected);
         if (endProb > (ONE_R1 - tolerance)) {
             return -ONE_R1;
         }
@@ -160,7 +162,7 @@ protected:
         } else {
             angles[perm] -= 2 * eta * M_PI;
 
-            endProb = Predict(expected, false);
+            endProb = Predict(expected);
             if (endProb > (ONE_R1 - tolerance)) {
                 return -ONE_R1;
             }

--- a/include/qneuron.hpp
+++ b/include/qneuron.hpp
@@ -88,7 +88,7 @@ public:
     {
         if (resetInit) {
             qReg->SetBit(outputIndex, false);
-            qReg->RY(M_PI, outputIndex);
+            qReg->RY(M_PI_2, outputIndex);
         }
 
         if (inputCount == 0) {

--- a/include/qneuron.hpp
+++ b/include/qneuron.hpp
@@ -133,12 +133,29 @@ public:
      */
     void LearnPermutation(bool expected, real1 eta)
     {
+        //WARNING: LearnPermutation() is only correct when fitting parameters are loaded into lowest bits.
+        //TODO: Convert MReg() & inputMask to permutation.
+
         real1 startProb = Predict(expected);
         if (startProb > (ONE_R1 - tolerance)) {
             return;
         }
 
-        bitCapInt perm = qReg->MReg(0, qReg->GetQubitCount()) & inputMask;
+        bitCapInt mask = qReg->MReg(0, qReg->GetQubitCount()) & inputMask;
+
+        bitCapInt perm = 0;
+        bitCapInt v = inputMask; // count the number of bits set in v
+        bitCapInt oldV;
+        bitLenInt length; // c accumulates the total bits set in v
+        bitCapInt power;
+        std::vector<bitLenInt> bits;
+        std::vector<bool> bitsSet;
+        for (length = 0; v; length++) {
+            oldV = v;
+            v &= v - 1; // clear the least significant bit set
+            power = (v ^ oldV) & oldV;
+            perm |= (!(!(power & mask))) ? (1U << length) : 0;
+        }
 
         LearnInternal(expected, eta, perm, startProb);
     }

--- a/include/qneuron.hpp
+++ b/include/qneuron.hpp
@@ -112,7 +112,7 @@ public:
      */
     void Learn(bool expected, real1 eta)
     {
-        real1 startProb = Predict(expected);
+        real1 startProb = Predict(expected, false);
         if (startProb > (ONE_R1 - tolerance)) {
             return;
         }
@@ -131,7 +131,7 @@ public:
      */
     void LearnPermutation(bool expected, real1 eta)
     {
-        real1 startProb = Predict(expected);
+        real1 startProb = Predict(expected, false);
         if (startProb > (ONE_R1 - tolerance)) {
             return;
         }
@@ -150,7 +150,7 @@ protected:
         origAngle = angles[perm];
         angles[perm] += eta * M_PI;
 
-        endProb = Predict(expected);
+        endProb = Predict(expected, false);
         if (endProb > (ONE_R1 - tolerance)) {
             return -ONE_R1;
         }
@@ -160,7 +160,7 @@ protected:
         } else {
             angles[perm] -= 2 * eta * M_PI;
 
-            endProb = Predict(expected);
+            endProb = Predict(expected, false);
             if (endProb > (ONE_R1 - tolerance)) {
                 return -ONE_R1;
             }

--- a/include/qneuron.hpp
+++ b/include/qneuron.hpp
@@ -127,9 +127,6 @@ public:
      */
     void LearnPermutation(bool expected, real1 eta, bool resetInit = true)
     {
-        //WARNING: LearnPermutation() is only correct when fitting parameters are loaded into lowest bits.
-        //TODO: Convert MReg() & inputMask to permutation.
-
         real1 startProb = Predict(expected, resetInit);
         if (startProb > (ONE_R1 - tolerance)) {
             return;

--- a/include/qneuron.hpp
+++ b/include/qneuron.hpp
@@ -49,8 +49,10 @@ public:
     {
         qReg = reg;
 
-        inputIndices = new bitLenInt[inputCount];
-        std::copy(inputIndcs, inputIndcs + inputCount, inputIndices);
+        if (inputCount > 0) {
+            inputIndices = new bitLenInt[inputCount];
+            std::copy(inputIndcs, inputIndcs + inputCount, inputIndices);
+        }
 
         inputMask = 0;
         for (bitLenInt i = 0; i < inputCount; i++) {
@@ -86,9 +88,16 @@ public:
     {
         if (resetInit) {
             qReg->SetBit(outputIndex, false);
-            qReg->RY(M_PI / 2, outputIndex);
+            qReg->RY(M_PI, outputIndex);
         }
-        qReg->UniformlyControlledRY(inputIndices, inputCount, outputIndex, angles);
+
+        if (inputCount == 0) {
+            // If there are no controls, this "neuron" is actually just a bias.
+            qReg->RY(M_PI + 2 * M_PI * angles[0], outputIndex);
+        } else {
+            // Otherwise, the action can always be represented as a uniformly controlled gate.
+            qReg->UniformlyControlledRY(inputIndices, inputCount, outputIndex, angles);
+        }
         real1 prob = qReg->Prob(outputIndex);
         if (!expected) {
             prob = ONE_R1 - prob;

--- a/include/qneuron.hpp
+++ b/include/qneuron.hpp
@@ -105,6 +105,9 @@ public:
      *
      * Inputs must be already loaded into "qReg" before calling this method. "expected" is the true binary output
      * category, for training. "eta" is a volatility or "learning rate" parameter with a maximum value of 1.
+     *
+     * In the feedback process of learning, default initial conditions forward untrained predictions to 1/sqrt(2) * (|0>
+     * + |1>) for the output bit. If you want to initialize other conditions before "Learn()," set "resetInit" to false.
      */
     void Learn(bool expected, real1 eta, bool resetInit = true)
     {
@@ -124,6 +127,10 @@ public:
      *
      * Inputs must be already loaded into "qReg" before calling this method. "expected" is the true binary output
      * category, for training. "eta" is a volatility or "learning rate" parameter with a maximum value of 1.
+     *
+     * In the feedback process of learning, default initial conditions forward untrained predictions to 1/sqrt(2) * (|0>
+     * + |1>) for the output bit. If you want to initialize other conditions before "LearnPermutation()," set
+     * "resetInit" to false.
      */
     void LearnPermutation(bool expected, real1 eta, bool resetInit = true)
     {

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -2852,5 +2852,4 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_qneuron")
         test = ((~perm) + 1U) & (OutputPower - 1);
         REQUIRE(comp == test);
     }
-
 }


### PR DESCRIPTION
Based on experiments with training QNeuron networks, changes have been made to the class, focusing on its initial conditions. Additionally, a bug has been fixed in the indexing of variational angles in LearnPermutation().

(Benn is not available to review this PR.)