### PR TITLE
RDRAND option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ set(PSTRIDE "16" CACHE STRING "Stride of parallel for loops")
 # Declare the library
 add_library (qrack STATIC
     src/common/parallel_for.cpp
+    src/common/rdrandwrapper.cpp
     src/qinterface/qinterface.cpp
     src/qinterface/protected.cpp
     src/qinterface/operators.cpp
@@ -82,11 +83,11 @@ message ("Single accuracy is: ${ENABLE_COMPLEX8}")
 message ("Complex_x2/AVX Support is: ${ENABLE_COMPLEX_X2}")
 
 if (MSVC)
-    set(QRACK_COMPILE_OPTS -std=c++11 -Wall)
-    set(TEST_COMPILE_OPTS -std=c++11 -Wall)
+    set(QRACK_COMPILE_OPTS -std=c++11 -mrdrnd -Wall)
+    set(TEST_COMPILE_OPTS -std=c++11 -mrdrnd -Wall)
 else (MSVC)
-    set(QRACK_COMPILE_OPTS -O3 -std=c++11 -Wall -Werror -fPIC)
-    set(TEST_COMPILE_OPTS -O3 -std=c++11 -Wall -Werror)
+    set(QRACK_COMPILE_OPTS -O3 -std=c++11 -Wall -Werror -mrdrnd -fPIC)
+    set(TEST_COMPILE_OPTS -O3 -std=c++11 -Wall -mrdrnd -Werror)
 endif(MSVC)
 
 if (ENABLE_COMPLEX_X2 AND NOT ENABLE_COMPLEX8)
@@ -123,6 +124,7 @@ install (FILES
     include/common/complex8x2simd.hpp
     include/common/oclengine.hpp
     include/common/parallel_for.hpp
+    include/common/rdrandwrapper.hpp
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/qrack/common
     )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,16 +83,18 @@ message ("Single accuracy is: ${ENABLE_COMPLEX8}")
 message ("Complex_x2/AVX Support is: ${ENABLE_COMPLEX_X2}")
 
 if (MSVC)
-    set(QRACK_COMPILE_OPTS -std=c++11 -mrdrnd -Wall)
-    set(TEST_COMPILE_OPTS -std=c++11 -mrdrnd -Wall)
+    set(QRACK_COMPILE_OPTS -std=c++11 -Wall)
+    set(TEST_COMPILE_OPTS -std=c++11 -Wall)
 else (MSVC)
-    set(QRACK_COMPILE_OPTS -O3 -std=c++11 -Wall -Werror -mrdrnd -fPIC)
-    set(TEST_COMPILE_OPTS -O3 -std=c++11 -Wall -mrdrnd -Werror)
+    set(QRACK_COMPILE_OPTS -O3 -std=c++11 -Wall -Werror -fPIC)
+    set(TEST_COMPILE_OPTS -O3 -std=c++11 -Wall -Werror)
 endif(MSVC)
 
 if (ENABLE_COMPLEX_X2 AND NOT ENABLE_COMPLEX8)
     set(QRACK_COMPILE_OPTS ${QRACK_COMPILE_OPTS} -mavx)
 endif (ENABLE_COMPLEX_X2 AND NOT ENABLE_COMPLEX8)
+
+include ("cmake/RDRand.cmake")
 
 configure_file(include/common/config.h.in include/common/config.h @ONLY)
 include_directories(${CMAKE_CURRENT_BINARY_DIR}/include/common)

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Turn off the option to attempt using on-chip hardware random number generation, 
 
 Relatively recent Intel processors may provide the RDRAND (and RDSEED) processor operation codes, for hardware random number generation. The authors of Qrack cannot promise anything about the security or quality of these random numbers. (It is not hard to modify Qrack to use an entropy source you personally trust.) However, there is reason to suspect based on descriptions of the on-chip generator that the conditioned hardware entropy stream typically has a high von Neumann entropy content, (depending partly on load,) that this is "quantum" or "true" random entropy.
 
-There is little or no obvious benefit or detriment, in choosing between deterministic and nondeterminstic sources of high quality random numbers, for quantum computation simulation. However, it is the opinion of one of the authors of Qrack, that seemingly the one aspect of a quantum computer that cannot be simulated even in principle by a deterministic machine is "unitarity breaking," "true random numbers," whether this makes any measurable or falsifiable difference.
+There is little or no obvious benefit or detriment, in choosing between deterministic and nondeterminstic sources of high quality random numbers, for quantum computation simulation. However, it is the opinion of one of the authors of Qrack, that seemingly the one aspect of a quantum computer that cannot be emulated even in principle by a deterministic machine is "unitarity breaking," "true random numbers," whether this makes any measurable or falsifiable difference.
 
 ## Pure 32 bit OpenCL kernels (including Raspberry Pi 3)
 

--- a/README.md
+++ b/README.md
@@ -116,10 +116,6 @@ $ cmake -DENABLE_RDRAND=OFF ..
 ```
 Turn off the option to attempt using on-chip hardware random number generation, which is on by default. If the option is on, Qrack might still compile to attempt using hardware random number generation, but fall back to software generation if the RDRAND opcode is not actually available. Some systems' compilers, such as that of the Raspberry Pi 3, do not recognize the compilation flag for enabling RDRAND, in which case this option needs to be turned off.
 
-Relatively recent Intel processors may provide the RDRAND (and RDSEED) processor operation codes, for hardware random number generation. The authors of Qrack cannot promise anything about the security or quality of these random numbers. (It is not hard to modify Qrack to use an entropy source you personally trust.) However, there is reason to suspect based on descriptions of the on-chip generator that the conditioned hardware entropy stream typically has a high von Neumann entropy content, (depending partly on load,) that this is "quantum" or "true" random entropy.
-
-There is little or no obvious benefit or detriment, in choosing between deterministic and nondeterminstic sources of high quality random numbers, for quantum computation simulation. However, it is the opinion of one of the authors of Qrack, that seemingly the one aspect of a quantum computer that cannot be emulated even in principle by a deterministic machine is "unitarity breaking," "true random numbers," whether this makes any measurable or falsifiable difference.
-
 ## Pure 32 bit OpenCL kernels (including Raspberry Pi 3)
 
 ```

--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ CMake on Windows will set up a 32-bit Visual Studio project by default, (if usin
 
 ```
     $ mkdir _build
-	$ cd _build
-	$ cmake -DCMAKE_GENERATOR_PLATFORM=x64 -DXXD_BIN="C:/Program Files (x86)/Vim/vim81/xxd.exe" ..
+    $ cd _build
+    $ cmake -DCMAKE_GENERATOR_PLATFORM=x64 -DXXD_BIN="C:/Program Files (x86)/Vim/vim81/xxd.exe" ..
 ```
 
 After CMake, the project must be built in Visual Studio.
@@ -108,6 +108,17 @@ Multiply complex numbers two at a time instead of one at a time. Requires AVX fo
 $ cmake -DENABLE_COMPLEX8=ON ..
 ```
 Reduce to float accuracy for complex numbers. Requires half as much RAM (1 additional qubit). Compatible with SSE 1.0 and single precision accelerator devices.
+
+## On-Chip Hardware Random Number Generation 
+
+```
+$ cmake -DENABLE_MDRAND=OFF ..
+```
+Turn off the option to attempt using on-chip hardware random number generation, which is on by default. If the option is on, Qrack might still compile to attempt using hardware random number generation, but fall back to software generation if the RDRAND opcode is not actually available. Some systems' compilers, such as that of the Raspberry Pi 3, do not recognize the compilation flag for enabling RDRAND, in which case this option needs to be turned off.
+
+Relatively recent Intel processors may provide the RDRAND (and RDSEED) processor operation codes, for hardware random number generation. The authors of Qrack cannot promise anything about the security or quality of these random numbers. (It is not hard to modify Qrack to use an entropy source you personally trust.) However, there is reason to suspect based on descriptions of the on-chip generator that the conditioned hardware entropy stream typically has a high von Neumann entropy content, (depending partly on load,) that this is "quantum" or "true" random entropy.
+
+There is little or no obvious benefit or detriment, in choosing between deterministic and nondeterminstic sources of high quality random numbers, for quantum computation simulation. However, it is the opinion of one of the authors of Qrack, that seemingly the one aspect of a quantum computer that cannot be simulated even in principle by a deterministic machine is "unitarity breaking," "true random numbers," whether this makes any measurable or falsifiable difference.
 
 ## Pure 32 bit OpenCL kernels (including Raspberry Pi 3)
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ There is little or no obvious benefit or detriment, in choosing between determin
 ```
 $ cmake -DENABLE_PURE32=ON ..
 ```
-This option is needed for certain older or simpler hardware. This removes all use of 64 bit types from the OpenCL kernels, as well as completely removing the use of SIMD intrinsics. Note that this build option theoretically supports only up 32 qubits, whereas `-DENABLE_PURE32=OFF` could support up to 64 qubits, (if the memory requirements were realistically attainable for either 32-bit or 64-bit hardware). `-DENABLE_PURE32=ON` should be necessary but sufficient to support the VC4CL OpenCL compiler for the VideoCore GPU of the Raspberry Pi 3.
+This option is needed for certain older or simpler hardware. This removes all use of 64 bit types from the OpenCL kernels, as well as completely removing the use of SIMD intrinsics. Note that this build option theoretically supports only up to 32 qubits, whereas `-DENABLE_PURE32=OFF` could support up to 64 qubits, (if the memory requirements were realistically attainable for either 32-bit or 64-bit hardware). `-DENABLE_PURE32=ON` should be necessary but sufficient to support the VC4CL OpenCL compiler for the VideoCore GPU of the Raspberry Pi 3.
 
 ## Copyright and License
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Reduce to float accuracy for complex numbers. Requires half as much RAM (1 addit
 ## On-Chip Hardware Random Number Generation 
 
 ```
-$ cmake -DENABLE_MDRAND=OFF ..
+$ cmake -DENABLE_RDRAND=OFF ..
 ```
 Turn off the option to attempt using on-chip hardware random number generation, which is on by default. If the option is on, Qrack might still compile to attempt using hardware random number generation, but fall back to software generation if the RDRAND opcode is not actually available. Some systems' compilers, such as that of the Raspberry Pi 3, do not recognize the compilation flag for enabling RDRAND, in which case this option needs to be turned off.
 

--- a/cmake/RDRand.cmake
+++ b/cmake/RDRand.cmake
@@ -4,3 +4,5 @@ if (ENABLE_RDRAND)
     set(QRACK_COMPILE_OPTS ${QRACK_COMPILE_OPTS} -mrdrnd)
     target_compile_definitions(qrack PUBLIC ENABLE_RDRAND=1)
 endif (ENABLE_RDRAND)
+
+message ("Try RDRAND is: ${ENABLE_RDRAND}")

--- a/cmake/RDRand.cmake
+++ b/cmake/RDRand.cmake
@@ -1,0 +1,6 @@
+option (ENABLE_RDRAND "Use RDRAND hardware random number generation, if available" ON)
+
+if (ENABLE_RDRAND)
+    set(QRACK_COMPILE_OPTS ${QRACK_COMPILE_OPTS} -mrdrnd)
+    target_compile_definitions(qrack PUBLIC ENABLE_RDRAND=1)
+endif (ENABLE_RDRAND)

--- a/include/common/rdrandwrapper.hpp
+++ b/include/common/rdrandwrapper.hpp
@@ -1,3 +1,15 @@
+//////////////////////////////////////////////////////////////////////////////////////
+//
+// (C) Daniel Strano and the Qrack contributors 2017-2019. All rights reserved.
+//
+// This class allows access to on-chip RNG capabilities. The class is adapted from these two sources:
+// https://codereview.stackexchange.com/questions/147656/checking-if-cpu-supports-rdrand/150230
+// https://stackoverflow.com/questions/45460146/how-to-use-intels-rdrand-using-inline-assembly-with-net
+//
+// Licensed under the GNU Lesser General Public License V3.
+// See LICENSE.md in the project root or https://www.gnu.org/licenses/lgpl-3.0.en.html
+// for details.
+
 #include <cpuid.h>
 #include <immintrin.h>
 
@@ -5,14 +17,12 @@
 
 namespace RdRandWrapper {
 
-  bool getRdRand(unsigned int* pv);
+bool getRdRand(unsigned int* pv);
 
-  class RdRandom
-  {
-  public:
-
+class RdRandom {
+public:
     bool SupportsRDRAND();
 
     double Next();
-  };
-}
+};
+} // namespace RdRandWrapper

--- a/include/common/rdrandwrapper.hpp
+++ b/include/common/rdrandwrapper.hpp
@@ -1,0 +1,18 @@
+#include <cpuid.h>
+#include <immintrin.h>
+
+#pragma once
+
+namespace RdRandWrapper {
+
+  bool getRdRand(unsigned int* pv);
+
+  class RdRandom
+  {
+  public:
+
+    bool SupportsRDRAND();
+
+    double Next();
+  };
+}

--- a/include/common/rdrandwrapper.hpp
+++ b/include/common/rdrandwrapper.hpp
@@ -10,8 +10,10 @@
 // See LICENSE.md in the project root or https://www.gnu.org/licenses/lgpl-3.0.en.html
 // for details.
 
+#if ENABLE_RDRAND
 #include <cpuid.h>
 #include <immintrin.h>
+#endif
 
 #pragma once
 

--- a/include/common/rdrandwrapper.hpp
+++ b/include/common/rdrandwrapper.hpp
@@ -11,7 +11,13 @@
 // for details.
 
 #if ENABLE_RDRAND
+
+#if _MSC_VER
+#include <intrin.h>
+#else
 #include <cpuid.h>
+#endif
+
 #include <immintrin.h>
 #endif
 

--- a/include/qengine.hpp
+++ b/include/qengine.hpp
@@ -43,8 +43,8 @@ protected:
 
 public:
     QEngine(bitLenInt n, qrack_rand_gen_ptr rgp = nullptr, bool doNorm = true, bool randomGlobalPhase = true,
-        bool useHostMem = false)
-        : QInterface(n, rgp, doNorm)
+        bool useHostMem = false, bool useHardwareRNG = true)
+        : QInterface(n, rgp, doNorm, useHardwareRNG)
         , randGlobalPhase(randomGlobalPhase)
         , useHostRam(useHostMem)
         , runningNorm(ONE_R1){};

--- a/include/qengine_cpu.hpp
+++ b/include/qengine_cpu.hpp
@@ -39,7 +39,7 @@ protected:
 public:
     QEngineCPU(bitLenInt qBitCount, bitCapInt initState, qrack_rand_gen_ptr rgp = nullptr,
         complex phaseFac = complex(-999.0, -999.0), bool doNorm = true, bool randomGlobalPhase = true,
-        bool ignored = false);
+        bool ignored = false, int ignored2 = -1, bool useHardwareRNG = true);
     QEngineCPU(QEngineCPUPtr toCopy);
     ~QEngineCPU() { FreeStateVec(); }
 

--- a/include/qengine_opencl.hpp
+++ b/include/qengine_opencl.hpp
@@ -93,7 +93,7 @@ public:
 
     QEngineOCL(bitLenInt qBitCount, bitCapInt initState, qrack_rand_gen_ptr rgp = nullptr,
         complex phaseFac = complex(-999.0, -999.0), bool doNorm = true, bool randomGlobalPhase = true,
-        bool useHostMem = false, int devID = -1);
+        bool useHostMem = false, int devID = -1, bool useHardwareRNG = true);
     QEngineOCL(QEngineOCLPtr toCopy);
     ~QEngineOCL()
     {

--- a/include/qfusion.hpp
+++ b/include/qfusion.hpp
@@ -48,7 +48,7 @@ protected:
 public:
     QFusion(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState = 0, qrack_rand_gen_ptr rgp = nullptr,
         complex phaseFac = complex(-999.0, -999.0), bool doNorm = true, bool randomGlobalPhase = true,
-        bool useHostMem = false);
+        bool useHostMem = false, int deviceID = -1, bool useHardwareRNG = true);
     QFusion(QInterfacePtr target);
 
     virtual void SetQuantumState(complex* inputState);

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -22,6 +22,7 @@
 
 #include "common/parallel_for.hpp"
 #include "common/qrack_types.hpp"
+#include "rdrandwrapper.hpp"
 #include "hamiltonian.hpp"
 
 namespace Qrack {
@@ -90,6 +91,7 @@ protected:
     uint32_t randomSeed;
     qrack_rand_gen_ptr rand_generator;
     std::uniform_real_distribution<real1> rand_distribution;
+    std::shared_ptr<RdRandWrapper::RdRandom> hardware_rand_generator;
     bool doNormalize;
 
     virtual void SetQubitCount(bitLenInt qb)
@@ -136,11 +138,19 @@ protected:
     }
 
 public:
-    QInterface(bitLenInt n, qrack_rand_gen_ptr rgp = nullptr, bool doNorm = true)
+    QInterface(bitLenInt n, qrack_rand_gen_ptr rgp = nullptr, bool doNorm = true, bool useHardwareRNG = true)
         : rand_distribution(0.0, 1.0)
+        , hardware_rand_generator(NULL)
         , doNormalize(doNorm)
     {
         SetQubitCount(n);
+
+        if (useHardwareRNG) {
+            hardware_rand_generator = std::make_shared<RdRandWrapper::RdRandom>();
+            if (!(hardware_rand_generator->SupportsRDRAND())) {
+                hardware_rand_generator = NULL;
+            }
+        }
 
         if (rgp == NULL) {
             rand_generator = std::make_shared<qrack_rand_gen>();
@@ -161,7 +171,13 @@ public:
     int GetMaxQPower() { return maxQPower; }
 
     /** Generate a random real number between 0 and 1 */
-    virtual real1 Rand() { return rand_distribution(*rand_generator); }
+    virtual real1 Rand() {
+        if (hardware_rand_generator != NULL) {
+            return hardware_rand_generator->Next();
+        } else {
+            return rand_distribution(*rand_generator);
+        }
+    }
 
     /** Set an arbitrary pure quantum state representation
      *

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -22,8 +22,8 @@
 
 #include "common/parallel_for.hpp"
 #include "common/qrack_types.hpp"
-#include "rdrandwrapper.hpp"
 #include "hamiltonian.hpp"
+#include "rdrandwrapper.hpp"
 
 namespace Qrack {
 
@@ -171,7 +171,8 @@ public:
     int GetMaxQPower() { return maxQPower; }
 
     /** Generate a random real number between 0 and 1 */
-    virtual real1 Rand() {
+    virtual real1 Rand()
+    {
         if (hardware_rand_generator != NULL) {
             return hardware_rand_generator->Next();
         } else {

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -34,11 +34,13 @@ class QUnit : public QInterface {
 protected:
     QInterfaceEngine engine;
     QInterfaceEngine subengine;
+    int devID;
     std::vector<QEngineShard> shards;
     complex phaseFactor;
     bool doNormalize;
     bool randGlobalPhase;
     bool useHostRam;
+    bool useRDRAND;
 
     qrack_rand_gen_ptr rand_generator;
 
@@ -51,10 +53,10 @@ protected:
 public:
     QUnit(QInterfaceEngine eng, QInterfaceEngine subEng, bitLenInt qBitCount, bitCapInt initState = 0,
         qrack_rand_gen_ptr rgp = nullptr, complex phaseFac = complex(-999.0, -999.0), bool doNorm = true,
-        bool randomGlobalPhase = true, bool useHostMem = true);
+        bool randomGlobalPhase = true, bool useHostMem = true, int deviceID = -1, bool useHardwareRNG = true);
     QUnit(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState = 0, qrack_rand_gen_ptr rgp = nullptr,
         complex phaseFac = complex(-999.0, -999.0), bool doNorm = true, bool randomGlobalPhase = true,
-        bool useHostMem = true);
+        bool useHostMem = true, int deviceId = -1, bool useHardwareRNG = true);
 
     virtual void SetQuantumState(complex* inputState);
     virtual void GetQuantumState(complex* outputState);

--- a/src/common/rdrandwrapper.cpp
+++ b/src/common/rdrandwrapper.cpp
@@ -31,11 +31,19 @@ bool RdRandom::SupportsRDRAND()
 #if ENABLE_RDRAND
     const unsigned int flag_RDRAND = (1 << 30);
 
+#if _MSC_VER
+	int ex[4];
+	__cpuid(ex, 1);
+
+	return ((ex[2] & flag_RDRAND) == flag_RDRAND);
+#else
     unsigned int eax, ebx, ecx, edx;
     ecx = 0;
     __get_cpuid(1, &eax, &ebx, &ecx, &edx);
 
     return ((ecx & flag_RDRAND) == flag_RDRAND);
+#endif
+
 #else
     return false;
 #endif

--- a/src/common/rdrandwrapper.cpp
+++ b/src/common/rdrandwrapper.cpp
@@ -1,11 +1,25 @@
+//////////////////////////////////////////////////////////////////////////////////////
+//
+// (C) Daniel Strano and the Qrack contributors 2017-2019. All rights reserved.
+//
+// This class allows access to on-chip RNG capabilities. The class is adapted from these two sources:
+// https://codereview.stackexchange.com/questions/147656/checking-if-cpu-supports-rdrand/150230
+// https://stackoverflow.com/questions/45460146/how-to-use-intels-rdrand-using-inline-assembly-with-net
+//
+// Licensed under the GNU Lesser General Public License V3.
+// See LICENSE.md in the project root or https://www.gnu.org/licenses/lgpl-3.0.en.html
+// for details.
+
 #include "rdrandwrapper.hpp"
 
 namespace RdRandWrapper {
 
-bool getRdRand(unsigned int* pv) {
+bool getRdRand(unsigned int* pv)
+{
     const int max_rdrand_tries = 10;
     for (int i = 0; i < max_rdrand_tries; ++i) {
-      if (_rdrand32_step(pv)) return true;
+        if (_rdrand32_step(pv))
+            return true;
     }
     return false;
 }
@@ -21,21 +35,22 @@ bool RdRandom::SupportsRDRAND()
     return ((ecx & flag_RDRAND) == flag_RDRAND);
 }
 
-double RdRandom::Next() {
-  unsigned int v;
-  double res = 0;
-  double part = 1;
-  if (!getRdRand(&v)) {
-    throw "Failed to get hardware RNG number.";
-  }
-  v &= 0x7fffffff;
-  for (int i = 0; i < 31; i++) {
-      part /= 2;
-      if (v & (1U << i)) {
-          res += part;
-      }
-  }
-  return res;
+double RdRandom::Next()
+{
+    unsigned int v;
+    double res = 0;
+    double part = 1;
+    if (!getRdRand(&v)) {
+        throw "Failed to get hardware RNG number.";
+    }
+    v &= 0x7fffffff;
+    for (int i = 0; i < 31; i++) {
+        part /= 2;
+        if (v & (1U << i)) {
+            res += part;
+        }
+    }
+    return res;
 }
 
-}
+} // namespace RdRandWrapper

--- a/src/common/rdrandwrapper.cpp
+++ b/src/common/rdrandwrapper.cpp
@@ -16,16 +16,19 @@ namespace RdRandWrapper {
 
 bool getRdRand(unsigned int* pv)
 {
+#if ENABLE_RDRAND
     const int max_rdrand_tries = 10;
     for (int i = 0; i < max_rdrand_tries; ++i) {
         if (_rdrand32_step(pv))
             return true;
     }
+#endif
     return false;
 }
 
 bool RdRandom::SupportsRDRAND()
 {
+#if ENABLE_RDRAND
     const unsigned int flag_RDRAND = (1 << 30);
 
     unsigned int eax, ebx, ecx, edx;
@@ -33,6 +36,9 @@ bool RdRandom::SupportsRDRAND()
     __get_cpuid(1, &eax, &ebx, &ecx, &edx);
 
     return ((ecx & flag_RDRAND) == flag_RDRAND);
+#else
+    return false;
+#endif
 }
 
 double RdRandom::Next()

--- a/src/common/rdrandwrapper.cpp
+++ b/src/common/rdrandwrapper.cpp
@@ -1,0 +1,41 @@
+#include "rdrandwrapper.hpp"
+
+namespace RdRandWrapper {
+
+bool getRdRand(unsigned int* pv) {
+    const int max_rdrand_tries = 10;
+    for (int i = 0; i < max_rdrand_tries; ++i) {
+      if (_rdrand32_step(pv)) return true;
+    }
+    return false;
+}
+
+bool RdRandom::SupportsRDRAND()
+{
+    const unsigned int flag_RDRAND = (1 << 30);
+
+    unsigned int eax, ebx, ecx, edx;
+    ecx = 0;
+    __get_cpuid(1, &eax, &ebx, &ecx, &edx);
+
+    return ((ecx & flag_RDRAND) == flag_RDRAND);
+}
+
+double RdRandom::Next() {
+  unsigned int v;
+  double res = 0;
+  double part = 1;
+  if (!getRdRand(&v)) {
+    throw "Failed to get hardware RNG number.";
+  }
+  v &= 0x7fffffff;
+  for (int i = 0; i < 31; i++) {
+      part /= 2;
+      if (v & (1U << i)) {
+          res += part;
+      }
+  }
+  return res;
+}
+
+}

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -55,8 +55,8 @@ namespace Qrack {
     queue.enqueueUnmapMemObject(buff, array, NULL, &(device_context->wait_events->back()));
 
 QEngineOCL::QEngineOCL(bitLenInt qBitCount, bitCapInt initState, qrack_rand_gen_ptr rgp, complex phaseFac, bool doNorm,
-    bool randomGlobalPhase, bool useHostMem, int devID)
-    : QEngine(qBitCount, rgp, doNorm, randomGlobalPhase, useHostMem)
+    bool randomGlobalPhase, bool useHostMem, int devID, bool useHardwareRNG)
+    : QEngine(qBitCount, rgp, doNorm, randomGlobalPhase, useHostMem, useHardwareRNG)
     , stateVec(NULL)
     , deviceID(devID)
     , wait_refs()
@@ -77,7 +77,7 @@ QEngineOCL::QEngineOCL(bitLenInt qBitCount, bitCapInt initState, qrack_rand_gen_
 
 QEngineOCL::QEngineOCL(QEngineOCLPtr toCopy)
     : QEngine(
-          toCopy->qubitCount, toCopy->rand_generator, toCopy->doNormalize, toCopy->randGlobalPhase, toCopy->useHostRam)
+          toCopy->qubitCount, toCopy->rand_generator, toCopy->doNormalize, toCopy->randGlobalPhase, toCopy->useHostRam, toCopy->hardware_rand_generator != NULL)
     , stateVec(NULL)
     , deviceID(toCopy->deviceID)
     , wait_refs()

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -76,8 +76,8 @@ QEngineOCL::QEngineOCL(bitLenInt qBitCount, bitCapInt initState, qrack_rand_gen_
 }
 
 QEngineOCL::QEngineOCL(QEngineOCLPtr toCopy)
-    : QEngine(
-          toCopy->qubitCount, toCopy->rand_generator, toCopy->doNormalize, toCopy->randGlobalPhase, toCopy->useHostRam, toCopy->hardware_rand_generator != NULL)
+    : QEngine(toCopy->qubitCount, toCopy->rand_generator, toCopy->doNormalize, toCopy->randGlobalPhase,
+          toCopy->useHostRam, toCopy->hardware_rand_generator != NULL)
     , stateVec(NULL)
     , deviceID(toCopy->deviceID)
     , wait_refs()

--- a/src/qengine/state.cpp
+++ b/src/qengine/state.cpp
@@ -67,7 +67,8 @@ QEngineCPU::QEngineCPU(bitLenInt qBitCount, bitCapInt initState, qrack_rand_gen_
 }
 
 QEngineCPU::QEngineCPU(QEngineCPUPtr toCopy)
-    : QEngine(toCopy->qubitCount, toCopy->rand_generator, toCopy->doNormalize, toCopy->randGlobalPhase, true, toCopy->hardware_rand_generator != NULL)
+    : QEngine(toCopy->qubitCount, toCopy->rand_generator, toCopy->doNormalize, toCopy->randGlobalPhase, true,
+          toCopy->hardware_rand_generator != NULL)
     , stateVec(NULL)
 {
     SetConcurrencyLevel(std::thread::hardware_concurrency());

--- a/src/qengine/state.cpp
+++ b/src/qengine/state.cpp
@@ -37,8 +37,8 @@ namespace Qrack {
  * phase usually makes sense only if they are initialized at the same time.
  */
 QEngineCPU::QEngineCPU(bitLenInt qBitCount, bitCapInt initState, qrack_rand_gen_ptr rgp, complex phaseFac, bool doNorm,
-    bool randomGlobalPhase, bool useHostMem)
-    : QEngine(qBitCount, rgp, doNorm, randomGlobalPhase, true)
+    bool randomGlobalPhase, bool useHostMem, int deviceID, bool useHardwareRNG)
+    : QEngine(qBitCount, rgp, doNorm, randomGlobalPhase, true, useHardwareRNG)
     , stateVec(NULL)
 {
     SetConcurrencyLevel(std::thread::hardware_concurrency());
@@ -67,7 +67,7 @@ QEngineCPU::QEngineCPU(bitLenInt qBitCount, bitCapInt initState, qrack_rand_gen_
 }
 
 QEngineCPU::QEngineCPU(QEngineCPUPtr toCopy)
-    : QEngine(toCopy->qubitCount, toCopy->rand_generator, toCopy->doNormalize, toCopy->randGlobalPhase, true)
+    : QEngine(toCopy->qubitCount, toCopy->rand_generator, toCopy->doNormalize, toCopy->randGlobalPhase, true, toCopy->hardware_rand_generator != NULL)
     , stateVec(NULL)
 {
     SetConcurrencyLevel(std::thread::hardware_concurrency());

--- a/src/qfusion.cpp
+++ b/src/qfusion.cpp
@@ -28,8 +28,8 @@ QFusion::QFusion(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState,
     , bitBuffers(qBitCount)
     , bitControls(qBitCount)
 {
-    qReg =
-        CreateQuantumInterface(eng, qBitCount, initState, rgp, phaseFactor, doNormalize, randGlobalPhase, useHostMem, deviceID, useHardwareRNG);
+    qReg = CreateQuantumInterface(eng, qBitCount, initState, rgp, phaseFactor, doNormalize, randGlobalPhase, useHostMem,
+        deviceID, useHardwareRNG);
 }
 
 QFusion::QFusion(QInterfacePtr target)

--- a/src/qfusion.cpp
+++ b/src/qfusion.cpp
@@ -20,8 +20,8 @@
 namespace Qrack {
 
 QFusion::QFusion(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState, qrack_rand_gen_ptr rgp,
-    complex phaseFac, bool doNorm, bool randomGlobalPhase, bool useHostMem)
-    : QInterface(qBitCount, rgp)
+    complex phaseFac, bool doNorm, bool randomGlobalPhase, bool useHostMem, int deviceID, bool useHardwareRNG)
+    : QInterface(qBitCount, rgp, deviceID, useHardwareRNG)
     , phaseFactor(phaseFac)
     , doNormalize(doNorm)
     , randGlobalPhase(randomGlobalPhase)
@@ -29,7 +29,7 @@ QFusion::QFusion(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState,
     , bitControls(qBitCount)
 {
     qReg =
-        CreateQuantumInterface(eng, qBitCount, initState, rgp, phaseFactor, doNormalize, randGlobalPhase, useHostMem);
+        CreateQuantumInterface(eng, qBitCount, initState, rgp, phaseFactor, doNormalize, randGlobalPhase, useHostMem, deviceID, useHardwareRNG);
 }
 
 QFusion::QFusion(QInterfacePtr target)

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -85,8 +85,8 @@ void QUnit::CopyState(QUnit* orig)
         shard.prob = otherShard.prob;
         shard.isProbDirty = otherShard.isProbDirty;
         if (otherUnits.find(otherShard.unit) == otherUnits.end()) {
-            otherUnits[otherShard.unit] = CreateQuantumInterface(
-                engine, subengine, 1, 0, rand_generator, phaseFactor, doNormalize, useHostRam, devID, useRDRAND);
+            otherUnits[otherShard.unit] = CreateQuantumInterface(engine, subengine, 1, 0, rand_generator, phaseFactor,
+                doNormalize, randGlobalPhase, useHostRam, devID, useRDRAND);
             otherUnits[otherShard.unit]->CopyState(otherShard.unit);
         }
         shard.unit = otherUnits[otherShard.unit];
@@ -97,7 +97,7 @@ void QUnit::CopyState(QUnit* orig)
 void QUnit::CopyState(QInterfacePtr orig)
 {
     QInterfacePtr unit = CreateQuantumInterface(engine, subengine, orig->GetQubitCount(), 0, rand_generator,
-        phaseFactor, doNormalize, useHostRam, devID, useRDRAND);
+        phaseFactor, doNormalize, randGlobalPhase, useHostRam, devID, useRDRAND);
     unit->CopyState(orig);
 
     SetQubitCount(orig->GetQubitCount());
@@ -115,8 +115,8 @@ void QUnit::CopyState(QInterfacePtr orig)
 
 void QUnit::SetQuantumState(complex* inputState)
 {
-    auto unit = CreateQuantumInterface(
-        engine, subengine, qubitCount, 0, rand_generator, phaseFactor, doNormalize, useHostRam, devID, useRDRAND);
+    auto unit = CreateQuantumInterface(engine, subengine, qubitCount, 0, rand_generator, phaseFactor, doNormalize,
+        randGlobalPhase, useHostRam, devID, useRDRAND);
     unit->SetQuantumState(inputState);
 
     int idx = 0;
@@ -587,8 +587,8 @@ bool QUnit::ForceM(bitLenInt qubit, bool res, bool doForce)
         return result;
     }
 
-    QInterfacePtr dest = CreateQuantumInterface(
-        engine, subengine, 1, result ? 1 : 0, rand_generator, phaseFactor, doNormalize, useHostRam, devID, useRDRAND);
+    QInterfacePtr dest = CreateQuantumInterface(engine, subengine, 1, result ? 1 : 0, rand_generator, phaseFactor,
+        doNormalize, randGlobalPhase, useHostRam, devID, useRDRAND);
     unit->Dispose(mapped, 1);
 
     /* Update the mappings. */

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -21,13 +21,15 @@ namespace Qrack {
 
 QUnit::QUnit(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState, qrack_rand_gen_ptr rgp, complex phaseFac,
     bool doNorm, bool randomGlobalPhase, bool useHostMem, int deviceID, bool useHardwareRNG)
-    : QUnit(eng, eng, qBitCount, initState, rgp, phaseFac, doNorm, randomGlobalPhase, useHostMem, deviceID, useHardwareRNG)
+    : QUnit(eng, eng, qBitCount, initState, rgp, phaseFac, doNorm, randomGlobalPhase, useHostMem, deviceID,
+          useHardwareRNG)
 {
     // Intentionally left blank
 }
 
 QUnit::QUnit(QInterfaceEngine eng, QInterfaceEngine subEng, bitLenInt qBitCount, bitCapInt initState,
-    qrack_rand_gen_ptr rgp, complex phaseFac, bool doNorm, bool randomGlobalPhase, bool useHostMem, int deviceID, bool useHardwareRNG)
+    qrack_rand_gen_ptr rgp, complex phaseFac, bool doNorm, bool randomGlobalPhase, bool useHostMem, int deviceID,
+    bool useHardwareRNG)
     : QInterface(qBitCount, rgp, doNorm, useHardwareRNG)
     , engine(eng)
     , subengine(subEng)
@@ -83,8 +85,8 @@ void QUnit::CopyState(QUnit* orig)
         shard.prob = otherShard.prob;
         shard.isProbDirty = otherShard.isProbDirty;
         if (otherUnits.find(otherShard.unit) == otherUnits.end()) {
-            otherUnits[otherShard.unit] =
-                CreateQuantumInterface(engine, subengine, 1, 0, rand_generator, phaseFactor, doNormalize, useHostRam, devID, useRDRAND);
+            otherUnits[otherShard.unit] = CreateQuantumInterface(
+                engine, subengine, 1, 0, rand_generator, phaseFactor, doNormalize, useHostRam, devID, useRDRAND);
             otherUnits[otherShard.unit]->CopyState(otherShard.unit);
         }
         shard.unit = otherUnits[otherShard.unit];
@@ -94,8 +96,8 @@ void QUnit::CopyState(QUnit* orig)
 
 void QUnit::CopyState(QInterfacePtr orig)
 {
-    QInterfacePtr unit = CreateQuantumInterface(
-        engine, subengine, orig->GetQubitCount(), 0, rand_generator, phaseFactor, doNormalize, useHostRam, devID, useRDRAND);
+    QInterfacePtr unit = CreateQuantumInterface(engine, subengine, orig->GetQubitCount(), 0, rand_generator,
+        phaseFactor, doNormalize, useHostRam, devID, useRDRAND);
     unit->CopyState(orig);
 
     SetQubitCount(orig->GetQubitCount());
@@ -113,8 +115,8 @@ void QUnit::CopyState(QInterfacePtr orig)
 
 void QUnit::SetQuantumState(complex* inputState)
 {
-    auto unit =
-        CreateQuantumInterface(engine, subengine, qubitCount, 0, rand_generator, phaseFactor, doNormalize, useHostRam, devID, useRDRAND);
+    auto unit = CreateQuantumInterface(
+        engine, subengine, qubitCount, 0, rand_generator, phaseFactor, doNormalize, useHostRam, devID, useRDRAND);
     unit->SetQuantumState(inputState);
 
     int idx = 0;

--- a/test/accuracy_main.cpp
+++ b/test/accuracy_main.cpp
@@ -27,6 +27,7 @@ enum QInterfaceEngine testSubEngineType = QINTERFACE_CPU;
 enum QInterfaceEngine testSubSubEngineType = QINTERFACE_CPU;
 qrack_rand_gen_ptr rng;
 bool disable_normalization = false;
+bool disable_hardware_rng = false;
 bool async_time = false;
 
 int main(int argc, char* argv[])
@@ -53,7 +54,8 @@ int main(int argc, char* argv[])
         Opt(opencl_single)["--proc-opencl-single"]("Single (parallel) processor OpenCL tests") |
         Opt(disable_normalization)["--disable-normalization"]("Disable state vector normalization. (Usually less "
                                                               "accurate computation. Usually makes QEngine types "
-                                                              "faster and QUnit types slower.)");
+                                                              "faster and QUnit types slower.)") |
+        Opt(disable_hardware_rng)["--disable-hardware-rng"]("Modern Intel chips provide an instruction for hardware random number generation, which this option turns off. (Hardware generation is on by default, if available.)");
 
     session.cli(cli);
 
@@ -70,7 +72,13 @@ int main(int argc, char* argv[])
         return returnCode;
     }
 
-    session.config().stream() << "Random Seed: " << session.configData().rngSeed << std::endl;
+    session.config().stream() << "Random Seed: " << session.configData().rngSeed;
+
+    if (disable_hardware_rng) {
+        session.config().stream() << std::endl;
+    } else {
+        session.config().stream() << " (Overridden by hardware generation!)" << std::endl;
+    }
 
     if (!qengine && !qfusion && !qunit && !qunit_qfusion) {
         qfusion = true;
@@ -184,10 +192,5 @@ QInterfaceTestFixture::QInterfaceTestFixture()
     qrack_rand_gen_ptr rng = std::make_shared<qrack_rand_gen>();
     rng->seed(rngSeed);
 
-    if (disable_normalization) {
-        qftReg = CreateQuantumInterface(
-            testEngineType, testSubEngineType, testSubSubEngineType, 20, 0, rng, complex(ONE_R1, ZERO_R1), false);
-    } else {
-        qftReg = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 20, 0, rng);
-    }
+    qftReg = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 20, 0, rng, complex(ONE_R1, ZERO_R1), !disable_normalization, true, true, -1, !disable_hardware_rng);
 }

--- a/test/accuracy_main.cpp
+++ b/test/accuracy_main.cpp
@@ -55,7 +55,9 @@ int main(int argc, char* argv[])
         Opt(disable_normalization)["--disable-normalization"]("Disable state vector normalization. (Usually less "
                                                               "accurate computation. Usually makes QEngine types "
                                                               "faster and QUnit types slower.)") |
-        Opt(disable_hardware_rng)["--disable-hardware-rng"]("Modern Intel chips provide an instruction for hardware random number generation, which this option turns off. (Hardware generation is on by default, if available.)");
+        Opt(disable_hardware_rng)["--disable-hardware-rng"]("Modern Intel chips provide an instruction for hardware "
+                                                            "random number generation, which this option turns off. "
+                                                            "(Hardware generation is on by default, if available.)");
 
     session.cli(cli);
 
@@ -192,5 +194,6 @@ QInterfaceTestFixture::QInterfaceTestFixture()
     qrack_rand_gen_ptr rng = std::make_shared<qrack_rand_gen>();
     rng->seed(rngSeed);
 
-    qftReg = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 20, 0, rng, complex(ONE_R1, ZERO_R1), !disable_normalization, true, true, -1, !disable_hardware_rng);
+    qftReg = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 20, 0, rng,
+        complex(ONE_R1, ZERO_R1), !disable_normalization, true, true, -1, !disable_hardware_rng);
 }

--- a/test/benchmarks_main.cpp
+++ b/test/benchmarks_main.cpp
@@ -27,6 +27,7 @@ enum QInterfaceEngine testSubEngineType = QINTERFACE_CPU;
 enum QInterfaceEngine testSubSubEngineType = QINTERFACE_CPU;
 qrack_rand_gen_ptr rng;
 bool disable_normalization = false;
+bool disable_hardware_rng = false;
 bool async_time = false;
 
 int main(int argc, char* argv[])
@@ -53,10 +54,8 @@ int main(int argc, char* argv[])
         Opt(opencl_single)["--proc-opencl-single"]("Single (parallel) processor OpenCL tests") |
         Opt(disable_normalization)["--disable-normalization"]("Disable state vector normalization. (Usually less "
                                                               "accurate computation. Usually makes QEngine types "
-                                                              "faster.)") |
-        Opt(async_time)["--async-timing"](
-            "Base benchmarks on how quickly (asynchronous) methods return, rather than how long it takes to directly "
-            "chain tests. (OpenCL code is asynchronous, and CPU code can run while kernels are dispatched to GPU.)");
+                                                              "faster and QUnit types slower.)") |
+        Opt(disable_hardware_rng)["--disable-hardware-rng"]("Modern Intel chips provide an instruction for hardware random number generation, which this option turns off. (Hardware generation is on by default, if available.)");
 
     session.cli(cli);
 
@@ -73,7 +72,13 @@ int main(int argc, char* argv[])
         return returnCode;
     }
 
-    session.config().stream() << "Random Seed: " << session.configData().rngSeed << std::endl;
+    session.config().stream() << "Random Seed: " << session.configData().rngSeed;
+
+    if (disable_hardware_rng) {
+        session.config().stream() << std::endl;
+    } else {
+        session.config().stream() << " (Overridden by hardware generation!)" << std::endl;
+    }
 
     if (!qengine && !qfusion && !qunit && !qunit_qfusion) {
         qfusion = true;
@@ -186,4 +191,6 @@ QInterfaceTestFixture::QInterfaceTestFixture()
 
     qrack_rand_gen_ptr rng = std::make_shared<qrack_rand_gen>();
     rng->seed(rngSeed);
+
+    qftReg = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 20, 0, rng, complex(ONE_R1, ZERO_R1), !disable_normalization, true, true, -1, !disable_hardware_rng);
 }

--- a/test/benchmarks_main.cpp
+++ b/test/benchmarks_main.cpp
@@ -55,7 +55,9 @@ int main(int argc, char* argv[])
         Opt(disable_normalization)["--disable-normalization"]("Disable state vector normalization. (Usually less "
                                                               "accurate computation. Usually makes QEngine types "
                                                               "faster and QUnit types slower.)") |
-        Opt(disable_hardware_rng)["--disable-hardware-rng"]("Modern Intel chips provide an instruction for hardware random number generation, which this option turns off. (Hardware generation is on by default, if available.)");
+        Opt(disable_hardware_rng)["--disable-hardware-rng"]("Modern Intel chips provide an instruction for hardware "
+                                                            "random number generation, which this option turns off. "
+                                                            "(Hardware generation is on by default, if available.)");
 
     session.cli(cli);
 
@@ -192,5 +194,6 @@ QInterfaceTestFixture::QInterfaceTestFixture()
     qrack_rand_gen_ptr rng = std::make_shared<qrack_rand_gen>();
     rng->seed(rngSeed);
 
-    qftReg = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 20, 0, rng, complex(ONE_R1, ZERO_R1), !disable_normalization, true, true, -1, !disable_hardware_rng);
+    qftReg = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 20, 0, rng,
+        complex(ONE_R1, ZERO_R1), !disable_normalization, true, true, -1, !disable_hardware_rng);
 }

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -27,6 +27,7 @@ enum QInterfaceEngine testSubEngineType = QINTERFACE_CPU;
 enum QInterfaceEngine testSubSubEngineType = QINTERFACE_CPU;
 qrack_rand_gen_ptr rng;
 bool disable_normalization = false;
+bool disable_hardware_rng = false;
 bool async_time = false;
 
 int main(int argc, char* argv[])
@@ -53,7 +54,8 @@ int main(int argc, char* argv[])
         Opt(opencl_single)["--proc-opencl-single"]("Single (parallel) processor OpenCL tests") |
         Opt(disable_normalization)["--disable-normalization"]("Disable state vector normalization. (Usually less "
                                                               "accurate computation. Usually makes QEngine types "
-                                                              "faster and QUnit types slower.)");
+                                                              "faster and QUnit types slower.)") |
+        Opt(disable_hardware_rng)["--disable-hardware-rng"]("Modern Intel chips provide an instruction for hardware random number generation, which this option turns off. (Hardware generation is on by default, if available.)");
 
     session.cli(cli);
 
@@ -70,7 +72,13 @@ int main(int argc, char* argv[])
         return returnCode;
     }
 
-    session.config().stream() << "Random Seed: " << session.configData().rngSeed << std::endl;
+    session.config().stream() << "Random Seed: " << session.configData().rngSeed;
+
+    if (disable_hardware_rng) {
+        session.config().stream() << std::endl;
+    } else {
+        session.config().stream() << " (Overridden by hardware generation!)" << std::endl;
+    }
 
     if (!qengine && !qfusion && !qunit && !qunit_qfusion) {
         qfusion = true;
@@ -184,10 +192,5 @@ QInterfaceTestFixture::QInterfaceTestFixture()
     qrack_rand_gen_ptr rng = std::make_shared<qrack_rand_gen>();
     rng->seed(rngSeed);
 
-    if (disable_normalization) {
-        qftReg = CreateQuantumInterface(
-            testEngineType, testSubEngineType, testSubSubEngineType, 20, 0, rng, complex(ONE_R1, ZERO_R1), false);
-    } else {
-        qftReg = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 20, 0, rng);
-    }
+    qftReg = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 20, 0, rng, complex(ONE_R1, ZERO_R1), !disable_normalization, true, true, -1, !disable_hardware_rng);
 }

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -55,7 +55,9 @@ int main(int argc, char* argv[])
         Opt(disable_normalization)["--disable-normalization"]("Disable state vector normalization. (Usually less "
                                                               "accurate computation. Usually makes QEngine types "
                                                               "faster and QUnit types slower.)") |
-        Opt(disable_hardware_rng)["--disable-hardware-rng"]("Modern Intel chips provide an instruction for hardware random number generation, which this option turns off. (Hardware generation is on by default, if available.)");
+        Opt(disable_hardware_rng)["--disable-hardware-rng"]("Modern Intel chips provide an instruction for hardware "
+                                                            "random number generation, which this option turns off. "
+                                                            "(Hardware generation is on by default, if available.)");
 
     session.cli(cli);
 
@@ -192,5 +194,6 @@ QInterfaceTestFixture::QInterfaceTestFixture()
     qrack_rand_gen_ptr rng = std::make_shared<qrack_rand_gen>();
     rng->seed(rngSeed);
 
-    qftReg = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 20, 0, rng, complex(ONE_R1, ZERO_R1), !disable_normalization, true, true, -1, !disable_hardware_rng);
+    qftReg = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 20, 0, rng,
+        complex(ONE_R1, ZERO_R1), !disable_normalization, true, true, -1, !disable_hardware_rng);
 }


### PR DESCRIPTION
Turns out, there's a hardware source of entropy available in relatively recent Intel and AMD chips. This PR gives the option of using the RDRAND instruction, if it's available.

(I cannot promise anything at all, as far as the quality or nature of this generator. However, I read some background on it, including a Stack Overflow answer from someone claiming to be one of the original developers, and the generator _might_ be semi-quantum random in nature. There's a base hardware entropy generator which could reasonably be quantum in nature. If the throughput demanded from the RDRAND instruction is too high, it uses the base hardware entropy source to seed a "cryptographically secure" pseudo-random-generator. Alternatively, for low rates of generation demand, the base entropy source is used directly.)