### PR TITLE
Adding uniformly controlled gates to Hamiltonian simulation

### DIFF
--- a/include/hamiltonian.hpp
+++ b/include/hamiltonian.hpp
@@ -29,6 +29,7 @@ struct HamiltonianOp {
     bitLenInt controlLen;
     bool anti;
     bool* toggles;
+    bool uniform;
 
     HamiltonianOp(bitLenInt target, BitOp mtrx)
         : targetBit(target)
@@ -37,6 +38,7 @@ struct HamiltonianOp {
         , controlLen(0)
         , anti(false)
         , toggles(NULL)
+        , uniform(false)
     {
     }
 
@@ -48,6 +50,7 @@ struct HamiltonianOp {
         , controlLen(ctrlLen)
         , anti(antiCtrled)
         , toggles(NULL)
+        , uniform(false)
     {
         std::copy(ctrls, ctrls + ctrlLen, controls);
 
@@ -66,6 +69,16 @@ struct HamiltonianOp {
         if (toggles) {
             delete[] toggles;
         }
+    }
+};
+
+struct UniformHamiltonianOp : HamiltonianOp {
+    UniformHamiltonianOp(bitLenInt* ctrls, bitLenInt ctrlLen, bitLenInt target, BitOp mtrx)
+        : HamiltonianOp(ctrls, ctrlLen, target, mtrx)
+    {
+        std::copy(ctrls, ctrls + ctrlLen, controls);
+
+        uniform = true;
     }
 };
 

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -2786,6 +2786,37 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_timeevolve")
     REQUIRE_FLOAT(abs((ONE_R1 - qftReg->Prob(0)) - cos(aParam * tDiff) * cos(aParam * tDiff)), 0);
 }
 
+TEST_CASE_METHOD(QInterfaceTestFixture, "test_timeevolve_uniform")
+{
+    real1 aParam = (real1)1e-4;
+    real1 tDiff = 2.1f;
+    real1 e0 = sqrt(ONE_R1 - aParam * aParam);
+
+    BitOp o2neg1(new complex[8], std::default_delete<complex[]>());
+    o2neg1.get()[0] = complex(ONE_R1, ZERO_R1);
+    o2neg1.get()[1] = complex(ZERO_R1, ZERO_R1);
+    o2neg1.get()[2] = complex(ZERO_R1, ZERO_R1);
+    o2neg1.get()[3] = complex(ONE_R1, ZERO_R1);
+    o2neg1.get()[4] = complex(e0, ZERO_R1);
+    o2neg1.get()[5] = complex(-aParam, ZERO_R1);
+    o2neg1.get()[6] = complex(-aParam, ZERO_R1);
+    o2neg1.get()[7] = complex(e0, ZERO_R1);
+
+    bitLenInt controls[1] = { 1 };
+
+    HamiltonianOpPtr h0 = std::make_shared<UniformHamiltonianOp>(controls, 1, 0, o2neg1);
+    Hamiltonian h(1);
+    h[0] = h0;
+
+    REQUIRE(h0->uniform);
+
+    qftReg->SetPermutation(2);
+    qftReg->TimeEvolve(h, tDiff);
+
+    REQUIRE_FLOAT(abs(qftReg->Prob(0) - sin(aParam * tDiff) * sin(aParam * tDiff)), 0);
+    REQUIRE_FLOAT(abs((ONE_R1 - qftReg->Prob(0)) - cos(aParam * tDiff) * cos(aParam * tDiff)), 0);
+}
+
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_qfusion_controlled")
 {
     bitLenInt controls[2] = { 1, 2 };


### PR DESCRIPTION
One of the fastest, simplest, and most direct ways to specify an interacting Hamiltonian should be via "uniformly controlled gates." This does use somewhat more memory, though. Having the option to specify a Hamiltonian (component) this way could greatly reduce demand on the labor of users writing quantum time evolution simulations.