### PR TITLE
Change SetQuantumState() parameter to const

### DIFF
--- a/include/qengine_cpu.hpp
+++ b/include/qengine_cpu.hpp
@@ -43,7 +43,7 @@ public:
     QEngineCPU(QEngineCPUPtr toCopy);
     ~QEngineCPU() { FreeStateVec(); }
 
-    virtual void SetQuantumState(complex* inputState);
+    virtual void SetQuantumState(const complex* inputState);
     virtual void GetQuantumState(complex* outputState);
     complex GetAmplitude(bitCapInt perm);
 

--- a/include/qengine_opencl.hpp
+++ b/include/qengine_opencl.hpp
@@ -182,7 +182,7 @@ public:
     virtual void SetDevice(const int& dID, const bool& forceReInit = false);
     virtual int GetDeviceID() { return deviceID; }
 
-    virtual void SetQuantumState(complex* inputState);
+    virtual void SetQuantumState(const complex* inputState);
     virtual void GetQuantumState(complex* outputState);
     complex GetAmplitude(bitCapInt perm);
 

--- a/include/qfusion.hpp
+++ b/include/qfusion.hpp
@@ -51,7 +51,7 @@ public:
         bool useHostMem = false, int deviceID = -1, bool useHardwareRNG = true);
     QFusion(QInterfacePtr target);
 
-    virtual void SetQuantumState(complex* inputState);
+    virtual void SetQuantumState(const complex* inputState);
     virtual void GetQuantumState(complex* outputState);
     virtual complex GetAmplitude(bitCapInt perm);
     virtual void SetPermutation(bitCapInt perm, complex phaseFac = complex(-999.0, -999.0));

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -184,7 +184,7 @@ public:
      *
      * \warning PSEUDO-QUANTUM
      */
-    virtual void SetQuantumState(complex* inputState) = 0;
+    virtual void SetQuantumState(const complex* inputState) = 0;
 
     /** Get the pure quantum state representation
      *

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -58,7 +58,7 @@ public:
         complex phaseFac = complex(-999.0, -999.0), bool doNorm = true, bool randomGlobalPhase = true,
         bool useHostMem = true, int deviceId = -1, bool useHardwareRNG = true);
 
-    virtual void SetQuantumState(complex* inputState);
+    virtual void SetQuantumState(const complex* inputState);
     virtual void GetQuantumState(complex* outputState);
     virtual complex GetAmplitude(bitCapInt perm);
     virtual void SetPermutation(bitCapInt perm, complex phaseFac = complex(-999.0, -999.0));

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -1793,7 +1793,7 @@ void QEngineOCL::PhaseFlipIfLess(bitCapInt greaterPerm, bitLenInt start, bitLenI
 }
 
 /// Set arbitrary pure quantum state, in unsigned int permutation basis
-void QEngineOCL::SetQuantumState(complex* inputState)
+void QEngineOCL::SetQuantumState(const complex* inputState)
 {
     LockSync(CL_MAP_WRITE);
     std::copy(inputState, inputState + maxQPower, stateVec);

--- a/src/qengine/state.cpp
+++ b/src/qengine/state.cpp
@@ -124,7 +124,7 @@ void QEngineCPU::ResetStateVec(complex* nStateVec)
 }
 
 /// Set arbitrary pure quantum state, in unsigned int permutation basis
-void QEngineCPU::SetQuantumState(complex* inputState)
+void QEngineCPU::SetQuantumState(const complex* inputState)
 {
     std::copy(inputState, inputState + maxQPower, stateVec);
     runningNorm = ONE_R1;

--- a/src/qfusion.cpp
+++ b/src/qfusion.cpp
@@ -348,7 +348,7 @@ void QFusion::PhaseFlip()
 }
 
 // Every other operation just wraps the QEngine with the appropriate buffer flushes.
-void QFusion::SetQuantumState(complex* inputState)
+void QFusion::SetQuantumState(const complex* inputState)
 {
     DiscardAll();
     qReg->SetQuantumState(inputState);

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -113,7 +113,7 @@ void QUnit::CopyState(QInterfacePtr orig)
     }
 }
 
-void QUnit::SetQuantumState(complex* inputState)
+void QUnit::SetQuantumState(const complex* inputState)
 {
     auto unit = CreateQuantumInterface(engine, subengine, qubitCount, 0, rand_generator, phaseFactor, doNormalize,
         randGlobalPhase, useHostRam, devID, useRDRAND);


### PR DESCRIPTION
For a change in the ProjectQ integration, the parameter of SetQuantumState() should be const. (It is already treated as such within the method bodies.)