### PR TITLE
QUnit permutation probability optimization

### DIFF
--- a/include/qengine.hpp
+++ b/include/qengine.hpp
@@ -93,6 +93,8 @@ public:
     virtual void ProbMaskAll(const bitCapInt& mask, real1* probsArray);
 
 protected:
+    virtual bool IsIdentity(const complex* mtrx);
+
     virtual void Apply2x2(bitCapInt offset1, bitCapInt offset2, const complex* mtrx, const bitLenInt bitCount,
         const bitCapInt* qPowersSorted, bool doCalcNorm) = 0;
     virtual void ApplyControlled2x2(const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& target,

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -369,6 +369,61 @@ public:
         const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& target, const complex* mtrx) = 0;
 
     /**
+     * Apply a single bit transformation that only effects phase.
+     *
+     * If float rounding from the application of the matrix might change the state vector norm, "doCalcNorm" should be
+     * set to true.
+     */
+    virtual void ApplySinglePhase(
+        const complex topLeft, const complex bottomRight, bool doCalcNorm, bitLenInt qubitIndex);
+
+    /**
+     * Apply a single bit transformation that reverses bit probability and might effect phase.
+     *
+     * If float rounding from the application of the matrix might change the state vector norm, "doCalcNorm" should be
+     * set to true.
+     */
+    virtual void ApplySingleInvert(
+        const complex topRight, const complex bottomLeft, bool doCalcNorm, bitLenInt qubitIndex);
+
+    /**
+     * Apply a single bit transformation that only effects phase, with arbitrary control bits.
+     *
+     * If float rounding from the application of the matrix might change the state vector norm, "doCalcNorm" should be
+     * set to true.
+     */
+    virtual void ApplyControlledSinglePhase(const bitLenInt* controls, const bitLenInt& controlLen,
+        const bitLenInt& target, const complex topLeft, const complex bottomRight);
+
+    /**
+     * Apply a single bit transformation that reverses bit probability and might effect phase, with arbitrary control
+     * bits.
+     *
+     * If float rounding from the application of the matrix might change the state vector norm, "doCalcNorm" should be
+     * set to true.
+     */
+    virtual void ApplyControlledSingleInvert(const bitLenInt* controls, const bitLenInt& controlLen,
+        const bitLenInt& target, const complex topRight, const complex bottomLeft);
+
+    /**
+     * Apply a single bit transformation that only effects phase, with arbitrary (anti-)control bits.
+     *
+     * If float rounding from the application of the matrix might change the state vector norm, "doCalcNorm" should be
+     * set to true.
+     */
+    virtual void ApplyAntiControlledSinglePhase(const bitLenInt* controls, const bitLenInt& controlLen,
+        const bitLenInt& target, const complex topLeft, const complex bottomRight);
+
+    /**
+     * Apply a single bit transformation that reverses bit probability and might effect phase, with arbitrary
+     * (anti-)control bits.
+     *
+     * If float rounding from the application of the matrix might change the state vector norm, "doCalcNorm" should be
+     * set to true.
+     */
+    virtual void ApplyAntiControlledSingleInvert(const bitLenInt* controls, const bitLenInt& controlLen,
+        const bitLenInt& target, const complex topRight, const complex bottomLeft);
+    /**
      * Apply a "uniformly controlled" arbitrary single bit unitary transformation. (See
      * https://arxiv.org/abs/quant-ph/0312218)
      *

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -84,34 +84,18 @@ public:
      *@{
      */
 
-    using QInterface::X;
-    virtual void X(bitLenInt target);
-    using QInterface::Y;
-    virtual void Y(bitLenInt target);
-    using QInterface::Z;
-    virtual void Z(bitLenInt target);
-    using QInterface::CNOT;
-    virtual void CNOT(bitLenInt control, bitLenInt target);
-    using QInterface::AntiCNOT;
-    virtual void AntiCNOT(bitLenInt control, bitLenInt target);
-    using QInterface::CCNOT;
-    virtual void CCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target);
-    using QInterface::AntiCCNOT;
-    virtual void AntiCCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target);
-    using QInterface::CY;
-    virtual void CY(bitLenInt control, bitLenInt target);
-    using QInterface::CZ;
-    virtual void CZ(bitLenInt control, bitLenInt target);
-
-    using QInterface::RT;
-    virtual void RT(real1 radians, bitLenInt target);
-    using QInterface::RZ;
-    virtual void RZ(real1 radians, bitLenInt target);
-    using QInterface::CRT;
-    virtual void CRT(real1 radians, bitLenInt control, bitLenInt target);
-    using QInterface::CRZ;
-    virtual void CRZ(real1 radians, bitLenInt control, bitLenInt target);
-
+    virtual void ApplySinglePhase(
+        const complex topLeft, const complex bottomRight, bool doCalcNorm, bitLenInt qubitIndex);
+    virtual void ApplySingleInvert(
+        const complex topRight, const complex bottomLeft, bool doCalcNorm, bitLenInt qubitIndex);
+    virtual void ApplyControlledSinglePhase(const bitLenInt* controls, const bitLenInt& controlLen,
+        const bitLenInt& target, const complex topLeft, const complex bottomRight);
+    virtual void ApplyControlledSingleInvert(const bitLenInt* controls, const bitLenInt& controlLen,
+        const bitLenInt& target, const complex topRight, const complex bottomLeft);
+    virtual void ApplyAntiControlledSinglePhase(const bitLenInt* controls, const bitLenInt& controlLen,
+        const bitLenInt& target, const complex topLeft, const complex bottomRight);
+    virtual void ApplyAntiControlledSingleInvert(const bitLenInt* controls, const bitLenInt& controlLen,
+        const bitLenInt& target, const complex topRight, const complex bottomLeft);
     virtual void ApplySingleBit(const complex* mtrx, bool doCalcNorm, bitLenInt qubit);
     virtual void ApplyControlledSingleBit(
         const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& target, const complex* mtrx);

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -105,6 +105,12 @@ public:
 
     using QInterface::RT;
     virtual void RT(real1 radians, bitLenInt target);
+    using QInterface::RZ;
+    virtual void RZ(real1 radians, bitLenInt target);
+    using QInterface::CRT;
+    virtual void CRT(real1 radians, bitLenInt control, bitLenInt target);
+    using QInterface::CRZ;
+    virtual void CRZ(real1 radians, bitLenInt control, bitLenInt target);
 
     virtual void ApplySingleBit(const complex* mtrx, bool doCalcNorm, bitLenInt qubit);
     virtual void ApplyControlledSingleBit(

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -84,6 +84,21 @@ public:
      *@{
      */
 
+    using QInterface::X;
+    virtual void X(bitLenInt target);
+    using QInterface::Z;
+    virtual void Z(bitLenInt target);
+    using QInterface::CNOT;
+    virtual void CNOT(bitLenInt control, bitLenInt target);
+    using QInterface::AntiCNOT;
+    virtual void AntiCNOT(bitLenInt control, bitLenInt target);
+    using QInterface::CCNOT;
+    virtual void CCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target);
+    using QInterface::AntiCCNOT;
+    virtual void AntiCCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target);
+    using QInterface::CZ;
+    virtual void CZ(bitLenInt control, bitLenInt target);
+
     virtual void ApplySinglePhase(
         const complex topLeft, const complex bottomRight, bool doCalcNorm, bitLenInt qubitIndex);
     virtual void ApplySingleInvert(

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -86,8 +86,26 @@ public:
 
     using QInterface::X;
     virtual void X(bitLenInt target);
+    using QInterface::Y;
+    virtual void Y(bitLenInt target);
     using QInterface::Z;
     virtual void Z(bitLenInt target);
+    using QInterface::CNOT;
+    virtual void CNOT(bitLenInt control, bitLenInt target);
+    using QInterface::AntiCNOT;
+    virtual void AntiCNOT(bitLenInt control, bitLenInt target);
+    using QInterface::CCNOT;
+    virtual void CCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target);
+    using QInterface::AntiCCNOT;
+    virtual void AntiCCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target);
+    using QInterface::CY;
+    virtual void CY(bitLenInt control, bitLenInt target);
+    using QInterface::CZ;
+    virtual void CZ(bitLenInt control, bitLenInt target);
+
+    using QInterface::RT;
+    virtual void RT(real1 radians, bitLenInt target);
+
     virtual void ApplySingleBit(const complex* mtrx, bool doCalcNorm, bitLenInt qubit);
     virtual void ApplyControlledSingleBit(
         const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& target, const complex* mtrx);

--- a/src/qengine/gates.cpp
+++ b/src/qengine/gates.cpp
@@ -218,7 +218,11 @@ void QEngineCPU::Swap(bitLenInt start1, bitLenInt start2, bitLenInt length)
 /// Phase flip always - equivalent to Z X Z X on any bit in the QEngineCPU
 void QEngineCPU::PhaseFlip()
 {
-    par_for(0, maxQPower, [&](const bitCapInt lcv, const int cpu) { stateVec[lcv] = -stateVec[lcv]; });
+    // This gate has no physical consequence. We only enable it for "book-keeping," if the engine is not using global
+    // phase offsets.
+    if (!randGlobalPhase) {
+        par_for(0, maxQPower, [&](const bitCapInt lcv, const int cpu) { stateVec[lcv] = -stateVec[lcv]; });
+    }
 }
 
 } // namespace Qrack

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -1861,9 +1861,12 @@ void QEngineOCL::PhaseFlipX(OCLAPI api_call, bitCapInt* bciArgs)
 
 void QEngineOCL::PhaseFlip()
 {
-    bitCapInt bciArgs[BCI_ARG_LEN] = { maxQPower, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
-
-    PhaseFlipX(OCL_API_PHASEFLIP, bciArgs);
+    // This gate has no physical consequence. We only enable it for "book-keeping," if the engine is not using global
+    // phase offsets.
+    if (!randGlobalPhase) {
+        bitCapInt bciArgs[BCI_ARG_LEN] = { maxQPower, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+        PhaseFlipX(OCL_API_PHASEFLIP, bciArgs);
+    }
 }
 
 /// For chips with a zero flag, flip the phase of the state where the register equals zero.

--- a/src/qengine/qengine.cpp
+++ b/src/qengine/qengine.cpp
@@ -161,11 +161,7 @@ bool QEngine::IsIdentity(const complex* mtrx)
         if (toTest < (ONE_R1 - min_norm)) {
             return false;
         }
-        toTest = abs(real(mtrx[0]) - real(mtrx[3]));
-        if (toTest > min_norm) {
-            return false;
-        }
-        toTest = abs(imag(mtrx[0]) - imag(mtrx[3]));
+        toTest = norm(mtrx[0] - mtrx[3]);
         if (toTest > min_norm) {
             return false;
         }

--- a/src/qengine/qengine.cpp
+++ b/src/qengine/qengine.cpp
@@ -145,23 +145,41 @@ bitCapInt QEngine::ForceM(const bitLenInt* bits, const bitLenInt& length, const 
 
 bool QEngine::IsIdentity(const complex* mtrx)
 {
-    // If the effect of applying the buffer would be (approximately or exactly) that of applying the identity operator,
-    // then we can discard this buffer without applying it.
-    complex toTest = mtrx[0];
-    if ((real(toTest) < (ONE_R1 - min_norm)) || (imag(toTest) > min_norm)) {
+    // If the effect of applying the buffer would be (approximately or exactly) that of applying the identity
+    // operator, then we can discard this buffer without applying it.
+    if ((real(mtrx[1]) > min_norm) || (imag(mtrx[1]) > min_norm)) {
         return false;
     }
-    toTest = mtrx[1];
-    if ((real(toTest) > min_norm) || (imag(toTest) > min_norm)) {
+    if ((real(mtrx[2]) > min_norm) || (imag(mtrx[2]) > min_norm)) {
         return false;
     }
-    toTest = mtrx[2];
-    if ((real(toTest) > min_norm) || (imag(toTest) > min_norm)) {
-        return false;
-    }
-    toTest = mtrx[3];
-    if ((real(toTest) < (ONE_R1 - min_norm)) || (imag(toTest) > min_norm)) {
-        return false;
+
+    if (randGlobalPhase) {
+        // If the global phase offset has been randomized, we assume that global phase offsets are inconsequential, for
+        // the user's purposes.
+        real1 toTest = norm(mtrx[0]);
+        if (toTest < (ONE_R1 - min_norm)) {
+            return false;
+        }
+        toTest = abs(real(mtrx[0]) - real(mtrx[3]));
+        if (toTest > min_norm) {
+            return false;
+        }
+        toTest = abs(imag(mtrx[0]) - imag(mtrx[3]));
+        if (toTest > min_norm) {
+            return false;
+        }
+    } else {
+        // If the global phase offset has not been randomized, user code might explicitly depend on the global phase
+        // offset (but shouldn't).
+        complex toTest = mtrx[0];
+        if ((real(toTest) < (ONE_R1 - min_norm)) || (imag(toTest) > min_norm)) {
+            return false;
+        }
+        toTest = mtrx[3];
+        if ((real(toTest) < (ONE_R1 - min_norm)) || (imag(toTest) > min_norm)) {
+            return false;
+        }
     }
 
     // If we haven't returned false by now, we're buffering (approximately or exactly) an identity operator.

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -832,6 +832,28 @@ void QUnit::CZ(bitLenInt control, bitLenInt target)
 
 void QUnit::RT(real1 radians, bitLenInt target) { shards[target].unit->RT(radians, shards[target].mapped); }
 
+void QUnit::CRT(real1 radians, bitLenInt control, bitLenInt target)
+{
+    bitLenInt controls[1] = { control };
+    ApplyEitherControlled(controls, 1, { target }, false,
+        [&](QInterfacePtr unit, std::vector<bitLenInt> mappedControls) {
+            unit->CRT(radians, mappedControls[0], shards[target].mapped);
+        },
+        [&]() { RT(radians, target); });
+}
+
+void QUnit::RZ(real1 radians, bitLenInt target) { shards[target].unit->RZ(radians, shards[target].mapped); }
+
+void QUnit::CRZ(real1 radians, bitLenInt control, bitLenInt target)
+{
+    bitLenInt controls[1] = { control };
+    ApplyEitherControlled(controls, 1, { target }, false,
+        [&](QInterfacePtr unit, std::vector<bitLenInt> mappedControls) {
+            unit->CRZ(radians, mappedControls[0], shards[target].mapped);
+        },
+        [&]() { RZ(radians, target); });
+}
+
 void QUnit::ApplySingleBit(const complex* mtrx, bool doCalcNorm, bitLenInt qubit)
 {
     shards[qubit].isProbDirty = true;

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -756,13 +756,81 @@ void QUnit::UniformlyControlledSingleBit(
     delete[] mappedControls;
 }
 
-void QUnit::X(bitLenInt qubit)
+void QUnit::X(bitLenInt target)
 {
-    shards[qubit].prob = ONE_R1 - shards[qubit].prob;
-    shards[qubit].unit->X(shards[qubit].mapped);
+    shards[target].prob = ONE_R1 - shards[target].prob;
+    shards[target].unit->X(shards[target].mapped);
 }
 
-void QUnit::Z(bitLenInt qubit) { shards[qubit].unit->Z(shards[qubit].mapped); }
+void QUnit::Y(bitLenInt target)
+{
+    shards[target].prob = ONE_R1 - shards[target].prob;
+    shards[target].unit->Y(shards[target].mapped);
+}
+
+void QUnit::Z(bitLenInt target) { shards[target].unit->Z(shards[target].mapped); }
+
+void QUnit::CNOT(bitLenInt control, bitLenInt target)
+{
+    bitLenInt controls[1] = { control };
+    ApplyEitherControlled(controls, 1, { target }, false,
+        [&](QInterfacePtr unit, std::vector<bitLenInt> mappedControls) {
+            unit->CNOT(mappedControls[0], shards[target].mapped);
+        },
+        [&]() { X(target); });
+}
+
+void QUnit::AntiCNOT(bitLenInt control, bitLenInt target)
+{
+    bitLenInt controls[1] = { control };
+    ApplyEitherControlled(controls, 1, { target }, true,
+        [&](QInterfacePtr unit, std::vector<bitLenInt> mappedControls) {
+            unit->AntiCNOT(mappedControls[0], shards[target].mapped);
+        },
+        [&]() { X(target); });
+}
+
+void QUnit::CCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target)
+{
+    bitLenInt controls[2] = { control1, control2 };
+    ApplyEitherControlled(controls, 2, { target }, false,
+        [&](QInterfacePtr unit, std::vector<bitLenInt> mappedControls) {
+            unit->CCNOT(mappedControls[0], mappedControls[1], shards[target].mapped);
+        },
+        [&]() { X(target); });
+}
+
+void QUnit::AntiCCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target)
+{
+    bitLenInt controls[2] = { control1, control2 };
+    ApplyEitherControlled(controls, 2, { target }, true,
+        [&](QInterfacePtr unit, std::vector<bitLenInt> mappedControls) {
+            unit->AntiCCNOT(mappedControls[0], mappedControls[1], shards[target].mapped);
+        },
+        [&]() { X(target); });
+}
+
+void QUnit::CY(bitLenInt control, bitLenInt target)
+{
+    bitLenInt controls[1] = { control };
+    ApplyEitherControlled(controls, 1, { target }, false,
+        [&](QInterfacePtr unit, std::vector<bitLenInt> mappedControls) {
+            unit->CY(mappedControls[0], shards[target].mapped);
+        },
+        [&]() { Y(target); });
+}
+
+void QUnit::CZ(bitLenInt control, bitLenInt target)
+{
+    bitLenInt controls[1] = { control };
+    ApplyEitherControlled(controls, 1, { target }, false,
+        [&](QInterfacePtr unit, std::vector<bitLenInt> mappedControls) {
+            unit->CZ(mappedControls[0], shards[target].mapped);
+        },
+        [&]() { Z(target); });
+}
+
+void QUnit::RT(real1 radians, bitLenInt target) { shards[target].unit->RT(radians, shards[target].mapped); }
 
 void QUnit::ApplySingleBit(const complex* mtrx, bool doCalcNorm, bitLenInt qubit)
 {

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -756,6 +756,64 @@ void QUnit::UniformlyControlledSingleBit(
     delete[] mappedControls;
 }
 
+void QUnit::X(bitLenInt target)
+{
+    shards[target].prob = ONE_R1 - shards[target].prob;
+    shards[target].unit->X(shards[target].mapped);
+}
+
+void QUnit::Z(bitLenInt target) { shards[target].unit->Z(shards[target].mapped); }
+
+void QUnit::CNOT(bitLenInt control, bitLenInt target)
+{
+    bitLenInt controls[1] = { control };
+    ApplyEitherControlled(controls, 1, { target }, false,
+        [&](QInterfacePtr unit, std::vector<bitLenInt> mappedControls) {
+            unit->CNOT(mappedControls[0], shards[target].mapped);
+        },
+        [&]() { X(target); });
+}
+
+void QUnit::AntiCNOT(bitLenInt control, bitLenInt target)
+{
+    bitLenInt controls[1] = { control };
+    ApplyEitherControlled(controls, 1, { target }, true,
+        [&](QInterfacePtr unit, std::vector<bitLenInt> mappedControls) {
+            unit->AntiCNOT(mappedControls[0], shards[target].mapped);
+        },
+        [&]() { X(target); });
+}
+
+void QUnit::CCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target)
+{
+    bitLenInt controls[2] = { control1, control2 };
+    ApplyEitherControlled(controls, 2, { target }, false,
+        [&](QInterfacePtr unit, std::vector<bitLenInt> mappedControls) {
+            unit->CCNOT(mappedControls[0], mappedControls[1], shards[target].mapped);
+        },
+        [&]() { X(target); });
+}
+
+void QUnit::AntiCCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target)
+{
+    bitLenInt controls[2] = { control1, control2 };
+    ApplyEitherControlled(controls, 2, { target }, true,
+        [&](QInterfacePtr unit, std::vector<bitLenInt> mappedControls) {
+            unit->AntiCCNOT(mappedControls[0], mappedControls[1], shards[target].mapped);
+        },
+        [&]() { X(target); });
+}
+
+void QUnit::CZ(bitLenInt control, bitLenInt target)
+{
+    bitLenInt controls[1] = { control };
+    ApplyEitherControlled(controls, 1, { target }, false,
+        [&](QInterfacePtr unit, std::vector<bitLenInt> mappedControls) {
+            unit->CZ(mappedControls[0], shards[target].mapped);
+        },
+        [&]() { Z(target); });
+}
+
 void QUnit::ApplySinglePhase(const complex topLeft, const complex bottomRight, bool doCalcNorm, bitLenInt target)
 {
     shards[target].unit->ApplySinglePhase(topLeft, bottomRight, doCalcNorm, shards[target].mapped);

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -32,7 +32,7 @@ using namespace Qrack;
         REQUIRE(__tmp_b > (__tmp_b - EPSILON));                                                                        \
     } while (0);
 
-const bitLenInt MaxQubits = 28;
+const bitLenInt MaxQubits = 24;
 
 const double clockFactor = 1000.0 / CLOCKS_PER_SEC; // Report in ms
 
@@ -140,7 +140,7 @@ void benchmarkLoop(
 {
     benchmarkLoopVariable(fn, MaxQubits, resetRandomPerm, hadamardRandomBits);
 }
-#if 0
+
 TEST_CASE("test_cnot_single")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->CNOT(0, 1); });
@@ -393,7 +393,7 @@ TEST_CASE("test_qft_permutation_round_trip_separated")
         },
         true, false);
 }
-#endif
+
 TEST_CASE("test_qft_superposition_round_trip")
 {
     benchmarkLoop(

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -32,7 +32,7 @@ using namespace Qrack;
         REQUIRE(__tmp_b > (__tmp_b - EPSILON));                                                                        \
     } while (0);
 
-const bitLenInt MaxQubits = 24;
+const bitLenInt MaxQubits = 28;
 
 const double clockFactor = 1000.0 / CLOCKS_PER_SEC; // Report in ms
 
@@ -140,7 +140,7 @@ void benchmarkLoop(
 {
     benchmarkLoopVariable(fn, MaxQubits, resetRandomPerm, hadamardRandomBits);
 }
-
+#if 0
 TEST_CASE("test_cnot_single")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->CNOT(0, 1); });
@@ -393,7 +393,7 @@ TEST_CASE("test_qft_permutation_round_trip_separated")
         },
         true, false);
 }
-
+#endif
 TEST_CASE("test_qft_superposition_round_trip")
 {
     benchmarkLoop(


### PR DESCRIPTION
The "isProbDirty"-related optimization of QUnit can be carried further. Many common quantum gates will transform the permutation basis probability in a simple predictable way, such that it is not necessary to "dirty" the bits affected. This avoids costly permutation probability checks, by preserving the cache under classical transformations.

We seem to already have an improvement on the QFT, from this. I'll carry this type of optimization as far as I reasonably can, before I mark this PR ready for review.