### PR TITLE
Coverage

### DIFF
--- a/cmake/Coverage.cmake
+++ b/cmake/Coverage.cmake
@@ -22,8 +22,8 @@ if ( ENABLE_CODECOVERAGE )
         set( CMAKE_EXE_LINKER_FLAGS ${CMAKE_EXE_LINKER_FLAGS} --coverage )
 
         # Use 'make coverage' to build coverage report after running a test
-        add_custom_target( coverage_init ALL ${CODECOV_LCOV} --base-directory .  --directory ${CMAKE_BINARY_DIR} --output-file ${CODECOV_OUTPUTFILE} --capture --initial )
-        add_custom_target( coverage ${CODECOV_LCOV} --base-directory .  --directory ${CMAKE_BINARY_DIR} --output-file ${CODECOV_OUTPUTFILE} --capture COMMAND genhtml -o ${CODECOV_HTMLOUTPUTDIR} ${CODECOV_OUTPUTFILE} )
+        add_custom_target( coverage_init ALL ${CODECOV_LCOV} --base-directory .  --directory ${CMAKE_SOURCE_DIR} --no-external --output-file ${CODECOV_OUTPUTFILE} --capture --initial )
+        add_custom_target( coverage ${CODECOV_LCOV} --base-directory .  --directory ${CMAKE_SOURCE_DIR} --no-external --output-file ${CODECOV_OUTPUTFILE} --capture COMMAND ${CODECOV_LCOV} --remove ${CODECOV_OUTPUTFILE} '${CMAKE_SOURCE_DIR}/test/*' -o ${CODECOV_OUTPUTFILE} COMMAND genhtml -o ${CODECOV_HTMLOUTPUTDIR} ${CODECOV_OUTPUTFILE} )
     endif ( CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_GNUCXX )
 
 else ( ENABLE_CODECOVERAGE )

--- a/examples/ordered_list_search.cpp
+++ b/examples/ordered_list_search.cpp
@@ -52,7 +52,7 @@ int main()
     bool foundPerm = false;
 
     // We align our "classical" cache to 64 bit boundaries, for optimal OpenCL performance.
-    unsigned char* toLoad = qrack_alloc(1 << indexLength);
+    unsigned char* toLoad = cl_alloc(1 << indexLength);
 
     // We fill the example ordered list with dummy values. Up to the target index in the list, we fill (ordered) values
     // lower than the key:
@@ -232,7 +232,7 @@ int main()
         // returned. This could be done by only requiring a match to the value register, but we want to show here that
         // the index is correct.)
     }
-    free(toLoad);
+    cl_free(toLoad);
 
     std::cout << "Full index/value pair:";
     bitCapInt endState = qReg->MReg(0, 20);

--- a/include/qengine.hpp
+++ b/include/qengine.hpp
@@ -31,8 +31,6 @@ protected:
     /// summed, at each update. To normalize, we should always multiply by 1/sqrt(runningNorm).
     real1 runningNorm;
 
-    virtual void NormalizeState(real1 nrm = -999.0) = 0;
-
     complex GetNonunitaryPhase()
     {
         if (randGlobalPhase) {
@@ -91,6 +89,8 @@ public:
     virtual void ProbRegAll(const bitLenInt& start, const bitLenInt& length, real1* probsArray);
     virtual real1 ProbMask(const bitCapInt& mask, const bitCapInt& permutation) = 0;
     virtual void ProbMaskAll(const bitCapInt& mask, real1* probsArray);
+
+    virtual void NormalizeState(real1 nrm = -999.0) = 0;
 
 protected:
     virtual bool IsIdentity(const complex* mtrx);

--- a/include/qfusion.hpp
+++ b/include/qfusion.hpp
@@ -166,6 +166,7 @@ public:
     }
 
     virtual void UpdateRunningNorm();
+    virtual void NormalizeState(real1 nrm = -999.0);
     virtual void Finish()
     {
         FlushAll();

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -28,7 +28,8 @@
 namespace Qrack {
 
 // These are utility functions defined in qinterface/protected.cpp:
-unsigned char* qrack_alloc(size_t ucharCount);
+unsigned char* cl_alloc(size_t ucharCount);
+void cl_free(void* toFree);
 void mul2x2(complex* left, complex* right, complex* out);
 void exp2x2(complex* matrix2x2, complex* outMatrix2x2);
 void log2x2(complex* matrix2x2, complex* outMatrix2x2);
@@ -758,14 +759,6 @@ public:
      * Applies \f$ e^{-i*Op} \f$, where "Op" is a 2x2 matrix, (with controls on the application of the gate).
      */
     virtual void Exp(
-        bitLenInt* controls, bitLenInt controlLen, bitLenInt qubit, complex* matrix2x2, bool antiCtrled = false);
-
-    /**
-     *  Logarithm of arbitrary 2x2 gate
-     *
-     * Applies \f$ log(Op) \f$, where "Op" is a 2x2 matrix, (with controls on the application of the gate).
-     */
-    virtual void Log(
         bitLenInt* controls, bitLenInt controlLen, bitLenInt qubit, complex* matrix2x2, bool antiCtrled = false);
 
     /**

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -1585,6 +1585,15 @@ public:
     virtual void UpdateRunningNorm() = 0;
 
     /**
+     * Apply the normalization factor found by UpdateRunningNorm() or on the fly by a single bit gate. (On an actual
+     * quantum computer, the state should never require manual normalization.)
+     *
+     * \warning PSEUDO-QUANTUM
+     */
+
+    virtual void NormalizeState(real1 nrm = -999.0) = 0;
+
+    /**
      * If asynchronous work is still running, block until it finishes. Note that this is never necessary to get correct,
      * timely return values. QEngines and other layers will always internally "Finish" when necessary for correct return
      * values. This is primarily for debugging and benchmarking.

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -233,6 +233,7 @@ public:
     }
     virtual bool ApproxCompare(QUnitPtr toCompare);
     virtual void UpdateRunningNorm();
+    virtual void NormalizeState(real1 nrm = -999.0);
     virtual void Finish();
 
     virtual QInterfacePtr Clone();

--- a/src/qfusion.cpp
+++ b/src/qfusion.cpp
@@ -809,6 +809,9 @@ bool QFusion::ApproxCompare(QFusionPtr toCompare)
 // Avoid calling this, when a QFusion layer is being used:
 void QFusion::UpdateRunningNorm() { qReg->UpdateRunningNorm(); }
 
+// Avoid calling this, when a QFusion layer is being used:
+void QFusion::NormalizeState(real1 nrm) { qReg->NormalizeState(nrm); }
+
 bool QFusion::TrySeparate(bitLenInt start, bitLenInt length)
 {
     FlushReg(start, length);

--- a/src/qinterface/protected.cpp
+++ b/src/qinterface/protected.cpp
@@ -16,25 +16,32 @@
 
 namespace Qrack {
 
-unsigned char* qrack_alloc(size_t ucharCount)
+unsigned char* cl_alloc(size_t ucharCount)
 {
-// QRACK_ALIGN_SIZE is defined in common/qrack_types.hpp
 #if defined(__APPLE__)
     void* toRet;
     posix_memalign(&toRet, QRACK_ALIGN_SIZE,
-        ((sizeof(unsigned char) * ucharCount) < QRACK_ALIGN_SIZE) ? QRACK_ALIGN_SIZE
-                                                                  : (sizeof(unsigned char) * ucharCount));
+        ((sizeof(unsigned char) * ucharCount) < QRACK_ALIGN_SIZE) ? QRACK_ALIGN_SIZE : (sizeof(unsigned char) * ucharCount));
     return (unsigned char*)toRet;
 #elif defined(_WIN32) && !defined(__CYGWIN__)
-    return (unsigned char*)_aligned_malloc(((sizeof(unsigned char) * ucharCount) < QRACK_ALIGN_SIZE)
-            ? QRACK_ALIGN_SIZE
-            : (sizeof(unsigned char) * ucharCount),
-        QRACK_ALIGN_SIZE);
+    return (unsigned char*)_aligned_malloc(
+        ((sizeof(unsigned char) * ucharCount) < QRACK_ALIGN_SIZE) ? QRACK_ALIGN_SIZE : (sizeof(unsigned char) * ucharCount),
+        ALIGN_SIZE);
 #else
     return (unsigned char*)aligned_alloc(QRACK_ALIGN_SIZE,
-        ((sizeof(unsigned char) * ucharCount) < QRACK_ALIGN_SIZE) ? QRACK_ALIGN_SIZE
-                                                                  : (sizeof(unsigned char) * ucharCount));
+        ((sizeof(unsigned char) * ucharCount) < QRACK_ALIGN_SIZE) ? QRACK_ALIGN_SIZE : (sizeof(unsigned char) * ucharCount));
 #endif
+}
+
+void cl_free(void* toFree)
+{
+    if (toFree) {
+#if defined(_WIN32)
+        _aligned_free(toFree);
+#else
+        free(toFree);
+#endif
+    }
 }
 
 template <class BidirectionalIterator>

--- a/src/qinterface/protected.cpp
+++ b/src/qinterface/protected.cpp
@@ -35,13 +35,11 @@ unsigned char* cl_alloc(size_t ucharCount)
 
 void cl_free(void* toFree)
 {
-    if (toFree) {
 #if defined(_WIN32)
-        _aligned_free(toFree);
+    _aligned_free(toFree);
 #else
-        free(toFree);
+    free(toFree);
 #endif
-    }
 }
 
 template <class BidirectionalIterator>

--- a/src/qinterface/qinterface.cpp
+++ b/src/qinterface/qinterface.cpp
@@ -370,8 +370,6 @@ void QInterface::ExpX(real1 radians, bitLenInt start, bitLenInt length)
 /// Dyadic fraction Pauli X exponentiation gate - Applies exponentiation of the Pauli X operator
 void QInterface::ExpXDyad(int numerator, int denomPower, bitLenInt qubit)
 {
-    // if (qubit >= qubitCount)
-    //     throw std::invalid_argument("operation on bit index greater than total bits.");
     ExpX((-M_PI * numerator * 2) / pow(2, denomPower), qubit);
 }
 
@@ -440,8 +438,6 @@ void QInterface::RX(real1 radians, bitLenInt start, bitLenInt length)
 /// Dyadic fraction x axis rotation gate - Rotates around Pauli x axis.
 void QInterface::RXDyad(int numerator, int denomPower, bitLenInt qubit)
 {
-    // if (qubit >= qubitCount)
-    //     throw std::invalid_argument("operation on bit index greater than total bits.");
     RX((-M_PI * numerator * 2) / pow(2, denomPower), qubit);
 }
 
@@ -464,8 +460,6 @@ void QInterface::RY(real1 radians, bitLenInt start, bitLenInt length)
 /// Dyadic fraction y axis rotation gate - Rotates around Pauli y axis.
 void QInterface::RYDyad(int numerator, int denomPower, bitLenInt qubit)
 {
-    // if (qubit >= qubitCount)
-    //     throw std::invalid_argument("operation on bit index greater than total bits.");
     RY((-M_PI * numerator * 2) / pow(2, denomPower), qubit);
 }
 
@@ -509,12 +503,6 @@ void QInterface::CRT(real1 radians, bitLenInt control, bitLenInt target, bitLenI
 /// 2^denomPower) around |1> state
 void QInterface::CRTDyad(int numerator, int denomPower, bitLenInt control, bitLenInt target)
 {
-    // if (control >= qubitCount)
-    //     throw std::invalid_argument("operation on bit index greater than total bits.");
-    // if (target >= qubitCount)
-    //     throw std::invalid_argument("operation on bit index greater than total bits.");
-    if (control == target)
-        throw std::invalid_argument("CRTDyad control bit cannot also be target.");
     CRT((-M_PI * numerator * 2) / pow(2, denomPower), control, target);
 }
 
@@ -533,10 +521,6 @@ void QInterface::CRX(real1 radians, bitLenInt control, bitLenInt target, bitLenI
 /// Controlled dyadic fraction x axis rotation gate - Rotates around Pauli x axis.
 void QInterface::CRXDyad(int numerator, int denomPower, bitLenInt control, bitLenInt target)
 {
-    // if (control >= qubitCount)
-    //     throw std::invalid_argument("operation on bit index greater than total bits.");
-    if (control == target)
-        throw std::invalid_argument("CRXDyad control bit cannot also be target.");
     CRX((-M_PI * numerator * 2) / pow(2, denomPower), control, target);
 }
 
@@ -556,8 +540,6 @@ void QInterface::CRY(real1 radians, bitLenInt control, bitLenInt target, bitLenI
 /// Controlled dyadic fraction y axis rotation gate - Rotates around Pauli y axis.
 void QInterface::CRYDyad(int numerator, int denomPower, bitLenInt control, bitLenInt target)
 {
-    if (control == target)
-        throw std::invalid_argument("CRYDyad control bit cannot also be target.");
     CRY((-M_PI * numerator * 2) / pow(2, denomPower), control, target);
 }
 
@@ -577,8 +559,6 @@ void QInterface::CRZ(real1 radians, bitLenInt control, bitLenInt target, bitLenI
 /// Controlled dyadic fraction z axis rotation gate - Rotates around Pauli z axis.
 void QInterface::CRZDyad(int numerator, int denomPower, bitLenInt control, bitLenInt target)
 {
-    if (control == target)
-        throw std::invalid_argument("CRZDyad control bit cannot also be target.");
     CRZ((-M_PI * numerator * 2) / pow(2, denomPower), control, target);
 }
 

--- a/src/qinterface/rotational.cpp
+++ b/src/qinterface/rotational.cpp
@@ -121,18 +121,6 @@ void QInterface::Exp(bitLenInt* controls, bitLenInt controlLen, bitLenInt qubit,
     }
 }
 
-/// Logarithm of arbitrary single bit gate
-void QInterface::Log(bitLenInt* controls, bitLenInt controlLen, bitLenInt qubit, complex* matrix2x2, bool antiCtrled)
-{
-    complex toApply[4];
-    Qrack::log2x2(matrix2x2, toApply);
-    if (antiCtrled) {
-        ApplyAntiControlledSingleBit(controls, controlLen, qubit, toApply);
-    } else {
-        ApplyControlledSingleBit(controls, controlLen, qubit, toApply);
-    }
-}
-
 /// Exponentiate Pauli X operator
 void QInterface::ExpX(real1 radians, bitLenInt qubit)
 {

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1403,6 +1403,18 @@ void QUnit::UpdateRunningNorm()
     }
 }
 
+void QUnit::NormalizeState(real1 nrm)
+{
+    std::vector<QInterfacePtr> units;
+    for (bitLenInt i = 0; i < shards.size(); i++) {
+        QInterfacePtr toFind = shards[i].unit;
+        if (find(units.begin(), units.end(), toFind) == units.end()) {
+            units.push_back(toFind);
+            toFind->NormalizeState(nrm);
+        }
+    }
+}
+
 void QUnit::Finish()
 {
     std::vector<QInterfacePtr> units;

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -260,6 +260,21 @@ TEST_CASE("test_qengine_cpu_par_for_mask")
 }
 
 #if ENABLE_OPENCL
+TEST_CASE_METHOD(QInterfaceTestFixture, "test_oclengine")
+{
+    if (testEngineType == QINTERFACE_OPENCL) {
+        std::vector<DeviceContextPtr> devices = OCLEngine::Instance()->GetDeviceContextPtrVector();
+        REQUIRE(devices.size() > 0);
+
+        OCLEngine::Instance()->SetDefaultDeviceContext(OCLEngine::Instance()->GetDeviceContextPtr(-1));
+
+        CHECK_THROWS(OCLEngine::Instance()->GetDeviceContextPtr(-2));
+
+        Qrack::OCLEngine::InitOCL(true, true, "_test_ocl_kernel_compile/");
+        
+    }
+}
+
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_change_device")
 {
     if (testEngineType == QINTERFACE_OPENCL) {
@@ -270,6 +285,12 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_change_device")
     }
 }
 #endif
+
+TEST_CASE_METHOD(QInterfaceTestFixture, "test_qengine_getmaxqpower")
+{
+    // Assuming default engine has 20 qubits:
+    REQUIRE((qftReg->GetMaxQPower() == 1048576U));
+}
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_cnot")
 {

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -259,6 +259,33 @@ TEST_CASE("test_qengine_cpu_par_for_mask")
     });
 }
 
+TEST_CASE("test_exp2x2_log2x2")
+{
+    complex mtrx1[4] = { complex(ONE_R1, ZERO_R1), complex(ZERO_R1, ZERO_R1), complex(ZERO_R1, ZERO_R1),
+        complex(ONE_R1, ZERO_R1) };
+    complex mtrx2[4];
+
+    exp2x2(mtrx1, mtrx2);
+    REQUIRE_FLOAT(real(mtrx2[0]), M_E);
+    REQUIRE_FLOAT(imag(mtrx2[0]), ZERO_R1);
+    REQUIRE_FLOAT(real(mtrx2[1]), ZERO_R1);
+    REQUIRE_FLOAT(imag(mtrx2[1]), ZERO_R1);
+    REQUIRE_FLOAT(real(mtrx2[2]), ZERO_R1);
+    REQUIRE_FLOAT(imag(mtrx2[2]), ZERO_R1);
+    REQUIRE_FLOAT(real(mtrx2[3]), M_E);
+    REQUIRE_FLOAT(imag(mtrx2[3]), ZERO_R1);
+
+    log2x2(mtrx2, mtrx1);
+    REQUIRE_FLOAT(real(mtrx1[0]), ONE_R1);
+    REQUIRE_FLOAT(imag(mtrx1[0]), ZERO_R1);
+    REQUIRE_FLOAT(real(mtrx1[1]), ZERO_R1);
+    REQUIRE_FLOAT(imag(mtrx1[1]), ZERO_R1);
+    REQUIRE_FLOAT(real(mtrx1[2]), ZERO_R1);
+    REQUIRE_FLOAT(imag(mtrx1[2]), ZERO_R1);
+    REQUIRE_FLOAT(real(mtrx1[3]), ONE_R1);
+    REQUIRE_FLOAT(imag(mtrx1[3]), ZERO_R1);
+}
+
 #if ENABLE_OPENCL
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_oclengine")
 {
@@ -271,7 +298,6 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_oclengine")
         CHECK_THROWS(OCLEngine::Instance()->GetDeviceContextPtr(-2));
 
         Qrack::OCLEngine::InitOCL(true, true, "_test_ocl_kernel_compile/");
-        
     }
 }
 
@@ -491,6 +517,8 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_apply_controlled_single_bit")
     qftReg->H(1);
     qftReg->H(3);
     REQUIRE_THAT(qftReg, HasProbability(0, 20, 0x80001));
+    qftReg->ApplyControlledSingleBit(NULL, 0, 0, pauliX);
+    REQUIRE_THAT(qftReg, HasProbability(0, 20, 0x80000));
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_apply_anticontrolled_single_bit")
@@ -514,6 +542,18 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_apply_anticontrolled_single_bit")
     qftReg->H(1);
     qftReg->H(3);
     REQUIRE_THAT(qftReg, HasProbability(0, 20, 0x80001));
+    qftReg->ApplyAntiControlledSingleBit(NULL, 0, 0, pauliX);
+    REQUIRE_THAT(qftReg, HasProbability(0, 20, 0x80000));
+
+    qftReg->SetReg(0, 8, 0x02);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x02));
+    qftReg->H(0);
+    qftReg->ApplyAntiControlledSinglePhase(NULL, 0, 0, complex(ONE_R1, ZERO_R1), complex(-ONE_R1, ZERO_R1));
+    qftReg->H(0);
+    qftReg->H(1);
+    qftReg->ApplyAntiControlledSinglePhase(NULL, 0, 1, complex(ONE_R1, ZERO_R1), complex(-ONE_R1, ZERO_R1));
+    qftReg->H(1);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x01));
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_s")
@@ -1088,10 +1128,6 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_uniform_cry")
     qftReg->H(4);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x01));
 
-    complex pauliRY[4];
-    real1 cosine, sine;
-    bitLenInt i, j;
-
     qftReg->SetReg(0, 8, 0x02);
     QInterfacePtr qftReg2 = qftReg->Clone();
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x02));
@@ -1243,6 +1279,78 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_uniform_crz")
     qftReg->H(1, 2);
     qftReg->H(4);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x03));
+}
+
+TEST_CASE_METHOD(QInterfaceTestFixture, "test_uniform_c_single")
+{
+    bitLenInt controls[2] = { 4, 5 };
+    real1 angles[4] = { M_PI, M_PI, 0, 0 };
+    complex pauliRYs[16];
+
+    real1 cosine, sine;
+    for (bitCapInt i = 0; i < 4; i++) {
+        cosine = cos(angles[i] / 2);
+        sine = sin(angles[i] / 2);
+
+        pauliRYs[0 + 4 * i] = complex(cosine, ZERO_R1);
+        pauliRYs[1 + 4 * i] = complex(-sine, ZERO_R1);
+        pauliRYs[2 + 4 * i] = complex(sine, ZERO_R1);
+        pauliRYs[3 + 4 * i] = complex(cosine, ZERO_R1);
+    }
+
+    qftReg->SetReg(0, 8, 0x02);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x02));
+    qftReg->UniformlyControlledSingleBit(NULL, 0, 0, pauliRYs);
+    qftReg->UniformlyControlledSingleBit(NULL, 0, 1, pauliRYs);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x01));
+
+    qftReg->SetReg(0, 8, 0x02);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x02));
+    qftReg->UniformlyControlledSingleBit(controls, 2, 0, pauliRYs);
+    qftReg->UniformlyControlledSingleBit(controls, 2, 1, pauliRYs);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x01));
+
+    qftReg->SetReg(0, 8, 0x12);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x12));
+    qftReg->UniformlyControlledSingleBit(controls, 2, 0, pauliRYs);
+    qftReg->UniformlyControlledSingleBit(controls, 2, 1, pauliRYs);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x11));
+
+    qftReg->SetReg(0, 8, 0x22);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x22));
+    qftReg->UniformlyControlledSingleBit(controls, 2, 0, pauliRYs);
+    qftReg->UniformlyControlledSingleBit(controls, 2, 1, pauliRYs);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x22));
+
+    controls[0] = 5;
+    controls[1] = 4;
+
+    qftReg->SetReg(0, 8, 0x22);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x22));
+    qftReg->UniformlyControlledSingleBit(controls, 2, 0, pauliRYs);
+    qftReg->UniformlyControlledSingleBit(controls, 2, 1, pauliRYs);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x21));
+
+    controls[0] = 4;
+    controls[1] = 5;
+
+    qftReg->SetReg(0, 8, 0x02);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x02));
+    qftReg->H(4);
+    qftReg->UniformlyControlledSingleBit(controls, 2, 0, pauliRYs);
+    qftReg->UniformlyControlledSingleBit(controls, 2, 1, pauliRYs);
+    qftReg->H(4);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x01));
+
+    qftReg->SetReg(0, 8, 0x02);
+    QInterfacePtr qftReg2 = qftReg->Clone();
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x02));
+    REQUIRE_THAT(qftReg2, HasProbability(0, 8, 0x02));
+
+    qftReg->UniformlyControlledSingleBit(controls, 2, 0, pauliRYs);
+    qftReg2->QInterface::UniformlyControlledSingleBit(controls, 2, 0, pauliRYs);
+
+    REQUIRE(qftReg->ApproxCompare(qftReg2));
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_exp")
@@ -2117,6 +2225,15 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_probmask")
     REQUIRE(qftReg->ProbMask(0xF0, 0x40) < 0.01);
 }
 
+TEST_CASE_METHOD(QInterfaceTestFixture, "test_probmaskall")
+{
+    // We're trying to hit a hardware-specific case of the method, by allocating 1 qubit, but it might not work if the
+    // maximum work item count is extremely small.
+    qftReg = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 1, 0, rng);
+    REQUIRE(qftReg->ProbMask(1, 0) > 0.99);
+    REQUIRE(qftReg->ProbMask(1, 1) < 0.01);
+}
+
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_forcem")
 {
     qftReg->SetPermutation(0x0);
@@ -2128,7 +2245,9 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_forcem")
     bitLenInt bits[3] = { 0, 1, 2 };
     bool results[3] = { 0, 1, 0 };
 
+    qftReg->ForceM(bits, 1, results);
     qftReg->ForceM(bits, 3, results);
+    qftReg->ForceM(bits, 1, NULL);
 
     REQUIRE(qftReg->ProbMask(0x7, 0x2) > 0.99);
     REQUIRE_FLOAT(qftReg->ProbMask(0xF, 0x2), 0.5);
@@ -2146,7 +2265,36 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_getquantumstate")
     complex state[1U << 4U];
     qftReg = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 4, 0x0b, rng);
     qftReg->GetQuantumState(state);
+    for (bitCapInt i = 0; i < 16; i++) {
+        if (i == 0x0b) {
+            REQUIRE_FLOAT(norm(state[i]), ONE_R1);
+        } else {
+            REQUIRE_FLOAT(norm(state[i]), ZERO_R1);
+        }
+    }
     qftReg->SetQuantumState(state);
+}
+
+TEST_CASE_METHOD(QInterfaceTestFixture, "test_getprobs")
+{
+    real1 state[1U << 4U];
+    qftReg = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 4, 0x0b, rng);
+    qftReg->GetProbs(state);
+    for (bitCapInt i = 0; i < 16; i++) {
+        if (i == 0x0b) {
+            REQUIRE_FLOAT(state[i], ONE_R1);
+        } else {
+            REQUIRE_FLOAT(state[i], ZERO_R1);
+        }
+    }
+}
+
+TEST_CASE_METHOD(QInterfaceTestFixture, "test_normalize")
+{
+    qftReg->SetPermutation(0x03);
+    qftReg->UpdateRunningNorm();
+    qftReg->NormalizeState();
+    REQUIRE_FLOAT(norm(qftReg->GetAmplitude(0x03)), ONE_R1);
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_grover")


### PR DESCRIPTION
This PR removes coverage of external files and the "tests" directory, as well as greatly expanding overall coverage.

The only significant gaps that remain are in QEngineOCL, but these are specifically hardware dependent branches, (primarily multiple device and cross-device branches, and branches for optimizations which depend on device maximum work item counts). Tried on different devices, some of these gaps would no longer be gaps, depending on available hardware. In other cases, the unit tests cannot practically accommodate the cases, because they require a guarantee of at least two OpenCL devices available on the system. However, all these potential gaps in QEngineOCL have been manually tested on appropriate systems.