### PR TITLE
U and U2 gates

### DIFF
--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -521,6 +521,20 @@ public:
     virtual void AntiCNOT(bitLenInt control, bitLenInt target);
 
     /**
+     * General unitary gate
+     *
+     * Applies a gate guaranteed to be unitary, from three angles, as commonly defined, spanning all possible single bit unitary gates.
+     */
+    virtual void U(bitLenInt target, real1 theta, real1 phi, real1 lambda);
+
+    /**
+     * 2-parameter unitary gate
+     *
+     * Applies a gate guaranteed to be unitary, from two angles, as commonly defined.
+     */
+    virtual void U2(bitLenInt target, real1 phi, real1 lambda) { U(target, M_PI / 2, phi, lambda); }
+
+    /**
      * Hadamard gate
      *
      * Applies a Hadamard gate on qubit at "qubitIndex."
@@ -948,6 +962,12 @@ public:
      *
      * @{
      */
+
+    /** Bitwise general unitary */
+    virtual void U(bitLenInt start, bitLenInt length, real1 theta, real1 phi, real1 lambda);
+
+    /** Bitwise 2-paramter unitary */
+    virtual void U2(bitLenInt start, bitLenInt length, real1 phi, real1 lambda);
 
     /** Bitwise Hadamard */
     virtual void H(bitLenInt start, bitLenInt length);

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -966,7 +966,7 @@ public:
     /** Bitwise general unitary */
     virtual void U(bitLenInt start, bitLenInt length, real1 theta, real1 phi, real1 lambda);
 
-    /** Bitwise 2-paramter unitary */
+    /** Bitwise 2-parameter unitary */
     virtual void U2(bitLenInt start, bitLenInt length, real1 phi, real1 lambda);
 
     /** Bitwise Hadamard */

--- a/src/qinterface/gates.cpp
+++ b/src/qinterface/gates.cpp
@@ -71,6 +71,18 @@ void QInterface::ApplyAntiControlledSingleInvert(const bitLenInt* controls, cons
     ApplyAntiControlledSingleBit(controls, controlLen, target, mtrx);
 }
 
+/// General unitary gate
+void QInterface::U(bitLenInt target, real1 theta, real1 phi, real1 lambda)
+{
+    real1 cos0 = cos(theta / 2);
+    real1 sin0 = sin(theta / 2);
+    const complex uGate[4] = {
+            complex(cos0, ZERO_R1), sin0 * complex(-cos(lambda), -sin(lambda)),
+            sin0 * complex(cos(phi), sin(phi)), cos0 * complex(cos(phi + lambda), sin(phi + lambda))
+        };
+    ApplySingleBit(uGate, true, target);
+}
+
 /// Hadamard gate
 void QInterface::H(bitLenInt qubit)
 {

--- a/src/qinterface/qinterface.cpp
+++ b/src/qinterface/qinterface.cpp
@@ -116,6 +116,22 @@ void QInterface::X(bitLenInt start, bitLenInt length)
 
 // Single register instructions:
 
+/// Apply general unitary gate to each bit in "length," starting from bit index "start"
+void QInterface::U(bitLenInt start, bitLenInt length, real1 theta, real1 phi, real1 lambda)
+{
+    for (bitLenInt bit = 0; bit < length; bit++) {
+        U(start + bit, theta, phi, lambda);
+    }
+}
+
+/// Apply 2-parameter unitary gate to each bit in "length," starting from bit index "start"
+void QInterface::U2(bitLenInt start, bitLenInt length, real1 phi, real1 lambda)
+{
+    for (bitLenInt bit = 0; bit < length; bit++) {
+        U2(start + bit, phi, lambda);
+    }
+}
+
 /// Apply Hadamard gate to each bit in "length," starting from bit index "start"
 void QInterface::H(bitLenInt start, bitLenInt length)
 {

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -495,6 +495,32 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_apply_anticontrolled_single_bit")
     REQUIRE_THAT(qftReg, HasProbability(0, 20, 0x80001));
 }
 
+TEST_CASE_METHOD(QInterfaceTestFixture, "test_u")
+{
+    qftReg->SetReg(0, 8, 0x02);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x02));
+    qftReg->U(0, M_PI / 2, 0, M_PI);
+    qftReg->S(0);
+    qftReg->S(0);
+    qftReg->U2(0, 0, M_PI);
+    qftReg->U(1, M_PI / 2, 0, M_PI);
+    qftReg->S(1);
+    qftReg->S(1);
+    qftReg->U2(1, 0, M_PI);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x01));
+}
+
+TEST_CASE_METHOD(QInterfaceTestFixture, "test_u_reg")
+{
+    qftReg->SetReg(0, 8, 2);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x02));
+    qftReg->U(1, 2, M_PI / 2, 0, M_PI);
+    qftReg->S(1, 2);
+    qftReg->S(1, 2);
+    qftReg->U2(1, 2, 0, M_PI);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x04));
+}
+
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_s")
 {
     qftReg->SetReg(0, 8, 0x02);


### PR DESCRIPTION
This adds the "U" and "U2" gates, as commonly defined.

These are extremely convenient, because the parameters of U cover all unitary single bit gates, and therefore all possible _valid_ single bit gates, and all values of the angle parameters are also valid.