### PR TITLE
Vectorizable OCL matrix multiplication

### DIFF
--- a/include/qengine_opencl.hpp
+++ b/include/qengine_opencl.hpp
@@ -32,8 +32,6 @@ enum SPECIAL_2X2 { NONE = 0, PAULIX, PAULIZ };
 
 typedef std::shared_ptr<cl::Buffer> BufferPtr;
 
-class OCLEngine;
-
 class QEngineOCL;
 
 typedef std::shared_ptr<QEngineOCL> QEngineOCLPtr;

--- a/src/common/qengine.cl
+++ b/src/common/qengine.cl
@@ -15,7 +15,7 @@ inline cmplx zmul(const cmplx lhs, const cmplx rhs)
     return (cmplx)((lhs.x * rhs.x) - (lhs.y * rhs.y), (lhs.x * rhs.y) + (lhs.y * rhs.x));
 }
 
-inline cmplx2 zmad(const real1 nrm, const cmplx4 lhs, const cmplx2 rhs)
+inline cmplx2 zmatrixmul(const real1 nrm, const cmplx4 lhs, const cmplx2 rhs)
 {
     return nrm * ((cmplx2)(
         (lhs.lo.x * rhs.x) - (lhs.lo.y * rhs.y) + (lhs.lo.z * rhs.z) - (lhs.lo.w * rhs.w),
@@ -80,7 +80,7 @@ inline real1 arg(const cmplx cmp)
     mulRes.lo = stateVec[i | OFFSET1_ARG];                                           \
     mulRes.hi = stateVec[i | OFFSET2_ARG];                                           \
                                                                                      \
-    mulRes = zmad(nrm, mtrx, mulRes);                                                \
+    mulRes = zmatrixmul(nrm, mtrx, mulRes);                                                \
                                                                                      \
     stateVec[i | OFFSET1_ARG] = mulRes.lo;                                           \
     stateVec[i | OFFSET2_ARG] = mulRes.hi
@@ -113,7 +113,7 @@ inline real1 arg(const cmplx cmp)
     mulRes.lo = stateVec[i | OFFSET1_ARG];                                           \
     mulRes.hi = stateVec[i | OFFSET2_ARG];                                           \
                                                                                      \
-    mulRes = zmad(nrm, mtrx, mulRes);                                                \
+    mulRes = zmatrixmul(nrm, mtrx, mulRes);                                                \
                                                                                      \
     partNrm += dot(mulRes, mulRes);                                                  \
                                                                                      \
@@ -311,7 +311,7 @@ void kernel uniformlycontrolled(global cmplx* stateVec, constant bitCapInt* bitC
         qubit.lo = stateVec[i];
         qubit.hi = stateVec[i | targetPower];
 
-        qubit = zmad(nrm, mtrxs[offset], qubit);
+        qubit = zmatrixmul(nrm, mtrxs[offset], qubit);
 
         partNrm += dot(qubit, qubit);
 

--- a/src/common/qengine.cl
+++ b/src/common/qengine.cl
@@ -80,7 +80,7 @@ inline real1 arg(const cmplx cmp)
     mulRes.lo = stateVec[i | OFFSET1_ARG];                                           \
     mulRes.hi = stateVec[i | OFFSET2_ARG];                                           \
                                                                                      \
-    mulRes = zmatrixmul(nrm, mtrx, mulRes);                                                \
+    mulRes = zmatrixmul(nrm, mtrx, mulRes);                                          \
                                                                                      \
     stateVec[i | OFFSET1_ARG] = mulRes.lo;                                           \
     stateVec[i | OFFSET2_ARG] = mulRes.hi
@@ -113,7 +113,7 @@ inline real1 arg(const cmplx cmp)
     mulRes.lo = stateVec[i | OFFSET1_ARG];                                           \
     mulRes.hi = stateVec[i | OFFSET2_ARG];                                           \
                                                                                      \
-    mulRes = zmatrixmul(nrm, mtrx, mulRes);                                                \
+    mulRes = zmatrixmul(nrm, mtrx, mulRes);                                          \
                                                                                      \
     partNrm += dot(mulRes, mulRes);                                                  \
                                                                                      \

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -32,7 +32,7 @@ using namespace Qrack;
         REQUIRE(__tmp_b > (__tmp_b - EPSILON));                                                                        \
     } while (0);
 
-const bitLenInt MaxQubits = 28;
+const bitLenInt MaxQubits = 24;
 
 const double clockFactor = 1000.0 / CLOCKS_PER_SEC; // Report in ms
 

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -1935,10 +1935,7 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_qft_h")
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 85));
 }
 
-TEST_CASE_METHOD(QInterfaceTestFixture, "test_isfinished")
-{
-    REQUIRE(qftReg->isFinished());
-}
+TEST_CASE_METHOD(QInterfaceTestFixture, "test_isfinished") { REQUIRE(qftReg->isFinished()); }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_tryseparate")
 {


### PR DESCRIPTION
Often, we use a series of single complex multiplications (`zmul()`) to accomplish the common task of multiplying a 2x2 complex matrix by a 2 component vector. The OCL compiler(s) could probably optimize this, except it's harder given the bounds of the function closure.

Sure enough, if we pull the whole matrix multiplication operation into its own function, we get both a general speed boost and a significant reduction in CPU binary size. Most modern GPUs are based on "warp" units, I think, which don't use SIMD, though simply pulling the entire operation into the same closure gives the GPUs' compilers more chance to optimize. The large reduction in CPU binary size, however, is probably because the compiler is now able to effectively reduce this task to SIMD instructions, also increasing speed.