### PR TITLE
QUnit arithmetic separability

### DIFF
--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -258,6 +258,7 @@ protected:
         bitLenInt* controls, bitLenInt controlLen);
     typedef void (QInterface::*CMULModFn)(bitCapInt toMod, bitCapInt modN, bitLenInt start, bitLenInt carryStart,
         bitLenInt length, bitLenInt* controls, bitLenInt controlLen);
+    void CollapseCarry(bitLenInt flagIndex, bitLenInt start, bitLenInt length);
     void INCx(INCxFn fn, bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt flagIndex);
     void INCxx(
         INCxxFn fn, bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt flag1Index, bitLenInt flag2Index);

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -272,6 +272,7 @@ protected:
         bitLenInt length, bitLenInt* controls, bitLenInt controlLen);
     bool CArithmeticOptimize(bitLenInt start, bitLenInt length, bitLenInt* controls, bitLenInt controlLen,
         std::vector<bitLenInt>* controlVec);
+    bool INTCOptimize(bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt carryIndex, bool isAdd);
 
     virtual QInterfacePtr Entangle(std::vector<bitLenInt*> bits);
     virtual QInterfacePtr EntangleRange(bitLenInt start, bitLenInt length);
@@ -279,6 +280,10 @@ protected:
     virtual QInterfacePtr EntangleRange(
         bitLenInt start, bitLenInt length, bitLenInt start2, bitLenInt length2, bitLenInt start3, bitLenInt length3);
     virtual QInterfacePtr EntangleAll();
+
+    virtual bool CheckBitPermutation(bitLenInt qubitIndex);
+    virtual bool CheckBitsPermutation(bitLenInt start, bitLenInt length);
+    virtual bitCapInt GetCachedPermutation(bitLenInt start, bitLenInt length);
 
     virtual QInterfacePtr EntangleIterator(
         std::vector<bitLenInt*>::iterator first, std::vector<bitLenInt*>::iterator last);

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -274,6 +274,8 @@ protected:
         std::vector<bitLenInt>* controlVec);
     bool INTCOptimize(bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt carryIndex, bool isAdd);
     bool INTSOptimize(bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt overflowIndex, bool isAdd);
+    bool INTSCOptimize(
+        bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt overflowIndex, bitLenInt carryIndex, bool isAdd);
     bool IsOverflowAdd(bitCapInt inOutInt, bitCapInt inInt, bitCapInt signMask, bitCapInt lengthPower);
     bool IsOverflowSub(bitCapInt inOutInt, bitCapInt inInt, bitCapInt signMask, bitCapInt lengthPower);
 

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -273,6 +273,9 @@ protected:
     bool CArithmeticOptimize(bitLenInt start, bitLenInt length, bitLenInt* controls, bitLenInt controlLen,
         std::vector<bitLenInt>* controlVec);
     bool INTCOptimize(bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt carryIndex, bool isAdd);
+    bool INTSOptimize(bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt overflowIndex, bool isAdd);
+    bool IsOverflowAdd(bitCapInt inOutInt, bitCapInt inInt, bitCapInt signMask, bitCapInt lengthPower);
+    bool IsOverflowSub(bitCapInt inOutInt, bitCapInt inInt, bitCapInt signMask, bitCapInt lengthPower);
 
     virtual QInterfacePtr Entangle(std::vector<bitLenInt*> bits);
     virtual QInterfacePtr EntangleRange(bitLenInt start, bitLenInt length);

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -272,10 +272,10 @@ protected:
         bitLenInt length, bitLenInt* controls, bitLenInt controlLen);
     bool CArithmeticOptimize(bitLenInt start, bitLenInt length, bitLenInt* controls, bitLenInt controlLen,
         std::vector<bitLenInt>* controlVec);
-    bool INTCOptimize(bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt carryIndex, bool isAdd);
-    bool INTSOptimize(bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt overflowIndex, bool isAdd);
+    bool INTCOptimize(bitCapInt toMod, bitLenInt start, bitLenInt length, bool isAdd, bitLenInt carryIndex);
+    bool INTSOptimize(bitCapInt toMod, bitLenInt start, bitLenInt length, bool isAdd, bitLenInt overflowIndex);
     bool INTSCOptimize(
-        bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt overflowIndex, bitLenInt carryIndex, bool isAdd);
+        bitCapInt toMod, bitLenInt start, bitLenInt length, bool isAdd, bitLenInt carryIndex, bitLenInt overflowIndex);
     bool IsOverflowAdd(bitCapInt inOutInt, bitCapInt inInt, bitCapInt signMask, bitCapInt lengthPower);
     bool IsOverflowSub(bitCapInt inOutInt, bitCapInt inInt, bitCapInt signMask, bitCapInt lengthPower);
 

--- a/src/qengine/operators.cpp
+++ b/src/qengine/operators.cpp
@@ -877,11 +877,12 @@ void QEngineCPU::DECBCDC(
 
 void QEngineCPU::MUL(bitCapInt toMul, bitLenInt inOutStart, bitLenInt carryStart, bitLenInt length)
 {
+    SetReg(carryStart, length, 0);
+
     bitCapInt lowMask = (1U << length) - 1U;
     toMul &= lowMask;
     if (toMul == 0) {
         SetReg(inOutStart, length, 0);
-        SetReg(carryStart, length, 0);
         return;
     }
     if (toMul == 1U) {

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1390,6 +1390,12 @@ void QUnit::INCSC(bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt 
 
 void QUnit::INCSC(bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt carryIndex)
 {
+    // The phase effect is the overflow is undetectable, if this check passes:
+    if (INTCOptimize(toMod, start, length, true, carryIndex)) {
+        return;
+    }
+
+    // Otherwise, form the potentially entangled representation:
     INCx(&QInterface::INCSC, toMod, start, length, carryIndex);
 }
 
@@ -1456,6 +1462,12 @@ void QUnit::DECSC(bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt 
 
 void QUnit::DECSC(bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt carryIndex)
 {
+    // The phase effect is the overflow is undetectable, if this check passes:
+    if (INTCOptimize(toMod, start, length, false, carryIndex)) {
+        return;
+    }
+
+    // Otherwise, form the potentially entangled representation:
     INCx(&QInterface::DECSC, toMod, start, length, carryIndex);
 }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1264,108 +1264,108 @@ void QUnit::INCxx(
 
 bool QUnit::INTCOptimize(bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt carryIndex, bool isAdd)
 {
-    if (CheckBitsPermutation(start, length)) {
-        bool carryIn = M(carryIndex);
-        if (carryIn == isAdd) {
-            toMod++;
-        }
-        bitCapInt lengthPower = 1U << length;
-        bitCapInt res;
-        if (isAdd) {
-            res = GetCachedPermutation(start, length) + toMod;
-        } else {
-            res = (lengthPower + GetCachedPermutation(start, length)) - toMod;
-        }
-        bool carryOut = (res >= lengthPower);
-        if (carryOut) {
-            res &= (lengthPower - 1U);
-        }
-        if (carryIn != carryOut) {
-            X(carryIndex);
-        }
-        SetReg(start, length, res);
-
-        return true;
+    if (!CheckBitsPermutation(start, length)) {
+        return false;
     }
 
-    return false;
+    bool carryIn = M(carryIndex);
+    if (carryIn == isAdd) {
+        toMod++;
+    }
+    bitCapInt lengthPower = 1U << length;
+    bitCapInt res;
+    if (isAdd) {
+        res = GetCachedPermutation(start, length) + toMod;
+    } else {
+        res = (lengthPower + GetCachedPermutation(start, length)) - toMod;
+    }
+    bool carryOut = (res >= lengthPower);
+    if (carryOut) {
+        res &= (lengthPower - 1U);
+    }
+    if (carryIn != carryOut) {
+        X(carryIndex);
+    }
+    SetReg(start, length, res);
+
+    return true;
 }
 
 bool QUnit::INTSOptimize(bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt overflowIndex, bool isAdd)
 {
-    if (CheckBitsPermutation(start, length)) {
-        bitCapInt lengthPower = 1U << length;
-        bitCapInt signMask = 1U << (length - 1U);
-        bitCapInt inOutInt = GetCachedPermutation(start, length);
-        bitCapInt inInt = toMod;
-
-        bool isOverflow;
-        bitCapInt outInt;
-        if (isAdd) {
-            isOverflow = IsOverflowAdd(inOutInt, inInt, signMask, lengthPower);
-            outInt = inOutInt + toMod;
-        } else {
-            isOverflow = IsOverflowSub(inOutInt, inInt, signMask, lengthPower);
-            outInt = (inOutInt + lengthPower) - toMod;
-            if (outInt >= lengthPower) {
-                outInt &= (lengthPower - 1U);
-            }
-        }
-
-        SetReg(start, length, outInt);
-
-        if (isOverflow) {
-            Z(overflowIndex);
-        }
-
-        return true;
+    if (!CheckBitsPermutation(start, length)) {
+        return false;
     }
 
-    return false;
+    bitCapInt lengthPower = 1U << length;
+    bitCapInt signMask = 1U << (length - 1U);
+    bitCapInt inOutInt = GetCachedPermutation(start, length);
+    bitCapInt inInt = toMod;
+
+    bool isOverflow;
+    bitCapInt outInt;
+    if (isAdd) {
+        isOverflow = IsOverflowAdd(inOutInt, inInt, signMask, lengthPower);
+        outInt = inOutInt + toMod;
+    } else {
+        isOverflow = IsOverflowSub(inOutInt, inInt, signMask, lengthPower);
+        outInt = (inOutInt + lengthPower) - toMod;
+        if (outInt >= lengthPower) {
+            outInt &= (lengthPower - 1U);
+        }
+    }
+
+    SetReg(start, length, outInt);
+
+    if (isOverflow) {
+        Z(overflowIndex);
+    }
+
+    return true;
 }
 
 bool QUnit::INTSCOptimize(
     bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt overflowIndex, bitLenInt carryIndex, bool isAdd)
 {
-    if (CheckBitsPermutation(start, length)) {
-        bool carryIn = M(carryIndex);
-        if (carryIn == isAdd) {
-            toMod++;
-        }
-
-        bitCapInt lengthPower = 1U << length;
-        bitCapInt signMask = 1U << (length - 1U);
-        bitCapInt inOutInt = GetCachedPermutation(start, length);
-        bitCapInt inInt = toMod;
-
-        bool isOverflow;
-        bitCapInt outInt;
-        if (isAdd) {
-            isOverflow = IsOverflowAdd(inOutInt, inInt, signMask, lengthPower);
-            outInt = inOutInt + toMod;
-        } else {
-            isOverflow = IsOverflowSub(inOutInt, inInt, signMask, lengthPower);
-            outInt = (inOutInt + lengthPower) - toMod;
-        }
-
-        bool carryOut = (outInt >= lengthPower);
-        if (carryOut) {
-            outInt &= (lengthPower - 1U);
-        }
-        if (carryIn != carryOut) {
-            X(carryIndex);
-        }
-
-        SetReg(start, length, outInt);
-
-        if (isOverflow) {
-            Z(overflowIndex);
-        }
-
-        return true;
+    if (!CheckBitsPermutation(start, length)) {
+        return false;
     }
 
-    return false;
+    bool carryIn = M(carryIndex);
+    if (carryIn == isAdd) {
+        toMod++;
+    }
+
+    bitCapInt lengthPower = 1U << length;
+    bitCapInt signMask = 1U << (length - 1U);
+    bitCapInt inOutInt = GetCachedPermutation(start, length);
+    bitCapInt inInt = toMod;
+
+    bool isOverflow;
+    bitCapInt outInt;
+    if (isAdd) {
+        isOverflow = IsOverflowAdd(inOutInt, inInt, signMask, lengthPower);
+        outInt = inOutInt + toMod;
+    } else {
+        isOverflow = IsOverflowSub(inOutInt, inInt, signMask, lengthPower);
+        outInt = (inOutInt + lengthPower) - toMod;
+    }
+
+    bool carryOut = (outInt >= lengthPower);
+    if (carryOut) {
+        outInt &= (lengthPower - 1U);
+    }
+    if (carryIn != carryOut) {
+        X(carryIndex);
+    }
+
+    SetReg(start, length, outInt);
+
+    if (isOverflow) {
+        Z(overflowIndex);
+    }
+
+    return true;
 }
 
 bool QUnit::IsOverflowAdd(bitCapInt inOutInt, bitCapInt inInt, bitCapInt signMask, bitCapInt lengthPower)

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1522,7 +1522,6 @@ void QUnit::MUL(bitCapInt toMul, bitLenInt inOutStart, bitLenInt carryStart, bit
 void QUnit::DIV(bitCapInt toDiv, bitLenInt inOutStart, bitLenInt carryStart, bitLenInt length)
 {
     // Keep the bits separate, if cheap to do so:
-
     if (toDiv == 1) {
         return;
     }

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1390,7 +1390,7 @@ void QUnit::INCSC(bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt 
 
 void QUnit::INCSC(bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt carryIndex)
 {
-    // The phase effect is the overflow is undetectable, if this check passes:
+    // The phase effect of the overflow is undetectable, if this check passes:
     if (INTCOptimize(toMod, start, length, true, carryIndex)) {
         return;
     }
@@ -1462,7 +1462,7 @@ void QUnit::DECSC(bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt 
 
 void QUnit::DECSC(bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt carryIndex)
 {
-    // The phase effect is the overflow is undetectable, if this check passes:
+    // The phase effect of the overflow is undetectable, if this check passes:
     if (INTCOptimize(toMod, start, length, false, carryIndex)) {
         return;
     }


### PR DESCRIPTION
This branch checks whether arithmetic registers in QUnit are already sufficiently separated to effectively carry out integer arithmetic classically. The primary upthrust of these optimizations is that arithmetic operations can be used to quickly initialize register states without auxiliary classical "gate fusion" optimization. In the case that even one quantum arithmetic operation is avoided (say, an addition operation on an 8 or 16 bit register,) these optimizations probably return a speed gain.

This is not an exhaustive separability arithmetic optimization PR, and more work is planned for this weekend and coming week. Tests have shown me that the separability optimizations of QUnit work best (or only) when entangled separations are _proactively_ _avoided_, rather than reduced after-the-fact. The exception is that user calls to probability checks necessitate most of the overhead of after-the-fact separation, and it is during these user calls that representational entanglement _reduction_ is relatively cheap. The goal for the future of QUnit, then, is to always identify where we can avoid increasing the representational entanglement in the first place. The more proactive separability optimizations we have, the greater their chances to "synergize."