### PR TITLE
QUnit stabilizer optimization

### DIFF
--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -347,6 +347,13 @@ protected:
         }
     }
 
+    void DirtyShardRangePhase(bitLenInt start, bitLenInt length)
+    {
+        for (bitLenInt i = 0; i < length; i++) {
+            shards[start + i].isPhaseDirty = true;
+        }
+    }
+
     void DirtyShardIndexArray(bitLenInt* bitIndices, bitLenInt length)
     {
         for (bitLenInt i = 0; i < length; i++) {

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -23,8 +23,10 @@ namespace Qrack {
 struct QEngineShard {
     QInterfacePtr unit;
     bitLenInt mapped;
-    real1 prob;
     bool isProbDirty;
+    real1 prob;
+    bool isPhaseDirty;
+    real1 phase;
 };
 
 class QUnit;
@@ -48,6 +50,19 @@ protected:
     {
         shards.resize(qb);
         QInterface::SetQubitCount(qb);
+    }
+
+    real1 ClampPhase(real1 phase)
+    {
+        while (phase < 0) {
+            phase += 2 * M_PI;
+        }
+
+        while (phase >= (2 * M_PI)) {
+            phase -= 2 * M_PI;
+        }
+
+        return phase;
     }
 
 public:
@@ -84,6 +99,8 @@ public:
      *@{
      */
 
+    using QInterface::H;
+    virtual void H(bitLenInt target);
     using QInterface::X;
     virtual void X(bitLenInt target);
     using QInterface::Z;
@@ -326,6 +343,7 @@ protected:
     {
         for (bitLenInt i = 0; i < length; i++) {
             shards[start + i].isProbDirty = true;
+            shards[start + i].isPhaseDirty = true;
         }
     }
 
@@ -333,6 +351,7 @@ protected:
     {
         for (bitLenInt i = 0; i < length; i++) {
             shards[bitIndices[i]].isProbDirty = true;
+            shards[bitIndices[i]].isPhaseDirty = true;
         }
     }
 };

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -333,8 +333,6 @@ protected:
     void ApplyEitherControlled(const bitLenInt* controls, const bitLenInt& controlLen,
         const std::vector<bitLenInt> targets, const bool& anti, CF cfn, F f);
 
-    bool DoesOperatorPhaseShift(const complex* mtrx);
-
     /* Debugging and diagnostic routines. */
     void DumpShards();
     QInterfacePtr GetUnit(bitLenInt bit) { return shards[bit].unit; }

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1824,7 +1824,7 @@ bitCapInt QUnit::IndexedLDA(
     bitCapInt toRet = shards[indexStart].unit->IndexedLDA(
         shards[indexStart].mapped, indexLength, shards[valueStart].mapped, valueLength, values);
 
-    DirtyShardRange(indexStart, indexLength);
+    DirtyShardRangePhase(indexStart, indexLength);
     DirtyShardRange(valueStart, valueLength);
 
     return toRet;
@@ -1838,7 +1838,7 @@ bitCapInt QUnit::IndexedADC(bitLenInt indexStart, bitLenInt indexLength, bitLenI
     bitCapInt toRet = shards[indexStart].unit->IndexedADC(shards[indexStart].mapped, indexLength,
         shards[valueStart].mapped, valueLength, shards[carryIndex].mapped, values);
 
-    DirtyShardRange(indexStart, indexLength);
+    DirtyShardRangePhase(indexStart, indexLength);
     DirtyShardRange(valueStart, valueLength);
     shards[carryIndex].isProbDirty = true;
     shards[carryIndex].isPhaseDirty = true;
@@ -1854,7 +1854,7 @@ bitCapInt QUnit::IndexedSBC(bitLenInt indexStart, bitLenInt indexLength, bitLenI
     bitCapInt toRet = shards[indexStart].unit->IndexedSBC(shards[indexStart].mapped, indexLength,
         shards[valueStart].mapped, valueLength, shards[carryIndex].mapped, values);
 
-    DirtyShardRange(indexStart, indexLength);
+    DirtyShardRangePhase(indexStart, indexLength);
     DirtyShardRange(valueStart, valueLength);
     shards[carryIndex].isProbDirty = true;
     shards[carryIndex].isPhaseDirty = true;

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1038,6 +1038,8 @@ void QUnit::ApplyEitherControlled(const bitLenInt* controls, const bitLenInt& co
                 controlIndex++;
             }
             continue;
+        } else {
+            controlIndex++;
         }
         for (j = 0; j < targets.size(); j++) {
             // If the shard doesn't have a cached probability, and if it's in the same shard unit as any of the targets,

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1012,16 +1012,15 @@ void QUnit::ApplyEitherControlled(const bitLenInt* controls, const bitLenInt& co
             } else {
                 controlIndex++;
             }
-            continue;
         } else {
             controlIndex++;
-        }
-        for (j = 0; j < targets.size(); j++) {
-            // If the shard doesn't have a cached probability, and if it's in the same shard unit as any of the targets,
-            // it isn't worth trying the next optimization.
-            if (shards[controls[i]].unit == shards[targets[j]].unit) {
-                isSeparated = false;
-                break;
+            for (j = 0; j < targets.size(); j++) {
+                // If the shard doesn't have a cached probability, and if it's in the same shard unit as any of the
+                // targets, it isn't worth trying the next optimization.
+                if (shards[controls[i]].unit == shards[targets[j]].unit) {
+                    isSeparated = false;
+                    break;
+                }
             }
         }
     }
@@ -1213,6 +1212,7 @@ void QUnit::CINT(
     std::vector<bitLenInt> controlsMapped(controlVec.size() == 0 ? 1 : controlVec.size());
     for (bitLenInt i = 0; i < controlVec.size(); i++) {
         controlsMapped[i] = shards[controlVec[i]].mapped;
+        shards[controlVec[i]].isPhaseDirty = true;
     }
 
     ((*unit).*fn)(toMod, shards[start].mapped, length, &(controlsMapped[0]), controlVec.size());
@@ -1635,6 +1635,7 @@ QInterfacePtr QUnit::CMULEntangle(std::vector<bitLenInt> controlVec, bitLenInt s
     controlsMapped->resize(controlVec.size() == 0 ? 1 : controlVec.size());
     for (bitLenInt i = 0; i < controlVec.size(); i++) {
         (*controlsMapped)[i] = shards[controlVec[i]].mapped;
+        shards[controlVec[i]].isPhaseDirty = true;
     }
 
     return unit;

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -780,8 +780,9 @@ void QUnit::UniformlyControlledSingleBit(
         mappedControls[i] = shards[controls[i]].mapped;
     }
 
-    shards[qubitIndex].isProbDirty = true;
     unit->UniformlyControlledSingleBit(mappedControls, controlLen, shards[qubitIndex].mapped, mtrxs);
+
+    shards[qubitIndex].isProbDirty = true;
 
     delete[] mappedControls;
 }
@@ -801,8 +802,8 @@ void QUnit::UniformlyControlledSingleBit(
 
 void QUnit::X(bitLenInt target)
 {
-    shards[target].prob = ONE_R1 - shards[target].prob;
     shards[target].unit->X(shards[target].mapped);
+    shards[target].prob = ONE_R1 - shards[target].prob;
 }
 
 void QUnit::Z(bitLenInt target) { shards[target].unit->Z(shards[target].mapped); }
@@ -849,8 +850,8 @@ void QUnit::ApplySinglePhase(const complex topLeft, const complex bottomRight, b
 
 void QUnit::ApplySingleInvert(const complex topRight, const complex bottomLeft, bool doCalcNorm, bitLenInt target)
 {
-    shards[target].prob = ONE_R1 - shards[target].prob;
     shards[target].unit->ApplySingleInvert(topRight, bottomLeft, doCalcNorm, shards[target].mapped);
+    shards[target].prob = ONE_R1 - shards[target].prob;
 }
 
 void QUnit::ApplyControlledSinglePhase(const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& target,
@@ -1138,8 +1139,6 @@ void QUnit::CINT(
     }
 
     // Otherwise, we have to "dirty" the register.
-    DirtyShardRange(start, length);
-
     std::vector<bitLenInt> bits(controlVec.size() + 1);
     for (bitLenInt i = 0; i < controlVec.size(); i++) {
         bits[i] = controlVec[i];
@@ -1160,6 +1159,8 @@ void QUnit::CINT(
     }
 
     ((*unit).*fn)(toMod, shards[start].mapped, length, &(controlsMapped[0]), controlVec.size());
+
+    DirtyShardRange(start, length);
 }
 
 void QUnit::CINC(bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt* controls, bitLenInt controlLen)
@@ -1326,10 +1327,9 @@ void QUnit::INC(bitCapInt toMod, bitLenInt start, bitLenInt length)
     }
 
     // Otherwise, form the potentially entangled representation:
-    DirtyShardRange(start, length);
-
     EntangleRange(start, length);
     shards[start].unit->INC(toMod, shards[start].mapped, length);
+    DirtyShardRange(start, length);
 }
 
 void QUnit::INCC(bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt carryIndex)
@@ -1379,10 +1379,9 @@ void QUnit::INCSC(bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt 
 void QUnit::INCBCD(bitCapInt toMod, bitLenInt start, bitLenInt length)
 {
     // BCD variants are low priority for optimization, for the time being.
-    DirtyShardRange(start, length);
-
     EntangleRange(start, length);
     shards[start].unit->INCBCD(toMod, shards[start].mapped, length);
+    DirtyShardRange(start, length);
 }
 
 void QUnit::INCBCDC(bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt carryIndex)
@@ -1400,10 +1399,9 @@ void QUnit::DEC(bitCapInt toMod, bitLenInt start, bitLenInt length)
     }
 
     // Otherwise, form the potentially entangled representation:
-    DirtyShardRange(start, length);
-
     EntangleRange(start, length);
     shards[start].unit->DEC(toMod, shards[start].mapped, length);
+    DirtyShardRange(start, length);
 }
 
 void QUnit::DECC(bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt carryIndex)
@@ -1453,10 +1451,9 @@ void QUnit::DECSC(bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt 
 void QUnit::DECBCD(bitCapInt toMod, bitLenInt start, bitLenInt length)
 {
     // BCD variants are low priority for optimization, for the time being.
-    DirtyShardRange(start, length);
-
     EntangleRange(start, length);
     shards[start].unit->DECBCD(toMod, shards[start].mapped, length);
+    DirtyShardRange(start, length);
 }
 
 void QUnit::DECBCDC(bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt carryIndex)
@@ -1486,11 +1483,10 @@ void QUnit::MUL(bitCapInt toMul, bitLenInt inOutStart, bitLenInt carryStart, bit
     }
 
     // Otherwise, form the potentially entangled representation:
-    DirtyShardRange(inOutStart, length);
-    DirtyShardRange(carryStart, length);
-
     EntangleRange(inOutStart, length, carryStart, length);
     shards[inOutStart].unit->MUL(toMul, shards[inOutStart].mapped, shards[carryStart].mapped, length);
+    DirtyShardRange(inOutStart, length);
+    DirtyShardRange(carryStart, length);
 }
 
 void QUnit::DIV(bitCapInt toDiv, bitLenInt inOutStart, bitLenInt carryStart, bitLenInt length)
@@ -1513,11 +1509,10 @@ void QUnit::DIV(bitCapInt toDiv, bitLenInt inOutStart, bitLenInt carryStart, bit
     }
 
     // Otherwise, form the potentially entangled representation:
-    DirtyShardRange(inOutStart, length);
-    DirtyShardRange(carryStart, length);
-
     EntangleRange(inOutStart, length, carryStart, length);
     shards[inOutStart].unit->DIV(toDiv, shards[inOutStart].mapped, shards[carryStart].mapped, length);
+    DirtyShardRange(inOutStart, length);
+    DirtyShardRange(carryStart, length);
 }
 
 void QUnit::MULModNOut(bitCapInt toMod, bitCapInt modN, bitLenInt inStart, bitLenInt outStart, bitLenInt length)
@@ -1536,10 +1531,9 @@ void QUnit::MULModNOut(bitCapInt toMod, bitCapInt modN, bitLenInt inStart, bitLe
     }
 
     // Otherwise, form the potentially entangled representation:
-    DirtyShardRange(outStart, length);
-
     EntangleRange(inStart, length, outStart, length);
     shards[inStart].unit->MULModNOut(toMod, modN, shards[inStart].mapped, shards[outStart].mapped, length);
+    DirtyShardRange(outStart, length);
 }
 
 void QUnit::POWModNOut(bitCapInt toMod, bitCapInt modN, bitLenInt inStart, bitLenInt outStart, bitLenInt length)
@@ -1552,17 +1546,16 @@ void QUnit::POWModNOut(bitCapInt toMod, bitCapInt modN, bitLenInt inStart, bitLe
     }
 
     // Otherwise, form the potentially entangled representation:
-    DirtyShardRange(outStart, length);
-
     EntangleRange(inStart, length, outStart, length);
     shards[inStart].unit->POWModNOut(toMod, modN, shards[inStart].mapped, shards[outStart].mapped, length);
+    DirtyShardRange(outStart, length);
 }
 
 QInterfacePtr QUnit::CMULEntangle(std::vector<bitLenInt> controlVec, bitLenInt start, bitCapInt carryStart,
     bitLenInt length, std::vector<bitLenInt>* controlsMapped)
 {
-    DirtyShardRange(carryStart, length);
     EntangleRange(carryStart, length);
+    DirtyShardRange(carryStart, length);
 
     std::vector<bitLenInt> bits(controlVec.size() + 2);
     for (bitLenInt i = 0; i < controlVec.size(); i++) {
@@ -1598,13 +1591,13 @@ void QUnit::CMULx(CMULFn fn, bitCapInt toMod, bitLenInt start, bitLenInt carrySt
     }
 
     // Otherwise, we have to "dirty" the register.
-    DirtyShardRange(start, length);
-
     std::vector<bitLenInt> controlsMapped;
     QInterfacePtr unit = CMULEntangle(controlVec, start, carryStart, length, &controlsMapped);
 
     ((*unit).*fn)(
         toMod, shards[start].mapped, shards[carryStart].mapped, length, &(controlsMapped[0]), controlVec.size());
+
+    DirtyShardRange(start, length);
 }
 
 void QUnit::CMULModx(CMULModFn fn, bitCapInt toMod, bitCapInt modN, bitLenInt start, bitLenInt carryStart,
@@ -1680,10 +1673,9 @@ void QUnit::ZeroPhaseFlip(bitLenInt start, bitLenInt length)
     }
 
     // Otherwise, form the potentially entangled representation:
-    DirtyShardRange(start, length);
-
     EntangleRange(start, length);
     shards[start].unit->ZeroPhaseFlip(shards[start].mapped, length);
+    DirtyShardRange(start, length);
 }
 
 void QUnit::PhaseFlipIfLess(bitCapInt greaterPerm, bitLenInt start, bitLenInt length)
@@ -1698,10 +1690,9 @@ void QUnit::PhaseFlipIfLess(bitCapInt greaterPerm, bitLenInt start, bitLenInt le
     }
 
     // Otherwise, form the potentially entangled representation:
-    DirtyShardRange(start, length);
-
     EntangleRange(start, length);
     shards[start].unit->PhaseFlipIfLess(greaterPerm, shards[start].mapped, length);
+    DirtyShardRange(start, length);
 }
 
 void QUnit::CPhaseFlipIfLess(bitCapInt greaterPerm, bitLenInt start, bitLenInt length, bitLenInt flagIndex)
@@ -1718,9 +1709,6 @@ void QUnit::CPhaseFlipIfLess(bitCapInt greaterPerm, bitLenInt start, bitLenInt l
     }
 
     // Otherwise, form the potentially entangled representation:
-    DirtyShardRange(start, length);
-    shards[flagIndex].isProbDirty = true;
-
     EntangleRange(start, length);
 
     std::vector<bitLenInt> bits(2);
@@ -1735,6 +1723,9 @@ void QUnit::CPhaseFlipIfLess(bitCapInt greaterPerm, bitLenInt start, bitLenInt l
     QInterfacePtr unit = EntangleIterator(ebits.begin(), ebits.end());
 
     unit->CPhaseFlipIfLess(greaterPerm, shards[start].mapped, length, shards[flagIndex].mapped);
+
+    DirtyShardRange(start, length);
+    shards[flagIndex].isProbDirty = true;
 }
 
 void QUnit::PhaseFlip() { shards[0].unit->PhaseFlip(); }
@@ -1742,39 +1733,45 @@ void QUnit::PhaseFlip() { shards[0].unit->PhaseFlip(); }
 bitCapInt QUnit::IndexedLDA(
     bitLenInt indexStart, bitLenInt indexLength, bitLenInt valueStart, bitLenInt valueLength, unsigned char* values)
 {
+    EntangleRange(indexStart, indexLength, valueStart, valueLength);
+
+    bitCapInt toRet = shards[indexStart].unit->IndexedLDA(
+        shards[indexStart].mapped, indexLength, shards[valueStart].mapped, valueLength, values);
+
     DirtyShardRange(indexStart, indexLength);
     DirtyShardRange(valueStart, valueLength);
 
-    EntangleRange(indexStart, indexLength, valueStart, valueLength);
-
-    return shards[indexStart].unit->IndexedLDA(
-        shards[indexStart].mapped, indexLength, shards[valueStart].mapped, valueLength, values);
+    return toRet;
 }
 
 bitCapInt QUnit::IndexedADC(bitLenInt indexStart, bitLenInt indexLength, bitLenInt valueStart, bitLenInt valueLength,
     bitLenInt carryIndex, unsigned char* values)
 {
+    EntangleRange(indexStart, indexLength, valueStart, valueLength, carryIndex, 1);
+
+    bitCapInt toRet = shards[indexStart].unit->IndexedADC(shards[indexStart].mapped, indexLength, shards[valueStart].mapped,
+        valueLength, shards[carryIndex].mapped, values);
+
     DirtyShardRange(indexStart, indexLength);
     DirtyShardRange(valueStart, valueLength);
     shards[carryIndex].isProbDirty = true;
 
-    EntangleRange(indexStart, indexLength, valueStart, valueLength, carryIndex, 1);
-
-    return shards[indexStart].unit->IndexedADC(shards[indexStart].mapped, indexLength, shards[valueStart].mapped,
-        valueLength, shards[carryIndex].mapped, values);
+    return toRet;
 }
 
 bitCapInt QUnit::IndexedSBC(bitLenInt indexStart, bitLenInt indexLength, bitLenInt valueStart, bitLenInt valueLength,
     bitLenInt carryIndex, unsigned char* values)
 {
+    EntangleRange(indexStart, indexLength, valueStart, valueLength, carryIndex, 1);
+
+    bitCapInt toRet = shards[indexStart].unit->IndexedSBC(shards[indexStart].mapped, indexLength, shards[valueStart].mapped,
+        valueLength, shards[carryIndex].mapped, values);
+
     DirtyShardRange(indexStart, indexLength);
     DirtyShardRange(valueStart, valueLength);
     shards[carryIndex].isProbDirty = true;
 
-    EntangleRange(indexStart, indexLength, valueStart, valueLength, carryIndex, 1);
-
-    return shards[indexStart].unit->IndexedSBC(shards[indexStart].mapped, indexLength, shards[valueStart].mapped,
-        valueLength, shards[carryIndex].mapped, values);
+    return toRet;
 }
 
 void QUnit::UpdateRunningNorm()

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -747,34 +747,6 @@ void QUnit::ISqrtSwap(bitLenInt qubit1, bitLenInt qubit2)
     EntangleAndCallMember(PTR2(ISqrtSwap), qubit1, qubit2);
 }
 
-bool QUnit::DoesOperatorPhaseShift(const complex* mtrx)
-{
-    bool doesShift = false;
-    real1 phase = -M_PI * 2;
-    for (int i = 0; i < 4; i++) {
-        if (norm(mtrx[i]) > min_norm) {
-            if (phase < -M_PI) {
-                phase = arg(mtrx[i]);
-                continue;
-            }
-
-            real1 diff = arg(mtrx[i]) - phase;
-            if (diff < ZERO_R1) {
-                diff = -diff;
-            }
-            if (diff > M_PI) {
-                diff = (2 * M_PI) - diff;
-            }
-            if (diff > min_norm) {
-                doesShift = true;
-                break;
-            }
-        }
-    }
-
-    return doesShift;
-}
-
 void QUnit::UniformlyControlledSingleBit(
     const bitLenInt* controls, const bitLenInt& controlLen, bitLenInt qubitIndex, const complex* mtrxs)
 {

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -778,6 +778,8 @@ bool QUnit::DoesOperatorPhaseShift(const complex* mtrx)
 void QUnit::UniformlyControlledSingleBit(
     const bitLenInt* controls, const bitLenInt& controlLen, bitLenInt qubitIndex, const complex* mtrxs)
 {
+    // TODO: Controls that have exactly 0 or 1 probability can be optimized out of the gate.
+
     // If there are no controls, this is equivalent to the single bit gate.
     if (controlLen == 0) {
         ApplySingleBit(mtrxs, true, qubitIndex);
@@ -803,6 +805,7 @@ void QUnit::UniformlyControlledSingleBit(
     bitLenInt* mappedControls = new bitLenInt[controlLen];
     for (i = 0; i < controlLen; i++) {
         mappedControls[i] = shards[controls[i]].mapped;
+        shards[controls[i]].isPhaseDirty = true;
     }
 
     unit->UniformlyControlledSingleBit(mappedControls, controlLen, shards[qubitIndex].mapped, mtrxs);

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -828,7 +828,7 @@ void QUnit::H(bitLenInt target)
     real1 phase = shard.phase;
 
     complex zeroAmpIn = ((real1)sqrt(ONE_R1 - prob)) * complex(ONE_R1, ZERO_R1);
-    complex oneAmpOut = ((real)sqrt(prob)) * complex(cos(phase), sin(phase));
+    complex oneAmpOut = ((real1)sqrt(prob)) * complex(cos(phase), sin(phase));
 
     complex zeroAmpOut = ((real1)M_SQRT1_2) * (zeroAmpIn + oneAmpOut);
     oneAmpOut = ((real1)M_SQRT1_2) * (zeroAmpIn - oneAmpOut);
@@ -836,6 +836,14 @@ void QUnit::H(bitLenInt target)
     prob = norm(oneAmpOut);
     shard.prob = prob;
     shard.phase = ClampPhase(arg(oneAmpOut) - arg(zeroAmpOut));
+
+    if (shard.unit->GetQubitCount() > 1) {
+        if (prob < min_norm) {
+            SeparateBit(false, target);
+        } else if (prob > (ONE_R1 - min_norm)) {
+            SeparateBit(true, target);
+        }
+    }
 }
 
 void QUnit::X(bitLenInt target)
@@ -1089,6 +1097,7 @@ void QUnit::ApplyEitherControlled(const bitLenInt* controls, const bitLenInt& co
     std::vector<bitLenInt> controlsMapped(controlVec.size() == 0 ? 1 : controlVec.size());
     for (i = 0; i < controlVec.size(); i++) {
         controlsMapped[i] = shards[controlVec[i]].mapped;
+        shards[controlVec[i]].isPhaseDirty = true;
     }
 
     cfn(shards[targets[0]].unit, controlsMapped);

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1058,11 +1058,6 @@ void QUnit::ApplyEitherControlled(const bitLenInt* controls, const bitLenInt& co
             // avoiding an entangled representation.
             fn();
 
-            for (i = 0; i < (bitLenInt)targets.size(); i++) {
-                shards[targets[i]].isProbDirty = true;
-                shards[targets[i]].isPhaseDirty = true;
-            }
-
             return;
         }
     }

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1054,10 +1054,17 @@ void QUnit::ApplyEitherControlled(const bitLenInt* controls, const bitLenInt& co
     if (isSeparated) {
         // The controls are entirely separated from the targets already, in this branch. If the probability of a change
         // in state from this gate is 0 or 1, we can just act the gate or skip it, without entangling the bits further.
+        controlIndex = 0;
         real1 prob = ONE_R1;
         real1 bitProb;
-        for (i = 0; i < controlLen; i++) {
-            bitProb = Prob(controls[i]);
+        for (i = 0; i < controlVec.size(); i++) {
+            bitProb = Prob(controlVec[controlIndex]);
+
+            if ((bitProb < min_norm) || ((ONE_R1 - bitProb) < min_norm)) {
+                controlVec.erase(controlVec.begin() + controlIndex);
+            } else {
+                controlIndex++;
+            }
 
             if (anti) {
                 prob *= ONE_R1 - bitProb;

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -827,8 +827,8 @@ void QUnit::H(bitLenInt target)
     real1 prob = shard.prob;
     real1 phase = shard.phase;
 
-    complex zeroAmpIn = sqrt(ONE_R1 - prob) * complex(ONE_R1, ZERO_R1);
-    complex oneAmpOut = sqrt(prob) * complex(cos(phase), sin(phase));
+    complex zeroAmpIn = ((real1)sqrt(ONE_R1 - prob)) * complex(ONE_R1, ZERO_R1);
+    complex oneAmpOut = ((real)sqrt(prob)) * complex(cos(phase), sin(phase));
 
     complex zeroAmpOut = ((real1)M_SQRT1_2) * (zeroAmpIn + oneAmpOut);
     oneAmpOut = ((real1)M_SQRT1_2) * (zeroAmpIn - oneAmpOut);

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -409,6 +409,7 @@ TEST_CASE("test_qft_permutation_round_trip_entangled")
         },
         true, false, testEngineType == QINTERFACE_QUNIT);
 }
+
 TEST_CASE("test_qft_superposition_round_trip")
 {
     benchmarkLoop(


### PR DESCRIPTION
QUnit is generally based on an approach like "stabilizer" quantum circuits. (See https://arxiv.org/abs/quant-ph/0406196.) Compared to other stabilizer engines like it, QUnit has a few advantages:
- On demand, it exceeds the limitations of Clifford gates, to encompass an essentially unconstrained gate set.
- Its theory recovers polynomial time executions and RAM savings **_beyond_** strict, common stabilizer simulators, (though also see related papers referenced in the introduction of the above paper by Vidal, Valiant, and Ter-hal and DiVincenzo, etc.)
- It represents the quantum state as a vector and does not rely on the use of "stabilizer matrices"

(QUnit was originally based on "Breaking the 49-qubit barrier," by Pednault et al., https://arxiv.org/abs/1710.05867, for reference)

Following QUnit's general approach, we should try to incorporate as much of these other approaches as possible. It would be nice, to start, if QUnit was a super set of other simulators based on the Gottesman-Knill theorem.

So far, in this PR, I have added a "memoized" bit phase offset, which lets us add Hadamard gates to QUnit's optimizations. I suspect the combination of "memoized" bit probability and bit phase takes us a long way. The target, for now, is to encompass Gottesman-Knill as fully as possible while not degrading QFT and other benchmark performance.