### PR TITLE
Cleanup (concomitant with ProjectQ debugging)

### DIFF
--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -456,12 +456,7 @@ void QEngineOCL::SetPermutation(bitCapInt perm, complex phaseFac)
 
     complex amp;
     if (phaseFac == complex(-999.0, -999.0)) {
-        if (randGlobalPhase) {
-            real1 angle = Rand() * 2.0 * PI_R1;
-            amp = complex(cos(angle), sin(angle));
-        } else {
-            amp = complex(ONE_R1, ZERO_R1);
-        }
+        amp = GetNonunitaryPhase();
     } else {
         amp = phaseFac;
     }

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -1111,7 +1111,8 @@ void QEngineOCL::DecomposeDispose(bitLenInt start, bitLenInt length, QEngineOCLP
     delete[] partStateProb;
     delete[] partStateAngle;
 
-    // We absolutely need to normalize, here. If the engine will not pick it up in stride, because "doNormalize" is false, then we need to force it right here.
+    // We absolutely need to normalize, here. If the engine will not pick it up in stride, because "doNormalize" is
+    // false, then we need to force it right here.
     UpdateRunningNorm();
     if (!doNormalize) {
         NormalizeState();
@@ -1119,7 +1120,7 @@ void QEngineOCL::DecomposeDispose(bitLenInt start, bitLenInt length, QEngineOCLP
     if (destination != nullptr) {
         destination->UpdateRunningNorm();
         if (!(destination->doNormalize)) {
-             destination->NormalizeState();
+            destination->NormalizeState();
         }
     }
 }
@@ -1547,8 +1548,8 @@ void QEngineOCL::INTSC(
     bitCapInt inOutMask = (lengthPower - 1U) << start;
     bitCapInt otherMask = ((1U << qubitCount) - 1U) ^ (inOutMask | carryMask);
 
-    bitCapInt bciArgs[BCI_ARG_LEN] = { maxQPower >> 1U, inOutMask, otherMask, lengthPower, carryMask, start, toMod, 0, 0,
-        0 };
+    bitCapInt bciArgs[BCI_ARG_LEN] = { maxQPower >> 1U, inOutMask, otherMask, lengthPower, carryMask, start, toMod, 0,
+        0, 0 };
 
     ArithmeticCall(api_call, bciArgs);
 }

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -895,9 +895,9 @@ bitLenInt QEngineOCL::Compose(QEngineOCLPtr toCopy)
 
     bitCapInt oQubitCount = toCopy->qubitCount;
     bitCapInt nQubitCount = qubitCount + oQubitCount;
-    bitCapInt nMaxQPower = 1 << nQubitCount;
-    bitCapInt startMask = (1 << qubitCount) - 1;
-    bitCapInt endMask = ((1 << (toCopy->qubitCount)) - 1) << qubitCount;
+    bitCapInt nMaxQPower = 1U << nQubitCount;
+    bitCapInt startMask = maxQPower - 1U;
+    bitCapInt endMask = (toCopy->maxQPower - 1U) << qubitCount;
     bitCapInt bciArgs[BCI_ARG_LEN] = { nMaxQPower, qubitCount, startMask, endMask, 0, 0, 0, 0, 0, 0 };
 
     OCLAPI api_call;
@@ -918,10 +918,10 @@ bitLenInt QEngineOCL::Compose(QEngineOCLPtr toCopy, bitLenInt start)
 
     bitCapInt oQubitCount = toCopy->qubitCount;
     bitCapInt nQubitCount = qubitCount + oQubitCount;
-    bitCapInt nMaxQPower = 1 << nQubitCount;
-    bitCapInt startMask = (1 << start) - 1;
-    bitCapInt midMask = ((1 << oQubitCount) - 1) << start;
-    bitCapInt endMask = ((1 << (qubitCount + oQubitCount)) - 1) & ~(startMask | midMask);
+    bitCapInt nMaxQPower = 1U << nQubitCount;
+    bitCapInt startMask = (1U << start) - 1U;
+    bitCapInt midMask = ((1U << oQubitCount) - 1U) << start;
+    bitCapInt endMask = ((1U << (qubitCount + oQubitCount)) - 1U) & ~(startMask | midMask);
     bitCapInt bciArgs[BCI_ARG_LEN] = { nMaxQPower, qubitCount, oQubitCount, startMask, midMask, endMask, start, 0, 0,
         0 };
 
@@ -944,8 +944,8 @@ void QEngineOCL::DecomposeDispose(bitLenInt start, bitLenInt length, QEngineOCLP
         NormalizeState();
     }
 
-    bitCapInt partPower = 1 << length;
-    bitCapInt remainderPower = 1 << (qubitCount - length);
+    bitCapInt partPower = 1U << length;
+    bitCapInt remainderPower = 1U << (qubitCount - length);
     bitCapInt bciArgs[BCI_ARG_LEN] = { partPower, remainderPower, start, length, 0, 0, 0, 0, 0, 0 };
 
     EventVecPtr waitVec = ResetWaitEvents();
@@ -991,7 +991,7 @@ void QEngineOCL::DecomposeDispose(bitLenInt start, bitLenInt length, QEngineOCLP
     while ((i < remainderPower) && (remainderStateProb[i] < min_norm)) {
         i++;
     }
-    k = i & ((1U << start) - 1);
+    k = i & ((1U << start) - 1U);
     k |= (i ^ k) << (start + length);
 
     while ((j < partPower) && (partStateProb[j] < min_norm)) {
@@ -1160,9 +1160,9 @@ real1 QEngineOCL::Prob(bitLenInt qubit)
         return ProbAll(1);
     }
 
-    bitCapInt qPower = 1 << qubit;
+    bitCapInt qPower = 1U << qubit;
 
-    bitCapInt bciArgs[BCI_ARG_LEN] = { maxQPower >> 1, qPower, 0, 0, 0, 0, 0, 0, 0, 0 };
+    bitCapInt bciArgs[BCI_ARG_LEN] = { maxQPower >> 1U, qPower, 0, 0, 0, 0, 0, 0, 0, 0 };
 
     return Probx(OCL_API_PROB, bciArgs);
 }
@@ -1274,7 +1274,7 @@ void QEngineOCL::ProbMaskAll(const bitCapInt& mask, real1* probsArray)
     std::vector<bitCapInt> powersVec;
     for (length = 0; v; length++) {
         oldV = v;
-        v &= v - 1; // clear the least significant bit set
+        v &= v - 1U; // clear the least significant bit set
         powersVec.push_back((v ^ oldV) & oldV);
     }
 
@@ -1292,13 +1292,13 @@ void QEngineOCL::ProbMaskAll(const bitCapInt& mask, real1* probsArray)
         return;
     }
 
-    v = (~mask) & (maxQPower - 1); // count the number of bits set in v
+    v = (~mask) & (maxQPower - 1U); // count the number of bits set in v
     bitCapInt skipPower;
     bitLenInt skipLength = 0; // c accumulates the total bits set in v
     std::vector<bitCapInt> skipPowersVec;
     for (skipLength = 0; v; skipLength++) {
         oldV = v;
-        v &= v - 1; // clear the least significant bit set
+        v &= v - 1U; // clear the least significant bit set
         skipPower = (v ^ oldV) & oldV;
         skipPowersVec.push_back(skipPower);
     }
@@ -1341,18 +1341,18 @@ void QEngineOCL::ProbMaskAll(const bitCapInt& mask, real1* probsArray)
 
 void QEngineOCL::ROx(OCLAPI api_call, bitLenInt shift, bitLenInt start, bitLenInt length)
 {
-    if (length == 0U) {
+    if (length == 0) {
         return;
     }
 
     shift %= length;
-    if (shift == 0U) {
+    if (shift == 0) {
         return;
     }
 
-    bitCapInt lengthPower = 1 << length;
-    bitCapInt regMask = (lengthPower - 1) << start;
-    bitCapInt otherMask = (maxQPower - 1) & (~regMask);
+    bitCapInt lengthPower = 1U << length;
+    bitCapInt regMask = (lengthPower - 1U) << start;
+    bitCapInt otherMask = (maxQPower - 1U) & (~regMask);
     bitCapInt bciArgs[BCI_ARG_LEN] = { maxQPower, regMask, otherMask, lengthPower, start, shift, length, 0, 0, 0 };
 
     ArithmeticCall(api_call, bciArgs);
@@ -1364,19 +1364,19 @@ void QEngineOCL::ROL(bitLenInt shift, bitLenInt start, bitLenInt length) { ROx(O
 /// Add or Subtract integer (without sign or carry)
 void QEngineOCL::INT(OCLAPI api_call, bitCapInt toMod, const bitLenInt start, const bitLenInt length)
 {
-    if (length == 0U) {
+    if (length == 0) {
         return;
     }
 
     bitCapInt lengthPower = 1U << length;
     bitCapInt lengthMask = lengthPower - 1U;
     toMod &= lengthMask;
-    if (toMod == 0U) {
+    if (toMod == 0) {
         return;
     }
 
     bitCapInt regMask = lengthMask << start;
-    bitCapInt otherMask = (maxQPower - 1) & ~(regMask);
+    bitCapInt otherMask = (maxQPower - 1U) & ~(regMask);
 
     bitCapInt bciArgs[BCI_ARG_LEN] = { maxQPower, regMask, otherMask, lengthPower, start, toMod, 0, 0, 0, 0 };
 
@@ -1387,20 +1387,20 @@ void QEngineOCL::INT(OCLAPI api_call, bitCapInt toMod, const bitLenInt start, co
 void QEngineOCL::CINT(OCLAPI api_call, bitCapInt toMod, const bitLenInt start, const bitLenInt length,
     const bitLenInt* controls, const bitLenInt controlLen)
 {
-    if (length == 0U) {
+    if (length == 0) {
         return;
     }
 
     bitCapInt lengthPower = 1U << length;
     bitCapInt lengthMask = lengthPower - 1U;
     toMod &= lengthMask;
-    if (toMod == 0U) {
+    if (toMod == 0) {
         return;
     }
 
     bitCapInt regMask = lengthMask << start;
 
-    bitCapInt controlMask = 0U;
+    bitCapInt controlMask = 0;
     bitCapInt* controlPowers = new bitCapInt[controlLen];
     for (bitLenInt i = 0; i < controlLen; i++) {
         controlPowers[i] = 1U << controls[i];
@@ -1408,7 +1408,7 @@ void QEngineOCL::CINT(OCLAPI api_call, bitCapInt toMod, const bitLenInt start, c
     }
     std::sort(controlPowers, controlPowers + controlLen);
 
-    bitCapInt otherMask = (maxQPower - 1) ^ (regMask | controlMask);
+    bitCapInt otherMask = (maxQPower - 1U) ^ (regMask | controlMask);
 
     bitCapInt bciArgs[BCI_ARG_LEN] = { maxQPower >> controlLen, regMask, otherMask, lengthPower, start, toMod,
         controlLen, controlMask, 0, 0 };
@@ -1439,22 +1439,22 @@ void QEngineOCL::CINC(
 void QEngineOCL::INTC(
     OCLAPI api_call, bitCapInt toMod, const bitLenInt start, const bitLenInt length, const bitLenInt carryIndex)
 {
-    if (length == 0U) {
+    if (length == 0) {
         return;
     }
 
     bitCapInt lengthPower = 1U << length;
     bitCapInt lengthMask = lengthPower - 1U;
     toMod &= lengthMask;
-    if (toMod == 0U) {
+    if (toMod == 0) {
         return;
     }
 
-    bitCapInt carryMask = 1 << carryIndex;
-    bitCapInt regMask = (lengthPower - 1) << start;
-    bitCapInt otherMask = (maxQPower - 1) & (~(regMask | carryMask));
+    bitCapInt carryMask = 1U << carryIndex;
+    bitCapInt regMask = (lengthPower - 1U) << start;
+    bitCapInt otherMask = (maxQPower - 1U) & (~(regMask | carryMask));
 
-    bitCapInt bciArgs[BCI_ARG_LEN] = { maxQPower >> 1, regMask, otherMask, lengthPower, carryMask, start, toMod, 0, 0,
+    bitCapInt bciArgs[BCI_ARG_LEN] = { maxQPower >> 1U, regMask, otherMask, lengthPower, carryMask, start, toMod, 0, 0,
         0 };
 
     ArithmeticCall(api_call, bciArgs);
@@ -1471,14 +1471,14 @@ void QEngineOCL::INCDECC(
 void QEngineOCL::INTS(
     OCLAPI api_call, bitCapInt toMod, const bitLenInt start, const bitLenInt length, const bitLenInt overflowIndex)
 {
-    if (length == 0U) {
+    if (length == 0) {
         return;
     }
 
     bitCapInt lengthPower = 1U << length;
     bitCapInt lengthMask = lengthPower - 1U;
     toMod &= lengthMask;
-    if (toMod == 0U) {
+    if (toMod == 0) {
         return;
     }
 
@@ -1502,14 +1502,14 @@ void QEngineOCL::INCS(bitCapInt toAdd, const bitLenInt start, const bitLenInt le
 void QEngineOCL::INTSC(OCLAPI api_call, bitCapInt toMod, const bitLenInt start, const bitLenInt length,
     const bitLenInt overflowIndex, const bitLenInt carryIndex)
 {
-    if (length == 0U) {
+    if (length == 0) {
         return;
     }
 
     bitCapInt lengthPower = 1U << length;
     bitCapInt lengthMask = lengthPower - 1U;
     toMod &= lengthMask;
-    if (toMod == 0U) {
+    if (toMod == 0) {
         return;
     }
 
@@ -1535,12 +1535,12 @@ void QEngineOCL::INCDECSC(bitCapInt toAdd, const bitLenInt& start, const bitLenI
 void QEngineOCL::INTSC(
     OCLAPI api_call, bitCapInt toMod, const bitLenInt start, const bitLenInt length, const bitLenInt carryIndex)
 {
-    bitCapInt carryMask = 1 << carryIndex;
-    bitCapInt lengthPower = 1 << length;
-    bitCapInt inOutMask = (lengthPower - 1) << start;
-    bitCapInt otherMask = ((1 << qubitCount) - 1) ^ (inOutMask | carryMask);
+    bitCapInt carryMask = 1U << carryIndex;
+    bitCapInt lengthPower = 1U << length;
+    bitCapInt inOutMask = (lengthPower - 1U) << start;
+    bitCapInt otherMask = ((1U << qubitCount) - 1U) ^ (inOutMask | carryMask);
 
-    bitCapInt bciArgs[BCI_ARG_LEN] = { maxQPower >> 1, inOutMask, otherMask, lengthPower, carryMask, start, toMod, 0, 0,
+    bitCapInt bciArgs[BCI_ARG_LEN] = { maxQPower >> 1U, inOutMask, otherMask, lengthPower, carryMask, start, toMod, 0, 0,
         0 };
 
     ArithmeticCall(api_call, bciArgs);

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -732,7 +732,7 @@ void QEngineOCL::Apply2x2(bitCapInt offset1, bitCapInt offset2, const complex* m
         // If we have calculated the norm of the state vector in this call, we need to sum the buffer of partial norm
         // values into a single normalization constant.
         WAIT_REAL1_SUM(*nrmBuffer, ngc / ngs, nrmArray, &runningNorm);
-    } else if ((bitCount == 1) && !isXGate) {
+    } else if ((bitCount == 1) && (!isXGate) && (!isZGate)) {
         runningNorm = ONE_R1;
     }
 }

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -916,11 +916,11 @@ bitLenInt QEngineOCL::Compose(QEngineOCLPtr toCopy, bitLenInt start)
 {
     bitLenInt result = start;
 
-    bitCapInt oQubitCount = toCopy->qubitCount;
-    bitCapInt nQubitCount = qubitCount + oQubitCount;
+    bitLenInt oQubitCount = toCopy->qubitCount;
+    bitLenInt nQubitCount = qubitCount + oQubitCount;
     bitCapInt nMaxQPower = 1U << nQubitCount;
     bitCapInt startMask = (1U << start) - 1U;
-    bitCapInt midMask = ((1U << oQubitCount) - 1U) << start;
+    bitCapInt midMask = bitRegMask(start, oQubitCount);
     bitCapInt endMask = ((1U << (qubitCount + oQubitCount)) - 1U) & ~(startMask | midMask);
     bitCapInt bciArgs[BCI_ARG_LEN] = { nMaxQPower, qubitCount, oQubitCount, startMask, midMask, endMask, start, 0, 0,
         0 };

--- a/src/qengine/qengine.cpp
+++ b/src/qengine/qengine.cpp
@@ -157,10 +157,10 @@ bool QEngine::IsIdentity(const complex* mtrx)
 {
     // If the effect of applying the buffer would be (approximately or exactly) that of applying the identity
     // operator, then we can discard this buffer without applying it.
-    if ((real(mtrx[1]) > min_norm) || (imag(mtrx[1]) > min_norm)) {
+    if (norm(mtrx[1]) > min_norm) {
         return false;
     }
-    if ((real(mtrx[2]) > min_norm) || (imag(mtrx[2]) > min_norm)) {
+    if (norm(mtrx[2]) > min_norm) {
         return false;
     }
 

--- a/src/qengine/qengine.cpp
+++ b/src/qengine/qengine.cpp
@@ -366,37 +366,31 @@ void QEngine::AntiCISqrtSwap(
 void QEngine::ApplyControlled2x2(const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& target,
     const complex* mtrx, bool doCalcNorm)
 {
-    bitCapInt* qPowers = new bitCapInt[controlLen + 1U];
     bitCapInt* qPowersSorted = new bitCapInt[controlLen + 1U];
     bitCapInt fullMask = 0U;
     bitCapInt controlMask;
     for (bitLenInt i = 0U; i < controlLen; i++) {
-        qPowers[i] = 1U << controls[i];
-        fullMask |= qPowers[i];
+        qPowersSorted[i] = 1U << controls[i];
+        fullMask |= qPowersSorted[i];
     }
     controlMask = fullMask;
-    qPowers[controlLen] = 1U << target;
-    fullMask |= qPowers[controlLen];
-    std::copy(qPowers, qPowers + controlLen + 1U, qPowersSorted);
+    qPowersSorted[controlLen] = 1U << target;
+    fullMask |= qPowersSorted[controlLen];
     std::sort(qPowersSorted, qPowersSorted + controlLen + 1U);
     Apply2x2(controlMask, fullMask, mtrx, controlLen + 1U, qPowersSorted, doCalcNorm);
-    delete[] qPowers;
     delete[] qPowersSorted;
 }
 
 void QEngine::ApplyAntiControlled2x2(const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& target,
     const complex* mtrx, bool doCalcNorm)
 {
-    bitCapInt* qPowers = new bitCapInt[controlLen + 1U];
     bitCapInt* qPowersSorted = new bitCapInt[controlLen + 1U];
-    for (int i = 0U; i < controlLen; i++) {
-        qPowers[i] = 1U << controls[i];
+    for (bitLenInt i = 0U; i < controlLen; i++) {
+        qPowersSorted[i] = 1U << controls[i];
     }
-    qPowers[controlLen] = 1U << target;
-    std::copy(qPowers, qPowers + controlLen + 1U, qPowersSorted);
+    qPowersSorted[controlLen] = 1U << target;
     std::sort(qPowersSorted, qPowersSorted + controlLen + 1U);
-    Apply2x2(0U, qPowers[controlLen], mtrx, controlLen + 1U, qPowersSorted, doCalcNorm);
-    delete[] qPowers;
+    Apply2x2(0U, 1U << target, mtrx, controlLen + 1U, qPowersSorted, doCalcNorm);
     delete[] qPowersSorted;
 }
 
@@ -409,11 +403,9 @@ void QEngine::Swap(bitLenInt qubit1, bitLenInt qubit2)
 
     const complex pauliX[4] = { complex(ZERO_R1, ZERO_R1), complex(ONE_R1, ZERO_R1), complex(ONE_R1, ZERO_R1),
         complex(ZERO_R1, ZERO_R1) };
-    bitCapInt qPowers[2];
     bitCapInt qPowersSorted[2];
-    qPowers[0] = 1 << qubit1;
-    qPowers[1] = 1 << qubit2;
-    std::copy(qPowers, qPowers + 2, qPowersSorted);
+    qPowersSorted[0] = 1 << qubit1;
+    qPowersSorted[1] = 1 << qubit2;
     std::sort(qPowersSorted, qPowersSorted + 2);
     Apply2x2(qPowersSorted[0], qPowersSorted[1], pauliX, 2, qPowersSorted, false);
 }
@@ -427,11 +419,9 @@ void QEngine::SqrtSwap(bitLenInt qubit1, bitLenInt qubit2)
 
     const complex sqrtX[4] = { complex(ONE_R1 / 2, ONE_R1 / 2), complex(ONE_R1 / 2, -ONE_R1 / 2),
         complex(ONE_R1 / 2, -ONE_R1 / 2), complex(ONE_R1 / 2, ONE_R1 / 2) };
-    bitCapInt qPowers[2];
     bitCapInt qPowersSorted[2];
-    qPowers[0] = 1 << qubit1;
-    qPowers[1] = 1 << qubit2;
-    std::copy(qPowers, qPowers + 2, qPowersSorted);
+    qPowersSorted[0] = 1 << qubit1;
+    qPowersSorted[1] = 1 << qubit2;
     std::sort(qPowersSorted, qPowersSorted + 2);
     Apply2x2(qPowersSorted[0], qPowersSorted[1], sqrtX, 2, qPowersSorted, false);
 }
@@ -445,11 +435,9 @@ void QEngine::ISqrtSwap(bitLenInt qubit1, bitLenInt qubit2)
 
     const complex iSqrtX[4] = { complex(ONE_R1 / 2, -ONE_R1 / 2), complex(ONE_R1 / 2, ONE_R1 / 2),
         complex(ONE_R1 / 2, ONE_R1 / 2), complex(ONE_R1 / 2, -ONE_R1 / 2) };
-    bitCapInt qPowers[2];
     bitCapInt qPowersSorted[2];
-    qPowers[0] = 1 << qubit1;
-    qPowers[1] = 1 << qubit2;
-    std::copy(qPowers, qPowers + 2, qPowersSorted);
+    qPowersSorted[0] = 1 << qubit1;
+    qPowersSorted[1] = 1 << qubit2;
     std::sort(qPowersSorted, qPowersSorted + 2);
     Apply2x2(qPowersSorted[0], qPowersSorted[1], iSqrtX, 2, qPowersSorted, false);
 }

--- a/src/qengine/qengine.cpp
+++ b/src/qengine/qengine.cpp
@@ -366,20 +366,20 @@ void QEngine::AntiCISqrtSwap(
 void QEngine::ApplyControlled2x2(const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& target,
     const complex* mtrx, bool doCalcNorm)
 {
-    bitCapInt* qPowers = new bitCapInt[controlLen + 1];
-    bitCapInt* qPowersSorted = new bitCapInt[controlLen + 1];
-    bitCapInt fullMask = 0;
+    bitCapInt* qPowers = new bitCapInt[controlLen + 1U];
+    bitCapInt* qPowersSorted = new bitCapInt[controlLen + 1U];
+    bitCapInt fullMask = 0U;
     bitCapInt controlMask;
-    for (int i = 0; i < controlLen; i++) {
-        qPowers[i] = 1 << controls[i];
+    for (bitLenInt i = 0U; i < controlLen; i++) {
+        qPowers[i] = 1U << controls[i];
         fullMask |= qPowers[i];
     }
     controlMask = fullMask;
-    qPowers[controlLen] = 1 << target;
+    qPowers[controlLen] = 1U << target;
     fullMask |= qPowers[controlLen];
-    std::copy(qPowers, qPowers + controlLen + 1, qPowersSorted);
-    std::sort(qPowersSorted, qPowersSorted + controlLen + 1);
-    Apply2x2(controlMask, fullMask, mtrx, controlLen + 1, qPowersSorted, doCalcNorm);
+    std::copy(qPowers, qPowers + controlLen + 1U, qPowersSorted);
+    std::sort(qPowersSorted, qPowersSorted + controlLen + 1U);
+    Apply2x2(controlMask, fullMask, mtrx, controlLen + 1U, qPowersSorted, doCalcNorm);
     delete[] qPowers;
     delete[] qPowersSorted;
 }
@@ -387,15 +387,15 @@ void QEngine::ApplyControlled2x2(const bitLenInt* controls, const bitLenInt& con
 void QEngine::ApplyAntiControlled2x2(const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& target,
     const complex* mtrx, bool doCalcNorm)
 {
-    bitCapInt* qPowers = new bitCapInt[controlLen + 1];
-    bitCapInt* qPowersSorted = new bitCapInt[controlLen + 1];
-    for (int i = 0; i < controlLen; i++) {
-        qPowers[i] = 1 << controls[i];
+    bitCapInt* qPowers = new bitCapInt[controlLen + 1U];
+    bitCapInt* qPowersSorted = new bitCapInt[controlLen + 1U];
+    for (int i = 0U; i < controlLen; i++) {
+        qPowers[i] = 1U << controls[i];
     }
-    qPowers[controlLen] = 1 << target;
-    std::copy(qPowers, qPowers + controlLen + 1, qPowersSorted);
-    std::sort(qPowersSorted, qPowersSorted + controlLen + 1);
-    Apply2x2(0, qPowers[controlLen], mtrx, controlLen + 1, qPowersSorted, doCalcNorm);
+    qPowers[controlLen] = 1U << target;
+    std::copy(qPowers, qPowers + controlLen + 1U, qPowersSorted);
+    std::sort(qPowersSorted, qPowersSorted + controlLen + 1U);
+    Apply2x2(0U, qPowers[controlLen], mtrx, controlLen + 1U, qPowersSorted, doCalcNorm);
     delete[] qPowers;
     delete[] qPowersSorted;
 }

--- a/src/qengine/qengine.cpp
+++ b/src/qengine/qengine.cpp
@@ -375,7 +375,7 @@ void QEngine::ApplyControlled2x2(const bitLenInt* controls, const bitLenInt& con
     }
     controlMask = fullMask;
     qPowersSorted[controlLen] = 1U << target;
-    fullMask |= qPowersSorted[controlLen];
+    fullMask |= 1U << target;
     std::sort(qPowersSorted, qPowersSorted + controlLen + 1U);
     Apply2x2(controlMask, fullMask, mtrx, controlLen + 1U, qPowersSorted, doCalcNorm);
     delete[] qPowersSorted;

--- a/src/qengine/state.cpp
+++ b/src/qengine/state.cpp
@@ -359,11 +359,11 @@ bitLenInt QEngineCPU::Compose(QEngineCPUPtr toCopy, bitLenInt start)
         toCopy->NormalizeState();
     }
 
-    bitCapInt oQubitCount = toCopy->qubitCount;
-    bitCapInt nQubitCount = qubitCount + oQubitCount;
+    bitLenInt oQubitCount = toCopy->qubitCount;
+    bitLenInt nQubitCount = qubitCount + oQubitCount;
     bitCapInt nMaxQPower = 1U << nQubitCount;
     bitCapInt startMask = (1U << start) - 1U;
-    bitCapInt midMask = ((1U << oQubitCount) - 1U) << start;
+    bitCapInt midMask = bitRegMask(start, oQubitCount);
     bitCapInt endMask = ((1U << (qubitCount + oQubitCount)) - 1U) & ~(startMask | midMask);
 
     complex* nStateVec = AllocStateVec(nMaxQPower);

--- a/src/qengine/state.cpp
+++ b/src/qengine/state.cpp
@@ -544,7 +544,7 @@ void QEngineCPU::DecomposeDispose(bitLenInt start, bitLenInt length, QEngineCPUP
         partStateAngle[l] += angleOffset;
     }
 
-    if ((maxQPower - partPower) == 0U) {
+    if ((maxQPower - partPower) == 0) {
         SetQubitCount(1);
     } else {
         SetQubitCount(qubitCount - length);
@@ -569,8 +569,8 @@ void QEngineCPU::DecomposeDispose(bitLenInt start, bitLenInt length, QEngineCPUP
     delete[] partStateProb;
     delete[] partStateAngle;
 
-
-    // We absolutely need to normalize, here. If the engine will not pick it up in stride, because "doNormalize" is false, then we need to force it right here.
+    // We absolutely need to normalize, here. If the engine will not pick it up in stride, because "doNormalize" is
+    // false, then we need to force it right here.
     UpdateRunningNorm();
     if (!doNormalize) {
         NormalizeState();
@@ -578,7 +578,7 @@ void QEngineCPU::DecomposeDispose(bitLenInt start, bitLenInt length, QEngineCPUP
     if (destination != nullptr) {
         destination->UpdateRunningNorm();
         if (!(destination->doNormalize)) {
-             destination->NormalizeState();
+            destination->NormalizeState();
         }
     }
 }
@@ -731,8 +731,8 @@ bool QEngineCPU::ApproxCompare(QEngineCPUPtr toCompare)
 /// For chips with a zero flag, flip the phase of the state where the register equals zero.
 void QEngineCPU::ZeroPhaseFlip(bitLenInt start, bitLenInt length)
 {
-    par_for_skip(0, maxQPower, 1U << start, length,
-        [&](const bitCapInt lcv, const int cpu) { stateVec[lcv] = -stateVec[lcv]; });
+    par_for_skip(
+        0, maxQPower, 1U << start, length, [&](const bitCapInt lcv, const int cpu) { stateVec[lcv] = -stateVec[lcv]; });
 }
 
 /// The 6502 uses its carry flag also as a greater-than/less-than flag, for the CMP operation.

--- a/src/qengine/state.cpp
+++ b/src/qengine/state.cpp
@@ -156,12 +156,14 @@ union ComplexUnion {
 void QEngineCPU::Apply2x2(bitCapInt offset1, bitCapInt offset2, const complex* mtrx, const bitLenInt bitCount,
     const bitCapInt* qPowersSorted, bool doCalcNorm)
 {
+    doCalcNorm &= doNormalize && (bitCount == 1);
+
     int numCores = GetConcurrencyLevel();
     real1 nrm = doNormalize ? (ONE_R1 / std::sqrt(runningNorm)) : ONE_R1;
     ComplexUnion mtrxCol1(mtrx[0], mtrx[2]);
     ComplexUnion mtrxCol2(mtrx[1], mtrx[3]);
 
-    if (doCalcNorm && (bitCount == 1)) {
+    if (doCalcNorm) {
         real1* rngNrm = new real1[numCores];
         std::fill(rngNrm, rngNrm + numCores, ZERO_R1);
         par_for_mask(0, maxQPower, qPowersSorted, bitCount, [&](const bitCapInt lcv, const int cpu) {
@@ -205,10 +207,12 @@ void QEngineCPU::Apply2x2(bitCapInt offset1, bitCapInt offset2, const complex* m
 void QEngineCPU::Apply2x2(bitCapInt offset1, bitCapInt offset2, const complex* mtrx, const bitLenInt bitCount,
     const bitCapInt* qPowersSorted, bool doCalcNorm)
 {
+    doCalcNorm &= doNormalize && (bitCount == 1);
+
     int numCores = GetConcurrencyLevel();
     real1 nrm = doNormalize ? (ONE_R1 / std::sqrt(runningNorm)) : ONE_R1;
 
-    if (doCalcNorm && (bitCount == 1)) {
+    if (doCalcNorm) {
         real1* rngNrm = new real1[numCores];
         std::fill(rngNrm, rngNrm + numCores, ZERO_R1);
         par_for_mask(0, maxQPower, qPowersSorted, bitCount, [&](const bitCapInt lcv, const int cpu) {

--- a/src/qengine/state.cpp
+++ b/src/qengine/state.cpp
@@ -46,14 +46,7 @@ QEngineCPU::QEngineCPU(bitLenInt qBitCount, bitCapInt initState, qrack_rand_gen_
     std::fill(stateVec, stateVec + maxQPower, complex(ZERO_R1, ZERO_R1));
 
     if (phaseFac == complex(-999.0, -999.0)) {
-        complex phase;
-        if (randGlobalPhase) {
-            real1 angle = Rand() * 2.0 * PI_R1;
-            phase = complex(cos(angle), sin(angle));
-        } else {
-            phase = complex(ONE_R1, ZERO_R1);
-        }
-        stateVec[initState] = phase;
+        stateVec[initState] = GetNonunitaryPhase();
     } else {
         stateVec[initState] = phaseFac;
     }

--- a/src/qengine/state.cpp
+++ b/src/qengine/state.cpp
@@ -198,7 +198,7 @@ void QEngineCPU::Apply2x2(bitCapInt offset1, bitCapInt offset2, const complex* m
             stateVec[lcv + offset2] = qubit.cmplx[1];
 #endif
         });
-        if (doNormalize && doCalcNorm) {
+        if (doCalcNorm) {
             UpdateRunningNorm();
         }
     }
@@ -246,7 +246,7 @@ void QEngineCPU::Apply2x2(bitCapInt offset1, bitCapInt offset2, const complex* m
             stateVec[lcv + offset1] = qubit[0];
             stateVec[lcv + offset2] = qubit[1];
         });
-        if (doNormalize && doCalcNorm) {
+        if (doCalcNorm) {
             UpdateRunningNorm();
         }
     }

--- a/src/qengine/state.cpp
+++ b/src/qengine/state.cpp
@@ -568,6 +568,19 @@ void QEngineCPU::DecomposeDispose(bitLenInt start, bitLenInt length, QEngineCPUP
     delete[] remainderStateAngle;
     delete[] partStateProb;
     delete[] partStateAngle;
+
+
+    // We absolutely need to normalize, here. If the engine will not pick it up in stride, because "doNormalize" is false, then we need to force it right here.
+    UpdateRunningNorm();
+    if (!doNormalize) {
+        NormalizeState();
+    }
+    if (destination != nullptr) {
+        destination->UpdateRunningNorm();
+        if (!(destination->doNormalize)) {
+             destination->NormalizeState();
+        }
+    }
 }
 
 void QEngineCPU::Decompose(bitLenInt start, bitLenInt length, QInterfacePtr destination)


### PR DESCRIPTION
I debugged ProjectQ support, today, and I diagnosed issues with that stack. A PR will be coming immediately on the Qrack fork of ProjectQ.

On the Qrack side of this process, we have a small internal refactor. Here's the standard I suggest for signed versus unsigned literals:
- Integral 0 literals should be signed, for simplicity. `0` implies signed 0.
- Integral 1 literals throughout the library should probably almost universally be unsigned 1, "`1U`."
- Floating point types should rely on `ONE_R1` and `ZERO_R1`.

This is premature, but it should be the guideline. `bitLenInt` and `bitCapInt` are unsigned types. Nothing in the library depends on the sign of 0, so terseness is preferable. Bit shifting patterns are used ubiquitously as `(1U << qubitIndex) - 1U`, and the safest and most explicit pattern for this uses unsigned 1 literals. We've already run into related typing problems with GCC on the Raspberry Pi, and ultimately, this makes the difference between maximum addressable qubits, and 1 qubit short of maximum, on less robust compilers.

This isn't high priority, but parity for debugging ProjectQ is.