### PR TITLE
Multi-compose in QEngineCPU removed, too low accuracy

### DIFF
--- a/include/qengine_cpu.hpp
+++ b/include/qengine_cpu.hpp
@@ -55,7 +55,6 @@ public:
 
     virtual bitLenInt Compose(QEngineCPUPtr toCopy);
     virtual bitLenInt Compose(QInterfacePtr toCopy) { return Compose(std::dynamic_pointer_cast<QEngineCPU>(toCopy)); }
-    virtual std::map<QInterfacePtr, bitLenInt> Compose(std::vector<QInterfacePtr> toCopy);
     virtual bitLenInt Compose(QEngineCPUPtr toCopy, bitLenInt start);
     virtual bitLenInt Compose(QInterfacePtr toCopy, bitLenInt start)
     {


### PR DESCRIPTION
I tested QEngineOCL extensively for the ProjectQ updates, but, of course, the CI on that repo tests based on QEngineCPU. Normalizing after decomposition fixed issues with my GPU, but this is apparently insufficient for QEngineCPU. The culprit seems to be the all-at-once composition of many QEngineCPUs, which does not achieve sufficient accuracy, it turns out.

We've had this override in for a long time, and it was very nice in theory. Accuracy precludes it, though. The public interface method is still available, but the operation will occur one unit at a time, "under the hood."