### PR TITLE
Debugging Decompose (for ProjectQ)

### DIFF
--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -123,10 +123,10 @@ protected:
 
     static inline real1 clampProb(real1 toClamp)
     {
-        if (toClamp < ZERO_R1) {
+        if (toClamp < min_norm) {
             toClamp = ZERO_R1;
         }
-        if (toClamp > ONE_R1) {
+        if (toClamp > (ONE_R1 - min_norm)) {
             toClamp = ONE_R1;
         }
         return toClamp;

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -86,7 +86,6 @@ public:
     {
         return Compose(std::dynamic_pointer_cast<QUnit>(toCopy), start);
     }
-    virtual void Compose(QUnitPtr toCopy, bool isMid, bitLenInt start);
     virtual void Decompose(bitLenInt start, bitLenInt length, QInterfacePtr dest)
     {
         Decompose(start, length, std::dynamic_pointer_cast<QUnit>(dest));

--- a/src/common/qengine.cl
+++ b/src/common/qengine.cl
@@ -1551,29 +1551,33 @@ void kernel approxcompare(global cmplx* stateVec1, global cmplx* stateVec2, cons
     basePerm--;
     amp = stateVec1[basePerm];
     nrm = dot(amp, amp);
-    basePhaseFac1 = (ONE_R1 / sqrt(nrm)) * amp;
 
-    amp = stateVec2[basePerm];
-    cmplx basePhaseFac2 = (ONE_R1 / sqrt(dot(amp, amp))) * amp;
+    // If the amplitude we sample for global phase offset correction doesn't match, we're done.
+    if (nrm > min_norm) {
+        basePhaseFac1 = (ONE_R1 / sqrt(nrm)) * amp;
 
-    for (lcv = ID; lcv < maxI; lcv += Nthreads) {
-        amp = zmul(basePhaseFac2, stateVec1[lcv]) - zmul(basePhaseFac1, stateVec2[lcv]);
-        partNrm += dot(amp, amp);
-    }
+        amp = stateVec2[basePerm];
+        cmplx basePhaseFac2 = (ONE_R1 / sqrt(dot(amp, amp))) * amp;
 
-    locID = get_local_id(0);
-    locNthreads = get_local_size(0);
-    lProbBuffer[locID] = partNrm;
+        for (lcv = ID; lcv < maxI; lcv += Nthreads) {
+            amp = zmul(basePhaseFac2, stateVec1[lcv]) - zmul(basePhaseFac1, stateVec2[lcv]);
+            partNrm += dot(amp, amp);
+        }
+
+        locID = get_local_id(0);
+        locNthreads = get_local_size(0);
+        lProbBuffer[locID] = partNrm;
     
-    for (lcv = (locNthreads >> 1U); lcv > 0U; lcv >>= 1U) {
-        barrier(CLK_LOCAL_MEM_FENCE);
-        if (locID < lcv) {
-            lProbBuffer[locID] += lProbBuffer[locID + lcv];
-        } 
-    }
+        for (lcv = (locNthreads >> 1U); lcv > 0U; lcv >>= 1U) {
+            barrier(CLK_LOCAL_MEM_FENCE);
+            if (locID < lcv) {
+                lProbBuffer[locID] += lProbBuffer[locID + lcv];
+            }
+        }
 
-    if (locID == 0U) {
-        norm_ptr[get_group_id(0)] = lProbBuffer[0];
+        if (locID == 0U) {
+            norm_ptr[get_group_id(0)] = lProbBuffer[0];
+        }
     }
 }
 

--- a/src/common/qengine.cl
+++ b/src/common/qengine.cl
@@ -1578,6 +1578,8 @@ void kernel approxcompare(global cmplx* stateVec1, global cmplx* stateVec2, cons
         if (locID == 0U) {
             norm_ptr[get_group_id(0)] = lProbBuffer[0];
         }
+    } else {
+        norm_ptr[get_group_id(0)] = 10;
     }
 }
 

--- a/src/common/qengine.cl
+++ b/src/common/qengine.cl
@@ -1538,9 +1538,26 @@ void kernel approxcompare(global cmplx* stateVec1, global cmplx* stateVec2, cons
     cmplx amp;
     real1 partNrm = ZERO_R1;
 
+    // Hopefully, since this is identical redundant work by all elements, the break hits for all at the same time.
+    cmplx basePhaseFac1;
+    real1 nrm;
+    bitCapInt basePerm = 0;
+    do {
+        amp = stateVec1[basePerm];
+        nrm = dot(amp, amp);
+        basePerm++;
+    } while (nrm < min_norm);
+
+    basePerm--;
+    amp = stateVec1[basePerm];
+    nrm = dot(amp, amp);
+    basePhaseFac1 = (ONE_R1 / sqrt(nrm)) * amp;
+
+    amp = stateVec2[basePerm];
+    cmplx basePhaseFac2 = (ONE_R1 / sqrt(dot(amp, amp))) * amp;
 
     for (lcv = ID; lcv < maxI; lcv += Nthreads) {
-        amp = stateVec1[lcv] - stateVec2[lcv];
+        amp = zmul(basePhaseFac2, stateVec1[lcv]) - zmul(basePhaseFac1, stateVec2[lcv]);
         partNrm += dot(amp, amp);
     }
 

--- a/src/common/qheader32.cl
+++ b/src/common/qheader32.cl
@@ -15,6 +15,7 @@
 #define cmplx4 float8
 #define real1 float
 #define ZERO_R1 0.0f
+#define ONE_R1 1.0f
 #define SineShift M_PI_2_F
 #define PI_R1 M_PI_F
 #define min_norm 1e-13f

--- a/src/common/qheader_double.cl
+++ b/src/common/qheader_double.cl
@@ -16,6 +16,7 @@
 #define cmplx4 double8
 #define real1 double
 #define ZERO_R1 0.0
+#define ONE_R1 1.0
 #define SineShift M_PI_2
 #define PI_R1 M_PI
 #define min_norm 1e-30

--- a/src/common/qheader_float.cl
+++ b/src/common/qheader_float.cl
@@ -15,6 +15,7 @@
 #define cmplx4 float8
 #define real1 float
 #define ZERO_R1 0.0f
+#define ONE_R1 1.0f
 #define SineShift M_PI_2_F
 #define PI_R1 M_PI_F
 #define min_norm 1e-13f

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -1212,9 +1212,6 @@ real1 QEngineOCL::ProbMask(const bitCapInt& mask, const bitCapInt& permutation)
 
     delete[] skipPowers;
 
-    if (oneChance > ONE_R1)
-        oneChance = ONE_R1;
-
     return clampProb(oneChance);
 }
 

--- a/src/qengine/state.cpp
+++ b/src/qengine/state.cpp
@@ -681,6 +681,11 @@ bool QEngineCPU::ApproxCompare(QEngineCPUPtr toCompare)
     }
 
     nrm = norm(toCompare->stateVec[basePerm]);
+    if (nrm < min_norm) {
+        // If the amplitude we sample for global phase offset correction doesn't match, we're done.
+        return false;
+    }
+
     complex basePhaseFac2 = (ONE_R1 / sqrt(nrm)) * toCompare->stateVec[basePerm];
 
     par_for(0, maxQPower, [&](const bitCapInt lcv, const int cpu) {

--- a/src/qengine/state.cpp
+++ b/src/qengine/state.cpp
@@ -675,7 +675,7 @@ bool QEngineCPU::ApproxCompare(QEngineCPUPtr toCompare)
     for (basePerm = 0; basePerm < maxQPower; basePerm++) {
         nrm = norm(stateVec[basePerm]);
         if (nrm > min_norm) {
-            basePhaseFac1 = (ONE_R1 / sqrt(nrm)) * stateVec[basePerm];
+            basePhaseFac1 = (ONE_R1 / (real1)sqrt(nrm)) * stateVec[basePerm];
             break;
         }
     }
@@ -686,7 +686,7 @@ bool QEngineCPU::ApproxCompare(QEngineCPUPtr toCompare)
         return false;
     }
 
-    complex basePhaseFac2 = (ONE_R1 / sqrt(nrm)) * toCompare->stateVec[basePerm];
+    complex basePhaseFac2 = (ONE_R1 / (real1)sqrt(nrm)) * toCompare->stateVec[basePerm];
 
     par_for(0, maxQPower, [&](const bitCapInt lcv, const int cpu) {
         real1 elemError = norm(basePhaseFac2 * stateVec[lcv] - basePhaseFac1 * toCompare->stateVec[lcv]);

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -169,50 +169,21 @@ complex QUnit::GetAmplitude(bitCapInt perm)
     return result;
 }
 
-/*
- * Append QInterface to the end of the unit.
- */
-void QUnit::Compose(QUnitPtr toCopy, bool isMid, bitLenInt start)
-{
-    bitLenInt oQubitCount = toCopy->GetQubitCount();
-    bitLenInt oldCount = qubitCount;
-
-    /* Increase the number of bits in this object. */
-    SetQubitCount(qubitCount + oQubitCount);
-
-    /* Create a clone of the quantum state in toCopy. */
-    QUnitPtr clone(toCopy);
-
-    /* Update shards to reference the cloned state. */
-    bitLenInt j;
-    for (bitLenInt i = 0; i < clone->GetQubitCount(); i++) {
-        j = i + oldCount;
-        shards[j].unit = clone->shards[i].unit;
-        shards[j].mapped = clone->shards[i].mapped;
-        shards[j].prob = clone->shards[i].prob;
-        shards[j].isProbDirty = clone->shards[i].isProbDirty;
-        shards[j].phase = clone->shards[i].phase;
-        shards[j].isPhaseDirty = clone->shards[i].isPhaseDirty;
-    }
-
-    if (isMid) {
-        ROL(oQubitCount, start, qubitCount - start);
-    }
-}
-
-bitLenInt QUnit::Compose(QUnitPtr toCopy)
-{
-    bitLenInt oldCount = qubitCount;
-    Compose(toCopy, false, 0);
-    return oldCount;
-}
+bitLenInt QUnit::Compose(QUnitPtr toCopy) { return Compose(toCopy, qubitCount); }
 
 /*
  * Append QInterface in the middle of QUnit.
  */
 bitLenInt QUnit::Compose(QUnitPtr toCopy, bitLenInt start)
 {
-    Compose(toCopy, true, start);
+    /* Create a clone of the quantum state in toCopy. */
+    QUnitPtr clone(toCopy);
+
+    /* Insert the new shards in the middle */
+    shards.insert(shards.begin() + start, clone->shards.begin(), clone->shards.end());
+
+    SetQubitCount(qubitCount + toCopy->GetQubitCount());
+
     return start;
 }
 


### PR DESCRIPTION
I am debugging Compose()/Decompose() for ProjectQ, while attempting to track down a numerical inaccuracy ProjectQ's decompositions with QUnit.

This led me to rethink the Decompose() algorithm. I think it works fine, under the assumption that the sub-units requested are actually already ideally separable. However, then, only relative phases _within_ the separable units should matter, not their global phase offsets relative each other. The part of the algortihm that adjusts the global phase offset against some particular gauge is confusing and expensive. I think the primary reason I had it in there was for round-trip with ApproxCompare() in TryDecompose(). However, if we offload the check for an arbitrary global phase offset into ApproxCompare(), not only do we optimize the much more commonly-executed Decompose(), but we also open up a literal dimension of accurate equality comparisons for ApproxCompare()! Ultimately, there is no measurable difference between two QInterface instances where amplitudes are equal _up_ _to_ _an_ _overall_ _phase_ _factor_, (preserving internal _relative_ phase offsets and probabilities).

This branch will be merged after I've finally tracked down the issue with ProjectQ.