### PR TITLE
QUnit classical bit emulation

### DIFF
--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -23,6 +23,7 @@ namespace Qrack {
 struct QEngineShard {
     QInterfacePtr unit;
     bitLenInt mapped;
+    bool isEmulated;
     bool isProbDirty;
     real1 prob;
     bool isPhaseDirty;
@@ -356,6 +357,34 @@ protected:
         for (bitLenInt i = 0; i < length; i++) {
             shards[bitIndices[i]].isProbDirty = true;
             shards[bitIndices[i]].isPhaseDirty = true;
+        }
+    }
+
+    void EndEmulation(QEngineShard& shard)
+    {
+        if (shard.isEmulated) {
+            shard.unit->SetBit(shard.mapped, shard.prob >= (ONE_R1 / 2));
+            shard.isEmulated = false;
+        }
+    }
+
+    void EndEmulation(const bitLenInt& target)
+    {
+        QEngineShard& shard = shards[target];
+        EndEmulation(shard);
+    }
+
+    void EndEmulation(bitLenInt* bitIndices, bitLenInt length)
+    {
+        for (bitLenInt i = 0; i < length; i++) {
+            EndEmulation(bitIndices[i]);
+        }
+    }
+
+    void EndAllEmulation()
+    {
+        for (bitLenInt i = 0; i < qubitCount; i++) {
+            EndEmulation(i);
         }
     }
 };

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1926,6 +1926,8 @@ bool QUnit::ApproxCompare(QUnitPtr toCompare)
 
 QInterfacePtr QUnit::Clone()
 {
+    EndAllEmulation();
+
     QUnitPtr copyPtr = std::make_shared<QUnit>(engine, subengine, qubitCount, 0, rand_generator,
         complex(ONE_R1, ZERO_R1), doNormalize, randGlobalPhase, useHostRam);
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -56,6 +56,7 @@ void QUnit::SetPermutation(bitCapInt perm, complex phaseFac)
         shards[i].unit = CreateQuantumInterface(engine, subengine, 1U, bitState ? 1U : 0U, rand_generator, phaseFac,
             doNormalize, randGlobalPhase, useHostRam, devID, useRDRAND);
         shards[i].mapped = 0;
+        shards[i].isEmulated = false;
         shards[i].prob = bitState ? ONE_R1 : ZERO_R1;
         shards[i].isProbDirty = false;
         shards[i].phase = ZERO_R1;
@@ -76,6 +77,7 @@ void QUnit::CopyState(QUnit* orig)
     for (auto&& otherShard : orig->shards) {
         QEngineShard shard;
         shard.mapped = otherShard.mapped;
+        shard.isEmulated = otherShard.isEmulated;
         shard.prob = otherShard.prob;
         shard.isProbDirty = otherShard.isProbDirty;
         shard.phase = otherShard.phase;
@@ -104,6 +106,7 @@ void QUnit::CopyState(QInterfacePtr orig)
         QEngineShard shard;
         shard.unit = unit;
         shard.mapped = i;
+        shard.isEmulated = false;
         shard.isProbDirty = true;
         shard.isPhaseDirty = true;
         shards.push_back(shard);
@@ -120,6 +123,7 @@ void QUnit::SetQuantumState(const complex* inputState)
     for (auto&& shard : shards) {
         shard.unit = unit;
         shard.mapped = idx++;
+        shard.isEmulated = false;
         shard.isProbDirty = true;
         shard.isPhaseDirty = true;
     }
@@ -210,6 +214,7 @@ void QUnit::Detach(bitLenInt start, bitLenInt length, QUnitPtr dest)
 
     if (dest) {
         for (bitLenInt i = 0; i < length; i++) {
+            dest->shards[start + i].isEmulated = shards[start + i].isEmulated;
             dest->shards[start + i].prob = shards[start + i].prob;
             dest->shards[start + i].isProbDirty = shards[start + i].isProbDirty;
             dest->shards[start + i].phase = shards[start + i].phase;
@@ -246,6 +251,10 @@ void QUnit::Dispose(bitLenInt start, bitLenInt length) { Detach(start, length, n
 
 QInterfacePtr QUnit::EntangleIterator(std::vector<bitLenInt*>::iterator first, std::vector<bitLenInt*>::iterator last)
 {
+    for (auto bit = first; bit < last; bit++) {
+        EndEmulation(shards[**bit]);
+    }
+
     std::vector<QInterfacePtr> units;
     units.reserve((int)(last - first));
 
@@ -622,6 +631,7 @@ void QUnit::SeparateBit(bool value, bitLenInt qubit)
     /* Update the mappings. */
     shards[qubit].unit = dest;
     shards[qubit].mapped = 0;
+    shards[qubit].isEmulated = false;
     shards[qubit].prob = value ? ONE_R1 : ZERO_R1;
     shards[qubit].isProbDirty = false;
     shards[qubit].phase = ZERO_R1;
@@ -636,6 +646,12 @@ void QUnit::SeparateBit(bool value, bitLenInt qubit)
 
 bool QUnit::ForceM(bitLenInt qubit, bool res, bool doForce)
 {
+    QEngineShard& shard = shards[qubit];
+
+    if (shard.isEmulated) {
+        return shard.prob >= (ONE_R1 / 2);
+    }
+
     bool result = shards[qubit].unit->ForceM(shards[qubit].mapped, res, doForce);
 
     if (shards[qubit].unit->GetQubitCount() == 1) {
@@ -661,7 +677,7 @@ void QUnit::SetReg(bitLenInt start, bitLenInt length, bitCapInt value)
     bool bitState;
     for (bitLenInt i = 0; i < length; i++) {
         bitState = value & (1 << i);
-        shards[i + start].unit->SetPermutation(bitState ? 1 : 0);
+        shards[i + start].isEmulated = true;
         shards[i + start].prob = bitState ? ONE_R1 : ZERO_R1;
         shards[i + start].isProbDirty = false;
         shards[i + start].phase = ZERO_R1;
@@ -675,20 +691,8 @@ void QUnit::Swap(bitLenInt qubit1, bitLenInt qubit2)
         return;
     }
 
-    QEngineShard& shard1 = shards[qubit1];
-    QEngineShard& shard2 = shards[qubit2];
-
     // Swap the bit mapping.
-    std::swap(shard1.mapped, shard2.mapped);
-
-    // Swap the QInterface object.
-    std::swap(shard1.unit, shard2.unit);
-
-    // Swap the cached probability.
-    std::swap(shard1.prob, shard2.prob);
-    std::swap(shard1.isProbDirty, shard2.isProbDirty);
-    std::swap(shard1.phase, shard2.phase);
-    std::swap(shard1.isPhaseDirty, shard2.isPhaseDirty);
+    std::swap(shards[qubit1], shards[qubit2]);
 }
 
 /* Unfortunately, many methods are overloaded, which prevents using just the address-to-member. */
@@ -762,6 +766,9 @@ void QUnit::UniformlyControlledSingleBit(
 void QUnit::H(bitLenInt target)
 {
     QEngineShard& shard = shards[target];
+
+    EndEmulation(shard);
+
     shard.unit->H(shard.mapped);
 
     if (shard.isProbDirty || shard.isPhaseDirty) {
@@ -794,18 +801,25 @@ void QUnit::H(bitLenInt target)
 
 void QUnit::X(bitLenInt target)
 {
-    shards[target].unit->X(shards[target].mapped);
-    shards[target].prob = ONE_R1 - shards[target].prob;
-    shards[target].phase = ClampPhase(2 * M_PI - shards[target].phase);
+    QEngineShard& shard = shards[target];
+    if (shard.isProbDirty || !((shard.prob < min_norm) || ((ONE_R1 - shard.prob) < min_norm))) {
+        shard.unit->X(shard.mapped);
+    } else {
+        shard.isEmulated = true;
+    }
+    shard.prob = ONE_R1 - shard.prob;
+    shard.phase = ClampPhase(2 * M_PI - shard.phase);
 }
 
-#define PHASE_MATTERS(shard) !randGlobalPhase || shard.isProbDirty || !((shard.prob < min_norm) || ((ONE_R1 - shard.prob) < min_norm))
+#define PHASE_MATTERS(shard)                                                                                           \
+    !randGlobalPhase || shard.isProbDirty || !((shard.prob < min_norm) || ((ONE_R1 - shard.prob) < min_norm))
 
 void QUnit::Z(bitLenInt target)
 {
     QEngineShard& shard = shards[target];
     // If the target bit is in a |0>/|1> eigenstate, this gate has no effect.
     if (PHASE_MATTERS(shard)) {
+        EndEmulation(shard);
         shard.unit->Z(shard.mapped);
         shard.phase = ClampPhase(shard.phase + M_PI);
     }
@@ -864,6 +878,7 @@ void QUnit::ApplySinglePhase(const complex topLeft, const complex bottomRight, b
     QEngineShard& shard = shards[target];
     // If the target bit is in a |0>/|1> eigenstate, this gate has no effect.
     if (PHASE_MATTERS(shard)) {
+        EndEmulation(shard);
         shard.unit->ApplySinglePhase(topLeft, bottomRight, doCalcNorm, shard.mapped);
         shard.phase = ClampPhase(shard.phase + arg(bottomRight) - arg(topLeft));
     }
@@ -871,9 +886,14 @@ void QUnit::ApplySinglePhase(const complex topLeft, const complex bottomRight, b
 
 void QUnit::ApplySingleInvert(const complex topRight, const complex bottomLeft, bool doCalcNorm, bitLenInt target)
 {
-    shards[target].unit->ApplySingleInvert(topRight, bottomLeft, doCalcNorm, shards[target].mapped);
-    shards[target].prob = ONE_R1 - shards[target].prob;
-    shards[target].phase = ClampPhase((2 * M_PI - shards[target].phase) + (arg(topRight) - arg(bottomLeft)));
+    QEngineShard& shard = shards[target];
+    if (shard.isProbDirty || !((shard.prob < min_norm) || ((ONE_R1 - shard.prob) < min_norm))) {
+        shard.unit->ApplySingleInvert(topRight, bottomLeft, doCalcNorm, shard.mapped);
+    } else {
+        shard.isEmulated = true;
+    }
+    shard.prob = ONE_R1 - shard.prob;
+    shard.phase = ClampPhase((2 * M_PI - shard.phase) + (arg(topRight) - arg(bottomLeft)));
 }
 
 void QUnit::ApplyControlledSinglePhase(const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& target,
@@ -910,9 +930,11 @@ void QUnit::ApplyAntiControlledSingleInvert(const bitLenInt* controls, const bit
 
 void QUnit::ApplySingleBit(const complex* mtrx, bool doCalcNorm, bitLenInt qubit)
 {
-    shards[qubit].isProbDirty = true;
-    shards[qubit].isPhaseDirty = true;
-    shards[qubit].unit->ApplySingleBit(mtrx, doCalcNorm, shards[qubit].mapped);
+    QEngineShard& shard = shards[qubit];
+    EndEmulation(shard);
+    shard.isProbDirty = true;
+    shard.isPhaseDirty = true;
+    shard.unit->ApplySingleBit(mtrx, doCalcNorm, shard.mapped);
 }
 
 void QUnit::ApplyControlledSingleBit(
@@ -1224,6 +1246,7 @@ void QUnit::CollapseCarry(bitLenInt flagIndex, bitLenInt start, bitLenInt length
         }
     }
     if (isFlagEntangled) {
+        EndEmulation(shards[flagIndex]);
         flagUnit->M(shards[flagIndex].mapped);
     } else {
         M(flagIndex);
@@ -1808,6 +1831,7 @@ bitCapInt QUnit::IndexedSBC(bitLenInt indexStart, bitLenInt indexLength, bitLenI
 
 void QUnit::UpdateRunningNorm()
 {
+    EndAllEmulation();
     std::vector<QInterfacePtr> units;
     for (bitLenInt i = 0; i < shards.size(); i++) {
         QInterfacePtr toFind = shards[i].unit;
@@ -1820,6 +1844,7 @@ void QUnit::UpdateRunningNorm()
 
 void QUnit::NormalizeState(real1 nrm)
 {
+    EndAllEmulation();
     std::vector<QInterfacePtr> units;
     for (bitLenInt i = 0; i < shards.size(); i++) {
         QInterfacePtr toFind = shards[i].unit;
@@ -1883,6 +1908,8 @@ bool QUnit::ApproxCompare(QUnitPtr toCompare)
 
 QInterfacePtr QUnit::Clone()
 {
+    EndAllEmulation();
+
     QUnitPtr copyPtr = std::make_shared<QUnit>(engine, subengine, qubitCount, 0, rand_generator,
         complex(ONE_R1, ZERO_R1), doNormalize, randGlobalPhase, useHostRam);
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -191,7 +191,7 @@ bitLenInt QUnit::Compose(QUnitPtr toCopy) { return Compose(toCopy, qubitCount); 
 bitLenInt QUnit::Compose(QUnitPtr toCopy, bitLenInt start)
 {
     /* Create a clone of the quantum state in toCopy. */
-    QUnitPtr clone(toCopy);
+    QUnitPtr clone = std::dynamic_pointer_cast<QUnit>(toCopy->Clone());
 
     /* Insert the new shards in the middle */
     shards.insert(shards.begin() + start, clone->shards.begin(), clone->shards.end());

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -801,8 +801,12 @@ void QUnit::X(bitLenInt target)
 
 void QUnit::Z(bitLenInt target)
 {
-    shards[target].unit->Z(shards[target].mapped);
-    shards[target].phase = ClampPhase(shards[target].phase + M_PI);
+    QEngineShard& shard = shards[target];
+    // If the target bit is in a |0>/|1> eigenstate, this gate has no effect.
+    if (shard.isProbDirty || !((shard.prob < min_norm) || ((ONE_R1 - shard.prob) < min_norm))) {
+        shard.unit->Z(shard.mapped);
+        shard.phase = ClampPhase(shard.phase + M_PI);
+    }
 }
 
 #define CTRLED_CALL_WRAP(ctrld, bare, anti)                                                                            \

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -873,8 +873,12 @@ void QUnit::ApplySingleInvert(const complex topRight, const complex bottomLeft, 
 void QUnit::ApplyControlledSinglePhase(const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& target,
     const complex topLeft, const complex bottomRight)
 {
-    CTRLED_CALL_WRAP(
-        ApplyControlledSinglePhase(CTRL_P_ARGS), ApplySinglePhase(topLeft, bottomRight, true, target), false);
+    QEngineShard& shard = shards[target];
+    // If the target bit is in a |0>/|1> eigenstate, this gate has no effect.
+    if (shard.isProbDirty || !((shard.prob < min_norm) || ((ONE_R1 - shard.prob) < min_norm))) {
+        CTRLED_CALL_WRAP(
+            ApplyControlledSinglePhase(CTRL_P_ARGS), ApplySinglePhase(topLeft, bottomRight, true, target), false);
+    }
 }
 
 void QUnit::ApplyControlledSingleInvert(const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& target,

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1911,6 +1911,8 @@ bool QUnit::ApproxCompare(QUnitPtr toCompare)
         return false;
     }
 
+    EndAllEmulation();
+
     QUnitPtr thisCopy = std::dynamic_pointer_cast<QUnit>(Clone());
     thisCopy->EntangleAll();
     thisCopy->OrderContiguous(thisCopy->shards[0].unit);

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -799,11 +799,13 @@ void QUnit::X(bitLenInt target)
     shards[target].phase = ClampPhase(2 * M_PI - shards[target].phase);
 }
 
+#define PHASE_MATTERS(shard) !randGlobalPhase || shard.isProbDirty || !((shard.prob < min_norm) || ((ONE_R1 - shard.prob) < min_norm))
+
 void QUnit::Z(bitLenInt target)
 {
     QEngineShard& shard = shards[target];
     // If the target bit is in a |0>/|1> eigenstate, this gate has no effect.
-    if (shard.isProbDirty || !((shard.prob < min_norm) || ((ONE_R1 - shard.prob) < min_norm))) {
+    if (PHASE_MATTERS(shard)) {
         shard.unit->Z(shard.mapped);
         shard.phase = ClampPhase(shard.phase + M_PI);
     }
@@ -861,7 +863,7 @@ void QUnit::ApplySinglePhase(const complex topLeft, const complex bottomRight, b
 {
     QEngineShard& shard = shards[target];
     // If the target bit is in a |0>/|1> eigenstate, this gate has no effect.
-    if (shard.isProbDirty || !((shard.prob < min_norm) || ((ONE_R1 - shard.prob) < min_norm))) {
+    if (PHASE_MATTERS(shard)) {
         shard.unit->ApplySinglePhase(topLeft, bottomRight, doCalcNorm, shard.mapped);
         shard.phase = ClampPhase(shard.phase + arg(bottomRight) - arg(topLeft));
     }
@@ -879,7 +881,7 @@ void QUnit::ApplyControlledSinglePhase(const bitLenInt* controls, const bitLenIn
 {
     QEngineShard& shard = shards[target];
     // If the target bit is in a |0>/|1> eigenstate, this gate has no effect.
-    if (shard.isProbDirty || !((shard.prob < min_norm) || ((ONE_R1 - shard.prob) < min_norm))) {
+    if (PHASE_MATTERS(shard)) {
         CTRLED_CALL_WRAP(
             ApplyControlledSinglePhase(CTRL_P_ARGS), ApplySinglePhase(topLeft, bottomRight, true, target), false);
     }

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -371,6 +371,8 @@ QInterfacePtr QUnit::EntangleRange(
 
 QInterfacePtr QUnit::EntangleAll()
 {
+    EndAllEmulation();
+
     std::vector<QInterfacePtr> units;
     units.reserve(qubitCount);
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1922,8 +1922,6 @@ bool QUnit::ApproxCompare(QUnitPtr toCompare)
 
 QInterfacePtr QUnit::Clone()
 {
-    EndAllEmulation();
-
     QUnitPtr copyPtr = std::make_shared<QUnit>(engine, subengine, qubitCount, 0, rand_generator,
         complex(ONE_R1, ZERO_R1), doNormalize, randGlobalPhase, useHostRam);
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -855,8 +855,12 @@ void QUnit::CZ(bitLenInt control, bitLenInt target)
 
 void QUnit::ApplySinglePhase(const complex topLeft, const complex bottomRight, bool doCalcNorm, bitLenInt target)
 {
-    shards[target].unit->ApplySinglePhase(topLeft, bottomRight, doCalcNorm, shards[target].mapped);
-    shards[target].phase = ClampPhase(shards[target].phase + arg(bottomRight) - arg(topLeft));
+    QEngineShard& shard = shards[target];
+    // If the target bit is in a |0>/|1> eigenstate, this gate has no effect.
+    if (shard.isProbDirty || !((shard.prob < min_norm) || ((ONE_R1 - shard.prob) < min_norm))) {
+        shard.unit->ApplySinglePhase(topLeft, bottomRight, doCalcNorm, shard.mapped);
+        shard.phase = ClampPhase(shard.phase + arg(bottomRight) - arg(topLeft));
+    }
 }
 
 void QUnit::ApplySingleInvert(const complex topRight, const complex bottomLeft, bool doCalcNorm, bitLenInt target)


### PR DESCRIPTION
This pull request adds two general types of optimizations to QUnit:
- If the constructor flag was set to indicate that overall phase factors are arbitrary, phase gates are skipped when a qubit is in a |0>/|1> eigenstate.
- If a qubit is being manipulated in such a way that the starting point and a sequence of operations is analogous to manipulating a classical bit, the classical bit state is cached. Operations are carried out directly on the classical cache, and we avoid dispatching the underlying simulation. (The cached value is loaded back into the qubit simulator, when generality is needed and classical emulation cannot continue.)

The point is, neither of these optimizations should have physical consequence, in terms of real-valued observables, (i.e. the expectation values of Hermitian operators).