### PR TITLE
QUnit Arithmetic

### DIFF
--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -106,7 +106,7 @@ protected:
 
     virtual void SetRandomSeed(uint32_t seed) { rand_generator->seed(seed); }
 
-    static inline bitCapInt log2(bitCapInt n)
+    static inline bitLenInt log2(bitCapInt n)
     {
         bitLenInt pow = 0;
         bitLenInt p = n >> 1;

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -266,8 +266,6 @@ protected:
 
     typedef void (QInterface::*INCxFn)(bitCapInt, bitLenInt, bitLenInt, bitLenInt);
     typedef void (QInterface::*INCxxFn)(bitCapInt, bitLenInt, bitLenInt, bitLenInt, bitLenInt);
-    typedef void (QInterface::*CINTFn)(
-        bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt* controls, bitLenInt controlLen);
     typedef void (QInterface::*CMULFn)(bitCapInt toMod, bitLenInt start, bitLenInt carryStart, bitLenInt length,
         bitLenInt* controls, bitLenInt controlLen);
     typedef void (QInterface::*CMULModFn)(bitCapInt toMod, bitCapInt modN, bitLenInt start, bitLenInt carryStart,
@@ -276,7 +274,6 @@ protected:
     void INCx(INCxFn fn, bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt flagIndex);
     void INCxx(
         INCxxFn fn, bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt flag1Index, bitLenInt flag2Index);
-    void CINT(CINTFn fn, bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt* controls, bitLenInt controlLen);
     QInterfacePtr CMULEntangle(std::vector<bitLenInt> controlVec, bitLenInt start, bitCapInt carryStart,
         bitLenInt length, std::vector<bitLenInt>* controlsMapped);
     std::vector<bitLenInt> CMULEntangle(

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -192,7 +192,6 @@ public:
     virtual void INCSC(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt carryIndex);
     virtual void INCBCD(bitCapInt toAdd, bitLenInt start, bitLenInt length);
     virtual void INCBCDC(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt carryIndex);
-    virtual void DEC(bitCapInt toSub, bitLenInt start, bitLenInt length);
     virtual void CDEC(
         bitCapInt toSub, bitLenInt inOutStart, bitLenInt length, bitLenInt* controls, bitLenInt controlLen);
     virtual void DECC(bitCapInt toSub, bitLenInt start, bitLenInt length, bitLenInt carryIndex);

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -270,6 +270,7 @@ protected:
     typedef void (QInterface::*CMULModFn)(bitCapInt toMod, bitCapInt modN, bitLenInt start, bitLenInt carryStart,
         bitLenInt length, bitLenInt* controls, bitLenInt controlLen);
     void CollapseCarry(bitLenInt flagIndex, bitLenInt start, bitLenInt length);
+    void INT(bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt carryIndex, bool hasCarry);
     void INCx(INCxFn fn, bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt flagIndex);
     void INCxx(
         INCxxFn fn, bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt flag1Index, bitLenInt flag2Index);
@@ -283,8 +284,7 @@ protected:
         bitLenInt length, bitLenInt* controls, bitLenInt controlLen);
     bool CArithmeticOptimize(bitLenInt start, bitLenInt length, bitLenInt* controls, bitLenInt controlLen,
         std::vector<bitLenInt>* controlVec);
-    void INCDECSC(bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt overflowIndex, bitLenInt carryIndex,
-        bool hasFlag);
+    void INCDECSC(bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt overflowIndex, bitLenInt carryIndex);
     bool INTCOptimize(bitCapInt toMod, bitLenInt start, bitLenInt length, bool isAdd, bitLenInt carryIndex);
     bool INTSOptimize(bitCapInt toMod, bitLenInt start, bitLenInt length, bool isAdd, bitLenInt overflowIndex);
     bool INTSCOptimize(

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -284,6 +284,7 @@ protected:
         bitLenInt length, bitLenInt* controls, bitLenInt controlLen);
     bool CArithmeticOptimize(bitLenInt start, bitLenInt length, bitLenInt* controls, bitLenInt controlLen,
         std::vector<bitLenInt>* controlVec);
+    void INCDECC(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt carryIndex);
     bool INTCOptimize(bitCapInt toMod, bitLenInt start, bitLenInt length, bool isAdd, bitLenInt carryIndex);
     bool INTSOptimize(bitCapInt toMod, bitLenInt start, bitLenInt length, bool isAdd, bitLenInt overflowIndex);
     bool INTSCOptimize(

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -271,6 +271,8 @@ protected:
         bitLenInt length, bitLenInt* controls, bitLenInt controlLen);
     void CollapseCarry(bitLenInt flagIndex, bitLenInt start, bitLenInt length);
     void INT(bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt carryIndex, bool hasCarry);
+    void INTS(bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt overflowIndex, bitLenInt carryIndex,
+        bool hasCarry);
     void INCx(INCxFn fn, bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt flagIndex);
     void INCxx(
         INCxxFn fn, bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt flag1Index, bitLenInt flag2Index);
@@ -284,7 +286,6 @@ protected:
         bitLenInt length, bitLenInt* controls, bitLenInt controlLen);
     bool CArithmeticOptimize(bitLenInt start, bitLenInt length, bitLenInt* controls, bitLenInt controlLen,
         std::vector<bitLenInt>* controlVec);
-    void INCDECSC(bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt overflowIndex, bitLenInt carryIndex);
     bool INTCOptimize(bitCapInt toMod, bitLenInt start, bitLenInt length, bool isAdd, bitLenInt carryIndex);
     bool INTSOptimize(bitCapInt toMod, bitLenInt start, bitLenInt length, bool isAdd, bitLenInt overflowIndex);
     bool INTSCOptimize(

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -192,8 +192,6 @@ public:
     virtual void INCSC(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt carryIndex);
     virtual void INCBCD(bitCapInt toAdd, bitLenInt start, bitLenInt length);
     virtual void INCBCDC(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt carryIndex);
-    virtual void CDEC(
-        bitCapInt toSub, bitLenInt inOutStart, bitLenInt length, bitLenInt* controls, bitLenInt controlLen);
     virtual void DECC(bitCapInt toSub, bitLenInt start, bitLenInt length, bitLenInt carryIndex);
     virtual void DECS(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt overflowIndex);
     virtual void DECSC(

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -283,8 +283,8 @@ protected:
         bitLenInt length, bitLenInt* controls, bitLenInt controlLen);
     bool CArithmeticOptimize(bitLenInt start, bitLenInt length, bitLenInt* controls, bitLenInt controlLen,
         std::vector<bitLenInt>* controlVec);
-    void INCDECC(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt carryIndex);
-    void INCDECSC(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt overflowIndex, bitLenInt carryIndex);
+    void INCDECSC(bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt overflowIndex, bitLenInt carryIndex,
+        bool hasFlag);
     bool INTCOptimize(bitCapInt toMod, bitLenInt start, bitLenInt length, bool isAdd, bitLenInt carryIndex);
     bool INTSOptimize(bitCapInt toMod, bitLenInt start, bitLenInt length, bool isAdd, bitLenInt overflowIndex);
     bool INTSCOptimize(

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -193,7 +193,6 @@ public:
     virtual void INCBCD(bitCapInt toAdd, bitLenInt start, bitLenInt length);
     virtual void INCBCDC(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt carryIndex);
     virtual void DECC(bitCapInt toSub, bitLenInt start, bitLenInt length, bitLenInt carryIndex);
-    virtual void DECS(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt overflowIndex);
     virtual void DECSC(
         bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt overflowIndex, bitLenInt carryIndex);
     virtual void DECSC(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt carryIndex);
@@ -285,6 +284,7 @@ protected:
     bool CArithmeticOptimize(bitLenInt start, bitLenInt length, bitLenInt* controls, bitLenInt controlLen,
         std::vector<bitLenInt>* controlVec);
     void INCDECC(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt carryIndex);
+    void INCDECSC(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt overflowIndex, bitLenInt carryIndex);
     bool INTCOptimize(bitCapInt toMod, bitLenInt start, bitLenInt length, bool isAdd, bitLenInt carryIndex);
     bool INTSOptimize(bitCapInt toMod, bitLenInt start, bitLenInt length, bool isAdd, bitLenInt overflowIndex);
     bool INTSCOptimize(

--- a/src/qinterface/arithmetic.cpp
+++ b/src/qinterface/arithmetic.cpp
@@ -15,6 +15,24 @@
 namespace Qrack {
 
 // Arithmetic:
+/// Add integer (without sign)
+void QInterface::INC(bitCapInt toAdd, bitLenInt inOutStart, bitLenInt length)
+{
+    // See Draper, https://arxiv.org/abs/quant-ph/0008033
+
+    QFT(inOutStart, length);
+
+    for (bitLenInt i = 0; i < length; i++) {
+        for (bitLenInt j = 0; j <= i; j++) {
+            if ((toAdd >> j) & 1U) {
+                RTDyad(1, (i + 1U) - j, inOutStart + i);
+            }
+        }
+    }
+
+    IQFT(inOutStart, length);
+}
+
 /// Subtract integer (without sign)
 void QInterface::DEC(bitCapInt toSub, bitLenInt inOutStart, bitLenInt length)
 {

--- a/src/qinterface/arithmetic.cpp
+++ b/src/qinterface/arithmetic.cpp
@@ -25,7 +25,7 @@ void QInterface::INC(bitCapInt toAdd, bitLenInt inOutStart, bitLenInt length)
     for (bitLenInt i = 0; i < length; i++) {
         for (bitLenInt j = 0; j <= i; j++) {
             if ((toAdd >> j) & 1U) {
-                RTDyad(1, (i + 1U) - j, inOutStart + i);
+                RTDyad(1, i - j, inOutStart + i);
             }
         }
     }

--- a/src/qinterface/qinterface.cpp
+++ b/src/qinterface/qinterface.cpp
@@ -273,6 +273,10 @@ void QInterface::QFT(bitLenInt start, bitLenInt length, bool trySeparate)
         for (j = 0; j < ((length - 1U) - i); j++) {
             CRTDyad(1, j + 2, (end - i) - (j + 1U), end - i);
         }
+
+        if (trySeparate) {
+            TrySeparate(end - i);
+        }
     }
 }
 
@@ -289,6 +293,10 @@ void QInterface::IQFT(bitLenInt start, bitLenInt length, bool trySeparate)
             CRTDyad(-1, j + 2, (start + i) - (j + 1U), start + i);
         }
         H(start + i);
+
+        if (trySeparate) {
+            TrySeparate(start + i);
+        }
     }
 }
 

--- a/src/qinterface/qinterface.cpp
+++ b/src/qinterface/qinterface.cpp
@@ -262,27 +262,16 @@ void QInterface::LSR(bitLenInt shift, bitLenInt start, bitLenInt length)
 /// Quantum Fourier Transform - Optimized for going from |0>/|1> to |+>/|-> basis
 void QInterface::QFT(bitLenInt start, bitLenInt length, bool trySeparate)
 {
-    if (length > 0) {
-        bool wasNormOn = doNormalize;
-        bitLenInt end = start + length;
-        int i, j;
-        for (i = start; i < end; i++) {
-            doNormalize = false;
-            H(i);
+    if (length == 0) {
+        return;
+    }
 
-            for (j = 1; j < ((end - 1) - i); j++) {
-                CRTDyad(1, j, i + j, i);
-            }
-
-            doNormalize = wasNormOn;
-
-            if (i < (end - 1)) {
-                CRTDyad(1, (end - i) - 1, end - 1, i);
-            }
-
-            if (trySeparate) {
-                TrySeparate(i);
-            }
+    bitLenInt end = start + (length - 1U);
+    bitLenInt i, j;
+    for (i = 0; i < length; i++) {
+        H(end - i);
+        for (j = 0; j < ((length - 1U) - i); j++) {
+            CRTDyad(1, j + 2, (end - i) - (j + 1U), end - i);
         }
     }
 }
@@ -290,25 +279,16 @@ void QInterface::QFT(bitLenInt start, bitLenInt length, bool trySeparate)
 /// Inverse Quantum Fourier Transform - Quantum Fourier transform optimized for going from |+>/|-> to |0>/|1> basis
 void QInterface::IQFT(bitLenInt start, bitLenInt length, bool trySeparate)
 {
-    if (length > 0) {
-        bool wasNormOn = doNormalize;
-        bitLenInt end = start + length;
-        int i, j;
-        for (i = (end - 1); i >= start; i--) {
-            doNormalize = false;
+    if (length == 0) {
+        return;
+    }
 
-            for (j = (end - 1) - i; j >= 1; j--) {
-                CRTDyad(-1, j, i + j, i);
-            }
-
-            doNormalize = wasNormOn;
-
-            H(i);
-
-            if (trySeparate) {
-                TrySeparate(i);
-            }
+    bitLenInt i, j;
+    for (i = 0; i < length; i++) {
+        for (j = 0; j < i; j++) {
+            CRTDyad(-1, j + 2, (start + i) - (j + 1U), start + i);
         }
+        H(start + i);
     }
 }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1401,8 +1401,10 @@ bool QUnit::INTSCOptimize(
 void QUnit::INC(bitCapInt toMod, bitLenInt start, bitLenInt length)
 {
     // Keep the bits separate, if cheap to do so:
-    if (CheckBitsPermutation(start, length)) {
-        SetReg(start, length, GetCachedPermutation(start, length) + toMod);
+
+    bitLenInt toModLen = log2(toMod) + 1U;
+    if (CheckBitsPermutation(start, toModLen)) {
+        SetReg(start, toModLen, GetCachedPermutation(start, toModLen) + toMod);
         return;
     }
 
@@ -1473,8 +1475,9 @@ void QUnit::INCBCDC(bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenIn
 void QUnit::DEC(bitCapInt toMod, bitLenInt start, bitLenInt length)
 {
     // Keep the bits separate, if cheap to do so:
-    if (CheckBitsPermutation(start, length)) {
-        SetReg(start, length, GetCachedPermutation(start, length) - toMod);
+    bitLenInt toModLen = log2(toMod) + 1U;
+    if (CheckBitsPermutation(start, toModLen)) {
+        SetReg(start, toModLen, GetCachedPermutation(start, toModLen) - toMod);
         return;
     }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1418,7 +1418,7 @@ void QUnit::INC(bitCapInt toMod, bitLenInt start, bitLenInt length)
             toMod >>= 1U;
             start++;
             length--;
-            // Nothing is changed, in this bit.
+            // Nothing is changed, in this bit. (The carry gets promoted to the next bit.)
             continue;
         }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1416,7 +1416,7 @@ void QUnit::INT(bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt ca
         return;
     }
 
-    // Try Ripple addition, to avoid entanglement.
+    // Try ripple addition, to avoid entanglement.
     bool toAdd, inReg;
     bool carry = false;
     int total;
@@ -1447,10 +1447,14 @@ void QUnit::INT(bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt ca
             length--;
             i++;
         } else {
+            // The carry-in is classical.
+            if (carry) {
+                carry = false;
+                toMod++;
+            }
+
             if (length == 1) {
-                if (carry) {
-                    toMod++;
-                }
+                // We need at least two quantum bits left to try to achieve further separability.
                 break;
             }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1241,11 +1241,6 @@ void QUnit::CINT(
 
 void QUnit::CINC(bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt* controls, bitLenInt controlLen)
 {
-    if (controlLen == 0) {
-        INC(toMod, start, length);
-        return;
-    }
-
     bool canSkip = true;
     for (bitLenInt i = 0; i < controlLen; i++) {
         if (CheckBitPermutation(controls[i])) {

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1212,9 +1212,11 @@ void QUnit::CINC(bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt* 
         return;
     }
 
+    // All controls not optimized out are either in "isProbDirty" state or definitely true.
+    // If all are definitely true, we're better off using INC.
     bool canSkip = true;
     for (bitLenInt i = 0; i < controlVec.size(); i++) {
-        if (!CheckBitPermutation(controlVec[i]) || (shards[controlVec[i]].prob < (ONE_R1 / 2))) {
+        if (!CheckBitPermutation(controlVec[i])) {
             canSkip = false;
             break;
         }

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1487,6 +1487,7 @@ void QUnit::INT(bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt ca
                     // is independent of the superposed output value of the quantum bit.
                     EntangleRange(start, partLength);
                     shards[start].unit->INC(partMod, shards[start].mapped, partLength);
+                    DirtyShardRange(start, partLength);
 
                     carry = toAdd;
                     toMod >>= partLength;
@@ -1496,12 +1497,7 @@ void QUnit::INT(bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt ca
                     // Break out of the inner loop and return to the flow of the containing loop.
                     break;
                 }
-            } while (i < (origLength - 1U));
-
-            if (i == (origLength - 1U)) {
-                // The last unit must be entangled, in this case.
-                break;
-            }
+            } while (i < origLength);
         }
     }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1482,27 +1482,31 @@ void QUnit::INT(bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt ca
                 }
 
                 inReg = (shards[partStart].prob >= (ONE_R1 / 2));
-                if (toAdd == inReg) {
-                    // If toAdd == inReg, this prevents superposition of the carry-out. The carry out of the truth table
-                    // is independent of the superposed output value of the quantum bit.
-                    EntangleRange(start, partLength);
-                    shards[start].unit->INC(partMod, shards[start].mapped, partLength);
-                    DirtyShardRange(start, partLength);
-
-                    carry = toAdd;
-                    toMod >>= partLength;
-                    start += partLength;
-                    length -= partLength;
-
-                    // Break out of the inner loop and return to the flow of the containing loop.
-                    break;
+                if (toAdd != inReg) {
+                    // If toAdd != inReg, the carry out might be superposed. Advance the loop.
+                    continue;
                 }
+
+                // If toAdd == inReg, this prevents superposition of the carry-out. The carry out of the truth table
+                // is independent of the superposed output value of the quantum bit.
+                EntangleRange(start, partLength);
+                shards[start].unit->INC(partMod, shards[start].mapped, partLength);
+                DirtyShardRange(start, partLength);
+
+                carry = toAdd;
+                toMod >>= partLength;
+                start += partLength;
+                length -= partLength;
+
+                // Break out of the inner loop and return to the flow of the containing loop.
+                // (Otherwise, we hit the "continue" calls above.)
+                break;
             } while (i < origLength);
         }
     }
 
     if ((toMod == 0) && (length == 0)) {
-        // We got lucky, and we were able to avoid entangling the cary.
+        // We were able to avoid entangling the cary.
         if (hasCarry && carry) {
             X(carryIndex);
         }

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1510,18 +1510,14 @@ void QUnit::INT(bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt ca
     }
 
     if ((toMod == 0) && (length == 0)) {
-        // We were able to avoid entangling the cary.
+        // We were able to avoid entangling the carry.
         if (hasCarry && carry) {
             X(carryIndex);
         }
         return;
     }
 
-    // Otherwise, we can try to use Draper addition and hope we avoid as much entanglement as possible.
-    // However, it loses accuracy due to float rounding of the dyadic rotation.
-    // QInterface::INC(toMod, start, length);
-
-    // We're stuck with this:
+    // Otherwise, we have one unit left that needs to be entangled, plus carry bit.
     if (hasCarry) {
         EntangleRange(start, length, carryIndex, 1);
         shards[start].unit->INCC(toMod, shards[start].mapped, length, shards[carryIndex].mapped);

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1246,17 +1246,25 @@ void QUnit::CINC(bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt* 
         return;
     }
 
-    CINT(&QInterface::CINC, toMod, start, length, controls, controlLen);
-}
+    bool canSkip = true;
+    for (bitLenInt i = 0; i < controlLen; i++) {
+        if (CheckBitPermutation(controls[i])) {
+            if (shards[controls[i]].prob < (ONE_R1 / 2)) {
+                return;
+            }
+        } else {
+            canSkip = false;
+            break;
+        }
+    }
 
-void QUnit::CDEC(bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt* controls, bitLenInt controlLen)
-{
-    if (controlLen == 0) {
-        DEC(toMod, start, length);
+    if (canSkip) {
+        // INC is much better optimized
+        INC(toMod, start, length);
         return;
     }
 
-    CINT(&QInterface::CDEC, toMod, start, length, controls, controlLen);
+    CINT(&QInterface::CINC, toMod, start, length, controls, controlLen);
 }
 
 /// Collapse the carry bit in an optimal way, before carry arithmetic.

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1448,8 +1448,11 @@ void QUnit::INC(bitCapInt toMod, bitLenInt start, bitLenInt length)
         return;
     }
 
-    // Otherwise, use Draper addition and hope we avoid as much entanglement as possible:
+    // Otherwise, we can try to use Draper addition and hope we avoid as much entanglement as possible.
+    // However, it loses accuracy due to float rounding of the dyadic rotation.
     // QInterface::INC(toMod, start, length);
+
+    // We're stuck with this:
     EntangleRange(start, length);
     shards[start].unit->INC(toMod, shards[start].mapped, length);
     DirtyShardRange(start, length);

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1453,7 +1453,7 @@ void QUnit::INT(bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt ca
         }
     }
 
-    if (toMod == 0) {
+    if ((toMod == 0) && (length == 0)) {
         // We got lucky, and we were able to totally avoid entanglement.
         if (hasCarry && carry) {
             X(carryIndex);

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1407,7 +1407,6 @@ void QUnit::INC(bitCapInt toMod, bitLenInt start, bitLenInt length)
     }
 
     // Try Ripple addition, to avoid entanglement.
-
     bool toAdd, inReg;
     bool carry = false;
     int total;
@@ -1415,7 +1414,7 @@ void QUnit::INC(bitCapInt toMod, bitLenInt start, bitLenInt length)
     for (bitLenInt i = 0; i < origLength; i++) {
         toAdd = toMod & 1U;
 
-        if (!toAdd && !carry) {
+        if (toAdd == carry) {
             toMod >>= 1U;
             start++;
             length--;
@@ -1426,7 +1425,7 @@ void QUnit::INC(bitCapInt toMod, bitLenInt start, bitLenInt length)
         if (CheckBitPermutation(start)) {
             inReg = (shards[start].prob >= (ONE_R1 / 2));
             total = (toAdd ? 1 : 0) + (inReg ? 1 : 0) + (carry ? 1 : 0);
-            if (inReg != (total & 1U)) {
+            if (inReg != (total & 1)) {
                 X(start);
             }
             carry = (total > 1);
@@ -1441,8 +1440,6 @@ void QUnit::INC(bitCapInt toMod, bitLenInt start, bitLenInt length)
                 toMod++;
                 break;
             }
-
-            // TODO: We don't have to restrict to low-to-high ripple addition, here.
         }
     }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1439,7 +1439,10 @@ void QUnit::INC(bitCapInt toMod, bitLenInt start, bitLenInt length)
             if (carry) {
                 // We've kept toMod up to date with only the work left to do.
                 toMod++;
+                break;
             }
+
+            // TODO: We don't have to restrict to low-to-high ripple addition, here.
         }
     }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -368,6 +368,11 @@ QInterfacePtr QUnit::EntangleRange(
         std::swap(length1, length3);
     }
 
+    if (start3 < start2) {
+        std::swap(start2, start3);
+        std::swap(length2, length3);
+    }
+
     for (auto i = 0; i < length1; i++) {
         bits[i] = i + start1;
         ebits[i] = &bits[i];

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -1610,6 +1610,15 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_inc")
     REQUIRE_FLOAT(ONE_R1 / 4, qftReg->ProbAll(126));
     REQUIRE_FLOAT(ONE_R1 / 4, qftReg->ProbAll(128));
     REQUIRE_FLOAT(ONE_R1 / 4, qftReg->ProbAll(254));
+
+    qftReg->SetPermutation(0);
+    qftReg->H(7);
+    qftReg->H(1);
+    qftReg->INC(1, 0, 8);
+    REQUIRE_FLOAT(ONE_R1 / 4, qftReg->ProbAll(1));
+    REQUIRE_FLOAT(ONE_R1 / 4, qftReg->ProbAll(3));
+    REQUIRE_FLOAT(ONE_R1 / 4, qftReg->ProbAll(129));
+    REQUIRE_FLOAT(ONE_R1 / 4, qftReg->ProbAll(131));
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_incs")
@@ -1648,6 +1657,12 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_incc")
     qftReg->INCC(1, 0, 8, 8);
     REQUIRE_FLOAT(ONE_R1 / 2, qftReg->ProbAll(256));
     REQUIRE_FLOAT(ONE_R1 / 2, qftReg->ProbAll(128));
+
+    qftReg->SetPermutation(255);
+    qftReg->H(7);
+    qftReg->INCC(255, 0, 8, 8);
+    REQUIRE_FLOAT(ONE_R1 / 2, qftReg->ProbAll(510));
+    REQUIRE_FLOAT(ONE_R1 / 2, qftReg->ProbAll(382));
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_incbcd")

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -1577,9 +1577,9 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_add_1")
     qftReg->IQFT(0, 2);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 1));
 
-    qftReg->SetPermutation(0);
-    qftReg->QInterface::INC(1, 0, 8);
-    REQUIRE_THAT(qftReg, HasProbability(0, 8, 1));
+    qftReg->SetPermutation(20);
+    qftReg->QInterface::INC(17, 0, 8);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 37));
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_inc")

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -1568,6 +1568,20 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_lsr")
     REQUIRE_THAT(qftReg, HasProbability(64));
 }
 
+TEST_CASE_METHOD(QInterfaceTestFixture, "test_add_1")
+{
+    qftReg->SetPermutation(0);
+    qftReg->QFT(0, 2);
+    qftReg->RTDyad(1, 0, 0);
+    qftReg->RTDyad(1, 1, 1);
+    qftReg->IQFT(0, 2);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 1));
+
+    qftReg->SetPermutation(0);
+    qftReg->QInterface::INC(1, 0, 8);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 1));
+}
+
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_inc")
 {
     int i;
@@ -1964,7 +1978,8 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_cpowmodnout")
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_qft_h")
 {
-    qftReg->SetPermutation(85);
+    bitCapInt randPerm = qftReg->Rand() * 256U;
+    qftReg->SetPermutation(randPerm);
 
     int i;
 
@@ -1980,7 +1995,7 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_qft_h")
         qftReg->H(i);
     }
 
-    REQUIRE_THAT(qftReg, HasProbability(0, 8, 85));
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, randPerm));
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_isfinished") { REQUIRE(qftReg->isFinished()); }

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -1595,6 +1595,21 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_inc")
             REQUIRE_THAT(qftReg, HasProbability(0, 8, i - 5));
         }
     }
+
+    qftReg->SetPermutation(255);
+    qftReg->H(7);
+    qftReg->INC(1, 0, 8);
+    REQUIRE_FLOAT(ONE_R1 / 2, qftReg->ProbAll(0));
+    REQUIRE_FLOAT(ONE_R1 / 2, qftReg->ProbAll(128));
+
+    qftReg->SetPermutation(255);
+    qftReg->H(7);
+    qftReg->H(1);
+    qftReg->INC(1, 0, 8);
+    REQUIRE_FLOAT(ONE_R1 / 4, qftReg->ProbAll(0));
+    REQUIRE_FLOAT(ONE_R1 / 4, qftReg->ProbAll(126));
+    REQUIRE_FLOAT(ONE_R1 / 4, qftReg->ProbAll(128));
+    REQUIRE_FLOAT(ONE_R1 / 4, qftReg->ProbAll(254));
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_incs")
@@ -1627,6 +1642,12 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_incc")
             REQUIRE_THAT(qftReg, HasProbability(0, 9, 2 + i - 8));
         }
     }
+
+    qftReg->SetPermutation(255);
+    qftReg->H(7);
+    qftReg->INCC(1, 0, 8, 8);
+    REQUIRE_FLOAT(ONE_R1 / 2, qftReg->ProbAll(256));
+    REQUIRE_FLOAT(ONE_R1 / 2, qftReg->ProbAll(128));
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_incbcd")


### PR DESCRIPTION
This PR adds Draper arithmetic to QInterface. (See https://arxiv.org/abs/quant-ph/0008033.) To make it work, I had debug the QFT and its inverse, which I realized have been wrong for a long time. A unit test was added specifically for a very  limited case of Draper arithmetic.

The point was to optimize QUnit arithmetic by performing it via the gate model. However, this might have been somewhat for naught; it seems like the dyadic fractions used in that algorithm might lead to too great inaccuracy for Grover's searches of sizes of 8 to 16 qubits carried out in the unit tests. This led me to find another way to optimize QUnit arithmetic. It turns out, going directly by the classical full adder truth table, there are still many cases with superposition where adding a classical integer might be partially or fully optimized to emulating the classical full adder.