### PR TITLE
Simple QUnit UniformlyControlledSingleBit() optimization

### DIFF
--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -298,9 +298,11 @@ protected:
         bitLenInt start, bitLenInt length, bitLenInt start2, bitLenInt length2, bitLenInt start3, bitLenInt length3);
     virtual QInterfacePtr EntangleAll();
 
-    virtual bool CheckBitPermutation(bitLenInt qubitIndex);
-    virtual bool CheckBitsPermutation(bitLenInt start, bitLenInt length);
-    virtual bitCapInt GetCachedPermutation(bitLenInt start, bitLenInt length);
+    virtual bool CheckBitPermutation(const bitLenInt& qubitIndex);
+    virtual bool CheckBitsPermutation(const bitLenInt& start, const bitLenInt& length);
+    virtual bool CheckBitsPermutation(const bitLenInt* bitArray, const bitLenInt& length);
+    virtual bitCapInt GetCachedPermutation(const bitLenInt& start, const bitLenInt& length);
+    virtual bitCapInt GetCachedPermutation(const bitLenInt* bitArray, const bitLenInt& length);
 
     virtual QInterfacePtr EntangleIterator(
         std::vector<bitLenInt*>::iterator first, std::vector<bitLenInt*>::iterator last);


### PR DESCRIPTION
In QUnit, checking whether all controls are in permutation basis eigenstates lets us catch the case where UniformlyControlledSingleBit() is equivalent to ApplySingleBit(), avoiding _all_ representational entanglement for virtually no cost. For neural net scripts I have experimented with, this should commonly reduce fitting times to the logarithm of their original fitting cost.

Avoiding entangling _some_ but not _all_ of the bits is a trickier and thornier case. To avoid one bit of entanglement, we limit to 3/2 the RAM use for the gate matrix definition plus a reduced copy, where the original gate arguments could already be the same size as the fully entangled state vector. Once any degree of entanglement sets in, each additional qubit basically adds a factor of 2 to execution time and state vector RAM for the extent of the full algorithm.

Trying to separate controls on an individual basis would help us handle cases like neural nets with missing data, or time evolution using UniformlyControlledSingleBit(). However, using 50/50 superposed bits for missing data still exponentially explodes the computation time, proportional to number of columns with any missing values, and time evolution might commonly be chaotic and quickly lose this advantage. For the former case, if possible, (though it is often is not,) one should consider removing any rows with missing data, (or maybe coding missing data in a way besides 50/50 superposition of a binary descriptor). For the latter case, I need to experiment with realistic Hamiltonians, in order to see whether and how we can reasonably gain an advantage.