### PR TITLE
Bit skipping for UniformlyControlledSingleBit; IndexedLDA/ADC/SBC optimization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,10 +90,12 @@ include ("cmake/OpenCL.cmake" )
 include ("cmake/Complex8.cmake")
 include ("cmake/Complex_x2.cmake")
 include ("cmake/Pure32.cmake")
+include ("cmake/VM6502Q.cmake")
 
 message ("Pure 32-bit compilation is: ${ENABLE_PURE32}")
 message ("Single accuracy is: ${ENABLE_COMPLEX8}")
 message ("Complex_x2/AVX Support is: ${ENABLE_COMPLEX_X2}")
+message ("VM6502Q disassembler support is: ${ENABLE_VM6502Q_DEBUG}")
 
 if (MSVC)
     set(QRACK_COMPILE_OPTS -std=c++11 -Wall)

--- a/README.md
+++ b/README.md
@@ -141,6 +141,13 @@ static void InitOCL(bool buildFromSource = false, bool saveBinaries = false, std
 ```
 The `home` argument default indicates that the default home directory path should be used. 
 
+## Pure 32 bit OpenCL kernels (including Raspberry Pi 3)
+
+```
+$ cmake -DENABLE_VM6502Q_DEBUG=ON ..
+```
+Qrack was originally written so that the disassembler of VM6502Q should show the classical expecation value of registers, following Ehrenfest's theorem. However, this incurs significant additional overhead for `QInterface::IndexedLDA()`, `QInterface::IndexedADC()`, and `QInterface::IndexedSBC()`. As such, this behavior in the VM6502Q disassembler is only supported when this CMake flag is specifically enabled. (It is off by default.) These three methods will return 0, if the flag is disabled.
+
 ## Copyright and License
 
 Copyright (c) Daniel Strano and the Qrack contributors 2017-2019. All rights reserved.

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ static void InitOCL(bool buildFromSource = false, bool saveBinaries = false, std
 ```
 The `home` argument default indicates that the default home directory path should be used. 
 
-## Pure 32 bit OpenCL kernels (including Raspberry Pi 3)
+## VM6502Q
 
 ```
 $ cmake -DENABLE_VM6502Q_DEBUG=ON ..

--- a/cmake/VM6502Q.cmake
+++ b/cmake/VM6502Q.cmake
@@ -1,0 +1,4 @@
+option (ENABLE_VM6502Q_DEBUG "Build so that the VM6502Q disassembler accurately follows Ehrenfest's theorem" OFF)
+if (ENABLE_VM6502Q_DEBUG)
+    target_compile_definitions (qrack PUBLIC ENABLE_VM6502Q_DEBUG=1)
+endif (ENABLE_VM6502Q_DEBUG)

--- a/include/qengine_cpu.hpp
+++ b/include/qengine_cpu.hpp
@@ -112,8 +112,9 @@ public:
         bitLenInt valueLength, bitLenInt carryIndex, unsigned char* values);
     virtual bitCapInt IndexedSBC(bitLenInt indexStart, bitLenInt indexLength, bitLenInt valueStart,
         bitLenInt valueLength, bitLenInt carryIndex, unsigned char* values);
-    virtual void UniformlyControlledSingleBit(
-        const bitLenInt* controls, const bitLenInt& controlLen, bitLenInt qubitIndex, const complex* mtrxs);
+    virtual void UniformlyControlledSingleBit(const bitLenInt* controls, const bitLenInt& controlLen,
+        bitLenInt qubitIndex, const complex* mtrxs, const bitCapInt* mtrxSkipPowers, const bitLenInt mtrxSkipLen,
+        const bitCapInt& mtrxSkipValueMask);
 
     /** @} */
 

--- a/include/qengine_opencl.hpp
+++ b/include/qengine_opencl.hpp
@@ -148,8 +148,9 @@ public:
     virtual void CopyState(QInterfacePtr orig);
     virtual real1 ProbAll(bitCapInt fullRegister);
 
-    virtual void UniformlyControlledSingleBit(
-        const bitLenInt* controls, const bitLenInt& controlLen, bitLenInt qubitIndex, const complex* mtrxs);
+    virtual void UniformlyControlledSingleBit(const bitLenInt* controls, const bitLenInt& controlLen,
+        bitLenInt qubitIndex, const complex* mtrxs, const bitCapInt* mtrxSkipPowers, const bitLenInt mtrxSkipLen,
+        const bitCapInt& mtrxSkipValueMask);
 
     /* Operations that have an improved implementation. */
     using QEngine::X;

--- a/include/qfusion.hpp
+++ b/include/qfusion.hpp
@@ -82,8 +82,9 @@ public:
         const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& target, const complex* mtrx);
     virtual void ApplyAntiControlledSingleBit(
         const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& target, const complex* mtrx);
-    virtual void UniformlyControlledSingleBit(
-        const bitLenInt* controls, const bitLenInt& controlLen, bitLenInt qubitIndex, const complex* mtrxs);
+    virtual void UniformlyControlledSingleBit(const bitLenInt* controls, const bitLenInt& controlLen,
+        bitLenInt qubitIndex, const complex* mtrxs, const bitCapInt* mtrxSkipPowers, const bitLenInt mtrxSkipLen,
+        const bitCapInt& mtrxSkipValueMask);
     virtual void CSwap(
         const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& qubit1, const bitLenInt& qubit2);
     virtual void AntiCSwap(

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -34,6 +34,7 @@ void exp2x2(complex* matrix2x2, complex* outMatrix2x2);
 void log2x2(complex* matrix2x2, complex* outMatrix2x2);
 bool isOverflowAdd(bitCapInt inOutInt, bitCapInt inInt, const bitCapInt& signMask, const bitCapInt& lengthPower);
 bool isOverflowSub(bitCapInt inOutInt, bitCapInt inInt, const bitCapInt& signMask, const bitCapInt& lengthPower);
+bitCapInt pushApartBits(const bitCapInt& perm, const bitCapInt* skipPowers, const bitLenInt skipPowersCount);
 bitCapInt intPow(bitCapInt base, bitCapInt power);
 inline bitCapInt bitRegMask(const bitLenInt& start, const bitLenInt& length) { return ((1U << length) - 1U) << start; }
 
@@ -446,8 +447,15 @@ public:
      * component ordering in each matrix is the same as all other gates with an arbitrary 2x2 applied to a single bit,
      * such as Qrack::ApplySingleBit.)
      */
+
     virtual void UniformlyControlledSingleBit(
-        const bitLenInt* controls, const bitLenInt& controlLen, bitLenInt qubitIndex, const complex* mtrxs);
+        const bitLenInt* controls, const bitLenInt& controlLen, bitLenInt qubitIndex, const complex* mtrxs)
+    {
+        UniformlyControlledSingleBit(controls, controlLen, qubitIndex, mtrxs, NULL, 0, 0);
+    }
+    virtual void UniformlyControlledSingleBit(const bitLenInt* controls, const bitLenInt& controlLen,
+        bitLenInt qubitIndex, const complex* mtrxs, const bitCapInt* mtrxSkipPowers, const bitLenInt mtrxSkipLen,
+        const bitCapInt& mtrxSkipValueMask);
 
     /**
      * To define a Hamiltonian, give a vector of controlled single bit gates ("HamiltonianOp" instances) that are

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -133,8 +133,9 @@ public:
         const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& target, const complex* mtrx);
     virtual void ApplyAntiControlledSingleBit(
         const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& target, const complex* mtrx);
-    virtual void UniformlyControlledSingleBit(
-        const bitLenInt* controls, const bitLenInt& controlLen, bitLenInt qubitIndex, const complex* mtrxs);
+    virtual void UniformlyControlledSingleBit(const bitLenInt* controls, const bitLenInt& controlLen,
+        bitLenInt qubitIndex, const complex* mtrxs, const bitCapInt* mtrxSkipPowers, const bitLenInt mtrxSkipLen,
+        const bitCapInt& mtrxSkipValueMask);
     virtual void CSwap(
         const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& qubit1, const bitLenInt& qubit2);
     virtual void AntiCSwap(

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -133,9 +133,7 @@ public:
         const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& target, const complex* mtrx);
     virtual void ApplyAntiControlledSingleBit(
         const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& target, const complex* mtrx);
-    virtual void UniformlyControlledSingleBit(const bitLenInt* controls, const bitLenInt& controlLen,
-        bitLenInt qubitIndex, const complex* mtrxs, const bitCapInt* mtrxSkipPowers, const bitLenInt mtrxSkipLen,
-        const bitCapInt& mtrxSkipValueMask);
+    using QInterface::UniformlyControlledSingleBit;
     virtual void CSwap(
         const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& qubit1, const bitLenInt& qubit2);
     virtual void AntiCSwap(
@@ -262,6 +260,9 @@ public:
     /** @} */
 
 protected:
+    virtual void UniformlyControlledSingleBit(const bitLenInt* controls, const bitLenInt& controlLen,
+        bitLenInt qubitIndex, const complex* mtrxs, const bitCapInt* mtrxSkipPowers, const bitLenInt mtrxSkipLen,
+        const bitCapInt& mtrxSkipValueMask);
     virtual void CopyState(QUnit* orig);
 
     typedef void (QInterface::*INCxFn)(bitCapInt, bitLenInt, bitLenInt, bitLenInt);

--- a/src/qengine/arithmetic.cpp
+++ b/src/qengine/arithmetic.cpp
@@ -753,12 +753,10 @@ void QEngineCPU::INCDECBCDC(
 bitCapInt QEngineCPU::IndexedLDA(
     bitLenInt indexStart, bitLenInt indexLength, bitLenInt valueStart, bitLenInt valueLength, unsigned char* values)
 {
-    bitCapInt i, outputInt;
     SetReg(valueStart, valueLength, 0);
 
     bitLenInt valueBytes = (valueLength + 7U) / 8U;
     bitCapInt inputMask = bitRegMask(indexStart, indexLength);
-    bitCapInt outputMask = bitRegMask(valueStart, valueLength);
     bitCapInt skipPower = 1U << valueStart;
 
     complex* nStateVec = AllocStateVec(maxQPower);
@@ -775,9 +773,12 @@ bitCapInt QEngineCPU::IndexedLDA(
         nStateVec[outputRes | lcv] = stateVec[lcv];
     });
 
+    real1 average = ZERO_R1;
+#if ENABLE_VM6502Q_DEBUG
     real1 prob;
     real1 totProb = ZERO_R1;
-    real1 average = ZERO_R1;
+    bitCapInt i, outputInt;
+    bitCapInt outputMask = bitRegMask(valueStart, valueLength);
     for (i = 0; i < maxQPower; i++) {
         outputInt = (i & outputMask) >> valueStart;
         prob = norm(nStateVec[i]);
@@ -787,6 +788,7 @@ bitCapInt QEngineCPU::IndexedLDA(
     if (totProb > ZERO_R1) {
         average /= totProb;
     }
+#endif
 
     ResetStateVec(nStateVec);
 
@@ -872,12 +874,13 @@ bitCapInt QEngineCPU::IndexedADC(bitLenInt indexStart, bitLenInt indexLength, bi
         nStateVec[outputRes | inputRes | otherRes | carryRes] = stateVec[lcv];
     });
 
+    real1 average = ZERO_R1;
+#if ENABLE_VM6502Q_DEBUG
     // At the end, just as a convenience, we return the expectation value for
     // the addition result.
     bitCapInt i, outputInt;
     real1 prob;
     real1 totProb = ZERO_R1;
-    real1 average = ZERO_R1;
     for (i = 0; i < maxQPower; i++) {
         outputInt = (i & outputMask) >> valueStart;
         prob = norm(nStateVec[i]);
@@ -887,6 +890,7 @@ bitCapInt QEngineCPU::IndexedADC(bitLenInt indexStart, bitLenInt indexLength, bi
     if (totProb > ZERO_R1) {
         average /= totProb;
     }
+#endif
 
     // Finally, we dealloc the old state vector and replace it with the one we
     // just calculated.
@@ -978,12 +982,13 @@ bitCapInt QEngineCPU::IndexedSBC(bitLenInt indexStart, bitLenInt indexLength, bi
         nStateVec[outputRes | inputRes | otherRes | carryRes] = stateVec[lcv];
     });
 
+    real1 average = ZERO_R1;
+#if ENABLE_VM6502Q_DEBUG
     // At the end, just as a convenience, we return the expectation value for
     // the addition result.
     bitCapInt i, outputInt;
     real1 prob;
     real1 totProb = ZERO_R1;
-    real1 average = ZERO_R1;
     for (i = 0; i < maxQPower; i++) {
         outputInt = (i & outputMask) >> valueStart;
         prob = norm(nStateVec[i]);
@@ -993,6 +998,7 @@ bitCapInt QEngineCPU::IndexedSBC(bitLenInt indexStart, bitLenInt indexLength, bi
     if (totProb > ZERO_R1) {
         average /= totProb;
     }
+#endif
 
     // Finally, we dealloc the old state vector and replace it with the one we
     // just calculated.

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -1824,16 +1824,17 @@ bitCapInt QEngineOCL::IndexedLDA(
     SetReg(valueStart, valueLength, 0);
     bitLenInt valueBytes = (valueLength + 7) / 8;
     bitCapInt inputMask = bitRegMask(indexStart, indexLength);
-    bitCapInt outputMask = bitRegMask(valueStart, valueLength);
     bitCapInt bciArgs[BCI_ARG_LEN] = { maxQPower >> valueLength, indexStart, inputMask, valueStart, valueBytes,
         valueLength, 0, 0, 0, 0 };
 
     ArithmeticCall(OCL_API_INDEXEDLDA, bciArgs, values, (1 << indexLength) * valueBytes);
 
-    real1 prob;
     real1 average = ZERO_R1;
+#if ENABLE_VM6502Q_DEBUG
+    real1 prob;
     real1 totProb = ZERO_R1;
     bitCapInt i, outputInt;
+    bitCapInt outputMask = bitRegMask(valueStart, valueLength);
     LockSync(CL_MAP_READ);
     for (i = 0; i < maxQPower; i++) {
         outputInt = (i & outputMask) >> valueStart;
@@ -1845,6 +1846,7 @@ bitCapInt QEngineOCL::IndexedLDA(
     if (totProb > ZERO_R1) {
         average /= totProb;
     }
+#endif
 
     return (bitCapInt)(average + (ONE_R1 / 2));
 }
@@ -1875,9 +1877,10 @@ bitCapInt QEngineOCL::OpIndexed(OCLAPI api_call, bitCapInt carryIn, bitLenInt in
 
     ArithmeticCall(api_call, bciArgs, values, (1 << indexLength) * valueBytes);
 
+    real1 average = ZERO_R1;
+#if ENABLE_VM6502Q_DEBUG
     // At the end, just as a convenience, we return the expectation value for the addition result.
     real1 prob;
-    real1 average = ZERO_R1;
     real1 totProb = ZERO_R1;
     bitCapInt i, outputInt;
     LockSync(CL_MAP_READ);
@@ -1891,6 +1894,7 @@ bitCapInt QEngineOCL::OpIndexed(OCLAPI api_call, bitCapInt carryIn, bitLenInt in
     if (totProb > ZERO_R1) {
         average /= totProb;
     }
+#endif
 
     // Return the expectation value.
     return (bitCapInt)(average + (ONE_R1 / 2));

--- a/src/qfusion.cpp
+++ b/src/qfusion.cpp
@@ -229,11 +229,13 @@ void QFusion::ApplyAntiControlledSingleBit(
     bitBuffers[target] = bfr->LeftRightCompose(bitBuffers[target]);
 }
 
-void QFusion::UniformlyControlledSingleBit(
-    const bitLenInt* controls, const bitLenInt& controlLen, bitLenInt qubitIndex, const complex* mtrxs)
+void QFusion::UniformlyControlledSingleBit(const bitLenInt* controls, const bitLenInt& controlLen, bitLenInt qubitIndex,
+    const complex* mtrxs, const bitCapInt* mtrxSkipPowers, const bitLenInt mtrxSkipLen,
+    const bitCapInt& mtrxSkipValueMask)
 {
     FlushAll();
-    qReg->UniformlyControlledSingleBit(controls, controlLen, qubitIndex, mtrxs);
+    qReg->UniformlyControlledSingleBit(
+        controls, controlLen, qubitIndex, mtrxs, mtrxSkipPowers, mtrxSkipLen, mtrxSkipValueMask);
 }
 
 // "Compose" will increase the cost of application of every currently buffered gate by a factor of 2 per "composed"

--- a/src/qinterface/gates.cpp
+++ b/src/qinterface/gates.cpp
@@ -173,12 +173,15 @@ void QInterface::CZ(bitLenInt control, bitLenInt target)
     ApplyControlledSinglePhase(controls, 1, target, complex(ONE_R1, ZERO_R1), complex(-ONE_R1, ZERO_R1));
 }
 
-void QInterface::UniformlyControlledSingleBit(
-    const bitLenInt* controls, const bitLenInt& controlLen, bitLenInt qubitIndex, const complex* mtrxs)
+void QInterface::UniformlyControlledSingleBit(const bitLenInt* controls, const bitLenInt& controlLen,
+    bitLenInt qubitIndex, const complex* mtrxs, const bitCapInt* mtrxSkipPowers, const bitLenInt mtrxSkipLen,
+    const bitCapInt& mtrxSkipValueMask)
 {
-    for (bitCapInt index = 0; index < (1U << controlLen); index++) {
+    bitCapInt index;
+    for (bitCapInt lcv = 0; lcv < (1U << controlLen); lcv++) {
+        index = pushApartBits(lcv, mtrxSkipPowers, mtrxSkipLen) | mtrxSkipValueMask;
         for (bitLenInt bit_pos = 0; bit_pos < controlLen; bit_pos++) {
-            if (!((index >> bit_pos) & 1)) {
+            if (!((lcv >> bit_pos) & 1)) {
                 X(controls[bit_pos]);
             }
         }
@@ -186,7 +189,7 @@ void QInterface::UniformlyControlledSingleBit(
         ApplyControlledSingleBit(controls, controlLen, qubitIndex, &(mtrxs[index * 4U]));
 
         for (bitLenInt bit_pos = 0; bit_pos < controlLen; bit_pos++) {
-            if (!((index >> bit_pos) & 1)) {
+            if (!((lcv >> bit_pos) & 1)) {
                 X(controls[bit_pos]);
             }
         }

--- a/src/qinterface/protected.cpp
+++ b/src/qinterface/protected.cpp
@@ -188,4 +188,23 @@ bool isOverflowSub(bitCapInt inOutInt, bitCapInt inInt, const bitCapInt& signMas
     return false;
 }
 
+bitCapInt pushApartBits(const bitCapInt& perm, const bitCapInt* skipPowers, const bitLenInt skipPowersCount)
+{
+    if (skipPowersCount == 0) {
+        return perm;
+    }
+
+    bitCapInt i, iHigh, iLow, p;
+    iHigh = perm;
+    i = 0;
+    for (p = 0; p < skipPowersCount; p++) {
+        iLow = iHigh & (skipPowers[p] - 1U);
+        i |= iLow;
+        iHigh = (iHigh ^ iLow) << 1U;
+    }
+    i |= iHigh;
+
+    return i;
+}
+
 } // namespace Qrack

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -797,13 +797,13 @@ void QUnit::UniformlyControlledSingleBit(const bitLenInt* controls, const bitLen
     std::vector<bitLenInt> trimmedControls;
     std::vector<bitCapInt> combinedSkipPowers(mtrxSkipLen);
     std::copy(mtrxSkipPowers, mtrxSkipPowers + mtrxSkipLen, combinedSkipPowers.begin());
-    bitCapInt combinedSkipValueMask = 0;
+    bitCapInt combinedSkipValueMask = mtrxSkipValueMask;
     for (i = 0; i < controlLen; i++) {
         if (!CheckBitPermutation(controls[i])) {
             trimmedControls.push_back(controls[i]);
         } else {
-            combinedSkipPowers.push_back(1U << controls[i]);
-            combinedSkipValueMask |= (shards[controls[i]].prob >= (ONE_R1 / 2)) ? combinedSkipPowers.back() : 0;
+            combinedSkipPowers.push_back(1U << i);
+            combinedSkipValueMask |= ((shards[controls[i]].prob >= (ONE_R1 / 2)) ? (1U << i) : 0);
         }
     }
     std::sort(combinedSkipPowers.begin(), combinedSkipPowers.end());

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -2010,6 +2010,7 @@ bitCapInt QUnit::IndexedLDA(
     bitLenInt indexStart, bitLenInt indexLength, bitLenInt valueStart, bitLenInt valueLength, unsigned char* values)
 {
     // TODO: Index bits that have exactly 0 or 1 probability can be optimized out of the gate.
+    // This could follow the logic of UniformlyControlledSingleBit().
     // In the meantime, checking if all index bits are in eigenstates takes very little overhead.
     if (CheckBitsPermutation(indexStart, indexLength)) {
         bitCapInt indexInt = GetCachedPermutation(indexStart, indexLength);
@@ -2040,10 +2041,12 @@ bitCapInt QUnit::IndexedLDA(
 bitCapInt QUnit::IndexedADC(bitLenInt indexStart, bitLenInt indexLength, bitLenInt valueStart, bitLenInt valueLength,
     bitLenInt carryIndex, unsigned char* values)
 {
-// TODO: Index bits that have exactly 0 or 1 probability can be optimized out of the gate.
-// In the meantime, checking if all index bits are in eigenstates takes very little overhead.
+
 #if ENABLE_VM6502Q_DEBUG
     if (CheckBitsPermutation(indexStart, indexLength) && CheckBitsPermutation(valueStart, valueLength)) {
+#else
+    if (CheckBitsPermutation(indexStart, indexLength)) {
+#endif
         bitCapInt indexInt = GetCachedPermutation(indexStart, indexLength);
         bitLenInt valueBytes = (valueLength + 7U) / 8U;
         bitCapInt value = 0;
@@ -2051,6 +2054,8 @@ bitCapInt QUnit::IndexedADC(bitLenInt indexStart, bitLenInt indexLength, bitLenI
             value |= values[indexInt * valueBytes + j] << (8U * j);
         }
         value = GetCachedPermutation(valueStart, valueLength) + value;
+
+#if ENABLE_VM6502Q_DEBUG
         bitCapInt valueMask = (1U << valueLength) - 1U;
         bool carry = false;
         if (value > valueMask) {
@@ -2062,20 +2067,11 @@ bitCapInt QUnit::IndexedADC(bitLenInt indexStart, bitLenInt indexLength, bitLenI
             X(carryIndex);
         }
         return value;
-    }
 #else
-    if (CheckBitsPermutation(indexStart, indexLength)) {
-        bitCapInt indexInt = GetCachedPermutation(indexStart, indexLength);
-        bitLenInt valueBytes = (valueLength + 7U) / 8U;
-        bitCapInt value = 0;
-        for (bitLenInt j = 0; j < valueBytes; j++) {
-            value |= values[indexInt * valueBytes + j] << (8U * j);
-        }
-        value = GetCachedPermutation(valueStart, valueLength) + value;
         INCC(value, valueStart, valueLength, carryIndex);
         return 0;
-    }
 #endif
+    }
 
     EntangleRange(indexStart, indexLength, valueStart, valueLength, carryIndex, 1);
 
@@ -2093,10 +2089,11 @@ bitCapInt QUnit::IndexedADC(bitLenInt indexStart, bitLenInt indexLength, bitLenI
 bitCapInt QUnit::IndexedSBC(bitLenInt indexStart, bitLenInt indexLength, bitLenInt valueStart, bitLenInt valueLength,
     bitLenInt carryIndex, unsigned char* values)
 {
-// TODO: Index bits that have exactly 0 or 1 probability can be optimized out of the gate.
-// In the meantime, checking if all index bits are in eigenstates takes very little overhead.
 #if ENABLE_VM6502Q_DEBUG
     if (CheckBitsPermutation(indexStart, indexLength) && CheckBitsPermutation(valueStart, valueLength)) {
+#else
+    if (CheckBitsPermutation(indexStart, indexLength)) {
+#endif
         bitCapInt indexInt = GetCachedPermutation(indexStart, indexLength);
         bitLenInt valueBytes = (valueLength + 7U) / 8U;
         bitCapInt value = 0;
@@ -2104,6 +2101,7 @@ bitCapInt QUnit::IndexedSBC(bitLenInt indexStart, bitLenInt indexLength, bitLenI
             value |= values[indexInt * valueBytes + j] << (8U * j);
         }
         value = GetCachedPermutation(valueStart, valueLength) - value;
+#if ENABLE_VM6502Q_DEBUG
         bitCapInt valueMask = (1U << valueLength) - 1U;
         bool carry = false;
         if (value > valueMask) {
@@ -2115,20 +2113,11 @@ bitCapInt QUnit::IndexedSBC(bitLenInt indexStart, bitLenInt indexLength, bitLenI
             X(carryIndex);
         }
         return value;
-    }
 #else
-    if (CheckBitsPermutation(indexStart, indexLength)) {
-        bitCapInt indexInt = GetCachedPermutation(indexStart, indexLength);
-        bitLenInt valueBytes = (valueLength + 7U) / 8U;
-        bitCapInt value = 0;
-        for (bitLenInt j = 0; j < valueBytes; j++) {
-            value |= values[indexInt * valueBytes + j] << (8U * j);
-        }
-        value = GetCachedPermutation(valueStart, valueLength) - value;
         DECC(value, valueStart, valueLength, carryIndex);
         return 0;
-    }
 #endif
+    }
 
     EntangleRange(indexStart, indexLength, valueStart, valueLength, carryIndex, 1);
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -795,18 +795,16 @@ void QUnit::UniformlyControlledSingleBit(const bitLenInt* controls, const bitLen
     bitLenInt i;
 
     std::vector<bitLenInt> trimmedControls;
-    std::vector<bitCapInt> combinedSkipPowers(mtrxSkipLen);
-    std::copy(mtrxSkipPowers, mtrxSkipPowers + mtrxSkipLen, combinedSkipPowers.begin());
-    bitCapInt combinedSkipValueMask = mtrxSkipValueMask;
+    std::vector<bitCapInt> skipPowers;
+    bitCapInt skipValueMask = 0;
     for (i = 0; i < controlLen; i++) {
         if (!CheckBitPermutation(controls[i])) {
             trimmedControls.push_back(controls[i]);
         } else {
-            combinedSkipPowers.push_back(1U << i);
-            combinedSkipValueMask |= ((shards[controls[i]].prob >= (ONE_R1 / 2)) ? (1U << i) : 0);
+            skipPowers.push_back(1U << i);
+            skipValueMask |= ((shards[controls[i]].prob >= (ONE_R1 / 2)) ? (1U << i) : 0);
         }
     }
-    std::sort(combinedSkipPowers.begin(), combinedSkipPowers.end());
 
     std::vector<bitLenInt> bits(trimmedControls.size() + 1);
     for (i = 0; i < trimmedControls.size(); i++) {
@@ -829,7 +827,7 @@ void QUnit::UniformlyControlledSingleBit(const bitLenInt* controls, const bitLen
     }
 
     unit->UniformlyControlledSingleBit(mappedControls, trimmedControls.size(), shards[qubitIndex].mapped, mtrxs,
-        &(combinedSkipPowers[0]), combinedSkipPowers.size(), combinedSkipValueMask);
+        &(skipPowers[0]), skipPowers.size(), skipValueMask);
 
     shards[qubitIndex].isProbDirty = true;
     shards[qubitIndex].isPhaseDirty = true;

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -2043,7 +2043,7 @@ bitCapInt QUnit::IndexedADC(bitLenInt indexStart, bitLenInt indexLength, bitLenI
             value &= valueMask;
             carry = true;
         }
-        SetReg(value, valueLength, value);
+        SetReg(valueStart, valueLength, value);
         if (carry) {
             X(carryIndex);
         }
@@ -2096,7 +2096,7 @@ bitCapInt QUnit::IndexedSBC(bitLenInt indexStart, bitLenInt indexLength, bitLenI
             value &= valueMask;
             carry = true;
         }
-        SetReg(value, valueLength, value);
+        SetReg(valueStart, valueLength, value);
         if (carry) {
             X(carryIndex);
         }

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -1303,14 +1303,6 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_uniform_c_single")
 
     qftReg->SetReg(0, 8, 0x02);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x02));
-    qftReg->H(4);
-    qftReg->UniformlyControlledSingleBit(NULL, 0, 0, pauliRYs);
-    qftReg->UniformlyControlledSingleBit(NULL, 0, 1, pauliRYs);
-    qftReg->H(4);
-    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x01));
-
-    qftReg->SetReg(0, 8, 0x02);
-    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x02));
     qftReg->UniformlyControlledSingleBit(controls, 2, 0, pauliRYs);
     qftReg->UniformlyControlledSingleBit(controls, 2, 1, pauliRYs);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x01));
@@ -1325,6 +1317,14 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_uniform_c_single")
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x22));
     qftReg->UniformlyControlledSingleBit(controls, 2, 0, pauliRYs);
     qftReg->UniformlyControlledSingleBit(controls, 2, 1, pauliRYs);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x22));
+
+    qftReg->SetReg(0, 8, 0x22);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x22));
+    qftReg->H(4);
+    qftReg->UniformlyControlledSingleBit(controls, 2, 0, pauliRYs);
+    qftReg->UniformlyControlledSingleBit(controls, 2, 1, pauliRYs);
+    qftReg->H(4);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x22));
 
     controls[0] = 5;

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -1303,6 +1303,14 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_uniform_c_single")
 
     qftReg->SetReg(0, 8, 0x02);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x02));
+    qftReg->H(4);
+    qftReg->UniformlyControlledSingleBit(NULL, 0, 0, pauliRYs);
+    qftReg->UniformlyControlledSingleBit(NULL, 0, 1, pauliRYs);
+    qftReg->H(4);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x01));
+
+    qftReg->SetReg(0, 8, 0x02);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x02));
     qftReg->UniformlyControlledSingleBit(controls, 2, 0, pauliRYs);
     qftReg->UniformlyControlledSingleBit(controls, 2, 1, pauliRYs);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x01));


### PR DESCRIPTION
These methods were optimized via two routes:
- Usually, it not necessary to calculate an expectation value for the returned results of these methods. This is usually only needed for debugging with the VM6502Q disassembler. A CMake flag has been added to restore this behavior, but it is off by default.
- Similar to `UniformlyControlledSingleBit()`, it's possible to optimize the base cases of these methods. I do not expect this to be a common use case, but it's hard to anticipate what won't be entered as inputs in QUnit.