### PR TITLE
Adding QEngineCPU option for sparse state vector

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,6 +150,7 @@ install (FILES
 install (FILES
     include/bitbuffer.hpp
     include/hamiltonian.hpp
+    include/statevector.hpp
     include/qfactory.hpp
     include/qengine.hpp
     include/qengine_cpu.hpp

--- a/include/common/parallel_for.hpp
+++ b/include/common/parallel_for.hpp
@@ -17,7 +17,7 @@
 
 /* Needed for bitCapInt typedefs. */
 #include "qrack_types.hpp"
-#include "statevector.hpp"
+#include "qrack/statevector.hpp"
 
 namespace Qrack {
 

--- a/include/common/parallel_for.hpp
+++ b/include/common/parallel_for.hpp
@@ -66,6 +66,9 @@ public:
     void par_for_mask(
         const bitCapInt, const bitCapInt, const bitCapInt* maskArray, const bitLenInt maskLen, ParallelFunc fn);
 
+    /** Iterate over a sparse state vector. */
+    void par_for_set(const std::set<bitCapInt>& sparseSet, ParallelFunc fn);
+
     /** Calculate the normal for the array. */
     real1 par_norm(const bitCapInt maxQPower, const StateVectorPtr stateArray);
 };

--- a/include/common/parallel_for.hpp
+++ b/include/common/parallel_for.hpp
@@ -16,8 +16,8 @@
 #include <vector>
 
 /* Needed for bitCapInt typedefs. */
-#include "qrack_types.hpp"
 #include "../statevector.hpp"
+#include "qrack_types.hpp"
 
 namespace Qrack {
 

--- a/include/common/parallel_for.hpp
+++ b/include/common/parallel_for.hpp
@@ -17,6 +17,7 @@
 
 /* Needed for bitCapInt typedefs. */
 #include "qrack_types.hpp"
+#include "statevector.hpp"
 
 namespace Qrack {
 
@@ -66,7 +67,7 @@ public:
         const bitCapInt, const bitCapInt, const bitCapInt* maskArray, const bitLenInt maskLen, ParallelFunc fn);
 
     /** Calculate the normal for the array. */
-    real1 par_norm(const bitCapInt maxQPower, const complex* stateArray);
+    real1 par_norm(const bitCapInt maxQPower, const StateVectorPtr stateArray);
 };
 
 } // namespace Qrack

--- a/include/common/parallel_for.hpp
+++ b/include/common/parallel_for.hpp
@@ -17,7 +17,7 @@
 
 /* Needed for bitCapInt typedefs. */
 #include "qrack_types.hpp"
-#include "qrack/statevector.hpp"
+#include "../statevector.hpp"
 
 namespace Qrack {
 

--- a/include/qengine.hpp
+++ b/include/qengine.hpp
@@ -25,7 +25,6 @@ typedef std::shared_ptr<QEngine> QEnginePtr;
  */
 class QEngine : public QInterface {
 protected:
-    complex* stateVec;
     bool randGlobalPhase;
     bool useHostRam;
     /// The value stored in runningNorm should always be the total probability implied by the norm of all amplitudes,
@@ -46,7 +45,6 @@ public:
     QEngine(bitLenInt qBitCount, qrack_rand_gen_ptr rgp = nullptr, bool doNorm = false, bool randomGlobalPhase = true,
         bool useHostMem = false, bool useHardwareRNG = true)
         : QInterface(qBitCount, rgp, doNorm, useHardwareRNG)
-        , stateVec(NULL)
         , randGlobalPhase(randomGlobalPhase)
         , useHostRam(useHostMem)
         , runningNorm(ONE_R1)
@@ -62,23 +60,7 @@ public:
         // Intentionally left blank
     }
 
-    virtual ~QEngine()
-    {
-        Finish();
-        FreeStateVec();
-    }
-
-    virtual void FreeStateVec()
-    {
-        if (stateVec) {
-#if defined(_WIN32)
-            _aligned_free(stateVec);
-#else
-            free(stateVec);
-#endif
-        }
-        stateVec = NULL;
-    }
+    virtual ~QEngine() { Finish(); }
 
     virtual bool ForceM(bitLenInt qubitIndex, bool result, bool doForce = true);
     virtual bitCapInt ForceM(const bitLenInt* bits, const bitLenInt& length, const bool* values);
@@ -135,8 +117,6 @@ public:
     virtual void NormalizeState(real1 nrm = -999.0) = 0;
 
 protected:
-    virtual complex* AllocStateVec(bitCapInt elemCount, bool doForceAlloc = false) = 0;
-    virtual void ResetStateVec(complex* nStateVec);
     virtual real1 GetExpectation(bitLenInt valueStart, bitLenInt valueLength) = 0;
 
     virtual bool IsIdentity(const complex* mtrx);

--- a/include/qengine_cpu.hpp
+++ b/include/qengine_cpu.hpp
@@ -16,6 +16,7 @@
 #include <memory>
 
 #include "qengine.hpp"
+#include "statevector.hpp"
 
 #include "common/parallel_for.hpp"
 
@@ -33,10 +34,14 @@ void rotate(BidirectionalIterator first, BidirectionalIterator middle, Bidirecti
  * General purpose QEngineCPU implementation
  */
 class QEngineCPU : virtual public QEngine, public ParallelFor {
+protected:
+    StateVectorPtr stateVec;
+    bool isSparse;
+
 public:
     QEngineCPU(bitLenInt qBitCount, bitCapInt initState, qrack_rand_gen_ptr rgp = nullptr,
         complex phaseFac = complex(-999.0, -999.0), bool doNorm = false, bool randomGlobalPhase = true,
-        bool ignored = false, int ignored2 = -1, bool useHardwareRNG = true);
+        bool ignored = false, int ignored2 = -1, bool useHardwareRNG = true, bool useSparseStateVec = false);
 
     QEngineCPU()
     {
@@ -47,6 +52,8 @@ public:
     {
         // Intentionally left blank
     }
+
+    virtual void FreeStateVec() { stateVec = NULL; }
 
     virtual void SetQuantumState(const complex* inputState);
     virtual void GetQuantumState(complex* outputState);
@@ -124,7 +131,8 @@ public:
      * @{
      */
 
-    virtual complex* GetStateVector();
+    virtual StateVectorPtr GetStateVector();
+    virtual void SetStateVector(StateVectorPtr sv);
     virtual void CopyState(QInterfacePtr orig);
     virtual real1 Prob(bitLenInt qubitIndex);
     virtual real1 ProbAll(bitCapInt fullRegister);
@@ -141,7 +149,8 @@ public:
     /** @} */
 
 protected:
-    virtual complex* AllocStateVec(bitCapInt elemCount, bool doForceAlloc = false);
+    virtual StateVectorPtr AllocStateVec(bitCapInt elemCount);
+    virtual void ResetStateVec(StateVectorPtr sv);
     virtual real1 GetExpectation(bitLenInt valueStart, bitLenInt valueLength);
 
     void DecomposeDispose(bitLenInt start, bitLenInt length, QEngineCPUPtr dest);

--- a/include/qengine_cpu.hpp
+++ b/include/qengine_cpu.hpp
@@ -133,7 +133,6 @@ public:
 
     virtual StateVectorPtr GetStateVector();
     virtual void SetStateVector(StateVectorPtr sv);
-    virtual void CopyState(QInterfacePtr orig);
     virtual real1 Prob(bitLenInt qubitIndex);
     virtual real1 ProbAll(bitCapInt fullRegister);
     virtual real1 ProbReg(const bitLenInt& start, const bitLenInt& length, const bitCapInt& permutation);

--- a/include/qengine_opencl.hpp
+++ b/include/qengine_opencl.hpp
@@ -159,7 +159,6 @@ public:
     }
 
     virtual void SetPermutation(bitCapInt perm, complex phaseFac = complex(-999.0, -999.0));
-    virtual void CopyState(QInterfacePtr orig);
     virtual real1 ProbAll(bitCapInt fullRegister);
 
     virtual void UniformlyControlledSingleBit(const bitLenInt* controls, const bitLenInt& controlLen,

--- a/include/qfusion.hpp
+++ b/include/qfusion.hpp
@@ -48,7 +48,7 @@ protected:
 public:
     QFusion(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState = 0, qrack_rand_gen_ptr rgp = nullptr,
         complex phaseFac = complex(-999.0, -999.0), bool doNorm = false, bool randomGlobalPhase = true,
-        bool useHostMem = false, int deviceID = -1, bool useHardwareRNG = true);
+        bool useHostMem = false, int deviceID = -1, bool useHardwareRNG = true, bool useSparseStateVec = false);
     QFusion(QInterfacePtr target);
 
     virtual void SetQuantumState(const complex* inputState);

--- a/include/qfusion.hpp
+++ b/include/qfusion.hpp
@@ -151,8 +151,6 @@ public:
     virtual void SqrtSwap(bitLenInt qubitIndex1, bitLenInt qubitIndex2);
     virtual void ISqrtSwap(bitLenInt qubitIndex1, bitLenInt qubitIndex2);
 
-    virtual void CopyState(QInterfacePtr orig) { return CopyState(std::dynamic_pointer_cast<QFusion>(orig)); }
-    virtual void CopyState(QFusionPtr orig);
     virtual real1 Prob(bitLenInt qubitIndex);
     virtual real1 ProbReg(const bitLenInt& start, const bitLenInt& length, const bitCapInt& permutation);
     virtual real1 ProbMask(const bitCapInt& mask, const bitCapInt& permutation);

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -1564,13 +1564,6 @@ public:
      */
 
     /**
-     * Direct copy of raw state vector to produce a clone
-     *
-     * \warning PSEUDO-QUANTUM
-     */
-    virtual void CopyState(QInterfacePtr orig) = 0;
-
-    /**
      * Direct measure of bit probability to be in |1> state
      *
      * \warning PSEUDO-QUANTUM

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -67,6 +67,8 @@ protected:
         return phase;
     }
 
+    QInterfacePtr MakeEngine(bitLenInt length, bitCapInt perm);
+
 public:
     QUnit(QInterfaceEngine eng, QInterfaceEngine subEng, bitLenInt qBitCount, bitCapInt initState = 0,
         qrack_rand_gen_ptr rgp = nullptr, complex phaseFac = complex(-999.0, -999.0), bool doNorm = false,

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -44,6 +44,7 @@ protected:
     bool randGlobalPhase;
     bool useHostRam;
     bool useRDRAND;
+    bool isSparse;
 
     qrack_rand_gen_ptr rand_generator;
 
@@ -69,10 +70,11 @@ protected:
 public:
     QUnit(QInterfaceEngine eng, QInterfaceEngine subEng, bitLenInt qBitCount, bitCapInt initState = 0,
         qrack_rand_gen_ptr rgp = nullptr, complex phaseFac = complex(-999.0, -999.0), bool doNorm = false,
-        bool randomGlobalPhase = true, bool useHostMem = true, int deviceID = -1, bool useHardwareRNG = true);
+        bool randomGlobalPhase = true, bool useHostMem = true, int deviceID = -1, bool useHardwareRNG = true,
+        bool useSparseStateVec = false);
     QUnit(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState = 0, qrack_rand_gen_ptr rgp = nullptr,
         complex phaseFac = complex(-999.0, -999.0), bool doNorm = true, bool randomGlobalPhase = true,
-        bool useHostMem = true, int deviceId = -1, bool useHardwareRNG = true);
+        bool useHostMem = true, int deviceId = -1, bool useHardwareRNG = true, bool useSparseStateVec = false);
 
     virtual void SetQuantumState(const complex* inputState);
     virtual void GetQuantumState(complex* outputState);

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -245,8 +245,6 @@ public:
      * @{
      */
 
-    virtual void CopyState(QUnitPtr orig);
-    virtual void CopyState(QInterfacePtr orig) { return CopyState(std::dynamic_pointer_cast<QUnit>(orig)); }
     virtual real1 Prob(bitLenInt qubit);
     virtual real1 ProbAll(bitCapInt fullRegister);
     virtual bool ApproxCompare(QInterfacePtr toCompare)
@@ -267,7 +265,6 @@ protected:
     virtual void UniformlyControlledSingleBit(const bitLenInt* controls, const bitLenInt& controlLen,
         bitLenInt qubitIndex, const complex* mtrxs, const bitCapInt* mtrxSkipPowers, const bitLenInt mtrxSkipLen,
         const bitCapInt& mtrxSkipValueMask);
-    virtual void CopyState(QUnit* orig);
 
     typedef void (QInterface::*INCxFn)(bitCapInt, bitLenInt, bitLenInt, bitLenInt);
     typedef void (QInterface::*INCxxFn)(bitCapInt, bitLenInt, bitLenInt, bitLenInt, bitLenInt);

--- a/include/statevector.hpp
+++ b/include/statevector.hpp
@@ -155,15 +155,13 @@ public:
 
     void write(const bitCapInt& i, const complex& c)
     {
+        mtx.lock();
         if (norm(c) < min_norm) {
-            mtx.lock();
             amplitudes.erase(i);
-            mtx.unlock();
         } else {
-            mtx.lock();
             amplitudes[i] = c;
-            mtx.unlock();
         }
+        mtx.unlock();
     }
 
     void write2(const bitCapInt& i1, const complex& c1, const bitCapInt& i2, const complex& c2)
@@ -171,7 +169,6 @@ public:
         if ((norm(c1) > min_norm) || (norm(c2) > min_norm)) {
             write(i1, c1);
             write(i2, c2);
-            mtx.unlock();
         }
     }
 
@@ -200,19 +197,17 @@ public:
 
     void copy(const StateVectorSparse& toCopy)
     {
-        capacity = toCopy.capacity;
         mtx.lock();
+        capacity = toCopy.capacity;
         amplitudes = toCopy.amplitudes;
         mtx.unlock();
     }
 
     void get_probs(real1* outArray)
     {
-        mtx.lock();
         for (bitCapInt i = 0; i < capacity; i++) {
             outArray[i] = norm(read(i));
         }
-        mtx.unlock();
     }
 };
 

--- a/include/statevector.hpp
+++ b/include/statevector.hpp
@@ -1,0 +1,201 @@
+//////////////////////////////////////////////////////////////////////////////////////
+//
+// (C) Daniel Strano and the Qrack contributors 2017-2019. All rights reserved.
+//
+// This header defines buffers for Qrack::QFusion.
+// QFusion adds an optional "gate fusion" layer on top of a QEngine or QUnit.
+// Single bit gates are buffered in per-bit 2x2 complex matrices, to reduce the cost
+// of successive application of single bit gates to the same bit.
+//
+// Licensed under the GNU Lesser General Public License V3.
+// See LICENSE.md in the project root or https://www.gnu.org/licenses/lgpl-3.0.en.html
+// for details.
+
+#pragma once
+
+#include <algorithm>
+#include <map>
+#include <mutex>
+
+#include "common/qrack_types.hpp"
+
+namespace Qrack {
+
+class StateVector;
+class StateVectorArray;
+class StateVectorSparse;
+
+typedef std::shared_ptr<StateVector> StateVectorPtr;
+typedef std::shared_ptr<StateVectorArray> StateVectorArrayPtr;
+typedef std::shared_ptr<StateVectorSparse> StateVectorSparsePtr;
+
+// This is a buffer struct that's capable of representing controlled single bit gates and arithmetic, when subclassed.
+class StateVector {
+protected:
+    bitCapInt capacity;
+
+public:
+    StateVector(bitCapInt cap)
+        : capacity(cap)
+    {
+    }
+    virtual complex get(const bitCapInt& i) = 0;
+    virtual void set(const bitCapInt& i, const complex& c) = 0;
+    virtual void clear() = 0;
+    virtual void copy_in(const complex* inArray) = 0;
+    virtual void copy_out(complex* outArray) = 0;
+    virtual void copy(const StateVector& toCopy) = 0;
+    virtual void get_probs(real1* outArray) = 0;
+};
+
+class StateVectorArray : public StateVector {
+protected:
+    complex* amplitudes;
+
+    static real1 normHelper(complex c) { return norm(c); }
+
+    complex* Alloc(bitCapInt elemCount)
+    {
+// elemCount is always a power of two, but might be smaller than QRACK_ALIGN_SIZE
+#if defined(__APPLE__)
+        void* toRet;
+        posix_memalign(&toRet, QRACK_ALIGN_SIZE,
+            ((sizeof(complex) * elemCount) < QRACK_ALIGN_SIZE) ? QRACK_ALIGN_SIZE : sizeof(complex) * elemCount);
+        return (complex*)toRet;
+#elif defined(_WIN32) && !defined(__CYGWIN__)
+        return (complex*)_aligned_malloc(
+            ((sizeof(complex) * elemCount) < QRACK_ALIGN_SIZE) ? QRACK_ALIGN_SIZE : sizeof(complex) * elemCount,
+            QRACK_ALIGN_SIZE);
+#else
+        return (complex*)aligned_alloc(QRACK_ALIGN_SIZE,
+            ((sizeof(complex) * elemCount) < QRACK_ALIGN_SIZE) ? QRACK_ALIGN_SIZE : sizeof(complex) * elemCount);
+#endif
+    }
+
+    virtual void Free()
+    {
+        if (amplitudes) {
+#if defined(_WIN32)
+            _aligned_free(amplitudes);
+#else
+            free(amplitudes);
+#endif
+        }
+        amplitudes = NULL;
+    }
+
+public:
+    StateVectorArray(bitCapInt cap)
+        : StateVector(cap)
+    {
+        amplitudes = Alloc(capacity);
+    }
+
+    ~StateVectorArray() { Free(); }
+
+    complex get(const bitCapInt& i) { return amplitudes[i]; };
+
+    void set(const bitCapInt& i, const complex& c) { amplitudes[i] = c; };
+
+    void clear() { std::fill(amplitudes, amplitudes + capacity, complex(ZERO_R1, ZERO_R1)); }
+
+    void copy_in(const complex* copyIn) { std::copy(copyIn, copyIn + capacity, amplitudes); }
+
+    void copy_out(complex* copyOut) { std::copy(amplitudes, amplitudes + capacity, copyOut); }
+
+    void copy(const StateVector& toCopy) { copy((const StateVectorArray&)toCopy); }
+
+    void copy(const StateVectorArray& toCopy)
+    {
+        if (capacity != toCopy.capacity) {
+            Free();
+            capacity = toCopy.capacity;
+            Alloc(capacity);
+        }
+        std::copy(toCopy.amplitudes, toCopy.amplitudes + capacity, amplitudes);
+    }
+
+    void get_probs(real1* outArray) { std::transform(amplitudes, amplitudes + capacity, outArray, normHelper); }
+};
+
+class StateVectorSparse : public StateVector {
+protected:
+    std::map<bitCapInt, complex> amplitudes;
+    std::recursive_mutex mtx;
+
+public:
+    StateVectorSparse(bitCapInt cap)
+        : StateVector(cap)
+        , amplitudes()
+    {
+    }
+
+    complex get(const bitCapInt& i)
+    {
+        mtx.lock();
+        complex toRet;
+        std::map<bitCapInt, complex>::const_iterator it = amplitudes.find(i);
+        if (it == amplitudes.end()) {
+            toRet = complex(ZERO_R1, ZERO_R1);
+        } else {
+            toRet = it->second;
+        }
+        mtx.unlock();
+        return toRet;
+    };
+
+    void set(const bitCapInt& i, const complex& c)
+    {
+        if (norm(c) < min_norm) {
+            mtx.lock();
+            amplitudes.erase(i);
+            mtx.unlock();
+        } else {
+            mtx.lock();
+            amplitudes[i] = c;
+            mtx.unlock();
+        }
+    };
+
+    void clear()
+    {
+        mtx.lock();
+        amplitudes.clear();
+        mtx.unlock();
+    }
+
+    void copy_in(const complex* copyIn)
+    {
+        for (bitCapInt i = 0; i < capacity; i++) {
+            set(i, copyIn[i]);
+        }
+    }
+
+    void copy_out(complex* copyOut)
+    {
+        for (bitCapInt i = 0; i < capacity; i++) {
+            copyOut[i] = get(i);
+        }
+    }
+
+    void copy(const StateVector& toCopy) { copy((const StateVectorSparse&)toCopy); }
+
+    void copy(const StateVectorSparse& toCopy)
+    {
+        capacity = toCopy.capacity;
+        mtx.lock();
+        amplitudes = toCopy.amplitudes;
+        mtx.unlock();
+    }
+
+    void get_probs(real1* outArray)
+    {
+        mtx.lock();
+        for (bitCapInt i = 0; i < capacity; i++) {
+            outArray[i] = norm(get(i));
+        }
+        mtx.unlock();
+    }
+};
+
+} // namespace Qrack

--- a/include/statevector.hpp
+++ b/include/statevector.hpp
@@ -41,6 +41,7 @@ public:
     }
     virtual complex get(const bitCapInt& i) = 0;
     virtual void set(const bitCapInt& i, const complex& c) = 0;
+    virtual void set2(const bitCapInt& i1, const complex& c1, const bitCapInt& i2, const complex& c2) = 0;
     virtual void clear() = 0;
     virtual void copy_in(const complex* inArray) = 0;
     virtual void copy_out(complex* outArray) = 0;
@@ -97,6 +98,11 @@ public:
 
     void set(const bitCapInt& i, const complex& c) { amplitudes[i] = c; };
 
+    void set2(const bitCapInt& i1, const complex& c1, const bitCapInt& i2, const complex& c2) {
+        amplitudes[i1] = c1;
+        amplitudes[i2] = c2;
+    };
+
     void clear() { std::fill(amplitudes, amplitudes + capacity, complex(ZERO_R1, ZERO_R1)); }
 
     void copy_in(const complex* copyIn) { std::copy(copyIn, copyIn + capacity, amplitudes); }
@@ -142,7 +148,7 @@ public:
         }
         mtx.unlock();
         return toRet;
-    };
+    }
 
     void set(const bitCapInt& i, const complex& c)
     {
@@ -155,7 +161,17 @@ public:
             amplitudes[i] = c;
             mtx.unlock();
         }
-    };
+    }
+
+    void set2(const bitCapInt& i1, const complex& c1, const bitCapInt& i2, const complex& c2)
+    {
+        if ((norm(c1) > min_norm) || (norm(c2) > min_norm)) {
+            mtx.lock();
+            amplitudes[i1] = c1;
+            amplitudes[i2] = c2;
+            mtx.unlock();
+        }
+    }
 
     void clear()
     {

--- a/include/statevector.hpp
+++ b/include/statevector.hpp
@@ -169,9 +169,8 @@ public:
     void write2(const bitCapInt& i1, const complex& c1, const bitCapInt& i2, const complex& c2)
     {
         if ((norm(c1) > min_norm) || (norm(c2) > min_norm)) {
-            mtx.lock();
-            amplitudes[i1] = c1;
-            amplitudes[i2] = c2;
+            write(i1, c1);
+            write(i2, c2);
             mtx.unlock();
         }
     }

--- a/include/statevector.hpp
+++ b/include/statevector.hpp
@@ -41,6 +41,7 @@ public:
     }
     virtual complex get(const bitCapInt& i) = 0;
     virtual void set(const bitCapInt& i, const complex& c) = 0;
+    /// Optimized "set" that is only guaranteed to set if either amplitude is nonzero. (Useful for the result of 2x2 tensor slicing.)
     virtual void set2(const bitCapInt& i1, const complex& c1, const bitCapInt& i2, const complex& c2) = 0;
     virtual void clear() = 0;
     virtual void copy_in(const complex* inArray) = 0;

--- a/include/statevector.hpp
+++ b/include/statevector.hpp
@@ -39,10 +39,11 @@ public:
         : capacity(cap)
     {
     }
-    virtual complex get(const bitCapInt& i) = 0;
-    virtual void set(const bitCapInt& i, const complex& c) = 0;
-    /// Optimized "set" that is only guaranteed to set if either amplitude is nonzero. (Useful for the result of 2x2 tensor slicing.)
-    virtual void set2(const bitCapInt& i1, const complex& c1, const bitCapInt& i2, const complex& c2) = 0;
+    virtual complex read(const bitCapInt& i) = 0;
+    virtual void write(const bitCapInt& i, const complex& c) = 0;
+    /// Optimized "write" that is only guaranteed to write if either amplitude is nonzero. (Useful for the result of 2x2
+    /// tensor slicing.)
+    virtual void write2(const bitCapInt& i1, const complex& c1, const bitCapInt& i2, const complex& c2) = 0;
     virtual void clear() = 0;
     virtual void copy_in(const complex* inArray) = 0;
     virtual void copy_out(complex* outArray) = 0;
@@ -95,11 +96,12 @@ public:
 
     ~StateVectorArray() { Free(); }
 
-    complex get(const bitCapInt& i) { return amplitudes[i]; };
+    complex read(const bitCapInt& i) { return amplitudes[i]; };
 
-    void set(const bitCapInt& i, const complex& c) { amplitudes[i] = c; };
+    void write(const bitCapInt& i, const complex& c) { amplitudes[i] = c; };
 
-    void set2(const bitCapInt& i1, const complex& c1, const bitCapInt& i2, const complex& c2) {
+    void write2(const bitCapInt& i1, const complex& c1, const bitCapInt& i2, const complex& c2)
+    {
         amplitudes[i1] = c1;
         amplitudes[i2] = c2;
     };
@@ -137,7 +139,7 @@ public:
     {
     }
 
-    complex get(const bitCapInt& i)
+    complex read(const bitCapInt& i)
     {
         mtx.lock();
         complex toRet;
@@ -151,7 +153,7 @@ public:
         return toRet;
     }
 
-    void set(const bitCapInt& i, const complex& c)
+    void write(const bitCapInt& i, const complex& c)
     {
         if (norm(c) < min_norm) {
             mtx.lock();
@@ -164,7 +166,7 @@ public:
         }
     }
 
-    void set2(const bitCapInt& i1, const complex& c1, const bitCapInt& i2, const complex& c2)
+    void write2(const bitCapInt& i1, const complex& c1, const bitCapInt& i2, const complex& c2)
     {
         if ((norm(c1) > min_norm) || (norm(c2) > min_norm)) {
             mtx.lock();
@@ -184,14 +186,14 @@ public:
     void copy_in(const complex* copyIn)
     {
         for (bitCapInt i = 0; i < capacity; i++) {
-            set(i, copyIn[i]);
+            write(i, copyIn[i]);
         }
     }
 
     void copy_out(complex* copyOut)
     {
         for (bitCapInt i = 0; i < capacity; i++) {
-            copyOut[i] = get(i);
+            copyOut[i] = read(i);
         }
     }
 
@@ -209,7 +211,7 @@ public:
     {
         mtx.lock();
         for (bitCapInt i = 0; i < capacity; i++) {
-            outArray[i] = norm(get(i));
+            outArray[i] = norm(read(i));
         }
         mtx.unlock();
     }

--- a/src/common/parallel_for.cpp
+++ b/src/common/parallel_for.cpp
@@ -182,7 +182,7 @@ real1 ParallelFor::par_norm(const bitCapInt maxQPower, const StateVectorPtr stat
         uint32_t cpu;
         for (cpu = 0; cpu < maxQPower; cpu++) {
             j = cpu;
-            futures[cpu] = std::async(std::launch::async, [j, stateArray]() { return norm(stateArray->get(j)); });
+            futures[cpu] = std::async(std::launch::async, [j, stateArray]() { return norm(stateArray->read(j)); });
         }
         for (cpu = 0; cpu < maxQPower; cpu++) {
             nrmSqr += futures[cpu].get();
@@ -202,7 +202,7 @@ real1 ParallelFor::par_norm(const bitCapInt maxQPower, const StateVectorPtr stat
             futures[cpu] = std::async(std::launch::async, [workUnit, offset, stateArray]() {
                 real1 result = 0.0;
                 for (bitCapInt j = 0; j < workUnit; j++) {
-                    result += norm(stateArray->get(offset + j));
+                    result += norm(stateArray->read(offset + j));
                 }
                 return result;
             });
@@ -227,7 +227,7 @@ real1 ParallelFor::par_norm(const bitCapInt maxQPower, const StateVectorPtr stat
                         k = i * PSTRIDE + j;
                         if (k >= maxQPower)
                             break;
-                        sqrNorm += norm(stateArray->get(k));
+                        sqrNorm += norm(stateArray->read(k));
                     }
                     if (k >= maxQPower)
                         break;

--- a/src/common/parallel_for.cpp
+++ b/src/common/parallel_for.cpp
@@ -173,7 +173,7 @@ void ParallelFor::par_for_mask(
     delete[] masks;
 }
 
-real1 ParallelFor::par_norm(const bitCapInt maxQPower, const complex* stateArray)
+real1 ParallelFor::par_norm(const bitCapInt maxQPower, const StateVectorPtr stateArray)
 {
     real1 nrmSqr = 0;
     if (maxQPower <= (bitCapInt)numCores) {
@@ -182,7 +182,7 @@ real1 ParallelFor::par_norm(const bitCapInt maxQPower, const complex* stateArray
         uint32_t cpu;
         for (cpu = 0; cpu < maxQPower; cpu++) {
             j = cpu;
-            futures[cpu] = std::async(std::launch::async, [j, stateArray]() { return norm(stateArray[j]); });
+            futures[cpu] = std::async(std::launch::async, [j, stateArray]() { return norm(stateArray->get(j)); });
         }
         for (cpu = 0; cpu < maxQPower; cpu++) {
             nrmSqr += futures[cpu].get();
@@ -202,7 +202,7 @@ real1 ParallelFor::par_norm(const bitCapInt maxQPower, const complex* stateArray
             futures[cpu] = std::async(std::launch::async, [workUnit, offset, stateArray]() {
                 real1 result = 0.0;
                 for (bitCapInt j = 0; j < workUnit; j++) {
-                    result += norm(stateArray[offset + j]);
+                    result += norm(stateArray->get(offset + j));
                 }
                 return result;
             });
@@ -227,7 +227,7 @@ real1 ParallelFor::par_norm(const bitCapInt maxQPower, const complex* stateArray
                         k = i * PSTRIDE + j;
                         if (k >= maxQPower)
                             break;
-                        sqrNorm += norm(stateArray[k]);
+                        sqrNorm += norm(stateArray->get(k));
                     }
                     if (k >= maxQPower)
                         break;

--- a/src/common/parallel_for.cpp
+++ b/src/common/parallel_for.cpp
@@ -95,6 +95,17 @@ void ParallelFor::par_for(const bitCapInt begin, const bitCapInt end, ParallelFu
     par_for_inc(begin, end - begin, [](const bitCapInt i, int cpu) { return i; }, fn);
 }
 
+void ParallelFor::par_for_set(const std::set<bitCapInt>& sparseSet, ParallelFunc fn)
+{
+    par_for_inc(0, sparseSet.size(),
+        [&sparseSet](const bitCapInt i, int cpu) {
+            auto it = sparseSet.begin();
+            std::advance(it, i);
+            return *it;
+        },
+        fn);
+}
+
 void ParallelFor::par_for_skip(
     const bitCapInt begin, const bitCapInt end, const bitCapInt skipMask, const bitLenInt maskWidth, ParallelFunc fn)
 {

--- a/src/qengine/gates.cpp
+++ b/src/qengine/gates.cpp
@@ -18,9 +18,9 @@ void QEngineCPU::ApplyM(bitCapInt regMask, bitCapInt result, complex nrm)
 {
     par_for(0, maxQPower, [&](const bitCapInt i, const int cpu) {
         if ((i & regMask) == result) {
-            stateVec->set(i, nrm * stateVec->get(i));
+            stateVec->write(i, nrm * stateVec->read(i));
         } else {
-            stateVec->set(i, complex(ZERO_R1, ZERO_R1));
+            stateVec->write(i, complex(ZERO_R1, ZERO_R1));
         }
     });
 
@@ -33,7 +33,7 @@ void QEngineCPU::PhaseFlip()
     // This gate has no physical consequence. We only enable it for "book-keeping," if the engine is not using global
     // phase offsets.
     if (!randGlobalPhase) {
-        par_for(0, maxQPower, [&](const bitCapInt lcv, const int cpu) { stateVec->set(lcv, -stateVec->get(lcv)); });
+        par_for(0, maxQPower, [&](const bitCapInt lcv, const int cpu) { stateVec->write(lcv, -stateVec->read(lcv)); });
     }
 }
 

--- a/src/qengine/gates.cpp
+++ b/src/qengine/gates.cpp
@@ -18,9 +18,9 @@ void QEngineCPU::ApplyM(bitCapInt regMask, bitCapInt result, complex nrm)
 {
     par_for(0, maxQPower, [&](const bitCapInt i, const int cpu) {
         if ((i & regMask) == result) {
-            stateVec[i] = nrm * stateVec[i];
+            stateVec->set(i, nrm * stateVec->get(i));
         } else {
-            stateVec[i] = complex(ZERO_R1, ZERO_R1);
+            stateVec->set(i, complex(ZERO_R1, ZERO_R1));
         }
     });
 
@@ -33,7 +33,7 @@ void QEngineCPU::PhaseFlip()
     // This gate has no physical consequence. We only enable it for "book-keeping," if the engine is not using global
     // phase offsets.
     if (!randGlobalPhase) {
-        par_for(0, maxQPower, [&](const bitCapInt lcv, const int cpu) { stateVec[lcv] = -stateVec[lcv]; });
+        par_for(0, maxQPower, [&](const bitCapInt lcv, const int cpu) { stateVec->set(lcv, -stateVec->get(lcv)); });
     }
 }
 

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -951,6 +951,10 @@ void QEngineOCL::DecomposeDispose(bitLenInt start, bitLenInt length, QEngineOCLP
         return;
     }
 
+    if (doNormalize) {
+        NormalizeState();
+    }
+
     if (length == qubitCount) {
         if (destination != nullptr) {
             if (deviceID == destination->deviceID) {
@@ -963,6 +967,8 @@ void QEngineOCL::DecomposeDispose(bitLenInt start, bitLenInt length, QEngineOCLP
                 destination->UnlockSync();
                 UnlockSync();
             }
+        } else { 
+            FreeStateVec();
         }
         SetQubitCount(1);
         // This will be cleared by the destructor:
@@ -972,10 +978,6 @@ void QEngineOCL::DecomposeDispose(bitLenInt start, bitLenInt length, QEngineOCLP
     }
 
     OCLAPI api_call = OCL_API_DECOMPOSEPROB;
-
-    if (doNormalize) {
-        NormalizeState();
-    }
 
     bitCapInt partPower = 1U << length;
     bitCapInt remainderPower = 1U << (qubitCount - length);

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -65,7 +65,7 @@ namespace Qrack {
     queue.enqueueUnmapMemObject(buff, array, NULL, &(device_context->wait_events->back()));
 
 QEngineOCL::QEngineOCL(bitLenInt qBitCount, bitCapInt initState, qrack_rand_gen_ptr rgp, complex phaseFac, bool doNorm,
-    bool randomGlobalPhase, bool useHostMem, int devID, bool useHardwareRNG)
+    bool randomGlobalPhase, bool useHostMem, int devID, bool useHardwareRNG, bool ignored)
     : QEngine(qBitCount, rgp, doNorm, randomGlobalPhase, useHostMem, useHardwareRNG)
     , deviceID(devID)
     , wait_refs()
@@ -442,6 +442,14 @@ real1 QEngineOCL::ParSum(real1* toSum, bitCapInt maxI)
 }
 
 void QEngineOCL::InitOCL(int devID) { SetDevice(devID, true); }
+
+void QEngineOCL::ResetStateVec(complex* nStateVec)
+{
+    if (stateVec) {
+        FreeStateVec();
+        stateVec = nStateVec;
+    }
+}
 
 void QEngineOCL::ResetStateBuffer(BufferPtr nStateBuffer) { stateBuffer = nStateBuffer; }
 

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -268,26 +268,6 @@ void QEngineOCL::DispatchQueue(cl_event event, cl_int type)
     device_context->wait_events->push_back(kernelEvent);
 }
 
-void QEngineOCL::CopyState(QInterfacePtr orig)
-{
-    QEngineOCLPtr src = std::dynamic_pointer_cast<QEngineOCL>(orig);
-
-    /* Set the size and reset the stateVec to the correct size. */
-    SetQubitCount(orig->GetQubitCount());
-
-    complex* nStateVec = AllocStateVec(maxQPower);
-    BufferPtr nStateBuffer = MakeStateVecBuffer(nStateVec);
-    ResetStateVec(nStateVec);
-    ResetStateBuffer(nStateBuffer);
-
-    src->LockSync(CL_MAP_READ);
-    LockSync(CL_MAP_WRITE);
-    runningNorm = src->runningNorm;
-    std::copy(src->stateVec, src->stateVec + (1 << (src->qubitCount)), stateVec);
-    src->UnlockSync();
-    UnlockSync();
-}
-
 real1 QEngineOCL::ProbAll(bitCapInt fullRegister)
 {
     if (doNormalize) {
@@ -967,7 +947,7 @@ void QEngineOCL::DecomposeDispose(bitLenInt start, bitLenInt length, QEngineOCLP
                 destination->UnlockSync();
                 UnlockSync();
             }
-        } else { 
+        } else {
             FreeStateVec();
         }
         SetQubitCount(1);

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -951,6 +951,26 @@ void QEngineOCL::DecomposeDispose(bitLenInt start, bitLenInt length, QEngineOCLP
         return;
     }
 
+    if (length == qubitCount) {
+        if (destination != nullptr) {
+            if (deviceID == destination->deviceID) {
+                destination->stateVec = stateVec;
+                destination->stateBuffer = stateBuffer;
+            } else {
+                LockSync();
+                destination->LockSync();
+                std::copy(stateVec, stateVec + maxQPower, destination->stateVec);
+                destination->UnlockSync();
+                UnlockSync();
+            }
+        }
+        SetQubitCount(1);
+        // This will be cleared by the destructor:
+        stateVec = AllocStateVec(2);
+        stateBuffer = MakeStateVecBuffer(stateVec);
+        return;
+    }
+
     OCLAPI api_call = OCL_API_DECOMPOSEPROB;
 
     if (doNormalize) {

--- a/src/qengine/qengine.cpp
+++ b/src/qengine/qengine.cpp
@@ -14,14 +14,6 @@
 
 namespace Qrack {
 
-void QEngine::ResetStateVec(complex* nStateVec)
-{
-    if (stateVec) {
-        FreeStateVec();
-        stateVec = nStateVec;
-    }
-}
-
 /// PSEUDO-QUANTUM - Acts like a measurement gate, except with a specified forced result.
 bool QEngine::ForceM(bitLenInt qubit, bool result, bool doForce)
 {

--- a/src/qengine/state.cpp
+++ b/src/qengine/state.cpp
@@ -192,8 +192,7 @@ void QEngineCPU::Apply2x2(bitCapInt offset1, bitCapInt offset2, const complex* m
             stateVec->set(lcv + offset2, complex(qubit.comp[2], qubit.comp[3]));
             rngNrm[cpu] += norm(qubit.cmplx2);
 #else
-            stateVec->set(lcv + offset1, qubit.cmplx[0]);
-            stateVec->set(lcv + offset2, qubit.cmplx[1]);
+            stateVec->set2(lcv + offset1, qubit.cmplx[0], lcv + offset2, qubit.cmplx[1]);
             rngNrm[cpu] += norm(qubit.cmplx[0]) + norm(qubit.cmplx[1]);
 #endif
         });
@@ -211,8 +210,7 @@ void QEngineCPU::Apply2x2(bitCapInt offset1, bitCapInt offset2, const complex* m
             stateVec->set(lcv + offset1, complex(qubit.comp[0], qubit.comp[1]));
             stateVec->set(lcv + offset2, complex(qubit.comp[2], qubit.comp[3]));
 #else
-            stateVec->set(lcv + offset1, qubit.cmplx[0]);
-            stateVec->set(lcv + offset2, qubit.cmplx[1]);
+            stateVec->set2(lcv + offset1, qubit.cmplx[0], lcv + offset2, qubit.cmplx[1]);
 #endif
         });
         if (doCalcNorm) {
@@ -242,8 +240,7 @@ void QEngineCPU::Apply2x2(bitCapInt offset1, bitCapInt offset2, const complex* m
             qubit[1] = nrm * ((mtrx[2] * Y0) + (mtrx[3] * qubit[1]));
             rngNrm[cpu] += norm(qubit[0]) + norm(qubit[1]);
 
-            stateVec->set(lcv + offset1, qubit[0]);
-            stateVec->set(lcv + offset2, qubit[1]);
+            stateVec->set2(lcv + offset1, qubit[0], lcv + offset2, qubit[1]);
         });
         runningNorm = ZERO_R1;
         for (int i = 0; i < numCores; i++) {
@@ -260,8 +257,7 @@ void QEngineCPU::Apply2x2(bitCapInt offset1, bitCapInt offset2, const complex* m
             qubit[0] = (mtrx[0] * Y0) + (mtrx[1] * qubit[1]);
             qubit[1] = (mtrx[2] * Y0) + (mtrx[3] * qubit[1]);
 
-            stateVec->set(lcv + offset1, qubit[0]);
-            stateVec->set(lcv + offset2, qubit[1]);
+            stateVec->set2(lcv + offset1, qubit[0], lcv + offset2, qubit[1]);
         });
         if (doCalcNorm) {
             UpdateRunningNorm();
@@ -327,8 +323,7 @@ void QEngineCPU::UniformlyControlledSingleBit(const bitLenInt* controls, const b
 
         rngNrm[cpu] += norm(qubit[0]) + norm(qubit[1]);
 
-        stateVec->set(lcv, qubit[0]);
-        stateVec->set(lcv | targetPower, qubit[1]);
+        stateVec->set2(lcv, qubit[0], lcv | targetPower, qubit[1]);
     });
 
     runningNorm = ZERO_R1;

--- a/src/qengine/state.cpp
+++ b/src/qengine/state.cpp
@@ -102,14 +102,6 @@ real1 QEngineCPU::GetExpectation(bitLenInt valueStart, bitLenInt valueLength)
     return average;
 }
 
-void QEngineCPU::CopyState(QInterfacePtr orig)
-{
-    /* Set the size and reset the stateVec to the correct size. */
-    SetQubitCount(orig->GetQubitCount());
-    QEngineCPUPtr src = std::dynamic_pointer_cast<QEngineCPU>(orig);
-    stateVec->copy(*(src->stateVec));
-}
-
 /// Set arbitrary pure quantum state, in unsigned int permutation basis
 void QEngineCPU::SetQuantumState(const complex* inputState)
 {

--- a/src/qengine/state.cpp
+++ b/src/qengine/state.cpp
@@ -37,34 +37,33 @@ namespace Qrack {
  * phase usually makes sense only if they are initialized at the same time.
  */
 QEngineCPU::QEngineCPU(bitLenInt qBitCount, bitCapInt initState, qrack_rand_gen_ptr rgp, complex phaseFac, bool doNorm,
-    bool randomGlobalPhase, bool useHostMem, int deviceID, bool useHardwareRNG)
+    bool randomGlobalPhase, bool useHostMem, int deviceID, bool useHardwareRNG, bool useSparseStateVec)
     : QEngine(qBitCount, rgp, doNorm, randomGlobalPhase, true, useHardwareRNG)
+    , isSparse(useSparseStateVec)
 {
     SetConcurrencyLevel(std::thread::hardware_concurrency());
 
     stateVec = AllocStateVec(maxQPower);
-    std::fill(stateVec, stateVec + maxQPower, complex(ZERO_R1, ZERO_R1));
+    stateVec->clear();
 
     if (phaseFac == complex(-999.0, -999.0)) {
-        stateVec[initState] = GetNonunitaryPhase();
+        stateVec->set(initState, GetNonunitaryPhase());
     } else {
-        stateVec[initState] = phaseFac;
+        stateVec->set(initState, phaseFac);
     }
 }
-
-complex* QEngineCPU::GetStateVector() { return stateVec; }
 
 complex QEngineCPU::GetAmplitude(bitCapInt perm)
 {
     if (doNormalize && (runningNorm != ONE_R1)) {
         NormalizeState();
     }
-    return stateVec[perm];
+    return stateVec->get(perm);
 }
 
 void QEngineCPU::SetPermutation(bitCapInt perm, complex phaseFac)
 {
-    std::fill(stateVec, stateVec + maxQPower, complex(ZERO_R1, ZERO_R1));
+    stateVec->clear();
 
     if (phaseFac == complex(-999.0, -999.0)) {
         complex phase;
@@ -74,10 +73,10 @@ void QEngineCPU::SetPermutation(bitCapInt perm, complex phaseFac)
         } else {
             phase = complex(ONE_R1, ZERO_R1);
         }
-        stateVec[perm] = phase;
+        stateVec->set(perm, phase);
     } else {
         real1 nrm = abs(phaseFac);
-        stateVec[perm] = phaseFac / nrm;
+        stateVec->set(perm, phaseFac / nrm);
     }
 
     runningNorm = ONE_R1;
@@ -92,7 +91,7 @@ real1 QEngineCPU::GetExpectation(bitLenInt valueStart, bitLenInt valueLength)
     bitCapInt outputMask = bitRegMask(valueStart, valueLength);
     for (i = 0; i < maxQPower; i++) {
         outputInt = (i & outputMask) >> valueStart;
-        prob = norm(stateVec[i]);
+        prob = norm(stateVec->get(i));
         totProb += prob;
         average += prob * outputInt;
     }
@@ -107,16 +106,14 @@ void QEngineCPU::CopyState(QInterfacePtr orig)
 {
     /* Set the size and reset the stateVec to the correct size. */
     SetQubitCount(orig->GetQubitCount());
-    ResetStateVec(AllocStateVec(maxQPower));
-
     QEngineCPUPtr src = std::dynamic_pointer_cast<QEngineCPU>(orig);
-    std::copy(src->stateVec, src->stateVec + src->maxQPower, stateVec);
+    stateVec->copy(*(src->stateVec));
 }
 
 /// Set arbitrary pure quantum state, in unsigned int permutation basis
 void QEngineCPU::SetQuantumState(const complex* inputState)
 {
-    std::copy(inputState, inputState + maxQPower, stateVec);
+    stateVec->copy_in(inputState);
     runningNorm = ONE_R1;
 }
 
@@ -127,7 +124,7 @@ void QEngineCPU::GetQuantumState(complex* outputState)
         NormalizeState();
     }
 
-    std::copy(stateVec, stateVec + maxQPower, outputState);
+    stateVec->copy_out(outputState);
 }
 
 /// Get all probabilities, in unsigned int permutation basis
@@ -137,7 +134,7 @@ void QEngineCPU::GetProbs(real1* outputProbs)
         NormalizeState();
     }
 
-    std::transform(stateVec, stateVec + maxQPower, outputProbs, normHelper);
+    stateVec->get_probs(outputProbs);
 }
 
     /**
@@ -187,16 +184,16 @@ void QEngineCPU::Apply2x2(bitCapInt offset1, bitCapInt offset2, const complex* m
         real1* rngNrm = new real1[numCores];
         std::fill(rngNrm, rngNrm + numCores, ZERO_R1);
         par_for_mask(0, maxQPower, qPowersSorted, bitCount, [&](const bitCapInt lcv, const int cpu) {
-            ComplexUnion qubit(stateVec[lcv + offset1], stateVec[lcv + offset2]);
+            ComplexUnion qubit(stateVec->get(lcv + offset1), stateVec->get(lcv + offset2));
 
             qubit.cmplx2 = matrixMul(nrm, mtrxCol1.cmplx2, mtrxCol2.cmplx2, qubit.cmplx2);
 #if ENABLE_COMPLEX8
-            stateVec[lcv + offset1] = complex(qubit.comp[0], qubit.comp[1]);
-            stateVec[lcv + offset2] = complex(qubit.comp[2], qubit.comp[3]);
+            stateVec->set(lcv + offset1, complex(qubit.comp[0], qubit.comp[1]));
+            stateVec->set(lcv + offset2, complex(qubit.comp[2], qubit.comp[3]));
             rngNrm[cpu] += norm(qubit.cmplx2);
 #else
-            stateVec[lcv + offset1] = qubit.cmplx[0];
-            stateVec[lcv + offset2] = qubit.cmplx[1];
+            stateVec->set(lcv + offset1, qubit.cmplx[0]);
+            stateVec->set(lcv + offset2, qubit.cmplx[1]);
             rngNrm[cpu] += norm(qubit.cmplx[0]) + norm(qubit.cmplx[1]);
 #endif
         });
@@ -207,15 +204,15 @@ void QEngineCPU::Apply2x2(bitCapInt offset1, bitCapInt offset2, const complex* m
         delete[] rngNrm;
     } else {
         par_for_mask(0, maxQPower, qPowersSorted, bitCount, [&](const bitCapInt lcv, const int cpu) {
-            ComplexUnion qubit(stateVec[lcv + offset1], stateVec[lcv + offset2]);
+            ComplexUnion qubit(stateVec->get(lcv + offset1), stateVec->get(lcv + offset2));
 
             qubit.cmplx2 = matrixMul(mtrxCol1.cmplx2, mtrxCol2.cmplx2, qubit.cmplx2);
 #if ENABLE_COMPLEX8
-            stateVec[lcv + offset1] = complex(qubit.comp[0], qubit.comp[1]);
-            stateVec[lcv + offset2] = complex(qubit.comp[2], qubit.comp[3]);
+            stateVec->set(lcv + offset1, complex(qubit.comp[0], qubit.comp[1]));
+            stateVec->set(lcv + offset2, complex(qubit.comp[2], qubit.comp[3]));
 #else
-            stateVec[lcv + offset1] = qubit.cmplx[0];
-            stateVec[lcv + offset2] = qubit.cmplx[1];
+            stateVec->set(lcv + offset1, qubit.cmplx[0]);
+            stateVec->set(lcv + offset2, qubit.cmplx[1]);
 #endif
         });
         if (doCalcNorm) {
@@ -238,15 +235,15 @@ void QEngineCPU::Apply2x2(bitCapInt offset1, bitCapInt offset2, const complex* m
         par_for_mask(0, maxQPower, qPowersSorted, bitCount, [&](const bitCapInt lcv, const int cpu) {
             complex qubit[2];
 
-            complex Y0 = stateVec[lcv + offset1];
-            qubit[1] = stateVec[lcv + offset2];
+            complex Y0 = stateVec->get(lcv + offset1);
+            qubit[1] = stateVec->get(lcv + offset2);
 
             qubit[0] = nrm * ((mtrx[0] * Y0) + (mtrx[1] * qubit[1]));
             qubit[1] = nrm * ((mtrx[2] * Y0) + (mtrx[3] * qubit[1]));
             rngNrm[cpu] += norm(qubit[0]) + norm(qubit[1]);
 
-            stateVec[lcv + offset1] = qubit[0];
-            stateVec[lcv + offset2] = qubit[1];
+            stateVec->set(lcv + offset1, qubit[0]);
+            stateVec->set(lcv + offset2, qubit[1]);
         });
         runningNorm = ZERO_R1;
         for (int i = 0; i < numCores; i++) {
@@ -257,14 +254,14 @@ void QEngineCPU::Apply2x2(bitCapInt offset1, bitCapInt offset2, const complex* m
         par_for_mask(0, maxQPower, qPowersSorted, bitCount, [&](const bitCapInt lcv, const int cpu) {
             complex qubit[2];
 
-            complex Y0 = stateVec[lcv + offset1];
-            qubit[1] = stateVec[lcv + offset2];
+            complex Y0 = stateVec->get(lcv + offset1);
+            qubit[1] = stateVec->get(lcv + offset2);
 
             qubit[0] = (mtrx[0] * Y0) + (mtrx[1] * qubit[1]);
             qubit[1] = (mtrx[2] * Y0) + (mtrx[3] * qubit[1]);
 
-            stateVec[lcv + offset1] = qubit[0];
-            stateVec[lcv + offset2] = qubit[1];
+            stateVec->set(lcv + offset1, qubit[0]);
+            stateVec->set(lcv + offset2, qubit[1]);
         });
         if (doCalcNorm) {
             UpdateRunningNorm();
@@ -322,16 +319,16 @@ void QEngineCPU::UniformlyControlledSingleBit(const bitLenInt* controls, const b
 
         complex qubit[2];
 
-        complex Y0 = stateVec[lcv];
-        qubit[1] = stateVec[lcv | targetPower];
+        complex Y0 = stateVec->get(lcv);
+        qubit[1] = stateVec->get(lcv | targetPower);
 
         qubit[0] = nrm * ((mtrxs[0 + offset] * Y0) + (mtrxs[1 + offset] * qubit[1]));
         qubit[1] = nrm * ((mtrxs[2 + offset] * Y0) + (mtrxs[3 + offset] * qubit[1]));
 
         rngNrm[cpu] += norm(qubit[0]) + norm(qubit[1]);
 
-        stateVec[lcv] = qubit[0];
-        stateVec[lcv | targetPower] = qubit[1];
+        stateVec->set(lcv, qubit[0]);
+        stateVec->set(lcv | targetPower, qubit[1]);
     });
 
     runningNorm = ZERO_R1;
@@ -365,10 +362,10 @@ bitLenInt QEngineCPU::Compose(QEngineCPUPtr toCopy)
     bitCapInt startMask = maxQPower - 1U;
     bitCapInt endMask = (toCopy->maxQPower - 1U) << qubitCount;
 
-    complex* nStateVec = AllocStateVec(nMaxQPower);
+    StateVectorPtr nStateVec = AllocStateVec(nMaxQPower);
 
     par_for(0, nMaxQPower, [&](const bitCapInt lcv, const int cpu) {
-        nStateVec[lcv] = stateVec[lcv & startMask] * toCopy->stateVec[(lcv & endMask) >> qubitCount];
+        nStateVec->set(lcv, stateVec->get(lcv & startMask) * toCopy->stateVec->get((lcv & endMask) >> qubitCount));
     });
 
     SetQubitCount(nQubitCount);
@@ -399,11 +396,12 @@ bitLenInt QEngineCPU::Compose(QEngineCPUPtr toCopy, bitLenInt start)
     bitCapInt midMask = bitRegMask(start, oQubitCount);
     bitCapInt endMask = ((1U << (qubitCount + oQubitCount)) - 1U) & ~(startMask | midMask);
 
-    complex* nStateVec = AllocStateVec(nMaxQPower);
+    StateVectorPtr nStateVec = AllocStateVec(nMaxQPower);
 
     par_for(0, nMaxQPower, [&](const bitCapInt lcv, const int cpu) {
-        nStateVec[lcv] =
-            stateVec[(lcv & startMask) | ((lcv & endMask) >> oQubitCount)] * toCopy->stateVec[(lcv & midMask) >> start];
+        nStateVec->set(lcv,
+            stateVec->get((lcv & startMask) | ((lcv & endMask) >> oQubitCount)) *
+                toCopy->stateVec->get((lcv & midMask) >> start));
     });
 
     SetQubitCount(nQubitCount);
@@ -451,14 +449,14 @@ std::map<QInterfacePtr, bitLenInt> QEngineCPU::Compose(std::vector<QInterfacePtr
 
     nMaxQPower = 1 << nQubitCount;
 
-    complex* nStateVec = AllocStateVec(nMaxQPower);
+    StateVectorPtr nStateVec = AllocStateVec(nMaxQPower);
 
     par_for(0, nMaxQPower, [&](const bitCapInt lcv, const int cpu) {
-        nStateVec[lcv] = stateVec[lcv & startMask];
+        nStateVec->set(lcv, stateVec->get(lcv & startMask));
 
         for (bitLenInt j = 0; j < toComposeCount; j++) {
             QEngineCPUPtr src = std::dynamic_pointer_cast<Qrack::QEngineCPU>(toCopy[j]);
-            nStateVec[lcv] *= src->stateVec[(lcv & mask[j]) >> offset[j]];
+            nStateVec->set(lcv, nStateVec->get(lcv) * src->stateVec->get((lcv & mask[j]) >> offset[j]));
         }
     });
 
@@ -507,11 +505,11 @@ void QEngineCPU::DecomposeDispose(bitLenInt start, bitLenInt length, QEngineCPUP
         for (k = 0; k < partPower; k++) {
             l = j | (k << start);
 
-            nrm = norm(stateVec[l]);
+            nrm = norm(stateVec->get(l));
             remainderStateProb[lcv] += nrm;
 
             if (nrm > min_norm) {
-                currentAngle = arg(stateVec[l]);
+                currentAngle = arg(stateVec->get(l));
                 if (firstAngle < (-8 * M_PI)) {
                     firstAngle = currentAngle;
                 }
@@ -533,11 +531,11 @@ void QEngineCPU::DecomposeDispose(bitLenInt start, bitLenInt length, QEngineCPUP
             l |= (k ^ l) << length;
             l = j | l;
 
-            nrm = norm(stateVec[l]);
+            nrm = norm(stateVec->get(l));
             partStateProb[lcv] += nrm;
 
             if (nrm > min_norm) {
-                currentAngle = arg(stateVec[l]);
+                currentAngle = arg(stateVec->get(l));
                 if (firstAngle < (-8 * M_PI)) {
                     firstAngle = currentAngle;
                 }
@@ -554,16 +552,17 @@ void QEngineCPU::DecomposeDispose(bitLenInt start, bitLenInt length, QEngineCPUP
 
     if (destination != nullptr) {
         par_for(0, partPower, [&](const bitCapInt lcv, const int cpu) {
-            destination->stateVec[lcv] =
-                (real1)(std::sqrt(partStateProb[lcv])) * complex(cos(partStateAngle[lcv]), sin(partStateAngle[lcv]));
+            destination->stateVec->set(lcv,
+                (real1)(std::sqrt(partStateProb[lcv])) * complex(cos(partStateAngle[lcv]), sin(partStateAngle[lcv])));
         });
     }
 
     ResetStateVec(AllocStateVec(maxQPower));
 
     par_for(0, remainderPower, [&](const bitCapInt lcv, const int cpu) {
-        stateVec[lcv] = (real1)(std::sqrt(remainderStateProb[lcv])) *
-            complex(cos(remainderStateAngle[lcv]), sin(remainderStateAngle[lcv]));
+        stateVec->set(lcv,
+            (real1)(std::sqrt(remainderStateProb[lcv])) *
+                complex(cos(remainderStateAngle[lcv]), sin(remainderStateAngle[lcv])));
     });
 
     delete[] remainderStateProb;
@@ -599,7 +598,7 @@ real1 QEngineCPU::Prob(bitLenInt qubit)
     par_for(0, maxQPower >> 1U, [&](const bitCapInt lcv, const int cpu) {
         bitCapInt i = lcv & qMask;
         i |= ((lcv ^ i) << 1U) | qPower;
-        oneChanceBuff[cpu] += norm(stateVec[i]);
+        oneChanceBuff[cpu] += norm(stateVec->get(i));
     });
 
     for (int i = 0; i < numCores; i++) {
@@ -618,7 +617,7 @@ real1 QEngineCPU::ProbAll(bitCapInt fullRegister)
         NormalizeState();
     }
 
-    return norm(stateVec[fullRegister]);
+    return norm(stateVec->get(fullRegister));
 }
 
 // Returns probability of permutation of the register
@@ -634,7 +633,7 @@ real1 QEngineCPU::ProbReg(const bitLenInt& start, const bitLenInt& length, const
     bitCapInt perm = permutation << start;
 
     par_for_skip(0, maxQPower, (1U << start), length,
-        [&](const bitCapInt lcv, const int cpu) { probs[cpu] += norm(stateVec[lcv | perm]); });
+        [&](const bitCapInt lcv, const int cpu) { probs[cpu] += norm(stateVec->get(lcv | perm)); });
 
     real1 prob = ZERO_R1;
     for (int thrd = 0; thrd < num_threads; thrd++) {
@@ -670,7 +669,7 @@ real1 QEngineCPU::ProbMask(const bitCapInt& mask, const bitCapInt& permutation)
     real1* probs = new real1[num_threads]();
 
     par_for_mask(0, maxQPower, skipPowers, skipPowersVec.size(),
-        [&](const bitCapInt lcv, const int cpu) { probs[cpu] += norm(stateVec[lcv | permutation]); });
+        [&](const bitCapInt lcv, const int cpu) { probs[cpu] += norm(stateVec->get(lcv | permutation)); });
 
     delete[] skipPowers;
 
@@ -706,23 +705,23 @@ bool QEngineCPU::ApproxCompare(QEngineCPUPtr toCompare)
     real1 nrm;
     bitCapInt basePerm;
     for (basePerm = 0; basePerm < maxQPower; basePerm++) {
-        nrm = norm(stateVec[basePerm]);
+        nrm = norm(stateVec->get(basePerm));
         if (nrm > min_norm) {
-            basePhaseFac1 = (ONE_R1 / (real1)sqrt(nrm)) * stateVec[basePerm];
+            basePhaseFac1 = (ONE_R1 / (real1)sqrt(nrm)) * stateVec->get(basePerm);
             break;
         }
     }
 
-    nrm = norm(toCompare->stateVec[basePerm]);
+    nrm = norm(toCompare->stateVec->get(basePerm));
     if (nrm < min_norm) {
         // If the amplitude we sample for global phase offset correction doesn't match, we're done.
         return false;
     }
 
-    complex basePhaseFac2 = (ONE_R1 / (real1)sqrt(nrm)) * toCompare->stateVec[basePerm];
+    complex basePhaseFac2 = (ONE_R1 / (real1)sqrt(nrm)) * toCompare->stateVec->get(basePerm);
 
     par_for(0, maxQPower, [&](const bitCapInt lcv, const int cpu) {
-        real1 elemError = norm(basePhaseFac2 * stateVec[lcv] - basePhaseFac1 * toCompare->stateVec[lcv]);
+        real1 elemError = norm(basePhaseFac2 * stateVec->get(lcv) - basePhaseFac1 * toCompare->stateVec->get(lcv));
         partError[cpu] += elemError;
     });
 
@@ -739,8 +738,8 @@ bool QEngineCPU::ApproxCompare(QEngineCPUPtr toCompare)
 /// For chips with a zero flag, flip the phase of the state where the register equals zero.
 void QEngineCPU::ZeroPhaseFlip(bitLenInt start, bitLenInt length)
 {
-    par_for_skip(
-        0, maxQPower, 1U << start, length, [&](const bitCapInt lcv, const int cpu) { stateVec[lcv] = -stateVec[lcv]; });
+    par_for_skip(0, maxQPower, 1U << start, length,
+        [&](const bitCapInt lcv, const int cpu) { stateVec->set(lcv, -stateVec->get(lcv)); });
 }
 
 /// The 6502 uses its carry flag also as a greater-than/less-than flag, for the CMP operation.
@@ -751,7 +750,7 @@ void QEngineCPU::CPhaseFlipIfLess(bitCapInt greaterPerm, bitLenInt start, bitLen
 
     par_for(0, maxQPower, [&](const bitCapInt lcv, const int cpu) {
         if ((((lcv & regMask) >> start) < greaterPerm) & ((lcv & flagMask) == flagMask))
-            stateVec[lcv] = -stateVec[lcv];
+            stateVec->set(lcv, -stateVec->get(lcv));
     });
 }
 
@@ -762,7 +761,7 @@ void QEngineCPU::PhaseFlipIfLess(bitCapInt greaterPerm, bitLenInt start, bitLenI
 
     par_for(0, maxQPower, [&](const bitCapInt lcv, const int cpu) {
         if (((lcv & regMask) >> start) < greaterPerm)
-            stateVec[lcv] = -stateVec[lcv];
+            stateVec->set(lcv, -stateVec->get(lcv));
     });
 }
 
@@ -777,28 +776,21 @@ void QEngineCPU::NormalizeState(real1 nrm)
 
     nrm = ONE_R1 / std::sqrt(nrm);
 
-    par_for(0, maxQPower, [&](const bitCapInt lcv, const int cpu) { stateVec[lcv] *= nrm; });
+    par_for(0, maxQPower, [&](const bitCapInt lcv, const int cpu) { stateVec->set(lcv, stateVec->get(lcv) * nrm); });
 
     runningNorm = ONE_R1;
 }
 
 void QEngineCPU::UpdateRunningNorm() { runningNorm = par_norm(maxQPower, stateVec); }
 
-complex* QEngineCPU::AllocStateVec(bitCapInt elemCount, bool ovrride)
+StateVectorPtr QEngineCPU::AllocStateVec(bitCapInt elemCount)
 {
-// elemCount is always a power of two, but might be smaller than QRACK_ALIGN_SIZE
-#if defined(__APPLE__)
-    void* toRet;
-    posix_memalign(&toRet, QRACK_ALIGN_SIZE,
-        ((sizeof(complex) * elemCount) < QRACK_ALIGN_SIZE) ? QRACK_ALIGN_SIZE : sizeof(complex) * elemCount);
-    return (complex*)toRet;
-#elif defined(_WIN32) && !defined(__CYGWIN__)
-    return (complex*)_aligned_malloc(
-        ((sizeof(complex) * elemCount) < QRACK_ALIGN_SIZE) ? QRACK_ALIGN_SIZE : sizeof(complex) * elemCount,
-        QRACK_ALIGN_SIZE);
-#else
-    return (complex*)aligned_alloc(QRACK_ALIGN_SIZE,
-        ((sizeof(complex) * elemCount) < QRACK_ALIGN_SIZE) ? QRACK_ALIGN_SIZE : sizeof(complex) * elemCount);
-#endif
+    if (isSparse) {
+        return std::make_shared<StateVectorSparse>(elemCount);
+    } else {
+        return std::make_shared<StateVectorArray>(elemCount);
+    }
 }
+
+void QEngineCPU::ResetStateVec(StateVectorPtr sv) { stateVec = sv; }
 } // namespace Qrack

--- a/src/qengine/state.cpp
+++ b/src/qengine/state.cpp
@@ -206,12 +206,12 @@ void QEngineCPU::Apply2x2(bitCapInt offset1, bitCapInt offset2, const complex* m
 
     if (stateVec->is_sparse()) {
         bitCapInt setMask = offset1 ^ offset2;
-        bitCapInt skipMask = 0;
+        bitCapInt filterMask = 0;
         for (bitLenInt i = 0; i < bitCount; i++) {
-            skipMask |= (qPowersSorted[i] & ~setMask);
+            filterMask |= (qPowersSorted[i] & ~setMask);
         }
-        bitCapInt skipValues = skipMask & offset1 & offset2;
-        par_for_set(stateVec->iterable(setMask, skipMask, skipValues), fn);
+        bitCapInt filterValues = filterMask & offset1 & offset2;
+        par_for_set(stateVec->iterable(setMask, filterMask, filterValues), fn);
     } else {
         par_for_mask(0, maxQPower, qPowersSorted, bitCount, fn);
     }
@@ -268,12 +268,12 @@ void QEngineCPU::Apply2x2(bitCapInt offset1, bitCapInt offset2, const complex* m
 
     if (stateVec->is_sparse()) {
         bitCapInt setMask = offset1 ^ offset2;
-        bitCapInt skipMask = 0;
+        bitCapInt filterMask = 0;
         for (bitLenInt i = 0; i < bitCount; i++) {
-            skipMask |= (qPowersSorted[i] & ~setMask);
+            filterMask |= (qPowersSorted[i] & ~setMask);
         }
-        bitCapInt skipValues = skipMask & offset1 & offset2;
-        par_for_set(stateVec->iterable(setMask, skipMask, skipValues), fn);
+        bitCapInt filterValues = filterMask & offset1 & offset2;
+        par_for_set(stateVec->iterable(setMask, filterMask, filterValues), fn);
     } else {
         par_for_mask(0, maxQPower, qPowersSorted, bitCount, fn);
     }

--- a/src/qengine/state.cpp
+++ b/src/qengine/state.cpp
@@ -476,16 +476,6 @@ void QEngineCPU::DecomposeDispose(bitLenInt start, bitLenInt length, QEngineCPUP
         return;
     }
 
-    if (length == qubitCount) {
-        if (destination != nullptr) {
-            destination->stateVec = stateVec;
-        }
-        SetQubitCount(1);
-        // This will be cleared by the destructor:
-        stateVec = AllocStateVec(2);
-        return;
-    }
-
     if (doNormalize && (runningNorm != ONE_R1)) {
         NormalizeState();
     }

--- a/src/qengine/state.cpp
+++ b/src/qengine/state.cpp
@@ -476,6 +476,20 @@ void QEngineCPU::DecomposeDispose(bitLenInt start, bitLenInt length, QEngineCPUP
         return;
     }
 
+    if (length == qubitCount) {
+        if (destination != nullptr) {
+            destination->stateVec = stateVec;
+        }
+        SetQubitCount(1);
+        // This will be cleared by the destructor:
+        if (isSparse) {
+            stateVec = std::make_shared<StateVectorSparse>(2);
+        } else {
+            stateVec = std::make_shared<StateVectorArray>(2);
+        }
+        return;
+    }
+
     if (doNormalize && (runningNorm != ONE_R1)) {
         NormalizeState();
     }

--- a/src/qengine/state.cpp
+++ b/src/qengine/state.cpp
@@ -482,11 +482,7 @@ void QEngineCPU::DecomposeDispose(bitLenInt start, bitLenInt length, QEngineCPUP
         }
         SetQubitCount(1);
         // This will be cleared by the destructor:
-        if (isSparse) {
-            stateVec = std::make_shared<StateVectorSparse>(2);
-        } else {
-            stateVec = std::make_shared<StateVectorArray>(2);
-        }
+        stateVec = AllocStateVec(2);
         return;
     }
 

--- a/src/qengine/utility.cpp
+++ b/src/qengine/utility.cpp
@@ -20,8 +20,9 @@ void QEngineCPU::SetStateVector(StateVectorPtr sv) { stateVec = sv; }
 
 QInterfacePtr QEngineCPU::Clone()
 {
-    QInterfacePtr clone = CreateQuantumInterface(
-        QINTERFACE_CPU, qubitCount, 0, rand_generator, complex(ONE_R1, ZERO_R1), doNormalize, randGlobalPhase, true);
+    QInterfacePtr clone =
+        CreateQuantumInterface(QINTERFACE_CPU, QINTERFACE_CPU, qubitCount, 0, rand_generator, complex(ONE_R1, ZERO_R1),
+            doNormalize, randGlobalPhase, false, 0, (hardware_rand_generator == NULL) ? false : true, isSparse);
     std::dynamic_pointer_cast<QEngineCPU>(clone)->stateVec->copy(*stateVec);
     return clone;
 }

--- a/src/qengine/utility.cpp
+++ b/src/qengine/utility.cpp
@@ -14,11 +14,15 @@
 
 namespace Qrack {
 
+StateVectorPtr QEngineCPU::GetStateVector() { return stateVec; }
+
+void QEngineCPU::SetStateVector(StateVectorPtr sv) { stateVec = sv; }
+
 QInterfacePtr QEngineCPU::Clone()
 {
     QInterfacePtr clone = CreateQuantumInterface(
         QINTERFACE_CPU, qubitCount, 0, rand_generator, complex(ONE_R1, ZERO_R1), doNormalize, randGlobalPhase, true);
-    clone->SetQuantumState(stateVec);
+    std::dynamic_pointer_cast<QEngineCPU>(clone)->stateVec->copy(*stateVec);
     return clone;
 }
 

--- a/src/qfusion.cpp
+++ b/src/qfusion.cpp
@@ -801,13 +801,6 @@ void QFusion::ISqrtSwap(bitLenInt qubitIndex1, bitLenInt qubitIndex2)
     }
 }
 
-void QFusion::CopyState(QFusionPtr orig)
-{
-    FlushAll();
-    orig->FlushAll();
-    qReg->CopyState(orig->qReg);
-}
-
 real1 QFusion::Prob(bitLenInt qubitIndex)
 {
     FlushBit(qubitIndex);

--- a/src/qfusion.cpp
+++ b/src/qfusion.cpp
@@ -20,7 +20,8 @@
 namespace Qrack {
 
 QFusion::QFusion(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState, qrack_rand_gen_ptr rgp,
-    complex phaseFac, bool doNorm, bool randomGlobalPhase, bool useHostMem, int deviceID, bool useHardwareRNG)
+    complex phaseFac, bool doNorm, bool randomGlobalPhase, bool useHostMem, int deviceID, bool useHardwareRNG,
+    bool useSparseStateVec)
     : QInterface(qBitCount, rgp, deviceID, useHardwareRNG)
     , phaseFactor(phaseFac)
     , doNormalize(doNorm)
@@ -29,7 +30,7 @@ QFusion::QFusion(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState,
     , bitControls(qBitCount)
 {
     qReg = CreateQuantumInterface(eng, qBitCount, initState, rgp, phaseFactor, doNormalize, randGlobalPhase, useHostMem,
-        deviceID, useHardwareRNG);
+        deviceID, useHardwareRNG, useSparseStateVec);
 }
 
 QFusion::QFusion(QInterfacePtr target)

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -120,19 +120,17 @@ void QUnit::SetQuantumState(const complex* inputState)
 void QUnit::GetQuantumState(complex* outputState)
 {
     EndAllEmulation();
-    QUnit qUnitCopy(engine, subengine, 1, 0);
-    qUnitCopy.CopyState((QUnit*)this);
-    qUnitCopy.OrderContiguous(qUnitCopy.EntangleAll());
-    qUnitCopy.shards[0].unit->GetQuantumState(outputState);
+    QUnitPtr clone = std::dynamic_pointer_cast<QUnit>(Clone());
+    clone->OrderContiguous(clone->EntangleAll());
+    clone->shards[0].unit->GetQuantumState(outputState);
 }
 
 void QUnit::GetProbs(real1* outputProbs)
 {
     EndAllEmulation();
-    QUnit qUnitCopy(engine, subengine, 1, 0);
-    qUnitCopy.CopyState((QUnit*)this);
-    qUnitCopy.OrderContiguous(qUnitCopy.EntangleAll());
-    qUnitCopy.shards[0].unit->GetProbs(outputProbs);
+    QUnitPtr clone = std::dynamic_pointer_cast<QUnit>(Clone());
+    clone->OrderContiguous(clone->EntangleAll());
+    clone->shards[0].unit->GetProbs(outputProbs);
 }
 
 complex QUnit::GetAmplitude(bitCapInt perm)

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -74,35 +74,6 @@ void QUnit::SetPermutation(bitCapInt perm, complex phaseFac)
     }
 }
 
-void QUnit::CopyState(QUnitPtr orig) { CopyState(orig.get()); }
-
-// protected method
-void QUnit::CopyState(QUnit* orig)
-{
-    EndAllEmulation();
-
-    SetQubitCount(orig->GetQubitCount());
-    shards.clear();
-
-    /* Set up the shards to refer to the new unit. */
-    std::map<QInterfacePtr, QInterfacePtr> otherUnits;
-    for (auto&& otherShard : orig->shards) {
-        QEngineShard shard;
-        shard.mapped = otherShard.mapped;
-        shard.isEmulated = otherShard.isEmulated;
-        shard.prob = otherShard.prob;
-        shard.isProbDirty = otherShard.isProbDirty;
-        shard.phase = otherShard.phase;
-        shard.isPhaseDirty = otherShard.isPhaseDirty;
-        if (otherUnits.find(otherShard.unit) == otherUnits.end()) {
-            otherUnits[otherShard.unit] = MakeEngine(1, 0);
-            otherUnits[otherShard.unit]->CopyState(otherShard.unit);
-        }
-        shard.unit = otherUnits[otherShard.unit];
-        shards.push_back(shard);
-    }
-}
-
 void QUnit::SetQuantumState(const complex* inputState)
 {
     EndAllEmulation();

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -50,6 +50,12 @@ QUnit::QUnit(QInterfaceEngine eng, QInterfaceEngine subEng, bitLenInt qBitCount,
     SetPermutation(initState, phaseFactor);
 }
 
+QInterfacePtr QUnit::MakeEngine(bitLenInt length, bitCapInt perm)
+{
+    return CreateQuantumInterface(engine, subengine, length, perm, rand_generator, phaseFactor, doNormalize,
+        randGlobalPhase, useHostRam, devID, useRDRAND, isSparse);
+}
+
 void QUnit::SetPermutation(bitCapInt perm, complex phaseFac)
 {
     bool bitState;
@@ -58,8 +64,7 @@ void QUnit::SetPermutation(bitCapInt perm, complex phaseFac)
 
     for (bitLenInt i = 0; i < qubitCount; i++) {
         bitState = ((1 << i) & perm) >> i;
-        shards[i].unit = CreateQuantumInterface(engine, subengine, 1U, bitState ? 1U : 0U, rand_generator, phaseFac,
-            doNormalize, randGlobalPhase, useHostRam, devID, useRDRAND, isSparse);
+        shards[i].unit = MakeEngine(1, bitState ? 1 : 0);
         shards[i].mapped = 0;
         shards[i].isEmulated = false;
         shards[i].prob = bitState ? ONE_R1 : ZERO_R1;
@@ -90,8 +95,7 @@ void QUnit::CopyState(QUnit* orig)
         shard.phase = otherShard.phase;
         shard.isPhaseDirty = otherShard.isPhaseDirty;
         if (otherUnits.find(otherShard.unit) == otherUnits.end()) {
-            otherUnits[otherShard.unit] = CreateQuantumInterface(engine, subengine, 1, 0, rand_generator, phaseFactor,
-                doNormalize, randGlobalPhase, useHostRam, devID, useRDRAND, isSparse);
+            otherUnits[otherShard.unit] = MakeEngine(1, 0);
             otherUnits[otherShard.unit]->CopyState(otherShard.unit);
         }
         shard.unit = otherUnits[otherShard.unit];
@@ -103,8 +107,7 @@ void QUnit::SetQuantumState(const complex* inputState)
 {
     EndAllEmulation();
 
-    auto unit = CreateQuantumInterface(engine, subengine, qubitCount, 0, rand_generator, phaseFactor, doNormalize,
-        randGlobalPhase, useHostRam, devID, useRDRAND, isSparse);
+    auto unit = MakeEngine(qubitCount, 0);
     unit->SetQuantumState(inputState);
 
     int idx = 0;
@@ -445,8 +448,7 @@ bool QUnit::TrySeparate(bitLenInt start, bitLenInt length)
         EndEmulation(start);
     }
 
-    QInterfacePtr separatedBits = CreateQuantumInterface(engine, subengine, length, 0, rand_generator,
-        complex(ONE_R1, ZERO_R1), doNormalize, randGlobalPhase, useHostRam, devID, useRDRAND, isSparse);
+    QInterfacePtr separatedBits = MakeEngine(length, 0);
 
     QInterfacePtr unitCopy = shards[start].unit->Clone();
 
@@ -664,8 +666,7 @@ void QUnit::SeparateBit(bool value, bitLenInt qubit)
 {
     QEngineShard origShard = shards[qubit];
 
-    QInterfacePtr dest = CreateQuantumInterface(engine, subengine, 1, value ? 1 : 0, rand_generator, phaseFactor,
-        doNormalize, randGlobalPhase, useHostRam, devID, useRDRAND, isSparse);
+    QInterfacePtr dest = MakeEngine(1, value ? 1 : 0);
 
     origShard.unit->Dispose(origShard.mapped, 1);
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -214,11 +214,7 @@ void QUnit::Detach(bitLenInt start, bitLenInt length, QUnitPtr dest)
             dest->shards[start + i].isPhaseDirty = shards[start + i].isPhaseDirty;
         }
 
-        if (unit->GetQubitCount() > length) {
-            unit->Decompose(mapped, length, destEngine);
-        } else {
-            destEngine->CopyState(unit);
-        }
+        unit->Decompose(mapped, length, destEngine);
     } else {
         unit->Dispose(mapped, length);
     }

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -29,6 +29,7 @@ qrack_rand_gen_ptr rng;
 bool enable_normalization = false;
 bool disable_hardware_rng = false;
 bool async_time = false;
+bool sparse = false;
 int device_id = -1;
 
 int main(int argc, char* argv[])
@@ -151,6 +152,15 @@ int main(int argc, char* argv[])
             num_failed = session.run();
         }
 
+        if (num_failed == 0 && cpu) {
+            session.config().stream() << "############ QUnit -> QEngine -> CPU (Sparse) ############" << std::endl;
+            testSubEngineType = QINTERFACE_CPU;
+            testSubEngineType = QINTERFACE_CPU;
+            sparse = true;
+            num_failed = session.run();
+            sparse = false;
+        }
+
 #if ENABLE_OPENCL
         if (num_failed == 0 && opencl_single) {
             session.config().stream() << "############ QUnit -> QEngine -> OpenCL ############" << std::endl;
@@ -169,6 +179,14 @@ int main(int argc, char* argv[])
             session.config().stream() << "############ QUnit -> QFusion -> CPU ############" << std::endl;
             testSubSubEngineType = QINTERFACE_CPU;
             num_failed = session.run();
+        }
+
+        if (num_failed == 0 && cpu) {
+            session.config().stream() << "############ QUnit -> QFusion -> CPU (Sparse) ############" << std::endl;
+            testSubSubEngineType = QINTERFACE_CPU;
+            sparse = true;
+            num_failed = session.run();
+            sparse = false;
         }
 
 #if ENABLE_OPENCL
@@ -196,5 +214,5 @@ QInterfaceTestFixture::QInterfaceTestFixture()
     rng->seed(rngSeed);
 
     qftReg = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 20, 0, rng,
-        complex(ONE_R1, ZERO_R1), enable_normalization, true, false, device_id, !disable_hardware_rng);
+        complex(ONE_R1, ZERO_R1), enable_normalization, true, false, device_id, !disable_hardware_rng, sparse);
 }

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -2483,15 +2483,6 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_getquantumstate")
     qftReg->SetQuantumState(state);
 }
 
-TEST_CASE_METHOD(QInterfaceTestFixture, "test_copystate")
-{
-    qftReg = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 4, 0x0b, rng);
-    qftReg->H(0, 2);
-    QInterfacePtr qftReg2 = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 4, 0, rng);
-    qftReg2->CopyState(qftReg);
-    REQUIRE(qftReg->ApproxCompare(qftReg2));
-}
-
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_getprobs")
 {
     real1 state[1U << 4U];


### PR DESCRIPTION
Benn, I'm going to need your oversight, for this.

I'm experimenting with an option for a sparse state vector, in QEngineCPU. This would typically only be useful in the context of QUnit.

Naively, a sparse state vector can be a bad approach. Applying Hadamard gates across every bit in a coherent unit of qubits fills every permutation basis ray with a nonzero value. However, with QUnit optimizations, this doesn't cause the sparse occupancy to blow up, because every one of those bits is _separable_. With QUnit, the RAM still scales like `2*n` for `n` qubits, in that case. Separability optimization in QUnit opens the possibility of significant RAM savings with a sparse array for a state vector. With or without QUnit, I have an example case in mind.

Say that we wanted to apply amplitude amplification (Grover's search) to a classical hashing function, to find a desired output of the function faster. Say the hash is `n` bits wide, and we start `m` bits of input in 50/50 superposition, with `m <= n`, strictly. Even simpler, say `m=2`.

We're superposing 4 possible inputs, and remember that the hashing function is classical, so there will only be 4 nonzero amplitudes superposed in the output. Depending on the hashing function, it's reasonable that _no_ bits can be separated along the rays of permutation basis. (The state _is_ "separable," but a single bit difference in the classical input could change _every_ bit in the classical output, such that permutation basis is an inconvenient basis to separate the representation in.)

For simulation purposes, we want to recover the RAM difference between representing `n` qubits compared to 4 possible outputs. One possible way to do this is to transform to a basis where QUnit can separate the bits. If we're trying to run Grover's search on this function, though, that might effectively be "begging the question": we probably don't know what a convenient basis for representational separation is until we finish analyzing the hash. (This is even leaving aside how we can practically transform gates to apply to the qubits in this basis, or transform the qubits across a changing opportune basis, to keep these RAM savings.)

QUnit, on its own, fails here. It blows up to full exponential RAM usage.

However, if the hashing function is classical, we know that there are exactly as many nonzero amplitudes in the output as there were in the input. Hence, a sparse state vector _will_ recover this RAM difference. (It'll be slow, but that's not our immediate consideration.) Additionally, if we pack sparse state vector engines into QUnit, they synergize, such that simple cases like applying Hadamard gates on all qubits in an input register don't ruin the sparseness.

So, that's the case this addresses. Benn, in particular, I'm asking you to evaluate the design and style, here. It might be infeasible to mimic the C array interface--or maybe it isn't.