### PR TITLE
QUnit: Fourier basis sub-units

### DIFF
--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -1276,6 +1276,10 @@ public:
     virtual void CINC(
         bitCapInt toAdd, bitLenInt inOutStart, bitLenInt length, bitLenInt* controls, bitLenInt controlLen) = 0;
 
+    /** When in Fourier basis, (after QFT,) this is equivalent to INC, after returning to permutation basis (after
+     * subsequent IQFT). */
+    virtual void QFTINC(bitCapInt toAdd, bitLenInt start, bitLenInt length);
+
     /** Add integer (without sign, with carry) */
     virtual void INCC(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt carryIndex) = 0;
 

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -476,11 +476,33 @@ protected:
 
     bool CheckRangeInBasis(const bitLenInt& start, const bitLenInt& length, const bitLenInt& fourier)
     {
+        QInterfacePtr fourierRoot = NULL;
         for (bitLenInt i = 0; i < length; i++) {
             if (fourier != (shards[start + i].fourierUnit != NULL)) {
                 return false;
+            } else if (fourier) {
+                if (fourierRoot == NULL) {
+                    fourierRoot = shards[start + i].fourierUnit;
+                } else if (fourierRoot != shards[start + i].fourierUnit) {
+                    return false;
+                }
             }
         }
+
+        if (fourier) {
+            for (bitLenInt i = 0; i < start; i++) {
+                if (shards[i].fourierUnit == fourierRoot) {
+                    return false;
+                }
+            }
+
+            for (bitLenInt i = (start + length); i < qubitCount; i++) {
+                if (shards[i].fourierUnit == fourierRoot) {
+                    return false;
+                }
+            }
+        }
+
         return true;
     }
 };

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -271,7 +271,8 @@ public:
      * @{
      */
 
-    virtual real1 Prob(bitLenInt qubit);
+    virtual real1 Prob(bitLenInt qubit) { return Prob(qubit, false); }
+    virtual real1 Prob(bitLenInt qubit, bool inCurrentBasis);
     virtual real1 ProbAll(bitCapInt fullRegister);
     virtual bool ApproxCompare(QInterfacePtr toCompare)
     {

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -230,13 +230,13 @@ public:
     virtual void QFT(bitLenInt start, bitLenInt length, bool trySeparate = false)
     {
         freezeBasis = !trySeparate;
-        QInterface::QFT(start, length, trySeparate);
+        QInterface::QFT(start, length, !isSparse);
         freezeBasis = false;
     }
     virtual void IQFT(bitLenInt start, bitLenInt length, bool trySeparate = false)
     {
         freezeBasis = !trySeparate;
-        QInterface::IQFT(start, length, trySeparate);
+        QInterface::IQFT(start, length, !isSparse);
         freezeBasis = false;
     }
 

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -411,105 +411,22 @@ protected:
         }
     }
 
-    void TransformBasis(const bool& toFourier, const bitLenInt& i)
-    {
-        if (isSparse) {
-            // Sparse state vector already fulfills the point of this optimization
-            return;
-        }
-
-        if ((shards[i].fourierUnit != NULL) == toFourier) {
-            // Already in target basis
-            return;
-        }
-
-        QInterfacePtr unit = toFourier ? shards[i].unit : shards[i].fourierUnit;
-        QUnit subUnit = QUnit(engine, subengine, unit->GetQubitCount(), 0, rand_generator, phaseFactor, doNormalize,
-            randGlobalPhase, useHostRam, devID, useRDRAND, isSparse);
-
-        for (bitLenInt i = 0; i < qubitCount; i++) {
-            if ((toFourier && (unit == shards[i].unit)) || (!toFourier && (unit == shards[i].fourierUnit))) {
-                if (toFourier) {
-                    subUnit.shards[shards[i].mapped] = shards[i];
-                } else {
-                    subUnit.shards[shards[i].fourierMapped] = shards[i];
-                    shards[i].fourierUnit = NULL;
-                    shards[i].fourierMapped = 0;
-                }
-            }
-        }
-
-        if (toFourier) {
-            subUnit.QFT(0, unit->GetQubitCount());
-        } else {
-            subUnit.IQFT(0, unit->GetQubitCount());
-        }
-
-        QInterfacePtr tUnit = subUnit.shards[0].unit;
-
-        for (bitLenInt i = 0; i < qubitCount; i++) {
-            if ((toFourier && (unit == shards[i].unit)) || (!toFourier && (unit == shards[i].fourierUnit))) {
-                if (toFourier) {
-                    bitLenInt tempMapped = shards[i].mapped;
-                    shards[i] = subUnit.shards[shards[i].mapped];
-                    shards[i].fourierUnit = tUnit;
-                    shards[i].fourierMapped = tempMapped;
-                } else {
-                    shards[i] = subUnit.shards[shards[i].fourierMapped];
-                    shards[i].fourierUnit = NULL;
-                    shards[i].fourierMapped = 0;
-                }
-            }
-        }
-    }
-
+    void TransformBasis(const bool& toFourier, const bitLenInt& i);
     void TransformBasis(const bool& toFourier, const bitLenInt& start, const bitLenInt& length)
     {
         for (bitLenInt i = 0; i < length; i++) {
             TransformBasis(toFourier, start + i);
         }
     }
-
     void TransformBasis(const bool& toFourier, const bitLenInt* bits, const bitLenInt& length)
     {
         for (bitLenInt i = 0; i < length; i++) {
             TransformBasis(toFourier, bits[i]);
         }
     }
-
     void TransformBasisAll(const bool& toFourier) { TransformBasis(toFourier, (bitLenInt)0, qubitCount); }
 
-    bool CheckRangeInBasis(const bitLenInt& start, const bitLenInt& length, const bitLenInt& fourier)
-    {
-        QInterfacePtr fourierRoot = NULL;
-        for (bitLenInt i = 0; i < length; i++) {
-            if (fourier != (shards[start + i].fourierUnit != NULL)) {
-                return false;
-            } else if (fourier) {
-                if (fourierRoot == NULL) {
-                    fourierRoot = shards[start + i].fourierUnit;
-                } else if (fourierRoot != shards[start + i].fourierUnit) {
-                    return false;
-                }
-            }
-        }
-
-        if (fourier) {
-            for (bitLenInt i = 0; i < start; i++) {
-                if (shards[i].fourierUnit == fourierRoot) {
-                    return false;
-                }
-            }
-
-            for (bitLenInt i = (start + length); i < qubitCount; i++) {
-                if (shards[i].fourierUnit == fourierRoot) {
-                    return false;
-                }
-            }
-        }
-
-        return true;
-    }
+    bool CheckRangeInBasis(const bitLenInt& start, const bitLenInt& length, const bitLenInt& fourier);
 };
 
 } // namespace Qrack

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -413,6 +413,8 @@ protected:
         }
     }
 
+    void TransformToFourier(const bitLenInt& i);
+    void TransformToPerm(const bitLenInt& i);
     void TransformBasis(const bool& toFourier, const bitLenInt& i);
     void TransformBasis(const bool& toFourier, const bitLenInt& start, const bitLenInt& length)
     {

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -279,6 +279,8 @@ public:
     /** @} */
 
 protected:
+    virtual void ZBase(const bitLenInt& target);
+
     virtual void UniformlyControlledSingleBit(const bitLenInt* controls, const bitLenInt& controlLen,
         bitLenInt qubitIndex, const complex* mtrxs, const bitCapInt* mtrxSkipPowers, const bitLenInt mtrxSkipLen,
         const bitCapInt& mtrxSkipValueMask);

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -413,6 +413,11 @@ protected:
 
     void TransformBasis(const bool& toFourier, const bitLenInt& i)
     {
+        if (isSparse) {
+            // Sparse state vector already fulfills the point of this optimization
+            return;
+        }
+
         if ((shards[i].fourierUnit != NULL) == toFourier) {
             // Already in target basis
             return;

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -227,18 +227,8 @@ public:
         bitLenInt* controls, bitLenInt controlLen);
     virtual void CPOWModNOut(bitCapInt base, bitCapInt modN, bitLenInt inStart, bitLenInt outStart, bitLenInt length,
         bitLenInt* controls, bitLenInt controlLen);
-    virtual void QFT(bitLenInt start, bitLenInt length, bool trySeparate = false)
-    {
-        freezeBasis = !trySeparate;
-        QInterface::QFT(start, length, !isSparse);
-        freezeBasis = false;
-    }
-    virtual void IQFT(bitLenInt start, bitLenInt length, bool trySeparate = false)
-    {
-        freezeBasis = !trySeparate;
-        QInterface::IQFT(start, length, !isSparse);
-        freezeBasis = false;
-    }
+    virtual void QFT(bitLenInt start, bitLenInt length, bool trySeparate = false);
+    virtual void IQFT(bitLenInt start, bitLenInt length, bool trySeparate = false);
 
     /** @} */
 
@@ -328,9 +318,11 @@ protected:
         bitLenInt start, bitLenInt length, bitLenInt start2, bitLenInt length2, bitLenInt start3, bitLenInt length3);
     virtual QInterfacePtr EntangleAll();
 
-    virtual bool CheckBitPermutation(const bitLenInt& qubitIndex);
-    virtual bool CheckBitsPermutation(const bitLenInt& start, const bitLenInt& length);
-    virtual bool CheckBitsPermutation(const bitLenInt* bitArray, const bitLenInt& length);
+    virtual bool CheckBitPermutation(const bitLenInt& qubitIndex, const bool& inCurrentBasis = false);
+    virtual bool CheckBitsPermutation(
+        const bitLenInt& start, const bitLenInt& length, const bool& inCurrentBasis = false);
+    virtual bool CheckBitsPermutation(
+        const bitLenInt* bitArray, const bitLenInt& length, const bool& inCurrentBasis = false);
     virtual bitCapInt GetCachedPermutation(const bitLenInt& start, const bitLenInt& length);
     virtual bitCapInt GetCachedPermutation(const bitLenInt* bitArray, const bitLenInt& length);
 
@@ -481,6 +473,16 @@ protected:
     }
 
     void TransformBasisAll(const bool& toFourier) { TransformBasis(toFourier, (bitLenInt)0, qubitCount); }
+
+    bool CheckRangeInBasis(const bitLenInt& start, const bitLenInt& length, const bitLenInt& fourier)
+    {
+        for (bitLenInt i = 0; i < length; i++) {
+            if (fourier != (shards[start + i].fourierUnit != NULL)) {
+                return false;
+            }
+        }
+        return true;
+    }
 };
 
 } // namespace Qrack

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -1588,7 +1588,7 @@ void QEngineOCL::MUL(bitCapInt toMul, bitLenInt inOutStart, bitLenInt carryStart
     SetReg(carryStart, length, 0);
 
     bitCapInt lowPower = 1U << length;
-    toMul %= lowPower;
+    toMul &= (lowPower - 1U);
     if (toMul == 0) {
         SetReg(inOutStart, length, 0);
         return;
@@ -1636,12 +1636,7 @@ void QEngineOCL::CMUL(bitCapInt toMul, bitLenInt inOutStart, bitLenInt carryStar
     SetReg(carryStart, length, 0);
 
     bitCapInt lowPower = 1U << length;
-    toMul %= lowPower;
-    if (toMul == 0) {
-        SetReg(inOutStart, length, 0);
-        return;
-    }
-
+    toMul &= (lowPower - 1U);
     if (toMul == 1) {
         return;
     }
@@ -1681,7 +1676,7 @@ void QEngineOCL::CMULModNOut(bitCapInt toMul, bitCapInt modN, bitLenInt inStart,
     SetReg(outStart, length, 0);
 
     bitCapInt lowPower = 1U << length;
-    toMul %= lowPower;
+    toMul &= (lowPower - 1U);
     if (toMul == 0) {
         return;
     }

--- a/src/qfusion.cpp
+++ b/src/qfusion.cpp
@@ -652,6 +652,8 @@ void QFusion::DECBCDC(bitCapInt toSub, bitLenInt start, bitLenInt length, bitLen
 void QFusion::MUL(bitCapInt toMul, bitLenInt inOutStart, bitLenInt carryStart, bitLenInt length)
 {
     if (toMul == 0U) {
+        DiscardReg(inOutStart, length);
+        DiscardReg(carryStart, length);
         SetReg(inOutStart, length, 0U);
         SetReg(carryStart, length, 0U);
     } else if (toMul > 1U) {

--- a/src/qinterface/arithmetic.cpp
+++ b/src/qinterface/arithmetic.cpp
@@ -15,12 +15,9 @@
 namespace Qrack {
 
 // Arithmetic:
-/// Add integer (without sign)
-void QInterface::INC(bitCapInt toAdd, bitLenInt inOutStart, bitLenInt length)
+void QInterface::QFTINC(bitCapInt toAdd, bitLenInt inOutStart, bitLenInt length)
 {
     // See Draper, https://arxiv.org/abs/quant-ph/0008033
-
-    QFT(inOutStart, length);
 
     for (bitLenInt i = 0; i < length; i++) {
         for (bitLenInt j = 0; j <= i; j++) {
@@ -29,7 +26,13 @@ void QInterface::INC(bitCapInt toAdd, bitLenInt inOutStart, bitLenInt length)
             }
         }
     }
+}
 
+/// Add integer (without sign)
+void QInterface::INC(bitCapInt toAdd, bitLenInt inOutStart, bitLenInt length)
+{
+    QFT(inOutStart, length);
+    QFTINC(toAdd, inOutStart, length);
     IQFT(inOutStart, length);
 }
 

--- a/src/qinterface/arithmetic.cpp
+++ b/src/qinterface/arithmetic.cpp
@@ -25,7 +25,7 @@ void QInterface::INC(bitCapInt toAdd, bitLenInt inOutStart, bitLenInt length)
     for (bitLenInt i = 0; i < length; i++) {
         for (bitLenInt j = 0; j <= i; j++) {
             if ((toAdd >> j) & 1U) {
-                RTDyad(1, i - j, inOutStart + i);
+                RT((-M_PI * 2) / intPow(2, i - j), inOutStart + i);
             }
         }
     }

--- a/src/qinterface/qinterface.cpp
+++ b/src/qinterface/qinterface.cpp
@@ -271,7 +271,7 @@ void QInterface::QFT(bitLenInt start, bitLenInt length, bool trySeparate)
     for (i = 0; i < length; i++) {
         H(end - i);
         for (j = 0; j < ((length - 1U) - i); j++) {
-            CRTDyad(1, j + 2, (end - i) - (j + 1U), end - i);
+            CRT((-M_PI * 2) / intPow(2, j + 2), (end - i) - (j + 1U), end - i);
         }
 
         if (trySeparate) {
@@ -290,7 +290,7 @@ void QInterface::IQFT(bitLenInt start, bitLenInt length, bool trySeparate)
     bitLenInt i, j;
     for (i = 0; i < length; i++) {
         for (j = 0; j < i; j++) {
-            CRTDyad(-1, j + 2, (start + i) - (j + 1U), start + i);
+            CRT((M_PI * 2) / intPow(2, j + 2), (start + i) - (j + 1U), start + i);
         }
         H(start + i);
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -2326,6 +2326,11 @@ QInterfacePtr QUnit::Clone()
 
 void QUnit::TransformBasis(const bool& toFourier, const bitLenInt& i)
 {
+    if (freezeBasis && toFourier) {
+        // Recursive call
+        return;
+    }
+
     if (isSparse) {
         // Sparse state vector already fulfills the point of this optimization
         return;

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -844,35 +844,12 @@ void QUnit::UniformlyControlledSingleBit(const bitLenInt* controls, const bitLen
 
 void QUnit::QFT(bitLenInt start, bitLenInt length, bool trySeparate)
 {
-    if (trySeparate) {
-        if (CheckRangeInBasis(start, length, false) && CheckBitsPermutation(start, length, true)) {
-            QInterfacePtr unit = shards[start].unit;
-            for (bitLenInt i = 0; i < length; i++) {
-                shards[start + i].fourierUnit = unit;
-                shards[start + i].fourierMapped = i;
-            }
-
-            return;
-        }
-    }
-
     freezeBasis = !trySeparate;
     QInterface::QFT(start, length, !isSparse && trySeparate);
     freezeBasis = false;
 }
 void QUnit::IQFT(bitLenInt start, bitLenInt length, bool trySeparate)
 {
-    if (trySeparate) {
-        if (CheckRangeInBasis(start, length, true) && CheckBitsPermutation(start, length, true)) {
-            for (bitLenInt i = 0; i < length; i++) {
-                shards[start + i].fourierUnit = NULL;
-                shards[start + i].fourierMapped = 0;
-            }
-
-            return;
-        }
-    }
-
     freezeBasis = !trySeparate;
     QInterface::IQFT(start, length, !isSparse && trySeparate);
     freezeBasis = false;
@@ -2326,7 +2303,7 @@ QInterfacePtr QUnit::Clone()
 
 void QUnit::TransformBasis(const bool& toFourier, const bitLenInt& i)
 {
-    if (freezeBasis && toFourier) {
+    if (freezeBasis) {
         // Recursive call
         return;
     }

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -215,8 +215,8 @@ void QUnit::Dispose(bitLenInt start, bitLenInt length) { Detach(start, length, n
 QInterfacePtr QUnit::EntangleIterator(std::vector<bitLenInt*>::iterator first, std::vector<bitLenInt*>::iterator last)
 {
     for (auto bit = first; bit < last; bit++) {
-        EndEmulation(shards[**bit]);
         TransformBasis(false, **bit);
+        EndEmulation(shards[**bit]);
     }
 
     std::vector<QInterfacePtr> units;
@@ -1388,6 +1388,8 @@ void QUnit::CINC(bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt* 
 /// Collapse the carry bit in an optimal way, before carry arithmetic.
 void QUnit::CollapseCarry(bitLenInt flagIndex, bitLenInt start, bitLenInt length)
 {
+    TransformBasis(false, flagIndex);
+
     // Measure the carry flag.
     // Don't separate the flag just to entangle it again, if it's in the same unit.
     QInterfacePtr flagUnit = shards[flagIndex].unit;
@@ -1410,7 +1412,6 @@ void QUnit::CollapseCarry(bitLenInt flagIndex, bitLenInt start, bitLenInt length
 
 void QUnit::INCx(INCxFn fn, bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt flagIndex)
 {
-    TransformBasis(false, flagIndex);
     CollapseCarry(flagIndex, start, length);
 
     /* Make sure the flag bit is entangled in the same QU. */
@@ -1433,7 +1434,6 @@ void QUnit::INCx(INCxFn fn, bitCapInt toMod, bitLenInt start, bitLenInt length, 
 void QUnit::INCxx(
     INCxxFn fn, bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt flag1Index, bitLenInt flag2Index)
 {
-    TransformBasis(false, flag2Index);
     /*
      * Overflow flag should not be measured, however the carry flag still needs
      * to be measured.

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -884,6 +884,17 @@ void QUnit::H(bitLenInt target)
     }
 }
 
+void QUnit::ZBase(const bitLenInt& target)
+{
+    QEngineShard& shard = shards[target];
+    // If the target bit is in a |0>/|1> eigenstate, this gate has no effect.
+    if (PHASE_MATTERS(shard)) {
+        EndEmulation(shard);
+        shard.unit->Z(shard.mapped);
+        shard.amp1 = -shard.amp1;
+    }
+}
+
 void QUnit::X(bitLenInt target)
 {
     QEngineShard& shard = shards[target];
@@ -895,12 +906,7 @@ void QUnit::X(bitLenInt target)
         }
         std::swap(shard.amp0, shard.amp1);
     } else {
-        // If the target bit is in a |0>/|1> eigenstate, this gate has no effect.
-        if (PHASE_MATTERS(shard)) {
-            EndEmulation(shard);
-            shard.unit->Z(shard.mapped);
-            shard.amp1 = -shard.amp1;
-        }
+        ZBase(target);
     }
 }
 
@@ -908,12 +914,7 @@ void QUnit::Z(bitLenInt target)
 {
     QEngineShard& shard = shards[target];
     if (shard.fourierUnit == NULL) {
-        // If the target bit is in a |0>/|1> eigenstate, this gate has no effect.
-        if (PHASE_MATTERS(shard)) {
-            EndEmulation(shard);
-            shard.unit->Z(shard.mapped);
-            shard.amp1 = -shard.amp1;
-        }
+        ZBase(target);
     } else {
         QInterface::Z(target);
     }

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1160,7 +1160,7 @@ void QUnit::AntiCISqrtSwap(
 
 #define CHECK_BREAK_AND_TRIM()                                                                                         \
     /* Check whether the bit probability is 0, (or 1, if "anti"). */                                                   \
-    bitProb = Prob(controlVec[controlIndex], true);                                                                    \
+    bitProb = Prob(controlVec[controlIndex]);                                                                          \
     if (bitProb < min_norm) {                                                                                          \
         if (!anti) {                                                                                                   \
             /* This gate does nothing, so return without applying anything. */                                         \

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1563,6 +1563,12 @@ void QUnit::INT(bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt ca
         return;
     }
 
+    // TODO: We can carry this further:
+    if (!hasCarry && CheckRangeInBasis(start, length, true)) {
+        QFTINC(toMod, start, length);
+        return;
+    }
+
     // Try ripple addition, to avoid entanglement.
     bool toAdd, inReg;
     bool carry = false;

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -155,7 +155,7 @@ void benchmarkLoop(std::function<void(QInterfacePtr, int)> fn, bool resetRandomP
 {
     benchmarkLoopVariable(fn, MaxQubits, resetRandomPerm, hadamardRandomBits, logNormal);
 }
-#if 0
+
 TEST_CASE("test_cnot_single")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->CNOT(0, 1); });
@@ -399,7 +399,7 @@ TEST_CASE("test_qft_permutation_init")
     benchmarkLoop(
         [](QInterfacePtr qftReg, int n) { qftReg->QFT(0, n, true); }, true, false, testEngineType == QINTERFACE_QUNIT);
 }
-#endif
+
 TEST_CASE("test_qft_permutation_round_trip_separated")
 {
     benchmarkLoop(

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -155,7 +155,7 @@ void benchmarkLoop(std::function<void(QInterfacePtr, int)> fn, bool resetRandomP
 {
     benchmarkLoopVariable(fn, MaxQubits, resetRandomPerm, hadamardRandomBits, logNormal);
 }
-
+#if 0
 TEST_CASE("test_cnot_single")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->CNOT(0, 1); });
@@ -399,7 +399,7 @@ TEST_CASE("test_qft_permutation_init")
     benchmarkLoop(
         [](QInterfacePtr qftReg, int n) { qftReg->QFT(0, n, true); }, true, false, testEngineType == QINTERFACE_QUNIT);
 }
-
+#endif
 TEST_CASE("test_qft_permutation_round_trip_separated")
 {
     benchmarkLoop(

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -156,7 +156,7 @@ void benchmarkLoop(std::function<void(QInterfacePtr, int)> fn, bool resetRandomP
 {
     benchmarkLoopVariable(fn, MaxQubits, resetRandomPerm, hadamardRandomBits, logNormal);
 }
-#if 0
+
 TEST_CASE("test_cnot_single")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->CNOT(0, 1); });
@@ -353,7 +353,7 @@ TEST_CASE("test_set_reg")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->SetReg(0, n, 1); });
 }
-#endif
+
 TEST_CASE("test_grover")
 {
 

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -71,8 +71,9 @@ void benchmarkLoopVariable(std::function<void(QInterfacePtr, int)> fn, bitLenInt
     double avgt, stdet;
 
     for (numBits = 4; numBits <= mxQbts; numBits++) {
-        QInterfacePtr qftReg = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, numBits,
-            0, rng, complex(ONE_R1, ZERO_R1), enable_normalization, true, false, device_id, !disable_hardware_rng);
+        QInterfacePtr qftReg =
+            CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, numBits, 0, rng,
+                complex(ONE_R1, ZERO_R1), enable_normalization, true, false, device_id, !disable_hardware_rng, false);
         avgt = 0.0;
 
         for (i = 0; i < ITERATIONS; i++) {

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -391,31 +391,31 @@ TEST_CASE("test_grover")
 
 TEST_CASE("test_qft_ideal_init")
 {
-    benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->QFT(0, n, false); }, false, false);
+    benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->QFT(0, n, true); }, false, false);
 }
 
 TEST_CASE("test_qft_permutation_init")
 {
     benchmarkLoop(
-        [](QInterfacePtr qftReg, int n) { qftReg->QFT(0, n, false); }, true, false, testEngineType == QINTERFACE_QUNIT);
+        [](QInterfacePtr qftReg, int n) { qftReg->QFT(0, n, true); }, true, false, testEngineType == QINTERFACE_QUNIT);
 }
 
-TEST_CASE("test_qft_permutation_round_trip_entangled")
+TEST_CASE("test_qft_permutation_round_trip_separated")
 {
     benchmarkLoop(
         [](QInterfacePtr qftReg, int n) {
-            qftReg->QFT(0, n, false);
-            qftReg->IQFT(0, n, false);
+            qftReg->QFT(0, n, true);
+            qftReg->IQFT(0, n, true);
         },
         true, false, testEngineType == QINTERFACE_QUNIT);
 }
 
-TEST_CASE("test_qft_superposition_round_trip")
+TEST_CASE("test_iqft_superposition_round_trip_separated")
 {
     benchmarkLoop(
         [](QInterfacePtr qftReg, int n) {
-            qftReg->QFT(0, n, false);
-            qftReg->IQFT(0, n, false);
+            qftReg->IQFT(0, n, true);
+            qftReg->QFT(0, n, true);
         },
         true, true, testEngineType == QINTERFACE_QUNIT);
 }

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -2520,7 +2520,8 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_grover")
 
     // std::cout << "Iterations:" << std::endl;
     // Twelve iterations maximizes the probablity for 256 searched elements.
-    for (i = 0; i < 12; i++) {
+    int optIter = M_PI / (4.0 * asin(1.0 / sqrt(1 << 8)));
+    for (i = 0; i < optIter; i++) {
         // Our "oracle" is true for an input of "100" and false for all other inputs.
         qftReg->DEC(100, 0, 8);
         qftReg->ZeroPhaseFlip(0, 8);
@@ -2530,7 +2531,8 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_grover")
         qftReg->ZeroPhaseFlip(0, 8);
         qftReg->H(0, 8);
         qftReg->PhaseFlip();
-        // std::cout << "\t" << std::setw(2) << i << "> chance of match:" << qftReg->ProbAll(TARGET_PROB) << std::endl;
+        // std::cout << "\t" << std::setw(2) << i << "> chance of match:" << qftReg->ProbAll(TARGET_PROB) <<
+        // std::endl;
     }
 
     // std::cout << "Ind Result:     " << std::showbase << qftReg << std::endl;


### PR DESCRIPTION
In approximately "digital" operation/simulation of a quantum computer program, states that are not separable in permutation basis are often likely to be separable in "Fourier basis," arising after the application of a QFT. This PR attempts to optimize entangled substates in QUnit, by maintaining ad hoc Fourier basis transformations of subsets of qubits. When operating on sub-units in a local Fourier basis, QUnit tries to transform gates to their equivalent in the alternate basis, rather than transforming the qubit sub-unit back to permutation basis.

QFT benchmarks are nearly moot, here. Often, we do not even need to perform a requested QFT operation to act further gates on the state with the appropriate adjustment for the basis.