### PR TITLE
Experimental Fourier basis optimizations

### DIFF
--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -364,6 +364,10 @@ protected:
     bitCapInt GetIndexedEigenstate(bitLenInt indexStart, bitLenInt indexLength, bitLenInt valueStart,
         bitLenInt valueLength, unsigned char* values);
 
+    void Transform2x2(const complex* mtrxIn, complex* mtrxOut);
+    void TransformPhase(const complex& topLeft, const complex& bottomRight, complex* mtrxOut);
+    void TransformInvert(const complex& topRight, const complex& bottomLeft, complex* mtrxOut);
+
     /* Debugging and diagnostic routines. */
     void DumpShards();
     QInterfacePtr GetUnit(bitLenInt bit) { return shards[bit].unit; }


### PR DESCRIPTION
(This PR is to be reviewed, and decided on for whether to merge, before completing #219, as supplement.)

I tried optimizing the SWAP gate in QUnit, in line with #219. (QUnit has a very optimal SWAP, so it significantly hurt the features of this QInterface type, for SWAP performance to degrade with that PR.) I multiplied out the composition of SWAP with the QFT (or its inverse) as the Jacobian, and the resulting matrix is slightly "messy." However, I noticed that SWAP commutes with Hadamard gates on both target bits, with each Hadamard gate representing the DFT of a single qubit. As an experiment, I inserted a commutative SWAP, and made sure Qrack had significant coverage for it: it worked. Up to overall phase offsets of separable subsystems, the effect was quantum computationally equivalently. The key is, "...up to overall phase offsets of separable subsystems..."

Think of a QFT that rearranges the "H" gates all to the extremity of either side of the circuit, with proper commutators used. I think, passing the line of "H" gates, |0>/|1> eigenstates on the other side experience no physically measurable difference from the rest of the gates, which are all phase gates. Hence, _up to overall phase offsets on separable subsystems_, expectation values of all Hermitian operators are recovered, (which, almost by definition, cannot depend on an overall phase offset).

We're going "whole hog" on _overall phase offsets of any and all separable subsystems having no physical effect_. Extending this treatment to controlled single bit gates, and to any gate, we expect to recover the expectation values of all Hermitian operators, which do not depend on phase of separable subsystems. The QFT, and every operation, is now up to overall phase offsets on all separable subsystems, if I've implemented this correctly.

I feel relatively comfortable merging this in, if that is actually the only effect these changes have--arbitrary _overall_ phase offsets on separable subsystems. I need to review to this to make sure I haven't done anything outside of that assumed symmetry, though.