### PR TITLE
Removing quantum-to-quantum-subtraction; adding controlled FullAdd

### DIFF
--- a/include/qfusion.hpp
+++ b/include/qfusion.hpp
@@ -126,8 +126,6 @@ public:
     virtual void DIV(bitCapInt toDiv, bitLenInt inOutStart, bitLenInt carryStart, bitLenInt length);
     virtual void MULModNOut(bitCapInt toMul, bitCapInt modN, bitLenInt inStart, bitLenInt outStart, bitLenInt length);
     virtual void POWModNOut(bitCapInt base, bitCapInt modN, bitLenInt inStart, bitLenInt outStart, bitLenInt length);
-    virtual void SBC(bitLenInt input1, bitLenInt input2, bitLenInt output, bitLenInt length, bitLenInt carry);
-    virtual void ISBC(bitLenInt input1, bitLenInt input2, bitLenInt output, bitLenInt length, bitLenInt carry);
     virtual void CMUL(bitCapInt toMul, bitLenInt inOutStart, bitLenInt carryStart, bitLenInt length,
         bitLenInt* controls, bitLenInt controlLen);
     virtual void CDIV(bitCapInt toDiv, bitLenInt inOutStart, bitLenInt carryStart, bitLenInt length,

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -1367,6 +1367,22 @@ public:
     virtual void IFullAdd(bitLenInt inputBit1, bitLenInt inputBit2, bitLenInt carryInSumOut, bitLenInt carryOut);
 
     /**
+     * Controlled quantum analog of classical "Full Adder" gate
+     *
+     * (Assumes the outputBit is in the 0 state)
+     */
+    virtual void CFullAdd(bitLenInt* controls, bitLenInt controlLen, bitLenInt inputBit1, bitLenInt inputBit2,
+        bitLenInt carryInSumOut, bitLenInt carryOut);
+
+    /**
+     * Inverse of CFullAdd
+     *
+     * (Can be thought of as "subtraction," but with a register convention that the same inputs invert CFullAdd.)
+     */
+    virtual void CIFullAdd(bitLenInt* controls, bitLenInt controlLen, bitLenInt inputBit1, bitLenInt inputBit2,
+        bitLenInt carryInSumOut, bitLenInt carryOut);
+
+    /**
      * Add a quantum integer to a quantum integer, with carry
      *
      * (Assumes the output register is in the 0 state)
@@ -1381,18 +1397,20 @@ public:
     virtual void IADC(bitLenInt input1, bitLenInt input2, bitLenInt output, bitLenInt length, bitLenInt carry);
 
     /**
-     * Subtract a quantum integer subtrahend from a quantum integer minuend, with carry
+     * Add a quantum integer to a quantum integer, with carry and with controls
      *
      * (Assumes the output register is in the 0 state)
      */
-    virtual void SBC(bitLenInt minuend, bitLenInt subtrahend, bitLenInt output, bitLenInt length, bitLenInt carry);
+    virtual void CADC(bitLenInt* controls, bitLenInt controlLen, bitLenInt input1, bitLenInt input2, bitLenInt output,
+        bitLenInt length, bitLenInt carry);
 
     /**
-     * Inverse of SBC
+     * Inverse of CADC
      *
-     * (Can be thought of as "addition," but with a register convention that the same inputs invert SBC.)
+     * (Can be thought of as "subtraction," but with a register convention that the same inputs invert CADC.)
      */
-    virtual void ISBC(bitLenInt minuend, bitLenInt subtrahend, bitLenInt output, bitLenInt length, bitLenInt carry);
+    virtual void CIADC(bitLenInt* controls, bitLenInt controlLen, bitLenInt input1, bitLenInt input2, bitLenInt output,
+        bitLenInt length, bitLenInt carry);
 
     /** @} */
 

--- a/src/qfusion.cpp
+++ b/src/qfusion.cpp
@@ -704,32 +704,6 @@ void QFusion::IFullAdd(bitLenInt input1, bitLenInt input2, bitLenInt carryInSumO
     qReg->IFullAdd(input1, input2, carryInSumOut, carryOut);
 }
 
-void QFusion::SBC(bitLenInt input1, bitLenInt input2, bitLenInt output, bitLenInt length, bitLenInt carry)
-{
-    if (length == 0) {
-        return;
-    }
-
-    FlushReg(input1, length);
-    FlushReg(input2, length);
-    FlushReg(output, length);
-    FlushBit(carry);
-    qReg->SBC(input1, input2, output, length, carry);
-}
-
-void QFusion::ISBC(bitLenInt input1, bitLenInt input2, bitLenInt output, bitLenInt length, bitLenInt carry)
-{
-    if (length == 0) {
-        return;
-    }
-
-    FlushReg(input1, length);
-    FlushReg(input2, length);
-    FlushReg(output, length);
-    FlushBit(carry);
-    qReg->ISBC(input1, input2, output, length, carry);
-}
-
 void QFusion::CMUL(bitCapInt toMul, bitLenInt inOutStart, bitLenInt carryStart, bitLenInt length, bitLenInt* controls,
     bitLenInt controlLen)
 {

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -1728,12 +1728,12 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_ifulladd")
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_adc")
 {
-    qftReg->SetPermutation(2);
+    qftReg->SetPermutation(0);
     qftReg->H(2, 2);
     qftReg->ADC(0, 2, 4, 2, 6);
-    qftReg->IADC(0, 2, 4, 2, 6);
+    qftReg->CNOT(2, 4, 2);
     qftReg->H(2, 2);
-    REQUIRE_THAT(qftReg, HasProbability(0, 8, 2));
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0));
 
     qftReg->SetPermutation(0);
     qftReg->H(0);
@@ -1786,68 +1786,162 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_iadc")
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 2));
 }
 
-TEST_CASE_METHOD(QInterfaceTestFixture, "test_sbc")
+TEST_CASE_METHOD(QInterfaceTestFixture, "test_cfulladd")
 {
-    qftReg->SetPermutation(2);
+    bitLenInt control[1] = { 10 };
+    qftReg->SetPermutation(0x00); // off
+    qftReg->CFullAdd(control, 1, 0, 1, 2, 3);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0));
+
+    qftReg->SetPermutation(0x01);
+    qftReg->X(control[0]); // on
+    qftReg->CFullAdd(control, 1, 0, 1, 2, 3);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x05));
+
+    qftReg->SetPermutation(0x02); // off
+    qftReg->CFullAdd(control, 1, 0, 1, 2, 3);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x02));
+
+    qftReg->SetPermutation(0x03);
+    qftReg->X(control[0]); // on
+    qftReg->CFullAdd(control, 1, 0, 1, 2, 3);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x0B));
+
+    qftReg->SetPermutation(0x04); // off
+    qftReg->CFullAdd(control, 1, 0, 1, 2, 3);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x04));
+
+    qftReg->SetPermutation(0x05);
+    qftReg->X(control[0]); // on
+    qftReg->CFullAdd(control, 1, 0, 1, 2, 3);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x09));
+
+    qftReg->SetPermutation(0x06); // off
+    qftReg->CFullAdd(control, 1, 0, 1, 2, 3);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x06));
+
+    qftReg->SetPermutation(0x07);
+    qftReg->X(control[0]); // on
+    qftReg->CFullAdd(control, 1, 0, 1, 2, 3);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x0F));
+}
+
+TEST_CASE_METHOD(QInterfaceTestFixture, "test_cifulladd")
+{
+    // This is contingent on the previous test passing.
+
+    bitLenInt control[1] = { 10 };
+
+    qftReg->SetPermutation(0x00); // off
+    qftReg->CFullAdd(control, 1, 0, 1, 2, 3);
+    qftReg->CIFullAdd(control, 1, 0, 1, 2, 3);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0));
+
+    qftReg->SetPermutation(0x01);
+    qftReg->X(control[0]); // on
+    qftReg->CFullAdd(control, 1, 0, 1, 2, 3);
+    qftReg->CIFullAdd(control, 1, 0, 1, 2, 3);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x01));
+
+    qftReg->SetPermutation(0x02); // off
+    qftReg->CFullAdd(control, 1, 0, 1, 2, 3);
+    qftReg->CIFullAdd(control, 1, 0, 1, 2, 3);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x02));
+
+    qftReg->SetPermutation(0x03);
+    qftReg->X(control[0]); // on
+    qftReg->CFullAdd(control, 1, 0, 1, 2, 3);
+    qftReg->CIFullAdd(control, 1, 0, 1, 2, 3);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x03));
+
+    qftReg->SetPermutation(0x04); // off
+    qftReg->CFullAdd(control, 1, 0, 1, 2, 3);
+    qftReg->CIFullAdd(control, 1, 0, 1, 2, 3);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x04));
+
+    qftReg->SetPermutation(0x05);
+    qftReg->X(control[0]); // on
+    qftReg->CFullAdd(control, 1, 0, 1, 2, 3);
+    qftReg->CIFullAdd(control, 1, 0, 1, 2, 3);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x05));
+
+    qftReg->X(control[0]); // off
+
+    qftReg->SetPermutation(0x06);
+    qftReg->CFullAdd(control, 1, 0, 1, 2, 3);
+    qftReg->CIFullAdd(control, 1, 0, 1, 2, 3);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x06));
+
+    qftReg->SetPermutation(0x07); // off
+    qftReg->CFullAdd(control, 1, 0, 1, 2, 3);
+    qftReg->CIFullAdd(control, 1, 0, 1, 2, 3);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x07));
+}
+
+TEST_CASE_METHOD(QInterfaceTestFixture, "test_cadc")
+{
+    bitLenInt control[1] = { 10 };
+
+    qftReg->SetPermutation(0); // off
     qftReg->H(2, 2);
-    qftReg->SBC(0, 2, 4, 2, 6);
-    qftReg->ISBC(0, 2, 4, 2, 6);
+    qftReg->CADC(control, 1, 0, 2, 4, 2, 6);
     qftReg->H(2, 2);
-    REQUIRE_THAT(qftReg, HasProbability(0, 8, 2));
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0));
 
     qftReg->SetPermutation(0);
+    qftReg->X(control[0]); // on
     qftReg->H(0);
     qftReg->CNOT(0, 2);
-    qftReg->SBC(0, 2, 4, 2, 6);
-    qftReg->ISBC(0, 2, 4, 2, 6);
+    qftReg->CADC(control, 1, 0, 2, 4, 2, 6);
+    qftReg->CIADC(control, 1, 0, 2, 4, 2, 6);
     qftReg->CNOT(0, 2);
     qftReg->H(0);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0));
 
     qftReg->SetPermutation(1);
-    qftReg->SBC(0, 1, 2, 1, 3);
+    qftReg->X(control[0]); // on
+    qftReg->CADC(control, 1, 0, 1, 2, 1, 3);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 5));
 
-    qftReg->SetPermutation(3);
-    qftReg->SBC(0, 1, 2, 1, 3);
-    REQUIRE_THAT(qftReg, HasProbability(0, 8, 3));
-
-    qftReg->SetPermutation(1);
-    qftReg->ADC(0, 1, 2, 0, 3);
+    qftReg->SetPermutation(1); // off
+    qftReg->CADC(control, 1, 0, 1, 2, 0, 3);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 1));
 }
 
-TEST_CASE_METHOD(QInterfaceTestFixture, "test_isbc")
+TEST_CASE_METHOD(QInterfaceTestFixture, "test_ciadc")
 {
     // This is contingent on the previous test passing.
+    bitLenInt control[1] = { 10 };
 
-    qftReg->SetPermutation(8);
+    qftReg->SetPermutation(8); // off
     qftReg->H(2, 2);
-    qftReg->SBC(0, 2, 4, 2, 6);
-    qftReg->ISBC(0, 2, 4, 2, 6);
+    qftReg->CADC(control, 1, 0, 2, 4, 2, 6);
+    qftReg->CIADC(control, 1, 0, 2, 4, 2, 6);
     qftReg->H(2, 2);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 8));
 
     qftReg->SetPermutation(0);
+    qftReg->X(control[0]); // on
     qftReg->H(0);
     qftReg->CNOT(0, 2);
-    qftReg->SBC(0, 2, 4, 2, 6);
-    qftReg->ISBC(0, 2, 4, 2, 6);
+    qftReg->CADC(control, 1, 0, 2, 4, 2, 6);
+    qftReg->CIADC(control, 1, 0, 2, 4, 2, 6);
     qftReg->CNOT(0, 2);
     qftReg->H(0);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0));
 
-    qftReg->SetPermutation(1);
-    qftReg->SBC(0, 1, 2, 1, 3);
-    REQUIRE_THAT(qftReg, HasProbability(0, 8, 5));
-    qftReg->ISBC(0, 1, 2, 1, 3);
-    REQUIRE_THAT(qftReg, HasProbability(0, 8, 1));
+    qftReg->SetPermutation(2);
+    qftReg->X(control[0]); // on
+    qftReg->CADC(control, 1, 0, 1, 2, 1, 3);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 6));
+    qftReg->CIADC(control, 1, 0, 1, 2, 1, 3);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 2));
 
-    qftReg->SetPermutation(1);
-    qftReg->SBC(0, 1, 2, 0, 3);
-    REQUIRE_THAT(qftReg, HasProbability(0, 8, 1));
-    qftReg->IADC(0, 1, 2, 0, 3);
-    REQUIRE_THAT(qftReg, HasProbability(0, 8, 1));
+    qftReg->SetPermutation(2); // off
+    qftReg->CADC(control, 1, 0, 1, 2, 0, 3);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 2));
+    qftReg->CIADC(control, 1, 0, 1, 2, 0, 3);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 2));
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_inc")

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -1731,7 +1731,7 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_adc")
     qftReg->SetPermutation(0);
     qftReg->H(2, 2);
     qftReg->ADC(0, 2, 4, 2, 6);
-    qftReg->CNOT(2, 4, 2);
+    qftReg->IADC(0, 2, 4, 2, 6);
     qftReg->H(2, 2);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0));
 


### PR DESCRIPTION
This is to clean up the work from last week. `FullSub`/`SBC` were wrong and have been removed, for now. Controlled `FullSub`/`ADC` variants were added, but these are QInterface-only implementations, (no optimized variants). Tests have been copied and slightly modified from the non-controlled variants.