### PR TITLE
Removing QUnit::Z() debugging

### DIFF
--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -889,7 +889,6 @@ void QUnit::X(bitLenInt target)
 
 void QUnit::Z(bitLenInt target)
 {
-    TransformBasis(false, target);
     QEngineShard& shard = shards[target];
     if (!shard.isPlusMinus) {
         if (PHASE_MATTERS(shard)) {


### PR DESCRIPTION
This PR removes a debugging statement in QUnit::Z(), which should have been taken out after testing.