### PR TITLE
WIP: 'Compressed' state vector

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,6 @@ script:
   - cd .. && sudo rm -r _build
   - mkdir _build && cd _build && cmake -DENABLE_OPENCL=OFF -DENABLE_COMPLEX8=ON .. && make -j 8 all
   - ./unittest --proc-cpu
-  - cd .. && git clone https://github.com/vm6502q/ProjectQ.git && cd ProjectQ
+  - cd .. && git clone -b fourier_basis https://github.com/vm6502q/ProjectQ.git && cd ProjectQ
   - sudo python3 setup.py --with-qracksimulator install
   - cd build && export OMP_NUM_THREADS=1 && sudo python3 -m pytest .

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,3 @@ script:
   - ./unittest --proc-cpu
   - cd .. && git clone https://github.com/vm6502q/ProjectQ.git && cd ProjectQ
   - sudo python3 setup.py --with-qracksimulator install
-  - cd build && export OMP_NUM_THREADS=1 && sudo python3 -m pytest .

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,4 @@ script:
   - ./unittest --proc-cpu
   - cd .. && git clone https://github.com/vm6502q/ProjectQ.git && cd ProjectQ
   - sudo python3 setup.py --with-qracksimulator install
+  - cd build && export OMP_NUM_THREADS=1 && sudo python3 -m pytest .

--- a/include/qengine_cpu.hpp
+++ b/include/qengine_cpu.hpp
@@ -41,7 +41,8 @@ protected:
 public:
     QEngineCPU(bitLenInt qBitCount, bitCapInt initState, qrack_rand_gen_ptr rgp = nullptr,
         complex phaseFac = complex(-999.0, -999.0), bool doNorm = false, bool randomGlobalPhase = true,
-        bool ignored = false, int ignored2 = -1, bool useHardwareRNG = true, bool useSparseStateVec = false);
+        bool ignored = false, int ignored2 = -1, bool useHardwareRNG = true, bool useSparseStateVec = false,
+        bool ignored3 = false);
 
     QEngineCPU()
     {

--- a/include/qengine_opencl.hpp
+++ b/include/qengine_opencl.hpp
@@ -132,7 +132,8 @@ public:
 
     QEngineOCL(bitLenInt qBitCount, bitCapInt initState, qrack_rand_gen_ptr rgp = nullptr,
         complex phaseFac = complex(-999.0, -999.0), bool doNorm = false, bool randomGlobalPhase = true,
-        bool useHostMem = false, int devID = -1, bool useHardwareRNG = true, bool ignored = false);
+        bool useHostMem = false, int devID = -1, bool useHardwareRNG = true, bool ignored = false,
+        bool ignored2 = false);
 
     QEngineOCL()
     {

--- a/include/qfusion.hpp
+++ b/include/qfusion.hpp
@@ -48,7 +48,8 @@ protected:
 public:
     QFusion(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState = 0, qrack_rand_gen_ptr rgp = nullptr,
         complex phaseFac = complex(-999.0, -999.0), bool doNorm = false, bool randomGlobalPhase = true,
-        bool useHostMem = false, int deviceID = -1, bool useHardwareRNG = true, bool useSparseStateVec = false);
+        bool useHostMem = false, int deviceID = -1, bool useHardwareRNG = true, bool useSparseStateVec = false,
+        bool ignored = false);
     QFusion(QInterfacePtr target);
 
     virtual void SetQuantumState(const complex* inputState);

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -396,6 +396,13 @@ protected:
     void TransformToFourier(const bitLenInt& i);
     void TransformToPerm(const bitLenInt& i);
 
+    void TransformToPermAll()
+    {
+        for (bitLenInt i = 0; i < qubitCount; i++) {
+            TransformToPerm(i);
+        }
+    }
+
     void CheckShardSeparable(const bitLenInt& target);
 
     void DirtyShardRange(bitLenInt start, bitLenInt length)

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -29,8 +29,8 @@ struct QEngineShard {
     complex amp0;
     complex amp1;
     bool isPlusMinus;
-    QInterfacePtr fourierUnit;
-    bitLenInt fourierMapped;
+    std::vector<QInterfacePtr> fourierUnits;
+    std::vector<bitLenInt> fourierMappings;
 
     QEngineShard()
         : unit(NULL)
@@ -41,8 +41,8 @@ struct QEngineShard {
         , amp0(complex(ONE_R1, ZERO_R1))
         , amp1(complex(ZERO_R1, ZERO_R1))
         , isPlusMinus(false)
-        , fourierUnit(NULL)
-        , fourierMapped(0)
+        , fourierUnits()
+        , fourierMappings()
     {
     }
 
@@ -53,8 +53,8 @@ struct QEngineShard {
         , isProbDirty(false)
         , isPhaseDirty(false)
         , isPlusMinus(false)
-        , fourierUnit(NULL)
-        , fourierMapped(0)
+        , fourierUnits(0)
+        , fourierMappings()
     {
         amp0 = set ? complex(ZERO_R1, ZERO_R1) : complex(ONE_R1, ZERO_R1);
         amp1 = set ? complex(ONE_R1, ZERO_R1) : complex(ZERO_R1, ZERO_R1);
@@ -70,8 +70,8 @@ struct QEngineShard {
         , amp0(complex(ONE_R1, ZERO_R1))
         , amp1(complex(ZERO_R1, ZERO_R1))
         , isPlusMinus(false)
-        , fourierUnit(NULL)
-        , fourierMapped(0)
+        , fourierUnits()
+        , fourierMappings()
     {
     }
 

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -98,6 +98,7 @@ protected:
     bool useRDRAND;
     bool isSparse;
     bool freezeBasis;
+    bool useCompression;
 
     virtual void SetQubitCount(bitLenInt qb)
     {
@@ -111,10 +112,11 @@ public:
     QUnit(QInterfaceEngine eng, QInterfaceEngine subEng, bitLenInt qBitCount, bitCapInt initState = 0,
         qrack_rand_gen_ptr rgp = nullptr, complex phaseFac = complex(-999.0, -999.0), bool doNorm = false,
         bool randomGlobalPhase = true, bool useHostMem = true, int deviceID = -1, bool useHardwareRNG = true,
-        bool useSparseStateVec = false);
+        bool useSparseStateVec = false, bool useQubitCompression = false);
     QUnit(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState = 0, qrack_rand_gen_ptr rgp = nullptr,
         complex phaseFac = complex(-999.0, -999.0), bool doNorm = true, bool randomGlobalPhase = true,
-        bool useHostMem = true, int deviceId = -1, bool useHardwareRNG = true, bool useSparseStateVec = false);
+        bool useHostMem = true, int deviceId = -1, bool useHardwareRNG = true, bool useSparseStateVec = false,
+        bool useQubitCompression = false);
 
     virtual void SetQuantumState(const complex* inputState);
     virtual void GetQuantumState(complex* outputState);

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -396,6 +396,13 @@ protected:
     void TransformToFourier(const bitLenInt& i);
     void TransformToPerm(const bitLenInt& i);
 
+    void TransformToPerm(const bitLenInt& start, const bitLenInt& length)
+    {
+        for (bitLenInt i = 0; i < length; i++) {
+            TransformToPerm(start + i);
+        }
+    }
+
     void TransformToPermAll()
     {
         for (bitLenInt i = 0; i < qubitCount; i++) {

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -29,6 +29,8 @@ struct QEngineShard {
     complex amp0;
     complex amp1;
     bool isPlusMinus;
+    QInterfacePtr fourierUnit;
+    bitLenInt fourierMapped;
 
     QEngineShard()
         : unit(NULL)
@@ -39,6 +41,8 @@ struct QEngineShard {
         , amp0(complex(ONE_R1, ZERO_R1))
         , amp1(complex(ZERO_R1, ZERO_R1))
         , isPlusMinus(false)
+        , fourierUnit(NULL)
+        , fourierMapped(0)
     {
     }
 
@@ -49,6 +53,8 @@ struct QEngineShard {
         , isProbDirty(false)
         , isPhaseDirty(false)
         , isPlusMinus(false)
+        , fourierUnit(NULL)
+        , fourierMapped(0)
     {
         amp0 = set ? complex(ZERO_R1, ZERO_R1) : complex(ONE_R1, ZERO_R1);
         amp1 = set ? complex(ONE_R1, ZERO_R1) : complex(ZERO_R1, ZERO_R1);
@@ -64,6 +70,8 @@ struct QEngineShard {
         , amp0(complex(ONE_R1, ZERO_R1))
         , amp1(complex(ZERO_R1, ZERO_R1))
         , isPlusMinus(false)
+        , fourierUnit(NULL)
+        , fourierMapped(0)
     {
     }
 
@@ -384,6 +392,9 @@ protected:
     void TransformBasisAll(const bool& toPlusMinus) { TransformBasis(toPlusMinus, 0, qubitCount); }
 
     bool CheckRangeInBasis(const bitLenInt& start, const bitLenInt& length, const bitLenInt& plusMinus);
+
+    void TransformToFourier(const bitLenInt& i);
+    void TransformToPerm(const bitLenInt& i);
 
     void CheckShardSeparable(const bitLenInt& target);
 

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -65,7 +65,7 @@ namespace Qrack {
     queue.enqueueUnmapMemObject(buff, array, NULL, &(device_context->wait_events->back()));
 
 QEngineOCL::QEngineOCL(bitLenInt qBitCount, bitCapInt initState, qrack_rand_gen_ptr rgp, complex phaseFac, bool doNorm,
-    bool randomGlobalPhase, bool useHostMem, int devID, bool useHardwareRNG, bool ignored)
+    bool randomGlobalPhase, bool useHostMem, int devID, bool useHardwareRNG, bool ignored, bool ignored2)
     : QEngine(qBitCount, rgp, doNorm, randomGlobalPhase, useHostMem, useHardwareRNG)
     , deviceID(devID)
     , wait_refs()

--- a/src/qengine/state.cpp
+++ b/src/qengine/state.cpp
@@ -37,7 +37,8 @@ namespace Qrack {
  * phase usually makes sense only if they are initialized at the same time.
  */
 QEngineCPU::QEngineCPU(bitLenInt qBitCount, bitCapInt initState, qrack_rand_gen_ptr rgp, complex phaseFac, bool doNorm,
-    bool randomGlobalPhase, bool useHostMem, int deviceID, bool useHardwareRNG, bool useSparseStateVec)
+    bool randomGlobalPhase, bool useHostMem, int deviceID, bool useHardwareRNG, bool useSparseStateVec,
+    bool useQubitCompression)
     : QEngine(qBitCount, rgp, doNorm, randomGlobalPhase, true, useHardwareRNG)
     , isSparse(useSparseStateVec)
 {

--- a/src/qfusion.cpp
+++ b/src/qfusion.cpp
@@ -21,7 +21,7 @@ namespace Qrack {
 
 QFusion::QFusion(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState, qrack_rand_gen_ptr rgp,
     complex phaseFac, bool doNorm, bool randomGlobalPhase, bool useHostMem, int deviceID, bool useHardwareRNG,
-    bool useSparseStateVec)
+    bool useSparseStateVec, bool ignored)
     : QInterface(qBitCount, rgp, deviceID, useHardwareRNG)
     , phaseFactor(phaseFac)
     , doNormalize(doNorm)

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -267,6 +267,7 @@ QInterfacePtr QUnit::Entangle(std::vector<bitLenInt*> bits)
 
 QInterfacePtr QUnit::EntangleRange(bitLenInt start, bitLenInt length)
 {
+    TransformToPerm(start, length);
     TransformBasis(false, start, length);
 
     if (length == 1) {
@@ -287,6 +288,8 @@ QInterfacePtr QUnit::EntangleRange(bitLenInt start, bitLenInt length)
 
 QInterfacePtr QUnit::EntangleRange(bitLenInt start1, bitLenInt length1, bitLenInt start2, bitLenInt length2)
 {
+    TransformToPerm(start1, length1);
+    TransformToPerm(start2, length2);
     TransformBasis(false, start1, length1);
     TransformBasis(false, start2, length2);
 
@@ -316,6 +319,9 @@ QInterfacePtr QUnit::EntangleRange(bitLenInt start1, bitLenInt length1, bitLenIn
 QInterfacePtr QUnit::EntangleRange(
     bitLenInt start1, bitLenInt length1, bitLenInt start2, bitLenInt length2, bitLenInt start3, bitLenInt length3)
 {
+    TransformToPerm(start1, length1);
+    TransformToPerm(start2, length2);
+    TransformToPerm(start3, length3);
     TransformBasis(false, start1, length1);
     TransformBasis(false, start2, length2);
     TransformBasis(false, start3, length3);
@@ -610,12 +616,14 @@ real1 QUnit::ProbBase(const bitLenInt& qubit)
 
 real1 QUnit::Prob(bitLenInt qubit)
 {
+    TransformToPerm(qubit);
     TransformBasis(false, qubit);
     return ProbBase(qubit);
 }
 
 real1 QUnit::ProbAll(bitCapInt perm)
 {
+    TransformToPermAll();
     TransformBasisAll(false);
     EndAllEmulation();
 
@@ -874,7 +882,6 @@ void QUnit::H(bitLenInt target)
 void QUnit::ZBase(const bitLenInt& target)
 {
     QEngineShard& shard = shards[target];
-    TransformToPerm(target);
     // If the target bit is in a |0>/|1> eigenstate, this gate has no effect.
     if (PHASE_MATTERS(shard)) {
         EndEmulation(shard);
@@ -1451,6 +1458,7 @@ void QUnit::CINC(bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt* 
 /// Collapse the carry bit in an optimal way, before carry arithmetic.
 void QUnit::CollapseCarry(bitLenInt flagIndex, bitLenInt start, bitLenInt length)
 {
+    TransformToPerm(flagIndex);
     TransformBasis(false, flagIndex);
 
     // Measure the carry flag.
@@ -2089,6 +2097,7 @@ void QUnit::PhaseFlipIfLess(bitCapInt greaterPerm, bitLenInt start, bitLenInt le
 
 void QUnit::CPhaseFlipIfLess(bitCapInt greaterPerm, bitLenInt start, bitLenInt length, bitLenInt flagIndex)
 {
+    TransformToPerm(flagIndex);
     TransformBasis(false, flagIndex);
 
     // Keep the bits separate, if cheap to do so:

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -28,16 +28,17 @@
 namespace Qrack {
 
 QUnit::QUnit(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState, qrack_rand_gen_ptr rgp, complex phaseFac,
-    bool doNorm, bool randomGlobalPhase, bool useHostMem, int deviceID, bool useHardwareRNG, bool useSparseStateVec)
+    bool doNorm, bool randomGlobalPhase, bool useHostMem, int deviceID, bool useHardwareRNG, bool useSparseStateVec,
+    bool useQubitCompression)
     : QUnit(eng, eng, qBitCount, initState, rgp, phaseFac, doNorm, randomGlobalPhase, useHostMem, deviceID,
-          useHardwareRNG, useSparseStateVec)
+          useHardwareRNG, useSparseStateVec, useQubitCompression)
 {
     // Intentionally left blank
 }
 
 QUnit::QUnit(QInterfaceEngine eng, QInterfaceEngine subEng, bitLenInt qBitCount, bitCapInt initState,
     qrack_rand_gen_ptr rgp, complex phaseFac, bool doNorm, bool randomGlobalPhase, bool useHostMem, int deviceID,
-    bool useHardwareRNG, bool useSparseStateVec)
+    bool useHardwareRNG, bool useSparseStateVec, bool useQubitCompression)
     : QInterface(qBitCount, rgp, doNorm, useHardwareRNG)
     , engine(eng)
     , subengine(subEng)
@@ -49,6 +50,7 @@ QUnit::QUnit(QInterfaceEngine eng, QInterfaceEngine subEng, bitLenInt qBitCount,
     , useRDRAND(useHardwareRNG)
     , isSparse(useSparseStateVec)
     , freezeBasis(false)
+    , useCompression(useQubitCompression)
 {
     shards.resize(qBitCount);
 
@@ -2432,7 +2434,7 @@ void QUnit::CheckShardSeparable(const bitLenInt& target)
 
 void QUnit::TransformToFourier(const bitLenInt& target)
 {
-    if (!randGlobalPhase || freezeBasis || isSparse) {
+    if (!useCompression || !randGlobalPhase || freezeBasis || isSparse) {
         // A sparse state vector already fulfills the point of this optimization.
         return;
     }
@@ -2483,7 +2485,7 @@ void QUnit::TransformToFourier(const bitLenInt& target)
 
 void QUnit::TransformToPerm(const bitLenInt& target)
 {
-    if (!randGlobalPhase || freezeBasis || isSparse || (shards[target].fourierUnits.size() == 0)) {
+    if (!useCompression || !randGlobalPhase || freezeBasis || isSparse || (shards[target].fourierUnits.size() == 0)) {
         // A sparse state vector already fulfills the point of this optimization,
         // or already in target basis.
         return;

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1269,6 +1269,7 @@ void QUnit::ApplyEitherControlled(const bitLenInt* controls, const bitLenInt& co
             if (isSeparated) {
                 CHECK_BREAK_AND_TRIM();
             } else {
+                TransformToPerm(controls[i]);
                 TransformBasis(false, controls[i]);
                 controlVec.push_back(controls[i]);
             }

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -2397,7 +2397,7 @@ void QUnit::CheckShardSeparable(const bitLenInt& target)
 
 void QUnit::TransformToFourier(const bitLenInt& target)
 {
-    if (freezeBasis || isSparse || (shards[target].fourierUnit != NULL)) {
+    if (!randGlobalPhase || freezeBasis || isSparse || (shards[target].fourierUnit != NULL)) {
         // A sparse state vector already fulfills the point of this optimization,
         // or already in target basis.
         return;
@@ -2435,7 +2435,7 @@ void QUnit::TransformToFourier(const bitLenInt& target)
 
 void QUnit::TransformToPerm(const bitLenInt& target)
 {
-    if (freezeBasis || isSparse || (shards[target].fourierUnit == NULL)) {
+    if (!randGlobalPhase || freezeBasis || isSparse || (shards[target].fourierUnit == NULL)) {
         // A sparse state vector already fulfills the point of this optimization,
         // or already in target basis.
         return;

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -435,6 +435,10 @@ bool QUnit::TrySeparate(bitLenInt start, bitLenInt length)
     } else {
         // If length == 1, this is usually all that's worth trying:
         real1 prob = ProbBase(start);
+        if (abs(prob - (ONE_R1 / 2)) < min_norm) {
+            TransformBasis(!shards[start].isPlusMinus, start);
+            prob = ProbBase(start);
+        }
         return ((prob < min_norm) || ((ONE_R1 - prob) < min_norm));
     }
 
@@ -1154,8 +1158,6 @@ void QUnit::ApplyAntiControlledSingleInvert(const bitLenInt* controls, const bit
 
 void QUnit::ApplySingleBit(const complex* mtrx, bool doCalcNorm, bitLenInt target)
 {
-    EndEmulation(target);
-
     QEngineShard& shard = shards[target];
 
     complex trnsMtrx[4];
@@ -1163,6 +1165,9 @@ void QUnit::ApplySingleBit(const complex* mtrx, bool doCalcNorm, bitLenInt targe
     if (shard.unit->GetQubitCount() > 1) {
         TransformToPerm(target);
     }
+
+    EndEmulation(target);
+
     bitLenInt order = shard.isPlusMinus ? 1 : 0;
     order += shard.fourierUnits.size();
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -437,10 +437,6 @@ bool QUnit::TrySeparate(bitLenInt start, bitLenInt length)
     } else {
         // If length == 1, this is usually all that's worth trying:
         real1 prob = ProbBase(start);
-        if (abs(prob - (ONE_R1 / 2)) < min_norm) {
-            TransformBasis(!shards[start].isPlusMinus, start);
-            prob = ProbBase(start);
-        }
         return ((prob < min_norm) || ((ONE_R1 - prob) < min_norm));
     }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -260,6 +260,9 @@ QInterfacePtr QUnit::EntangleInCurrentBasis(
 QInterfacePtr QUnit::Entangle(std::vector<bitLenInt*> bits)
 {
     for (bitLenInt i = 0; i < bits.size(); i++) {
+        TransformToPerm(*(bits[i]));
+    }
+    for (bitLenInt i = 0; i < bits.size(); i++) {
         TransformBasis(false, *(bits[i]));
     }
     return EntangleInCurrentBasis(bits.begin(), bits.end());

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -108,6 +108,7 @@ void QUnit::GetProbs(real1* outputProbs)
 
 complex QUnit::GetAmplitude(bitCapInt perm)
 {
+    TransformToPermAll();
     TransformBasisAll(false);
     EndAllEmulation();
 
@@ -359,10 +360,7 @@ QInterfacePtr QUnit::EntangleRange(
 
 QInterfacePtr QUnit::EntangleAll()
 {
-    for (bitLenInt i = 0; i < qubitCount; i++) {
-        TransformToPerm(i);
-    }
-
+    TransformToPermAll();
     TransformBasisAll(false);
     EndAllEmulation();
 
@@ -434,10 +432,6 @@ bool QUnit::TrySeparate(bitLenInt start, bitLenInt length)
     if (length > 1) {
         EntangleRange(start, length);
         OrderContiguous(shards[start].unit);
-    } else {
-        // If length == 1, this is usually all that's worth trying:
-        real1 prob = ProbBase(start);
-        return ((prob < min_norm) || ((ONE_R1 - prob) < min_norm));
     }
 
     QInterfacePtr separatedBits = MakeEngine(length, 0);

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -840,13 +840,12 @@ void QUnit::H(bitLenInt target)
 {
     QEngineShard& shard = shards[target];
 
-    TransformToPerm(target);
-
     if (!freezeBasis) {
         shard.isPlusMinus = !shard.isPlusMinus;
         return;
     }
 
+    TransformToPerm(target);
     EndEmulation(shard);
 
     shard.unit->H(shard.mapped);

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -39,7 +39,7 @@ const double clockFactor = 1000.0 / CLOCKS_PER_SEC; // Report in ms
 double formatTime(double t, bool logNormal)
 {
     if (logNormal) {
-        return pow(2.0, t);
+        return pow(2.0, pow(2.0, t));
     } else {
         return t;
     }
@@ -102,7 +102,7 @@ void benchmarkLoopVariable(std::function<void(QInterfacePtr, int)> fn, bitLenInt
             // Collect interval data
             tClock = clock() - iterClock;
             if (logNormal) {
-                trialClocks[i] = log2(tClock * clockFactor);
+                trialClocks[i] = log2(log2(tClock * clockFactor));
             } else {
                 trialClocks[i] = tClock * clockFactor;
             }

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -39,7 +39,11 @@ const double clockFactor = 1000.0 / CLOCKS_PER_SEC; // Report in ms
 double formatTime(double t, bool logNormal)
 {
     if (logNormal) {
-        return pow(2.0, pow(2.0, t));
+        if (compressed) {
+            return pow(2.0, pow(2.0, t));
+        } else {
+            return pow(2.0, t);
+        }
     } else {
         return t;
     }
@@ -102,7 +106,11 @@ void benchmarkLoopVariable(std::function<void(QInterfacePtr, int)> fn, bitLenInt
             // Collect interval data
             tClock = clock() - iterClock;
             if (logNormal) {
-                trialClocks[i] = log2(log2(tClock * clockFactor));
+                if (compressed) {
+                    trialClocks[i] = log2(log2(tClock * clockFactor));
+                } else {
+                    trialClocks[i] = log2(tClock * clockFactor);
+                }
             } else {
                 trialClocks[i] = tClock * clockFactor;
             }

--- a/test/benchmarks_main.cpp
+++ b/test/benchmarks_main.cpp
@@ -30,6 +30,8 @@ bool enable_normalization = false;
 bool disable_hardware_rng = false;
 bool async_time = false;
 int device_id = -1;
+bool sparse = false;
+bool compressed = false;
 
 int main(int argc, char* argv[])
 {
@@ -41,6 +43,8 @@ int main(int argc, char* argv[])
     bool qunit_qfusion = false;
     bool cpu = false;
     bool opencl_single = false;
+    bool selSparse = false;
+    bool selCompressed = false;
 
     using namespace Catch::clara;
 
@@ -60,7 +64,9 @@ int main(int argc, char* argv[])
         Opt(disable_hardware_rng)["--disable-hardware-rng"]("Modern Intel chips provide an instruction for hardware "
                                                             "random number generation, which this option turns off. "
                                                             "(Hardware generation is on by default, if available.)") |
-        Opt(device_id, "device-id")["-d"]["--device-id"]("Opencl device ID (\"-1\" for default device)");
+        Opt(device_id, "device-id")["-d"]["--device-id"]("Opencl device ID (\"-1\" for default device)") |
+        Opt(selSparse)["--opt-sparse"]("Enable sparse state vector (CPU only)") |
+        Opt(selCompressed)["--opt-compressed"]("Enable Fourier-basis-compressed state vector");
 
     session.cli(cli);
 
@@ -79,11 +85,12 @@ int main(int argc, char* argv[])
 
     session.config().stream() << "Random Seed: " << session.configData().rngSeed;
 
-    if (disable_hardware_rng) {
-        session.config().stream() << std::endl;
-    } else {
-        session.config().stream() << " (Overridden by hardware generation!)" << std::endl;
+#if ENABLE_RDRAND
+    if (!disable_hardware_rng) {
+        session.config().stream() << " (Overridden by hardware generation!)";
     }
+#endif
+    session.config().stream() << std::endl;
 
     if (!qengine && !qfusion && !qunit && !qunit_qfusion) {
         qfusion = true;
@@ -95,6 +102,11 @@ int main(int argc, char* argv[])
     if (!cpu && !opencl_single) {
         cpu = true;
         opencl_single = true;
+    }
+
+    if (!selSparse && !selCompressed) {
+        selSparse = true;
+        selCompressed = true;
     }
 
     int num_failed = 0;
@@ -147,8 +159,26 @@ int main(int argc, char* argv[])
         if (num_failed == 0 && cpu) {
             session.config().stream() << "############ QUnit -> QEngine -> CPU ############" << std::endl;
             testSubEngineType = QINTERFACE_CPU;
-            testSubEngineType = QINTERFACE_CPU;
+            testSubSubEngineType = QINTERFACE_CPU;
             num_failed = session.run();
+        }
+
+        if (num_failed == 0 && cpu && selSparse) {
+            session.config().stream() << "############ QUnit -> QEngine -> CPU (Sparse) ############" << std::endl;
+            testSubEngineType = QINTERFACE_CPU;
+            testSubSubEngineType = QINTERFACE_CPU;
+            sparse = true;
+            num_failed = session.run();
+            sparse = false;
+        }
+
+        if (num_failed == 0 && cpu && selCompressed) {
+            session.config().stream() << "############ QUnit -> QEngine -> CPU (Compressed) ############" << std::endl;
+            testSubEngineType = QINTERFACE_CPU;
+            testSubSubEngineType = QINTERFACE_CPU;
+            compressed = true;
+            num_failed = session.run();
+            compressed = false;
         }
 
 #if ENABLE_OPENCL
@@ -158,6 +188,16 @@ int main(int argc, char* argv[])
             testSubSubEngineType = QINTERFACE_OPENCL;
             CreateQuantumInterface(QINTERFACE_OPENCL, 1, 0).reset(); /* Get the OpenCL banner out of the way. */
             num_failed = session.run();
+        }
+
+        if (num_failed == 0 && opencl_single && selCompressed) {
+            session.config().stream() << "############ QUnit -> QEngine -> OpenCL (Compressed) ############"
+                                      << std::endl;
+            testSubEngineType = QINTERFACE_OPENCL;
+            testSubSubEngineType = QINTERFACE_OPENCL;
+            compressed = true;
+            num_failed = session.run();
+            compressed = false;
         }
 #endif
     }
@@ -171,12 +211,37 @@ int main(int argc, char* argv[])
             num_failed = session.run();
         }
 
+        if (num_failed == 0 && cpu && selSparse) {
+            session.config().stream() << "############ QUnit -> QFusion -> CPU (Sparse) ############" << std::endl;
+            testSubSubEngineType = QINTERFACE_CPU;
+            sparse = true;
+            num_failed = session.run();
+            sparse = false;
+        }
+
+        if (num_failed == 0 && cpu && selCompressed) {
+            session.config().stream() << "############ QUnit -> QFusion -> CPU (Compressed) ############" << std::endl;
+            testSubSubEngineType = QINTERFACE_CPU;
+            compressed = true;
+            num_failed = session.run();
+            compressed = false;
+        }
+
 #if ENABLE_OPENCL
         if (num_failed == 0 && opencl_single) {
             session.config().stream() << "############ QUnit -> QFusion -> OpenCL ############" << std::endl;
             testSubSubEngineType = QINTERFACE_OPENCL;
             CreateQuantumInterface(QINTERFACE_OPENCL, 1, 0).reset(); /* Get the OpenCL banner out of the way. */
             num_failed = session.run();
+        }
+
+        if (num_failed == 0 && opencl_single && selCompressed) {
+            session.config().stream() << "############ QUnit -> QFusion -> OpenCL (Compressed) ############"
+                                      << std::endl;
+            testSubSubEngineType = QINTERFACE_OPENCL;
+            compressed = true;
+            num_failed = session.run();
+            compressed = false;
         }
 #endif
     }
@@ -195,6 +260,7 @@ QInterfaceTestFixture::QInterfaceTestFixture()
     qrack_rand_gen_ptr rng = std::make_shared<qrack_rand_gen>();
     rng->seed(rngSeed);
 
-    qftReg = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 1, 0, rng,
-        complex(ONE_R1, ZERO_R1), enable_normalization, true, false, -1, !disable_hardware_rng);
+    qftReg = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 20, 0, rng,
+        complex(ONE_R1, ZERO_R1), enable_normalization, true, false, device_id, !disable_hardware_rng, sparse,
+        compressed);
 }

--- a/test/benchmarks_main.cpp
+++ b/test/benchmarks_main.cpp
@@ -43,6 +43,7 @@ int main(int argc, char* argv[])
     bool qunit_qfusion = false;
     bool cpu = false;
     bool opencl_single = false;
+    bool selDefault = false;
     bool selSparse = false;
     bool selCompressed = false;
 
@@ -65,6 +66,7 @@ int main(int argc, char* argv[])
                                                             "random number generation, which this option turns off. "
                                                             "(Hardware generation is on by default, if available.)") |
         Opt(device_id, "device-id")["-d"]["--device-id"]("Opencl device ID (\"-1\" for default device)") |
+        Opt(selSparse)["--opt-default"]("Enable tests with both sparse and compressed state vectors off") |
         Opt(selSparse)["--opt-sparse"]("Enable sparse state vector (CPU only)") |
         Opt(selCompressed)["--opt-compressed"]("Enable Fourier-basis-compressed state vector");
 
@@ -104,7 +106,8 @@ int main(int argc, char* argv[])
         opencl_single = true;
     }
 
-    if (!selSparse && !selCompressed) {
+    if (!selDefault && !selSparse && !selCompressed) {
+        selDefault = true;
         selSparse = true;
         selCompressed = true;
     }
@@ -156,8 +159,8 @@ int main(int argc, char* argv[])
 
     if (num_failed == 0 && qunit) {
         testEngineType = QINTERFACE_QUNIT;
-        if (num_failed == 0 && cpu) {
-            session.config().stream() << "############ QUnit -> QEngine -> CPU ############" << std::endl;
+        if (num_failed == 0 && cpu && selDefault) {
+            session.config().stream() << "############ QUnit -> QEngine -> CPU (Default) ############" << std::endl;
             testSubEngineType = QINTERFACE_CPU;
             testSubSubEngineType = QINTERFACE_CPU;
             num_failed = session.run();
@@ -182,8 +185,8 @@ int main(int argc, char* argv[])
         }
 
 #if ENABLE_OPENCL
-        if (num_failed == 0 && opencl_single) {
-            session.config().stream() << "############ QUnit -> QEngine -> OpenCL ############" << std::endl;
+        if (num_failed == 0 && opencl_single && selDefault) {
+            session.config().stream() << "############ QUnit -> QEngine -> OpenCL (Default) ############" << std::endl;
             testSubEngineType = QINTERFACE_OPENCL;
             testSubSubEngineType = QINTERFACE_OPENCL;
             CreateQuantumInterface(QINTERFACE_OPENCL, 1, 0).reset(); /* Get the OpenCL banner out of the way. */
@@ -205,8 +208,8 @@ int main(int argc, char* argv[])
     if (num_failed == 0 && qunit_qfusion) {
         testEngineType = QINTERFACE_QUNIT;
         testSubEngineType = QINTERFACE_QFUSION;
-        if (num_failed == 0 && cpu) {
-            session.config().stream() << "############ QUnit -> QFusion -> CPU ############" << std::endl;
+        if (num_failed == 0 && cpu && selDefault) {
+            session.config().stream() << "############ QUnit -> QFusion -> CPU (Default) ############" << std::endl;
             testSubSubEngineType = QINTERFACE_CPU;
             num_failed = session.run();
         }
@@ -228,8 +231,8 @@ int main(int argc, char* argv[])
         }
 
 #if ENABLE_OPENCL
-        if (num_failed == 0 && opencl_single) {
-            session.config().stream() << "############ QUnit -> QFusion -> OpenCL ############" << std::endl;
+        if (num_failed == 0 && opencl_single && selDefault) {
+            session.config().stream() << "############ QUnit -> QFusion -> OpenCL (Default) ############" << std::endl;
             testSubSubEngineType = QINTERFACE_OPENCL;
             CreateQuantumInterface(QINTERFACE_OPENCL, 1, 0).reset(); /* Get the OpenCL banner out of the way. */
             num_failed = session.run();

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -29,8 +29,9 @@ qrack_rand_gen_ptr rng;
 bool enable_normalization = false;
 bool disable_hardware_rng = false;
 bool async_time = false;
-bool sparse = false;
 int device_id = -1;
+bool sparse = false;
+bool compressed = false;
 
 int main(int argc, char* argv[])
 {
@@ -161,6 +162,15 @@ int main(int argc, char* argv[])
             sparse = false;
         }
 
+        if (num_failed == 0 && cpu) {
+            session.config().stream() << "############ QUnit -> QEngine -> CPU (Compressed) ############" << std::endl;
+            testSubEngineType = QINTERFACE_CPU;
+            testSubEngineType = QINTERFACE_CPU;
+            compressed = true;
+            num_failed = session.run();
+            compressed = false;
+        }
+
 #if ENABLE_OPENCL
         if (num_failed == 0 && opencl_single) {
             session.config().stream() << "############ QUnit -> QEngine -> OpenCL ############" << std::endl;
@@ -189,6 +199,14 @@ int main(int argc, char* argv[])
             sparse = false;
         }
 
+        if (num_failed == 0 && cpu) {
+            session.config().stream() << "############ QUnit -> QFusion -> CPU (Compressed) ############" << std::endl;
+            testSubSubEngineType = QINTERFACE_CPU;
+            compressed = true;
+            num_failed = session.run();
+            compressed = false;
+        }
+
 #if ENABLE_OPENCL
         if (num_failed == 0 && opencl_single) {
             session.config().stream() << "############ QUnit -> QFusion -> OpenCL ############" << std::endl;
@@ -214,5 +232,6 @@ QInterfaceTestFixture::QInterfaceTestFixture()
     rng->seed(rngSeed);
 
     qftReg = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 20, 0, rng,
-        complex(ONE_R1, ZERO_R1), enable_normalization, true, false, device_id, !disable_hardware_rng, sparse);
+        complex(ONE_R1, ZERO_R1), enable_normalization, true, false, device_id, !disable_hardware_rng, sparse,
+        compressed);
 }

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -43,6 +43,7 @@ int main(int argc, char* argv[])
     bool qunit_qfusion = false;
     bool cpu = false;
     bool opencl_single = false;
+    bool selDefault = false;
     bool selSparse = false;
     bool selCompressed = false;
 
@@ -64,6 +65,7 @@ int main(int argc, char* argv[])
                                                             "random number generation, which this option turns off. "
                                                             "(Hardware generation is on by default, if available.)") |
         Opt(device_id, "device-id")["-d"]["--device-id"]("Opencl device ID (\"-1\" for default device)") |
+        Opt(selSparse)["--opt-default"]("Enable tests with both sparse and compressed state vectors off") |
         Opt(selSparse)["--opt-sparse"]("Enable sparse state vector (CPU only)") |
         Opt(selCompressed)["--opt-compressed"]("Enable Fourier-basis-compressed state vector");
 
@@ -103,7 +105,8 @@ int main(int argc, char* argv[])
         opencl_single = true;
     }
 
-    if (!selSparse && !selCompressed) {
+    if (!selDefault && !selSparse && !selCompressed) {
+        selDefault = true;
         selSparse = true;
         selCompressed = true;
     }
@@ -155,8 +158,8 @@ int main(int argc, char* argv[])
 
     if (num_failed == 0 && qunit) {
         testEngineType = QINTERFACE_QUNIT;
-        if (num_failed == 0 && cpu) {
-            session.config().stream() << "############ QUnit -> QEngine -> CPU ############" << std::endl;
+        if (num_failed == 0 && cpu && selDefault) {
+            session.config().stream() << "############ QUnit -> QEngine -> CPU (Default) ############" << std::endl;
             testSubEngineType = QINTERFACE_CPU;
             testSubSubEngineType = QINTERFACE_CPU;
             num_failed = session.run();
@@ -181,8 +184,8 @@ int main(int argc, char* argv[])
         }
 
 #if ENABLE_OPENCL
-        if (num_failed == 0 && opencl_single) {
-            session.config().stream() << "############ QUnit -> QEngine -> OpenCL ############" << std::endl;
+        if (num_failed == 0 && opencl_single && selDefault) {
+            session.config().stream() << "############ QUnit -> QEngine -> OpenCL (Default) ############" << std::endl;
             testSubEngineType = QINTERFACE_OPENCL;
             testSubSubEngineType = QINTERFACE_OPENCL;
             CreateQuantumInterface(QINTERFACE_OPENCL, 1, 0).reset(); /* Get the OpenCL banner out of the way. */
@@ -204,8 +207,8 @@ int main(int argc, char* argv[])
     if (num_failed == 0 && qunit_qfusion) {
         testEngineType = QINTERFACE_QUNIT;
         testSubEngineType = QINTERFACE_QFUSION;
-        if (num_failed == 0 && cpu) {
-            session.config().stream() << "############ QUnit -> QFusion -> CPU ############" << std::endl;
+        if (num_failed == 0 && cpu && selDefault) {
+            session.config().stream() << "############ QUnit -> QFusion -> CPU (Default) ############" << std::endl;
             testSubSubEngineType = QINTERFACE_CPU;
             num_failed = session.run();
         }
@@ -227,8 +230,8 @@ int main(int argc, char* argv[])
         }
 
 #if ENABLE_OPENCL
-        if (num_failed == 0 && opencl_single) {
-            session.config().stream() << "############ QUnit -> QFusion -> OpenCL ############" << std::endl;
+        if (num_failed == 0 && opencl_single && selDefault) {
+            session.config().stream() << "############ QUnit -> QFusion -> OpenCL (Default) ############" << std::endl;
             testSubSubEngineType = QINTERFACE_OPENCL;
             CreateQuantumInterface(QINTERFACE_OPENCL, 1, 0).reset(); /* Get the OpenCL banner out of the way. */
             num_failed = session.run();

--- a/test/tests.hpp
+++ b/test/tests.hpp
@@ -32,6 +32,7 @@ extern bool enable_normalization;
 extern bool disable_hardware_rng;
 extern bool async_time;
 extern int device_id;
+extern bool compressed;
 
 /* Declare the stream-to-probability prior to including catch.hpp. */
 namespace Qrack {


### PR DESCRIPTION
This is an experimental optimization. It currently fails ProjectQ unit tests, but that seems like it might be entirely a matter of global phase offsets, which could be anticipated due to the direct amplitude checks in ProjectQ unit tests. I'm considering implementing an amplitude-agnostic verification of those tests, before merging. (In other words, the difference causing the failure is not be physically measurable/consequential.)

For a couple of weeks, I've been experimenting with decomposing sub-units in QUnit according to local "Fourier bases." This branch recursively compresses sub-units to single separable bits, each with a "breadcrumb trail" of Fourier transforms to reverse, to return to the natural basis. One way or another, this can "compress" the representation of sub-units which aren't in direct use, so long as an invariant measure of entanglement is not maximal.

If we can operate on compressed sub-units without needing to decompress, we might gain both speed and memory advantages. This PR also _attempts_ transforming gates without recourse to "decompression." The idea is, QUnit will typically be able to "compress" qubits all the way to single separable bits, along with a breadcrumb trail of Jacobian (basis) inversions. At maximum depth, since compressed qubits are separable, certain phase effects implied by the QFT breadcrumb trail (might) become irrelevant. Maybe, so long as the compressed representation is separable down to a single bit, second and higher order phase effects from the QFT trail are moot, (where "first order" is just the Hadamard gate alone, being the single qubit DFT,) passing along the breadcrumb trail of Fourier transformations, such that operations on the compressed bits only depend on the evenness or oddness of Fourier transformations, as commuting with even/odd sequences of Hadamard gates only.

I say "maybe" these effects are "moot," due to separability due to single qubits. So far, my justification for this is experimentation via Qrack itself. Hence, I marking this "WIP," pending satisfactory theoretical and/or "experimental"/simulation verification.