### PR TITLE
Issue #230: Variable qubit selection for benchmarks (and related improvements)

### DIFF
--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -68,9 +68,11 @@ void benchmarkLoopVariable(std::function<void(QInterfacePtr, int)> fn, bitLenInt
 
     double avgt, stdet;
 
-    bitLenInt mnQbts = 4;
+    bitLenInt mnQbts;
     if (single_qubit_run) {
         mnQbts = mxQbts;
+    } else {
+        mnQbts = 4;
     }
 
     for (numBits = mnQbts; numBits <= mxQbts; numBits++) {
@@ -356,37 +358,6 @@ TEST_CASE("test_set_reg", "[aux]")
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->SetReg(0, n, 1); });
 }
 
-TEST_CASE("test_qft_ideal_init", "[qft]")
-{
-    benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->QFT(0, n, false); }, false, false);
-}
-
-TEST_CASE("test_qft_permutation_init", "[qft]")
-{
-    benchmarkLoop(
-        [](QInterfacePtr qftReg, int n) { qftReg->QFT(0, n, false); }, true, false, testEngineType == QINTERFACE_QUNIT);
-}
-
-TEST_CASE("test_qft_permutation_round_trip_entangled", "[qft]")
-{
-    benchmarkLoop(
-        [](QInterfacePtr qftReg, int n) {
-            qftReg->QFT(0, n, false);
-            qftReg->IQFT(0, n, false);
-        },
-        true, false, testEngineType == QINTERFACE_QUNIT);
-}
-
-TEST_CASE("test_qft_superposition_round_trip", "[qft]")
-{
-    benchmarkLoop(
-        [](QInterfacePtr qftReg, int n) {
-            qftReg->QFT(0, n, false);
-            qftReg->IQFT(0, n, false);
-        },
-        true, true, testEngineType == QINTERFACE_QUNIT);
-}
-
 TEST_CASE("test_grover", "[grover]")
 {
 
@@ -419,4 +390,35 @@ TEST_CASE("test_grover", "[grover]")
 
         qftReg->MReg(0, n);
     });
+}
+
+TEST_CASE("test_qft_ideal_init", "[qft]")
+{
+    benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->QFT(0, n, false); }, false, false);
+}
+
+TEST_CASE("test_qft_permutation_init", "[qft]")
+{
+    benchmarkLoop(
+        [](QInterfacePtr qftReg, int n) { qftReg->QFT(0, n, false); }, true, false, testEngineType == QINTERFACE_QUNIT);
+}
+
+TEST_CASE("test_qft_permutation_round_trip_entangled", "[qft]")
+{
+    benchmarkLoop(
+        [](QInterfacePtr qftReg, int n) {
+            qftReg->QFT(0, n, false);
+            qftReg->IQFT(0, n, false);
+        },
+        true, false, testEngineType == QINTERFACE_QUNIT);
+}
+
+TEST_CASE("test_qft_superposition_round_trip", "[qft]")
+{
+    benchmarkLoop(
+        [](QInterfacePtr qftReg, int n) {
+            qftReg->QFT(0, n, false);
+            qftReg->IQFT(0, n, false);
+        },
+        true, true, testEngineType == QINTERFACE_QUNIT);
 }

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -156,147 +156,147 @@ void benchmarkLoop(std::function<void(QInterfacePtr, int)> fn, bool resetRandomP
     benchmarkLoopVariable(fn, MaxQubits, resetRandomPerm, hadamardRandomBits, logNormal);
 }
 
-TEST_CASE("test_cnot_single")
+TEST_CASE("test_cnot_single", "[gates]")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->CNOT(0, 1); });
 }
 
-TEST_CASE("test_x_single")
+TEST_CASE("test_x_single", "[gates]")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->X(0); });
 }
 
-TEST_CASE("test_y_single")
+TEST_CASE("test_y_single", "[gates]")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->Y(0); });
 }
 
-TEST_CASE("test_z_single")
+TEST_CASE("test_z_single", "[gates]")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->Z(0); });
 }
 
-TEST_CASE("test_swap_single")
+TEST_CASE("test_swap_single", "[gates]")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->Swap(0, 1); });
 }
 
-TEST_CASE("test_cnot_all")
+TEST_CASE("test_cnot_all", "[gates]")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->CNOT(0, n / 2, n / 2); });
 }
 
-TEST_CASE("test_x_all")
+TEST_CASE("test_x_all", "[gates]")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->X(0, n); });
 }
 
-TEST_CASE("test_y_all")
+TEST_CASE("test_y_all", "[gates]")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->Y(0, n); });
 }
 
-TEST_CASE("test_z_all")
+TEST_CASE("test_z_all", "[gates]")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->Z(0, n); });
 }
 
-TEST_CASE("test_swap_all")
+TEST_CASE("test_swap_all", "[gates]")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->Swap(0, n / 2, n / 2); });
 }
 
-TEST_CASE("test_ccnot_all")
+TEST_CASE("test_ccnot_all", "[gates]")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->CCNOT(0, n / 3, (2 * n) / 3, n / 3); });
 }
 
-TEST_CASE("test_and_all")
+TEST_CASE("test_and_all", "[gates]")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->AND(0, n / 3, (2 * n) / 3, n / 3); });
 }
 
-TEST_CASE("test_or_all")
+TEST_CASE("test_or_all", "[gates]")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->OR(0, n / 3, (2 * n) / 3, n / 3); });
 }
 
-TEST_CASE("test_xor_all")
+TEST_CASE("test_xor_all", "[gates]")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->XOR(0, n / 3, (2 * n) / 3, n / 3); });
 }
 
-TEST_CASE("test_cland_all")
+TEST_CASE("test_cland_all", "[gates]")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->CLAND(0, 0x0c, 0, n); });
 }
 
-TEST_CASE("test_clor_all")
+TEST_CASE("test_clor_all", "[gates]")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->CLOR(0, 0x0d, 0, n); });
 }
 
-TEST_CASE("test_clxor_all")
+TEST_CASE("test_clxor_all", "[gates]")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->CLXOR(0, 0x0d, 0, n); });
 }
 
-TEST_CASE("test_rt_all")
+TEST_CASE("test_rt_all", "[gates]")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->RT(M_PI, 0, n); });
 }
 
-TEST_CASE("test_crt_all")
+TEST_CASE("test_crt_all", "[gates]")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->CRT(M_PI, 0, n / 2, n / 2); });
 }
 
-TEST_CASE("test_rol")
+TEST_CASE("test_rol", "[gates]")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->ROL(1, 0, n); });
 }
 
-TEST_CASE("test_inc")
+TEST_CASE("test_inc", "[arithmetic]")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->INC(1, 0, n); });
 }
 
-TEST_CASE("test_incs")
+TEST_CASE("test_incs", "[arithmetic]")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->INCS(1, 0, n - 1, n - 1); });
 }
 
-TEST_CASE("test_incc")
+TEST_CASE("test_incc", "[arithmetic]")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->INCC(1, 0, n - 1, n - 1); });
 }
 
-TEST_CASE("test_incsc")
+TEST_CASE("test_incsc", "[arithmetic]")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->INCSC(1, 0, n - 2, n - 2, n - 1); });
 }
 
-TEST_CASE("test_zero_phase_flip")
+TEST_CASE("test_zero_phase_flip", "[phaseflip]")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->ZeroPhaseFlip(0, n); });
 }
 
-TEST_CASE("test_c_phase_flip_if_less")
+TEST_CASE("test_c_phase_flip_if_less", "[phaseflip]")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->CPhaseFlipIfLess(1, 0, n - 1, n - 1); });
 }
 
-TEST_CASE("test_phase_flip")
+TEST_CASE("test_phase_flip", "[phaseflip]")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->PhaseFlip(); });
 }
 
-TEST_CASE("test_m")
+TEST_CASE("test_m", "[measure]")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->M(n - 1); });
 }
 
-TEST_CASE("test_mreg")
+TEST_CASE("test_mreg", "[measure]")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->MReg(0, n); });
 }
@@ -317,49 +317,80 @@ void benchmarkSuperpose(std::function<void(QInterfacePtr, int, unsigned char*)> 
     delete[] testPage;
 }
 
-TEST_CASE("test_superposition_reg")
+TEST_CASE("test_superposition_reg", "[indexed]")
 {
     benchmarkSuperpose([](QInterfacePtr qftReg, int n, unsigned char* testPage) {
         qftReg->IndexedLDA(0, n / 2, n / 2, n / 2, testPage);
     });
 }
 
-TEST_CASE("test_adc_superposition_reg")
+TEST_CASE("test_adc_superposition_reg", "[indexed]")
 {
     benchmarkSuperpose([](QInterfacePtr qftReg, int n, unsigned char* testPage) {
         qftReg->IndexedADC(0, (n - 1) / 2, (n - 1) / 2, (n - 1) / 2, (n - 1), testPage);
     });
 }
 
-TEST_CASE("test_sbc_superposition_reg")
+TEST_CASE("test_sbc_superposition_reg", "[indexed]")
 {
     benchmarkSuperpose([](QInterfacePtr qftReg, int n, unsigned char* testPage) {
         qftReg->IndexedSBC(0, (n - 1) / 2, (n - 1) / 2, (n - 1) / 2, (n - 1), testPage);
     });
 }
 
-TEST_CASE("test_setbit")
+TEST_CASE("test_setbit", "[aux]")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->SetBit(0, true); });
 }
 
-TEST_CASE("test_proball")
+TEST_CASE("test_proball", "[aux]")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->ProbAll(0x02); });
 }
 
-TEST_CASE("test_set_reg")
+TEST_CASE("test_set_reg", "[aux]")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->SetReg(0, n, 1); });
 }
 
-TEST_CASE("test_grover")
+TEST_CASE("test_qft_ideal_init", "[qft]")
+{
+    benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->QFT(0, n, false); }, false, false);
+}
+
+TEST_CASE("test_qft_permutation_init", "[qft]")
+{
+    benchmarkLoop(
+        [](QInterfacePtr qftReg, int n) { qftReg->QFT(0, n, false); }, true, false, testEngineType == QINTERFACE_QUNIT);
+}
+
+TEST_CASE("test_qft_permutation_round_trip_entangled", "[qft]")
+{
+    benchmarkLoop(
+        [](QInterfacePtr qftReg, int n) {
+            qftReg->QFT(0, n, false);
+            qftReg->IQFT(0, n, false);
+        },
+        true, false, testEngineType == QINTERFACE_QUNIT);
+}
+
+TEST_CASE("test_qft_superposition_round_trip", "[qft]")
+{
+    benchmarkLoop(
+        [](QInterfacePtr qftReg, int n) {
+            qftReg->QFT(0, n, false);
+            qftReg->IQFT(0, n, false);
+        },
+        true, true, testEngineType == QINTERFACE_QUNIT);
+}
+
+TEST_CASE("test_grover", "[grover]")
 {
 
     // Grover's search inverts the function of a black box subroutine.
     // Our subroutine returns true only for an input of 3.
 
-    benchmarkLoopVariable(
+    benchmarkLoop(
         [](QInterfacePtr qftReg, int n) {
             int i;
             // Twelve iterations maximizes the probablity for 256 searched elements, for example.
@@ -385,37 +416,5 @@ TEST_CASE("test_grover")
             REQUIRE_THAT(qftReg, HasProbability(0x3));
 
             qftReg->MReg(0, n);
-        },
-        16);
-}
-
-TEST_CASE("test_qft_ideal_init")
-{
-    benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->QFT(0, n, false); }, false, false);
-}
-
-TEST_CASE("test_qft_permutation_init")
-{
-    benchmarkLoop(
-        [](QInterfacePtr qftReg, int n) { qftReg->QFT(0, n, false); }, true, false, testEngineType == QINTERFACE_QUNIT);
-}
-
-TEST_CASE("test_qft_permutation_round_trip_entangled")
-{
-    benchmarkLoop(
-        [](QInterfacePtr qftReg, int n) {
-            qftReg->QFT(0, n, false);
-            qftReg->IQFT(0, n, false);
-        },
-        true, false, testEngineType == QINTERFACE_QUNIT);
-}
-
-TEST_CASE("test_qft_superposition_round_trip")
-{
-    benchmarkLoop(
-        [](QInterfacePtr qftReg, int n) {
-            qftReg->QFT(0, n, false);
-            qftReg->IQFT(0, n, false);
-        },
-        true, true, testEngineType == QINTERFACE_QUNIT);
+        });
 }

--- a/test/benchmarks_main.cpp
+++ b/test/benchmarks_main.cpp
@@ -114,12 +114,12 @@ int main(int argc, char* argv[])
             CreateQuantumInterface(QINTERFACE_OPENCL, 1, 0).reset();
 
             DeviceContextPtr device_context = OCLEngine::Instance()->GetDeviceContextPtr(device_id);
-            size_t maxMem = device_context->device.getInfo<CL_DEVICE_GLOBAL_MEM_SIZE>();
-            size_t maxAlloc = device_context->device.getInfo<CL_DEVICE_MAX_MEM_ALLOC_SIZE>();
+            size_t maxMem = device_context->device.getInfo<CL_DEVICE_GLOBAL_MEM_SIZE>() / sizeof(complex);
+            size_t maxAlloc = device_context->device.getInfo<CL_DEVICE_MAX_MEM_ALLOC_SIZE>() / sizeof(complex);
 
             // Device RAM should be large enough for 2 times the size of the stateVec, plus some excess.
-            max_qubits = log2(maxAlloc / sizeof(complex));
-            if ((3 * (1U << max_qubits)) > maxMem) {
+            max_qubits = log2(maxAlloc);
+            if ((3 * (1U << max_qubits)) > maxMem ) {
                 max_qubits = log2(maxMem / 3);
             }
 #else

--- a/test/benchmarks_main.cpp
+++ b/test/benchmarks_main.cpp
@@ -118,7 +118,7 @@ int main(int argc, char* argv[])
             size_t maxAlloc = device_context->device.getInfo<CL_DEVICE_MAX_MEM_ALLOC_SIZE>();
 
             // Device RAM should be large enough for 2 times the size of the stateVec, plus some excess.
-            max_qubits = log2(maxAlloc);
+            max_qubits = log2(maxAlloc / sizeof(complex));
             if ((3 * (1U << max_qubits)) > maxMem) {
                 max_qubits = log2(maxMem / 3);
             }

--- a/test/tests.hpp
+++ b/test/tests.hpp
@@ -32,6 +32,8 @@ extern bool enable_normalization;
 extern bool disable_hardware_rng;
 extern bool async_time;
 extern int device_id;
+extern bitLenInt max_qubits;
+extern bool single_qubit_run;
 
 /* Declare the stream-to-probability prior to including catch.hpp. */
 namespace Qrack {


### PR DESCRIPTION
Per #230, the maximum number of qubits can be selected from the command line. Let me know if you decide you'd also like the minimum configurable, but I'm worried it will lead to confusion and frustration when users set the minimum below 3 or 4 qubits, which is the bare minimum for the general suite. Rather, I also added another Boolean option to run _only_ the maximum qubit count, which saves roughly half the time, on most tests.

Additionally, tests have been "tagged," and tags can be entered on the command line for specific inclusion ("[grover]") or exclusion ("~[grover]"). In part, this serves as a workaround for managing the extremely long-running Grover's algorithm tests.

Entering "-1" for the maximum qubit count parameter, if OpenCL tests will run, attempts to automatically scale the maximum qubits to the selected device. The largest allocation is the RAM segment size, which might commonly be 1/2 or 1/4 of the total device RAM, depending on OpenCL device. Additionally, arithmetic gates in particular might duplicate the state vector, once, and some further allocation on the device is likely to be required by Qrack, (depending on gate, but Qrack definitely does further allocation, worst case). So, the automatically scaled maximum is further clamped to use no more than 1/3 of the total device RAM for a single copy of the state vector. (Then, if you have 4 identical segments, the allocation will be exactly the maximum size of 1 segment. There are ways to increase your maximum possible qubits, like restricting your gate set, and/or using QUnit, but you'll have to manually enter your maximum qubits, then.)