### PR TITLE
CNOT optimization ("Gottesman-Knill"); "isEmulated" edge case; phase gate optimization 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Qrack
 
-[![Qrack Build Status](https://api.travis-ci.org/vm6502q/qrack.svg?branch=master)](https://travis-ci.org/vm6502q/qrack/builds) [![Mentioned in Awesome awesome-quantum-computing](https://awesome.re/mentioned-badge.svg)](https://github.com/desireevl/awesome-quantum-computing)
+[![DOI](https://zenodo.org/badge/114947047.svg)](https://zenodo.org/badge/latestdoi/114947047) [![Qrack Build Status](https://api.travis-ci.org/vm6502q/qrack.svg?branch=master)](https://travis-ci.org/vm6502q/qrack/builds) [![Mentioned in Awesome awesome-quantum-computing](https://awesome.re/mentioned-badge.svg)](https://github.com/desireevl/awesome-quantum-computing)
 
 This is a multithreaded framework for developing classically emulated virtual universal quantum processors. It has CPU, GPU, and multi-processor engine types.
 
@@ -151,6 +151,8 @@ Qrack was originally written so that the disassembler of VM6502Q should show the
 ## Copyright and License
 
 Copyright (c) Daniel Strano and the Qrack contributors 2017-2019. All rights reserved.
+
+(The given DOI date is that of first "official release.")
 
 Daniel Strano would like to specifically note that Benn Bollay is almost entirely responsible for the implementation of QUnit and tooling, including unit tests, in addition to large amounts of work on the documentation and many other various contributions in intensive reviews. Also, thank you to Marek Karcz for supplying an awesome base classical 6502 emulator for proof-of-concept. (Additionally, the font for the Qrack logo is "Electrickle," distributed as "Freeware" from [https://www.fontspace.com/fontastic/electrickle](https://www.fontspace.com/fontastic/electrickle).) Thank you to any and all contributors!
 

--- a/include/qengine.hpp
+++ b/include/qengine.hpp
@@ -25,7 +25,6 @@ typedef std::shared_ptr<QEngine> QEnginePtr;
  */
 class QEngine : public QInterface {
 protected:
-    bool randGlobalPhase;
     bool useHostRam;
     /// The value stored in runningNorm should always be the total probability implied by the norm of all amplitudes,
     /// summed, at each update. To normalize, we should always multiply by 1/sqrt(runningNorm).
@@ -44,8 +43,7 @@ protected:
 public:
     QEngine(bitLenInt qBitCount, qrack_rand_gen_ptr rgp = nullptr, bool doNorm = false, bool randomGlobalPhase = true,
         bool useHostMem = false, bool useHardwareRNG = true)
-        : QInterface(qBitCount, rgp, doNorm, useHardwareRNG)
-        , randGlobalPhase(randomGlobalPhase)
+        : QInterface(qBitCount, rgp, doNorm, useHardwareRNG, randomGlobalPhase)
         , useHostRam(useHostMem)
         , runningNorm(ONE_R1)
     {
@@ -118,8 +116,6 @@ public:
 
 protected:
     virtual real1 GetExpectation(bitLenInt valueStart, bitLenInt valueLength) = 0;
-
-    virtual bool IsIdentity(const complex* mtrx);
 
     virtual void Apply2x2(bitCapInt offset1, bitCapInt offset2, const complex* mtrx, const bitLenInt bitCount,
         const bitCapInt* qPowersSorted, bool doCalcNorm) = 0;

--- a/include/qfusion.hpp
+++ b/include/qfusion.hpp
@@ -32,7 +32,6 @@ protected:
     QInterfacePtr qReg;
     complex phaseFactor;
     bool doNormalize;
-    bool randGlobalPhase;
 
     std::vector<BitBufferPtr> bitBuffers;
     std::vector<std::vector<bitLenInt>> bitControls;

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -103,7 +103,7 @@ protected:
     virtual void SetQubitCount(bitLenInt qb)
     {
         qubitCount = qb;
-        maxQPower = 1 << qubitCount;
+        maxQPower = 1U << qubitCount;
     }
 
     virtual void SetRandomSeed(uint32_t seed) { rand_generator->seed(seed); }

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -98,6 +98,7 @@ protected:
     std::uniform_real_distribution<real1> rand_distribution;
     std::shared_ptr<RdRandWrapper::RdRandom> hardware_rand_generator;
     bool doNormalize;
+    bool randGlobalPhase;
 
     virtual void SetQubitCount(bitLenInt qb)
     {
@@ -147,11 +148,15 @@ protected:
         toFree = NULL;
     }
 
+    bool IsIdentity(const complex* mtrx);
+
 public:
-    QInterface(bitLenInt n, qrack_rand_gen_ptr rgp = nullptr, bool doNorm = false, bool useHardwareRNG = true)
+    QInterface(bitLenInt n, qrack_rand_gen_ptr rgp = nullptr, bool doNorm = false, bool useHardwareRNG = true,
+        bool randomGlobalPhase = true)
         : rand_distribution(0.0, 1.0)
         , hardware_rand_generator(NULL)
         , doNormalize(doNorm)
+        , randGlobalPhase(randomGlobalPhase)
     {
         SetQubitCount(n);
 

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -85,7 +85,6 @@ protected:
     std::vector<QEngineShard> shards;
     complex phaseFactor;
     bool doNormalize;
-    bool randGlobalPhase;
     bool useHostRam;
     bool useRDRAND;
     bool isSparse;

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -369,8 +369,6 @@ protected:
     bitCapInt GetIndexedEigenstate(bitLenInt indexStart, bitLenInt indexLength, bitLenInt valueStart,
         bitLenInt valueLength, unsigned char* values);
 
-    void CleanPlusMinus(bitLenInt target);
-
     void Transform2x2(const complex* mtrxIn, complex* mtrxOut);
     void TransformPhase(const complex& topLeft, const complex& bottomRight, complex* mtrxOut);
     void TransformInvert(const complex& topRight, const complex& bottomLeft, complex* mtrxOut);

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -437,6 +437,16 @@ protected:
         }
     }
 
+    template <typename F> void ApplyOrEmulate(QEngineShard& shard, F payload)
+    {
+        if (shard.unit->GetQubitCount() == 1) {
+            shard.isEmulated = true;
+        } else {
+            EndEmulation(shard);
+            payload(shard);
+        }
+    }
+
     /* Debugging and diagnostic routines. */
     void DumpShards();
     QInterfacePtr GetUnit(bitLenInt bit) { return shards[bit].unit; }

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -370,6 +370,8 @@ protected:
     bitCapInt GetIndexedEigenstate(bitLenInt indexStart, bitLenInt indexLength, bitLenInt valueStart,
         bitLenInt valueLength, unsigned char* values);
 
+    void CleanPlusMinus(bitLenInt target);
+
     void Transform2x2(const complex* mtrxIn, complex* mtrxOut);
     void TransformPhase(const complex& topLeft, const complex& bottomRight, complex* mtrxOut);
     void TransformInvert(const complex& topRight, const complex& bottomLeft, complex* mtrxOut);

--- a/include/statevector.hpp
+++ b/include/statevector.hpp
@@ -62,7 +62,7 @@ protected:
 
     static real1 normHelper(const complex& c) { return norm(c); }
 
-    complex* Alloc(const bitCapInt& elemCount)
+    complex* Alloc(bitCapInt elemCount)
     {
 // elemCount is always a power of two, but might be smaller than QRACK_ALIGN_SIZE
 #if defined(__APPLE__)

--- a/include/statevector.hpp
+++ b/include/statevector.hpp
@@ -60,9 +60,9 @@ class StateVectorArray : public StateVector {
 protected:
     complex* amplitudes;
 
-    static real1 normHelper(complex c) { return norm(c); }
+    static real1 normHelper(const complex& c) { return norm(c); }
 
-    complex* Alloc(bitCapInt elemCount)
+    complex* Alloc(const bitCapInt& elemCount)
     {
 // elemCount is always a power of two, but might be smaller than QRACK_ALIGN_SIZE
 #if defined(__APPLE__)

--- a/src/qengine/qengine.cpp
+++ b/src/qengine/qengine.cpp
@@ -145,45 +145,6 @@ bitCapInt QEngine::ForceM(const bitLenInt* bits, const bitLenInt& length, const 
     return result;
 }
 
-bool QEngine::IsIdentity(const complex* mtrx)
-{
-    // If the effect of applying the buffer would be (approximately or exactly) that of applying the identity
-    // operator, then we can discard this buffer without applying it.
-    if (norm(mtrx[1]) > min_norm) {
-        return false;
-    }
-    if (norm(mtrx[2]) > min_norm) {
-        return false;
-    }
-
-    if (randGlobalPhase) {
-        // If the global phase offset has been randomized, we assume that global phase offsets are inconsequential, for
-        // the user's purposes.
-        real1 toTest = norm(mtrx[0]);
-        if (toTest < (ONE_R1 - min_norm)) {
-            return false;
-        }
-        toTest = norm(mtrx[0] - mtrx[3]);
-        if (toTest > min_norm) {
-            return false;
-        }
-    } else {
-        // If the global phase offset has not been randomized, user code might explicitly depend on the global phase
-        // offset (but shouldn't).
-        complex toTest = mtrx[0];
-        if ((real(toTest) < (ONE_R1 - min_norm)) || (imag(toTest) > min_norm)) {
-            return false;
-        }
-        toTest = mtrx[3];
-        if ((real(toTest) < (ONE_R1 - min_norm)) || (imag(toTest) > min_norm)) {
-            return false;
-        }
-    }
-
-    // If we haven't returned false by now, we're buffering (approximately or exactly) an identity operator.
-    return true;
-}
-
 void QEngine::ApplySingleBit(const complex* mtrx, bool doCalcNorm, bitLenInt qubit)
 {
     if (IsIdentity(mtrx)) {

--- a/src/qfusion.cpp
+++ b/src/qfusion.cpp
@@ -22,22 +22,20 @@ namespace Qrack {
 QFusion::QFusion(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState, qrack_rand_gen_ptr rgp,
     complex phaseFac, bool doNorm, bool randomGlobalPhase, bool useHostMem, int deviceID, bool useHardwareRNG,
     bool useSparseStateVec)
-    : QInterface(qBitCount, rgp, deviceID, useHardwareRNG)
+    : QInterface(qBitCount, rgp, deviceID, useHardwareRNG, randomGlobalPhase)
     , phaseFactor(phaseFac)
     , doNormalize(doNorm)
-    , randGlobalPhase(randomGlobalPhase)
     , bitBuffers(qBitCount)
     , bitControls(qBitCount)
 {
-    qReg = CreateQuantumInterface(eng, qBitCount, initState, rgp, phaseFactor, doNormalize, randGlobalPhase, useHostMem,
-        deviceID, useHardwareRNG, useSparseStateVec);
+    qReg = CreateQuantumInterface(eng, qBitCount, initState, rgp, phaseFactor, doNormalize, randomGlobalPhase,
+        useHostMem, deviceID, useHardwareRNG, useSparseStateVec);
 }
 
 QFusion::QFusion(QInterfacePtr target)
     : QInterface(target->GetQubitCount())
     , phaseFactor(complex(-999.0, -999.0))
     , doNormalize(true)
-    , randGlobalPhase(true)
     , bitBuffers(target->GetQubitCount())
     , bitControls(target->GetQubitCount())
 {

--- a/src/qinterface/protected.cpp
+++ b/src/qinterface/protected.cpp
@@ -211,10 +211,7 @@ bool QInterface::IsIdentity(const complex* mtrx)
 {
     // If the effect of applying the buffer would be (approximately or exactly) that of applying the identity
     // operator, then we can discard this buffer without applying it.
-    if (norm(mtrx[1]) > min_norm) {
-        return false;
-    }
-    if (norm(mtrx[2]) > min_norm) {
+    if ((norm(mtrx[1]) > min_norm) || (norm(mtrx[2]) > min_norm)) {
         return false;
     }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1001,6 +1001,7 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
             CNOT(target, control);
         } else if (norm(tShard.amp0) < min_norm) {
             std::swap(cShard.amp0, cShard.amp1);
+            cShard.isEmulated = true;
         }
         return;
     }
@@ -1019,6 +1020,7 @@ void QUnit::AntiCNOT(bitLenInt control, bitLenInt target)
             AntiCNOT(target, control);
         } else if (norm(tShard.amp0) < min_norm) {
             std::swap(cShard.amp0, cShard.amp1);
+            cShard.isEmulated = true;
             tShard.amp0 *= -1;
             tShard.amp1 *= -1;
         }

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1195,6 +1195,8 @@ void QUnit::ApplySingleBit(const complex* mtrx, bool doCalcNorm, bitLenInt targe
         shard.isProbDirty = true;
         shard.isPhaseDirty = true;
         return;
+    } else {
+        shard.isEmulated = true;
     }
 
     complex Y0 = shard.amp0;

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1018,7 +1018,7 @@ void QUnit::AntiCNOT(bitLenInt control, bitLenInt target)
         if (!tShard.isPlusMinus) {
             AntiCNOT(target, control);
         } else if (norm(tShard.amp0) < min_norm) {
-            Swap(control, target);
+            std::swap(cShard.amp0, cShard.amp1);
             tShard.amp0 *= -1;
             tShard.amp1 *= -1;
         }

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1189,14 +1189,12 @@ void QUnit::ApplySingleBit(const complex* mtrx, bool doCalcNorm, bitLenInt targe
         Transform2x2(mtrx, trnsMtrx);
     }
 
+    shard.unit->ApplySingleBit(trnsMtrx, doCalcNorm, shard.mapped);
+
     if (DIRTY(shard)) {
-        EndEmulation(target);
-        shard.unit->ApplySingleBit(trnsMtrx, doCalcNorm, shard.mapped);
         shard.isProbDirty = true;
         shard.isPhaseDirty = true;
         return;
-    } else {
-        shard.isEmulated = true;
     }
 
     complex Y0 = shard.amp0;

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1010,6 +1010,15 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
 
 void QUnit::AntiCNOT(bitLenInt control, bitLenInt target)
 {
+    QEngineShard& cShard = shards[control];
+    QEngineShard& tShard = shards[target];
+    if (cShard.isPlusMinus && !DIRTY(cShard) && !DIRTY(tShard)) {
+        if (!tShard.isPlusMinus) {
+            AntiCNOT(target, control);
+        }
+        return;
+    }
+
     bitLenInt controls[1] = { control };
     bitLenInt controlLen = 1;
     CTRLED_CALL_WRAP(AntiCNOT(CTRL_1_ARGS), X(target), true);

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -25,14 +25,6 @@
         !((norm(shard.amp0) < min_norm) || (norm(shard.amp1) < min_norm)))
 #define DIRTY(shard) (shard.isProbDirty || shard.isPhaseDirty)
 
-#define APPLY_OR_EMULATE(shard, payload)                                                                               \
-    if (shard.unit->GetQubitCount() == 1) {                                                                            \
-        shard.isEmulated = true;                                                                                       \
-    } else {                                                                                                           \
-        EndEmulation(shard);                                                                                           \
-        shard.unit->payload;                                                                                           \
-    }
-
 namespace Qrack {
 
 QUnit::QUnit(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState, qrack_rand_gen_ptr rgp, complex phaseFac,
@@ -1081,7 +1073,9 @@ void QUnit::ApplySinglePhase(const complex topLeft, const complex bottomRight, b
     if (!shard.isPlusMinus) {
         // If the target bit is in a |0>/|1> eigenstate, this gate has no effect.
         if (PHASE_MATTERS(shard)) {
-            APPLY_OR_EMULATE(shard, ApplySinglePhase(topLeft, bottomRight, doCalcNorm, shard.mapped));
+            ApplyOrEmulate(shard, [&](QEngineShard& shard) {
+                shard.unit->ApplySinglePhase(topLeft, bottomRight, doCalcNorm, shard.mapped);
+            });
             shard.amp0 *= topLeft;
             shard.amp1 *= bottomRight;
         }
@@ -1089,7 +1083,7 @@ void QUnit::ApplySinglePhase(const complex topLeft, const complex bottomRight, b
         complex mtrx[4];
         TransformPhase(topLeft, bottomRight, mtrx);
 
-        APPLY_OR_EMULATE(shard, ApplySingleBit(mtrx, doCalcNorm, shard.mapped));
+        ApplyOrEmulate(shard, [&](QEngineShard& shard) { shard.unit->ApplySingleBit(mtrx, doCalcNorm, shard.mapped); });
 
         complex Y0 = shard.amp0;
 
@@ -1105,7 +1099,9 @@ void QUnit::ApplySingleInvert(const complex topRight, const complex bottomLeft, 
     QEngineShard& shard = shards[target];
 
     if (!shard.isPlusMinus) {
-        APPLY_OR_EMULATE(shard, ApplySingleInvert(topRight, bottomLeft, doCalcNorm, shard.mapped));
+        ApplyOrEmulate(shard, [&](QEngineShard& shard) {
+            shard.unit->ApplySingleInvert(topRight, bottomLeft, doCalcNorm, shard.mapped);
+        });
 
         complex tempAmp1 = shard.amp0 * bottomLeft;
         shard.amp0 = shard.amp1 * topRight;
@@ -1114,7 +1110,7 @@ void QUnit::ApplySingleInvert(const complex topRight, const complex bottomLeft, 
         complex mtrx[4];
         TransformInvert(topRight, bottomLeft, mtrx);
 
-        APPLY_OR_EMULATE(shard, ApplySingleBit(mtrx, doCalcNorm, shard.mapped));
+        ApplyOrEmulate(shard, [&](QEngineShard& shard) { shard.unit->ApplySingleBit(mtrx, doCalcNorm, shard.mapped); });
 
         complex Y0 = shard.amp0;
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -995,10 +995,14 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
 {
     QEngineShard& cShard = shards[control];
     QEngineShard& tShard = shards[target];
-    if (cShard.isPlusMinus && !tShard.isPlusMinus && !cShard.isProbDirty &&
-        (norm(cShard.amp0) < min_norm || norm(cShard.amp1) < min_norm)) {
-        CNOT(target, control);
-        return;
+    if (cShard.isPlusMinus && !cShard.isProbDirty && (norm(tShard.amp0) < min_norm || norm(tShard.amp1) < min_norm)) {
+        if (!tShard.isPlusMinus) {
+            CNOT(target, control);
+            return;
+        } else {
+            Swap(control, target);
+            return;
+        }
     }
 
     bitLenInt controls[1] = { control };

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -997,9 +997,7 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
     QEngineShard& cShard = shards[control];
     QEngineShard& tShard = shards[target];
     if (cShard.isPlusMinus && !DIRTY(cShard) && !DIRTY(tShard)) {
-        if (tShard.isPlusMinus) {
-            Swap(control, target);
-        } else {
+        if (!tShard.isPlusMinus) {
             CNOT(target, control);
         }
         return;

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -23,6 +23,7 @@
 #define PHASE_MATTERS(shard)                                                                                           \
     (!randGlobalPhase || shard.isPlusMinus || shard.isProbDirty || shard.isPhaseDirty ||                               \
         !((norm(shard.amp0) < min_norm) || (norm(shard.amp1) < min_norm)))
+#define DIRTY(shard) (shard.isProbDirty || shard.isPhaseDirty)
 
 namespace Qrack {
 
@@ -995,14 +996,13 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
 {
     QEngineShard& cShard = shards[control];
     QEngineShard& tShard = shards[target];
-    if (cShard.isPlusMinus && !cShard.isProbDirty && (norm(tShard.amp0) < min_norm || norm(tShard.amp1) < min_norm)) {
-        if (!tShard.isPlusMinus) {
-            CNOT(target, control);
-            return;
-        } else {
+    if (cShard.isPlusMinus && !DIRTY(cShard) && !DIRTY(tShard)) {
+        if (tShard.isPlusMinus) {
             Swap(control, target);
-            return;
+        } else {
+            CNOT(target, control);
         }
+        return;
     }
 
     bitLenInt controls[1] = { control };

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -999,6 +999,8 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
     if (cShard.isPlusMinus && !DIRTY(cShard) && !DIRTY(tShard)) {
         if (!tShard.isPlusMinus) {
             CNOT(target, control);
+        } else if (norm(tShard.amp0) < min_norm) {
+            std::swap(cShard.amp0, cShard.amp1);
         }
         return;
     }
@@ -1015,6 +1017,10 @@ void QUnit::AntiCNOT(bitLenInt control, bitLenInt target)
     if (cShard.isPlusMinus && !DIRTY(cShard) && !DIRTY(tShard)) {
         if (!tShard.isPlusMinus) {
             AntiCNOT(target, control);
+        } else if (norm(tShard.amp0) < min_norm) {
+            Swap(control, target);
+            tShard.amp0 *= -1;
+            tShard.amp1 *= -1;
         }
         return;
     }

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -993,6 +993,14 @@ void QUnit::TransformInvert(const complex& topRight, const complex& bottomLeft, 
 
 void QUnit::CNOT(bitLenInt control, bitLenInt target)
 {
+    QEngineShard& cShard = shards[control];
+    QEngineShard& tShard = shards[target];
+    if (cShard.isPlusMinus && !tShard.isPlusMinus && !cShard.isProbDirty &&
+        (norm(cShard.amp0) < min_norm || norm(cShard.amp1) < min_norm)) {
+        CNOT(target, control);
+        return;
+    }
+
     bitLenInt controls[1] = { control };
     bitLenInt controlLen = 1;
     CTRLED_CALL_WRAP(CNOT(CTRL_1_ARGS), X(target), false);

--- a/test/benchmarks_main.cpp
+++ b/test/benchmarks_main.cpp
@@ -231,6 +231,5 @@ QInterfaceTestFixture::QInterfaceTestFixture()
     qrack_rand_gen_ptr rng = std::make_shared<qrack_rand_gen>();
     rng->seed(rngSeed);
 
-    qftReg = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 1, 0, rng,
-        complex(ONE_R1, ZERO_R1), enable_normalization, true, false, -1, !disable_hardware_rng);
+    qftReg = NULL;
 }

--- a/test/benchmarks_main.cpp
+++ b/test/benchmarks_main.cpp
@@ -119,7 +119,7 @@ int main(int argc, char* argv[])
 
             // Device RAM should be large enough for 2 times the size of the stateVec, plus some excess.
             max_qubits = log2(maxAlloc);
-            if ((3 * (1U << max_qubits)) > maxMem ) {
+            if ((3 * (1U << max_qubits)) > maxMem) {
                 max_qubits = log2(maxMem / 3);
             }
 #else

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -305,6 +305,19 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_cnot")
     qftReg->CNOT(0, 1);
     qftReg->H(0, 2);
     REQUIRE_THAT(qftReg, HasProbability(0x02));
+
+    qftReg->SetPermutation(0x00);
+    qftReg->H(0, 2);
+    qftReg->Z(0);
+    qftReg->CNOT(0, 1);
+    qftReg->H(0, 2);
+    REQUIRE_THAT(qftReg, HasProbability(0x02));
+
+    qftReg->SetPermutation(0x00);
+    qftReg->H(0, 2);
+    qftReg->CNOT(0, 1);
+    qftReg->H(0, 2);
+    REQUIRE_THAT(qftReg, HasProbability(0x00));
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_anticnot")

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -299,6 +299,12 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_cnot")
     REQUIRE_THAT(qftReg, HasProbability(0x40001));
     qftReg->CNOT(18, 19);
     REQUIRE_THAT(qftReg, HasProbability(0xC0001));
+
+    qftReg->SetPermutation(0x01);
+    qftReg->H(0, 2);
+    qftReg->CNOT(0, 1);
+    qftReg->H(0, 2);
+    REQUIRE_THAT(qftReg, HasProbability(0x02));
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_anticnot")

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -304,14 +304,14 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_cnot")
     qftReg->H(0, 2);
     qftReg->CNOT(0, 1);
     qftReg->H(0, 2);
-    REQUIRE_THAT(qftReg, HasProbability(0x02));
+    REQUIRE_THAT(qftReg, HasProbability(0x01));
 
     qftReg->SetPermutation(0x00);
     qftReg->H(0, 2);
     qftReg->Z(0);
     qftReg->CNOT(0, 1);
     qftReg->H(0, 2);
-    REQUIRE_THAT(qftReg, HasProbability(0x02));
+    REQUIRE_THAT(qftReg, HasProbability(0x01));
 
     qftReg->SetPermutation(0x00);
     qftReg->H(0, 2);

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -330,6 +330,25 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_anticnot")
     REQUIRE_THAT(qftReg, HasProbability(0x00001));
     qftReg->AntiCNOT(18, 19);
     REQUIRE_THAT(qftReg, HasProbability(0x80001));
+
+    qftReg->SetPermutation(0x01);
+    qftReg->H(0, 2);
+    qftReg->AntiCNOT(0, 1);
+    qftReg->H(0, 2);
+    REQUIRE_THAT(qftReg, HasProbability(0x01));
+
+    qftReg->SetPermutation(0x00);
+    qftReg->H(0, 2);
+    qftReg->Z(0);
+    qftReg->AntiCNOT(0, 1);
+    qftReg->H(0, 2);
+    REQUIRE_THAT(qftReg, HasProbability(0x01));
+
+    qftReg->SetPermutation(0x00);
+    qftReg->H(0, 2);
+    qftReg->AntiCNOT(0, 1);
+    qftReg->H(0, 2);
+    REQUIRE_THAT(qftReg, HasProbability(0x00));
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_ccnot")

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -2754,7 +2754,7 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_trydecompose")
     qftReg->SetPermutation(0xb);
     qftReg->H(0, 4);
     qftReg->CNOT(0, 4, 4);
-    REQUIRE(qftReg->TryDecompose(0, 4, qftReg2) == false);
+    REQUIRE(qftReg->TryDecompose(0, 4, qftReg2) == (testEngineType == QINTERFACE_QUNIT));
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_setbit")

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -604,6 +604,18 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_s")
     qftReg->S(1);
     qftReg->H(1);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x01));
+
+    qftReg->SetReg(0, 8, 0x01);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x01));
+    qftReg->H(0);
+    qftReg->S(0);
+    qftReg->H(0);
+    qftReg->H(0);
+    qftReg->S(0);
+    qftReg->S(0);
+    qftReg->S(0);
+    qftReg->H(0);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x01));
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_s_reg")
@@ -626,6 +638,18 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_is")
     qftReg->IS(1);
     qftReg->S(1);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x02));
+
+    qftReg->SetReg(0, 8, 0x01);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x01));
+    qftReg->H(0);
+    qftReg->IS(0);
+    qftReg->H(0);
+    qftReg->H(0);
+    qftReg->IS(0);
+    qftReg->IS(0);
+    qftReg->IS(0);
+    qftReg->H(0);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x01));
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_is_reg")


### PR DESCRIPTION
Per issue #200, it'd be great if QUnit could be a super set of "stabilizer" simulators, ex. supporting a classically efficient Clifford group as CNOT, H, and phase gates, at least. For all QUnit already does, it was missing a (terminologically) "efficient" CNOT implementation. This PR should give it one. In fact, separability unit tests had to be updated to accommodate the fact that QUnit can now maintain a separated representation for cases of CNOT which QEngine types can not separate, since they can only do so along permutation basis rays. In a sense, the CNOT improvement is "ad hoc," in that it has not been generalized to more controls or different gate targets, but it does seems to be an at least minimally complete Clifford group.

The documentation should probably be updated to talk about the generally efficient and inefficient uses of QUnit, but this somewhat difficult to do, and it's frequently improving. Note that gates with arbitrary numbers of controls and arbitrary target gates already were able to avoid entangling control bits that QUnit could determine via caching to be in permutation basis eigenstates, but this optimization was previously prevented by H gates.

In the process of working on the above, I believe I caught an edge case in the "isEmulated"-flag-based optimization of QUnit. (The point of this optimization, at least from where I'm standing today, is to avoid dispatching a unit of work on a GPU or accelerator for literally just 2 amplitudes at a time, when most realistic accelerators obviously have much more than 1 to 2 logical parallel processing elements.) This has been fixed, ultimately without regression.

I thought the edge case bug _was_ going to cause a performance regression, however. Hence, I started tinkering with compensatory optimizations, and I realized I could pull some "phase relevance" optimizations higher in the priority order for QUnit, potentially avoiding unnecessary cache invalidation. By "phase relevance," I mean that phase gates might not lead to "physically measurable differences," i.e. differences in the expectation values of Hermitian operators, under certain caching preconditions, hence phase effects can sometimes be entirely skipped. (It's possible to force consistent accounting of these effects, anyway, by setting the `randomGlobalPhase` option in `QInterface` constructors to `false` as is done with the ProjectQ back end.) Though there's some redundancy with an identical layer in QEngine types underneath, QUnit has internally switched bits between |0>/|1> and |+>/|-> basis as opportune for some time, and the QEngine types might still catch additional optimizations this way by being agnostic to QUnit's intended basis.

I wanted to call attention to the bug fix in particular, with this WIP, but I still want to take some significant time to test the changes. It might also be possible to generalize the CNOT optimization, to an extent.