### PR TITLE
Controlled phase gate optimization; > 30 qubits fix

### DIFF
--- a/examples/ordered_list_search.cpp
+++ b/examples/ordered_list_search.cpp
@@ -32,7 +32,7 @@ int main()
     // At each step of the search, we select the quadrant with bounds that could contain our value. In an ideal
     // noiseless quantum computer, this search should be deterministic.
 
-    int i, j;
+    bitCapInt i, j;
     bitLenInt partStart;
     bitLenInt partLength;
 

--- a/examples/quantum_perceptron.cpp
+++ b/examples/quantum_perceptron.cpp
@@ -55,7 +55,7 @@ int main()
     }
 
     // Now, we prepare a superposition of all available powers of 2, to predict.
-    bitLenInt* powersOf2 = new bitLenInt[ControlCount];
+    unsigned char* powersOf2 = new unsigned char[ControlCount];
     for (bitLenInt i = 0; i < ControlCount; i++) {
         powersOf2[i] = 1U << i;
     }

--- a/include/common/qrack_types.hpp
+++ b/include/common/qrack_types.hpp
@@ -18,8 +18,10 @@
 #define bitLenInt uint8_t
 #if ENABLE_PURE32
 #define bitCapInt uint32_t
+#define ONE_BCI 1U
 #else
 #define bitCapInt uint64_t
+#define ONE_BCI 1ULL
 #endif
 #define bitsInByte 8
 #define qrack_rand_gen std::mt19937_64

--- a/include/common/qrack_types.hpp
+++ b/include/common/qrack_types.hpp
@@ -15,11 +15,10 @@
 #include <memory>
 #include <random>
 
+#define bitLenInt uint8_t
 #if ENABLE_PURE32
-#define bitLenInt uint32_t
 #define bitCapInt uint32_t
 #else
-#define bitLenInt uint64_t
 #define bitCapInt uint64_t
 #endif
 #define bitsInByte 8

--- a/include/common/qrack_types.hpp
+++ b/include/common/qrack_types.hpp
@@ -15,10 +15,11 @@
 #include <memory>
 #include <random>
 
-#define bitLenInt uint8_t
 #if ENABLE_PURE32
+#define bitLenInt uint32_t
 #define bitCapInt uint32_t
 #else
+#define bitLenInt uint64_t
 #define bitCapInt uint64_t
 #endif
 #define bitsInByte 8

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -36,7 +36,13 @@ bool isOverflowAdd(bitCapInt inOutInt, bitCapInt inInt, const bitCapInt& signMas
 bool isOverflowSub(bitCapInt inOutInt, bitCapInt inInt, const bitCapInt& signMask, const bitCapInt& lengthPower);
 bitCapInt pushApartBits(const bitCapInt& perm, const bitCapInt* skipPowers, const bitLenInt skipPowersCount);
 bitCapInt intPow(bitCapInt base, bitCapInt power);
-inline bitCapInt bitRegMask(const bitLenInt& start, const bitLenInt& length) { return ((1U << length) - 1U) << start; }
+inline bitCapInt pow2(const bitLenInt& p) { return 1UL << p; }
+inline bitCapInt pow2Mask(const bitLenInt& p) { return (1UL << p) - 1UL; }
+inline bitCapInt bitSlice(const bitLenInt& bit, const bitCapInt& source) { return (1UL << bit) & source; }
+inline bitCapInt bitRegMask(const bitLenInt& start, const bitLenInt& length)
+{
+    return ((1UL << length) - 1UL) << start;
+}
 
 class QInterface;
 typedef std::shared_ptr<QInterface> QInterfacePtr;

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -102,7 +102,7 @@ protected:
     virtual void SetQubitCount(bitLenInt qb)
     {
         qubitCount = qb;
-        maxQPower = 1 << qubitCount;
+        maxQPower = 1U << qubitCount;
     }
 
     virtual void SetRandomSeed(uint32_t seed) { rand_generator->seed(seed); }

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -36,12 +36,12 @@ bool isOverflowAdd(bitCapInt inOutInt, bitCapInt inInt, const bitCapInt& signMas
 bool isOverflowSub(bitCapInt inOutInt, bitCapInt inInt, const bitCapInt& signMask, const bitCapInt& lengthPower);
 bitCapInt pushApartBits(const bitCapInt& perm, const bitCapInt* skipPowers, const bitLenInt skipPowersCount);
 bitCapInt intPow(bitCapInt base, bitCapInt power);
-inline bitCapInt pow2(const bitLenInt& p) { return 1UL << p; }
-inline bitCapInt pow2Mask(const bitLenInt& p) { return (1UL << p) - 1UL; }
-inline bitCapInt bitSlice(const bitLenInt& bit, const bitCapInt& source) { return (1UL << bit) & source; }
+inline bitCapInt pow2(const bitLenInt& p) { return 1ULL << p; }
+inline bitCapInt pow2Mask(const bitLenInt& p) { return (1ULL << p) - 1ULL; }
+inline bitCapInt bitSlice(const bitLenInt& bit, const bitCapInt& source) { return (1ULL << bit) & source; }
 inline bitCapInt bitRegMask(const bitLenInt& start, const bitLenInt& length)
 {
-    return ((1UL << length) - 1UL) << start;
+    return ((1ULL << length) - 1ULL) << start;
 }
 
 class QInterface;
@@ -109,7 +109,7 @@ protected:
     virtual void SetQubitCount(bitLenInt qb)
     {
         qubitCount = qb;
-        maxQPower = 1U << qubitCount;
+        maxQPower = pow2(qubitCount);
     }
 
     virtual void SetRandomSeed(uint32_t seed) { rand_generator->seed(seed); }

--- a/src/common/parallel_for.cpp
+++ b/src/common/parallel_for.cpp
@@ -142,7 +142,7 @@ void ParallelFor::par_for_skip(
 void ParallelFor::par_for_mask(
     const bitCapInt begin, const bitCapInt end, const bitCapInt* maskArray, const bitLenInt maskLen, ParallelFunc fn)
 {
-    for (int i = 1; i < maskLen; i++) {
+    for (bitLenInt i = 1; i < maskLen; i++) {
         if (maskArray[i] < maskArray[i - 1]) {
             throw std::invalid_argument("Masks must be ordered by size");
         }
@@ -150,12 +150,12 @@ void ParallelFor::par_for_mask(
 
     /* Pre-calculate the masks to simplify the increment function later. */
     bitCapInt** masks = new bitCapInt*[maskLen];
-    for (int i = 0; i < maskLen; i++) {
+    for (bitLenInt i = 0; i < maskLen; i++) {
         masks[i] = new bitCapInt[2];
     }
 
     bool onlyLow = true;
-    for (int i = 0; i < maskLen; i++) {
+    for (bitLenInt i = 0; i < maskLen; i++) {
         masks[i][0] = maskArray[i] - 1; // low mask
         masks[i][1] = (~(masks[i][0] + maskArray[i])); // high mask
         if (maskArray[maskLen - i - 1] != (end >> (i + 1))) {
@@ -169,7 +169,7 @@ void ParallelFor::par_for_mask(
     } else {
         incFn = [&masks, maskLen](bitCapInt i, int cpu) {
             /* Push i apart, one mask at a time. */
-            for (int m = 0; m < maskLen; m++) {
+            for (bitLenInt m = 0; m < maskLen; m++) {
                 i = ((i << 1U) & masks[m][1]) | (i & masks[m][0]);
             }
             return i;
@@ -178,7 +178,7 @@ void ParallelFor::par_for_mask(
         par_for_inc(begin, (end - begin) >> maskLen, incFn, fn);
     }
 
-    for (int i = 0; i < maskLen; i++) {
+    for (bitLenInt i = 0; i < maskLen; i++) {
         delete[] masks[i];
     }
     delete[] masks;

--- a/src/common/parallel_for.cpp
+++ b/src/common/parallel_for.cpp
@@ -124,7 +124,7 @@ void ParallelFor::par_for_skip(
         return;
     }
 
-    bitCapInt lowMask = skipMask - 1;
+    bitCapInt lowMask = skipMask - 1UL;
     bitCapInt highMask = ~lowMask;
 
     IncrementFunc incFn;
@@ -170,7 +170,7 @@ void ParallelFor::par_for_mask(
         incFn = [&masks, maskLen](bitCapInt i, int cpu) {
             /* Push i apart, one mask at a time. */
             for (int m = 0; m < maskLen; m++) {
-                i = ((i << 1) & masks[m][1]) | (i & masks[m][0]);
+                i = ((i << 1U) & masks[m][1]) | (i & masks[m][0]);
             }
             return i;
         };

--- a/src/common/qengine.cl
+++ b/src/common/qengine.cl
@@ -60,21 +60,21 @@ inline real1 arg(const cmplx cmp)
     iHigh = lcv;                                                                     \
     i = 0U;                                                                          \
     for (p = 0U; p < BITCOUNT_ARG; p++) {                                            \
-        iLow = iHigh & (qPowersSorted[p] - 1U);                                      \
+        iLow = iHigh & (qPowersSorted[p] - ONE);                                      \
         i |= iLow;                                                                   \
-        iHigh = (iHigh ^ iLow) << 1U;                                                \
+        iHigh = (iHigh ^ iLow) << ONE;                                                \
     }                                                                                \
     i |= iHigh
 
 #define PUSH_APART_1()                                                               \
     i = lcv & qMask;                                                                 \
-    i |= (lcv ^ i) << 1U
+    i |= (lcv ^ i) << ONE
 
 #define PUSH_APART_2()                                                               \
     i = lcv & qMask1;                                                                \
-    iHigh = (lcv ^ i) << 1U;                                                         \
+    iHigh = (lcv ^ i) << ONE;                                                         \
     iLow = iHigh & qMask2;                                                           \
-    i |= iLow | ((iHigh ^ iLow) << 1U)
+    i |= iLow | ((iHigh ^ iLow) << ONE)
 
 #define APPLY_AND_OUT()                                                              \
     mulRes.lo = stateVec[i | OFFSET1_ARG];                                           \
@@ -98,7 +98,7 @@ inline real1 arg(const cmplx cmp)
     locNthreads = get_local_size(0);                                                 \
     lProbBuffer[locID] = partNrm;                                                    \
                                                                                      \
-    for (lcv = (locNthreads >> 1U); lcv > 0U; lcv >>= 1U) {                          \
+    for (lcv = (locNthreads >> ONE); lcv > 0U; lcv >>= ONE) {                          \
         barrier(CLK_LOCAL_MEM_FENCE);                                                \
         if (locID < lcv) {                                                           \
             lProbBuffer[locID] += lProbBuffer[locID + lcv];                          \
@@ -284,7 +284,7 @@ void kernel uniformlycontrolled(global cmplx* stateVec, constant bitCapInt* bitC
 
     bitCapInt maxI = bitCapIntPtr[0];
     bitCapInt targetPower = bitCapIntPtr[1];
-    bitCapInt targetMask = targetPower - 1;
+    bitCapInt targetMask = targetPower - ONE;
     bitCapInt controlLen = bitCapIntPtr[2];
     bitCapInt mtrxSkipLen = bitCapIntPtr[3];
     bitCapInt mtrxSkipValueMask = bitCapIntPtr[4];
@@ -301,21 +301,21 @@ void kernel uniformlycontrolled(global cmplx* stateVec, constant bitCapInt* bitC
 
     for (lcv = ID; lcv < maxI; lcv += Nthreads) {
         i = lcv & targetMask;
-        i |= (lcv ^ i) << 1U;
+        i |= (lcv ^ i) << ONE;
 
         offset = 0;
         for (p = 0; p < controlLen; p++) {
             if (i & qPowers[p]) {
-                offset |= 1U << p;
+                offset |= ONE << p;
             }
         }
 
         jHigh = offset;
         j = 0;
         for (p = 0; p < mtrxSkipLen; p++) {
-            jLow = jHigh & (qPowers[controlLen + p] - 1U);
+            jLow = jHigh & (qPowers[controlLen + p] - ONE);
             j |= jLow;
-            jHigh = (jHigh ^ jLow) << 1U;
+            jHigh = (jHigh ^ jLow) << ONE;
         }
         j |= jHigh;
         offset = j | mtrxSkipValueMask;
@@ -335,7 +335,7 @@ void kernel uniformlycontrolled(global cmplx* stateVec, constant bitCapInt* bitC
     locNthreads = get_local_size(0);
     lProbBuffer[locID] = partNrm;
     
-    for (lcv = (locNthreads >> 1U); lcv > 0U; lcv >>= 1U) {
+    for (lcv = (locNthreads >> ONE); lcv > 0U; lcv >>= ONE) {
         barrier(CLK_LOCAL_MEM_FENCE);
         if (locID < lcv) {
             lProbBuffer[locID] += lProbBuffer[locID + lcv];
@@ -415,7 +415,7 @@ void kernel decomposeprob(global cmplx* stateVec, constant bitCapInt* bitCapIntP
     real1 partProb, nrm, firstAngle, currentAngle;
 
     for (lcv = ID; lcv < remainderPower; lcv += Nthreads) {
-        j = lcv & ((1U << start) - 1);
+        j = lcv & ((ONE << start) - ONE);
         j |= (lcv ^ j) << len;
 
         partProb = ZERO_R1;
@@ -447,7 +447,7 @@ void kernel decomposeprob(global cmplx* stateVec, constant bitCapInt* bitCapIntP
         firstAngle = -16 * PI_R1;
 
         for (k = 0U; k < remainderPower; k++) {
-            l = k & ((1U << start) - 1);
+            l = k & ((ONE << start) - ONE);
             l |= (k ^ l) << len;
             l = j | l;
             
@@ -490,7 +490,7 @@ void kernel prob(global cmplx* stateVec, constant bitCapInt* bitCapIntPtr, globa
     bitCapInt2 args = vload2(0, bitCapIntPtr);
     bitCapInt maxI = args.x;
     bitCapInt qPower = args.y;
-    bitCapInt qMask = qPower - 1U;
+    bitCapInt qMask = qPower - ONE;
 
     real1 oneChancePart = ZERO_R1;
     cmplx amp;
@@ -498,7 +498,7 @@ void kernel prob(global cmplx* stateVec, constant bitCapInt* bitCapIntPtr, globa
 
     for (lcv = ID; lcv < maxI; lcv += Nthreads) {
         i = lcv & qMask;
-        i |= ((lcv ^ i) << 1U) | qPower;
+        i |= ((lcv ^ i) << ONE) | qPower;
         amp = stateVec[i];
         oneChancePart += dot(amp, amp);
     }
@@ -507,7 +507,7 @@ void kernel prob(global cmplx* stateVec, constant bitCapInt* bitCapIntPtr, globa
     locNthreads = get_local_size(0);
     lProbBuffer[locID] = oneChancePart;
     
-    for (lcv = (locNthreads >> 1U); lcv > 0U; lcv >>= 1U) {
+    for (lcv = (locNthreads >> ONE); lcv > 0U; lcv >>= ONE) {
         barrier(CLK_LOCAL_MEM_FENCE);
         if (locID < lcv) {
             lProbBuffer[locID] += lProbBuffer[locID + lcv];
@@ -530,7 +530,7 @@ void kernel probreg(global cmplx* stateVec, constant bitCapInt* bitCapIntPtr, gl
     bitCapInt perm = args.y;
     bitCapInt start = args.z;
     bitCapInt len = args.w;
-    bitCapInt qMask = (1U << start) - 1U;
+    bitCapInt qMask = (ONE << start) - ONE;
 
     real1 oneChancePart = ZERO_R1;
     cmplx amp;
@@ -547,7 +547,7 @@ void kernel probreg(global cmplx* stateVec, constant bitCapInt* bitCapIntPtr, gl
     locNthreads = get_local_size(0);
     lProbBuffer[locID] = oneChancePart;
     
-    for (lcv = (locNthreads >> 1U); lcv > 0U; lcv >>= 1U) {
+    for (lcv = (locNthreads >> ONE); lcv > 0U; lcv >>= ONE) {
         barrier(CLK_LOCAL_MEM_FENCE);
         if (locID < lcv) {
             lProbBuffer[locID] += lProbBuffer[locID + lcv];
@@ -570,7 +570,7 @@ void kernel probregall(global cmplx* stateVec, constant bitCapInt* bitCapIntPtr,
     bitCapInt maxJ = args.y;
     bitCapInt start = args.z;
     bitCapInt len = args.w;
-    bitCapInt qMask = (1U << start) - 1U;
+    bitCapInt qMask = (ONE << start) - ONE;
 
     real1 oneChancePart;
     cmplx amp;
@@ -610,9 +610,9 @@ void kernel probmask(global cmplx* stateVec, constant bitCapInt* bitCapIntPtr, g
         iHigh = lcv;
         i = 0U;
         for (p = 0U; p < len; p++) {
-            iLow = iHigh & (qPowers[p] - 1U);
+            iLow = iHigh & (qPowers[p] - ONE);
             i |= iLow;
-            iHigh = (iHigh ^ iLow) << 1U;
+            iHigh = (iHigh ^ iLow) << ONE;
         }
         i |= iHigh;
 
@@ -624,7 +624,7 @@ void kernel probmask(global cmplx* stateVec, constant bitCapInt* bitCapIntPtr, g
     locNthreads = get_local_size(0);
     lProbBuffer[locID] = oneChancePart;
     
-    for (lcv = (locNthreads >> 1U); lcv > 0U; lcv >>= 1U) {
+    for (lcv = (locNthreads >> ONE); lcv > 0U; lcv >>= ONE) {
         barrier(CLK_LOCAL_MEM_FENCE);
         if (locID < lcv) {
             lProbBuffer[locID] += lProbBuffer[locID + lcv];
@@ -657,9 +657,9 @@ void kernel probmaskall(global cmplx* stateVec, constant bitCapInt* bitCapIntPtr
         iHigh = lcv1;
         perm = 0U;
         for (p = 0U; p < skipLen; p++) {
-            iLow = iHigh & (qPowersSkip[p] - 1U);
+            iLow = iHigh & (qPowersSkip[p] - ONE);
             perm |= iLow;
-            iHigh = (iHigh ^ iLow) << 1U;
+            iHigh = (iHigh ^ iLow) << ONE;
         }
         perm |= iHigh;
 
@@ -668,9 +668,9 @@ void kernel probmaskall(global cmplx* stateVec, constant bitCapInt* bitCapIntPtr
             iHigh = lcv2;
             i = 0U;
             for (p = 0U; p < maskLen; p++) {
-                iLow = iHigh & (qPowersMask[p] - 1U);
+                iLow = iHigh & (qPowersMask[p] - ONE);
                 i |= iLow;
-                iHigh = (iHigh ^ iLow) << 1U;
+                iHigh = (iHigh ^ iLow) << ONE;
             }
             i |= iHigh;
 
@@ -689,7 +689,7 @@ void kernel rol(global cmplx* stateVec, constant bitCapInt* bitCapIntPtr, global
     bitCapInt maxI = bitCapIntPtr[0];
     bitCapInt regMask = bitCapIntPtr[1];
     bitCapInt otherMask = bitCapIntPtr[2];
-    bitCapInt lengthMask = bitCapIntPtr[3] - 1U;
+    bitCapInt lengthMask = bitCapIntPtr[3] - ONE;
     bitCapInt start = bitCapIntPtr[4];
     bitCapInt shift = bitCapIntPtr[5];
     bitCapInt length = bitCapIntPtr[6];
@@ -711,7 +711,7 @@ void kernel inc(global cmplx* stateVec, constant bitCapInt* bitCapIntPtr, global
     bitCapInt maxI = bitCapIntPtr[0];
     bitCapInt inOutMask = bitCapIntPtr[1];
     bitCapInt otherMask = bitCapIntPtr[2];
-    bitCapInt lengthMask = bitCapIntPtr[3] - 1U;
+    bitCapInt lengthMask = bitCapIntPtr[3] - ONE;
     bitCapInt inOutStart = bitCapIntPtr[4];
     bitCapInt toAdd = bitCapIntPtr[5];
     for (i = ID; i < maxI; i += Nthreads) {
@@ -727,7 +727,7 @@ void kernel cinc(global cmplx* stateVec, constant bitCapInt* bitCapIntPtr, globa
     bitCapInt maxI = bitCapIntPtr[0];
     bitCapInt inOutMask = bitCapIntPtr[1];
     bitCapInt otherMask = bitCapIntPtr[2];
-    bitCapInt lengthMask = bitCapIntPtr[3] - 1U;
+    bitCapInt lengthMask = bitCapIntPtr[3] - ONE;
     bitCapInt inOutStart = bitCapIntPtr[4];
     bitCapInt toAdd = bitCapIntPtr[5];
     bitCapInt controlLen = bitCapIntPtr[6];
@@ -739,9 +739,9 @@ void kernel cinc(global cmplx* stateVec, constant bitCapInt* bitCapIntPtr, globa
         iHigh = lcv;
         i = 0U;
         for (p = 0U; p < controlLen; p++) {
-            iLow = iHigh & (controlPowers[p] - 1U);
+            iLow = iHigh & (controlPowers[p] - ONE);
             i |= iLow;
-            iHigh = (iHigh ^ iLow) << 1U;
+            iHigh = (iHigh ^ iLow) << ONE;
         }
         i |= iHigh;
 
@@ -758,14 +758,14 @@ void kernel incdecc(global cmplx* stateVec, constant bitCapInt* bitCapIntPtr, gl
     bitCapInt maxI = bitCapIntPtr[0];
     bitCapInt inOutMask = bitCapIntPtr[1];
     bitCapInt otherMask = bitCapIntPtr[2];
-    bitCapInt lengthMask = bitCapIntPtr[3] - 1U;
+    bitCapInt lengthMask = bitCapIntPtr[3] - ONE;
     bitCapInt carryMask = bitCapIntPtr[4];
     bitCapInt inOutStart = bitCapIntPtr[5];
     bitCapInt toMod = bitCapIntPtr[6];
     bitCapInt otherRes, inOutRes, outInt, outRes, i;
     for (lcv = ID; lcv < maxI; lcv += Nthreads) {
-        i = lcv & (carryMask - 1U);
-        i |= (lcv ^ i) << 1U;
+        i = lcv & (carryMask - ONE);
+        i |= (lcv ^ i) << ONE;
 
         otherRes = i & otherMask;
         inOutRes = i & inOutMask;
@@ -789,7 +789,7 @@ void kernel incs(global cmplx* stateVec, constant bitCapInt* bitCapIntPtr, globa
     bitCapInt inOutMask = bitCapIntPtr[1];
     bitCapInt otherMask = bitCapIntPtr[2];
     bitCapInt lengthPower = bitCapIntPtr[3];
-    bitCapInt signMask = lengthPower >> 1U;
+    bitCapInt signMask = lengthPower >> ONE;
     bitCapInt overflowMask = bitCapIntPtr[4];
     bitCapInt inOutStart = bitCapIntPtr[5];
     bitCapInt toAdd = bitCapIntPtr[6];
@@ -810,8 +810,8 @@ void kernel incs(global cmplx* stateVec, constant bitCapInt* bitCapIntPtr, globa
         isOverflow = false;
         // Both negative:
         if (inOutInt & inInt & signMask) {
-            inOutInt = ((~inOutInt) & (lengthPower - 1U)) + 1U;
-            inInt = ((~inInt) & (lengthPower - 1U)) + 1U;
+            inOutInt = ((~inOutInt) & (lengthPower - ONE)) + ONE;
+            inInt = ((~inInt) & (lengthPower - ONE)) + ONE;
             if ((inOutInt + inInt) > signMask) {
                 isOverflow = true;
             }
@@ -839,7 +839,7 @@ void kernel incdecsc1(global cmplx* stateVec, constant bitCapInt* bitCapIntPtr, 
     bitCapInt inOutMask = bitCapIntPtr[1];
     bitCapInt otherMask = bitCapIntPtr[2];
     bitCapInt lengthPower = bitCapIntPtr[3];
-    bitCapInt signMask = lengthPower >> 1U;
+    bitCapInt signMask = lengthPower >> ONE;
     bitCapInt overflowMask = bitCapIntPtr[4];
     bitCapInt carryMask = bitCapIntPtr[5];
     bitCapInt inOutStart = bitCapIntPtr[6];
@@ -848,8 +848,8 @@ void kernel incdecsc1(global cmplx* stateVec, constant bitCapInt* bitCapIntPtr, 
     cmplx amp;
     bool isOverflow;
     for (lcv = ID; lcv < maxI; lcv += Nthreads) {
-        i = lcv & (carryMask - 1U);
-        i |= (lcv ^ i) << 1U;
+        i = lcv & (carryMask - ONE);
+        i |= (lcv ^ i) << ONE;
 
         otherRes = i & otherMask;
         inOutRes = i & inOutMask;
@@ -864,8 +864,8 @@ void kernel incdecsc1(global cmplx* stateVec, constant bitCapInt* bitCapIntPtr, 
         bool isOverflow = false;
         // Both negative:
         if (inOutInt & inInt & signMask) {
-            inOutInt = ((~inOutInt) & (lengthPower - 1U)) + 1U;
-            inInt = ((~inInt) & (lengthPower - 1U)) + 1U;
+            inOutInt = ((~inOutInt) & (lengthPower - ONE)) + ONE;
+            inInt = ((~inInt) & (lengthPower - ONE)) + ONE;
             if ((inOutInt + inInt) > signMask)
                 isOverflow = true;
         }
@@ -891,7 +891,7 @@ void kernel incdecsc2(global cmplx* stateVec, constant bitCapInt* bitCapIntPtr, 
     bitCapInt inOutMask = bitCapIntPtr[1];
     bitCapInt otherMask = bitCapIntPtr[2];
     bitCapInt lengthPower = bitCapIntPtr[3];
-    bitCapInt signMask = lengthPower >> 1U;
+    bitCapInt signMask = lengthPower >> ONE;
     bitCapInt carryMask = bitCapIntPtr[4];
     bitCapInt inOutStart = bitCapIntPtr[5];
     bitCapInt toAdd = bitCapIntPtr[6];
@@ -899,8 +899,8 @@ void kernel incdecsc2(global cmplx* stateVec, constant bitCapInt* bitCapIntPtr, 
     cmplx amp;
     bool isOverflow;
     for (lcv = ID; lcv < maxI; lcv += Nthreads) {
-        i = lcv & (carryMask - 1U);
-        i |= (lcv ^ i) << 1U;
+        i = lcv & (carryMask - ONE);
+        i |= (lcv ^ i) << ONE;
 
         otherRes = i & otherMask;
         inOutRes = i & inOutMask;
@@ -915,8 +915,8 @@ void kernel incdecsc2(global cmplx* stateVec, constant bitCapInt* bitCapIntPtr, 
         bool isOverflow = false;
         // Both negative:
         if (inOutInt & inInt & (signMask)) {
-            inOutInt = ((~inOutInt) & (lengthPower - 1U)) + 1U;
-            inInt = ((~inInt) & (lengthPower - 1U)) + 1U;
+            inOutInt = ((~inOutInt) & (lengthPower - ONE)) + ONE;
+            inInt = ((~inInt) & (lengthPower - ONE)) + ONE;
             if ((inOutInt + inInt) > signMask)
                 isOverflow = true;
         }
@@ -1020,8 +1020,8 @@ void kernel incdecbcdc(global cmplx* stateVec, constant bitCapInt* bitCapIntPtr,
     bool isValid;
     cmplx amp1, amp2;
     for (lcv = ID; lcv < maxI; lcv += Nthreads) {
-        i = lcv & (carryMask - 1U);
-        i |= (lcv ^ i) << 1U;
+        i = lcv & (carryMask - ONE);
+        i |= (lcv ^ i) << ONE;
 
         otherRes = i & otherMask;
         partToAdd = toAdd;
@@ -1087,7 +1087,7 @@ void kernel mul(global cmplx* stateVec, constant bitCapInt* bitCapIntPtr, global
     bitCapInt carryMask = bitCapIntPtr[3];
     bitCapInt otherMask = bitCapIntPtr[4];
     bitCapInt len = bitCapIntPtr[5];
-    bitCapInt lowMask = (1U << len) - 1U;
+    bitCapInt lowMask = (ONE << len) - ONE;
     bitCapInt highMask = lowMask << len;
     bitCapInt inOutStart = bitCapIntPtr[6];
     bitCapInt carryStart = bitCapIntPtr[7];
@@ -1116,7 +1116,7 @@ void kernel div(global cmplx* stateVec, constant bitCapInt* bitCapIntPtr, global
     bitCapInt carryMask = bitCapIntPtr[3];
     bitCapInt otherMask = bitCapIntPtr[4];
     bitCapInt len = bitCapIntPtr[5];
-    bitCapInt lowMask = (1U << len) - 1U;
+    bitCapInt lowMask = (ONE << len) - ONE;
     bitCapInt highMask = lowMask << len;
     bitCapInt inOutStart = bitCapIntPtr[6];
     bitCapInt carryStart = bitCapIntPtr[7];
@@ -1145,7 +1145,7 @@ void kernel mulmodnout(global cmplx* stateVec, constant bitCapInt* bitCapIntPtr,
     bitCapInt outMask = bitCapIntPtr[3];
     bitCapInt otherMask = bitCapIntPtr[4];
     bitCapInt len = bitCapIntPtr[5];
-    bitCapInt lowMask = (1U << len) - 1U;
+    bitCapInt lowMask = (ONE << len) - ONE;
     bitCapInt inStart = bitCapIntPtr[6];
     bitCapInt outStart = bitCapIntPtr[7];
     bitCapInt skipMask = bitCapIntPtr[8];
@@ -1175,7 +1175,7 @@ void kernel powmodnout(global cmplx* stateVec, constant bitCapInt* bitCapIntPtr,
     bitCapInt outMask = bitCapIntPtr[3];
     bitCapInt otherMask = bitCapIntPtr[4];
     bitCapInt len = bitCapIntPtr[5];
-    bitCapInt lowMask = (1U << len) - 1U;
+    bitCapInt lowMask = (ONE << len) - ONE;
     bitCapInt inStart = bitCapIntPtr[6];
     bitCapInt outStart = bitCapIntPtr[7];
     bitCapInt skipMask = bitCapIntPtr[8];
@@ -1218,11 +1218,11 @@ void kernel fulladd(global cmplx* stateVec, constant bitCapInt* bitCapIntPtr)
 
     bitCapInt qMask1, qMask2;
     if (carryInSumOutMask < carryOutMask) {
-        qMask1 = carryInSumOutMask - 1U;
-        qMask2 = carryOutMask - 1U;
+        qMask1 = carryInSumOutMask - ONE;
+        qMask2 = carryOutMask - ONE;
     } else {
-        qMask1 = carryOutMask - 1U;
-        qMask2 = carryInSumOutMask - 1U;
+        qMask1 = carryOutMask - ONE;
+        qMask2 = carryInSumOutMask - ONE;
     }
 
     cmplx ins0c0, ins0c1, ins1c0, ins1c1;
@@ -1298,11 +1298,11 @@ void kernel ifulladd(global cmplx* stateVec, constant bitCapInt* bitCapIntPtr)
 
     bitCapInt qMask1, qMask2;
     if (carryInSumOutMask < carryOutMask) {
-        qMask1 = carryInSumOutMask - 1U;
-        qMask2 = carryOutMask - 1U;
+        qMask1 = carryInSumOutMask - ONE;
+        qMask2 = carryOutMask - ONE;
     } else {
-        qMask1 = carryOutMask - 1U;
-        qMask2 = carryInSumOutMask - 1U;
+        qMask1 = carryOutMask - ONE;
+        qMask2 = carryInSumOutMask - ONE;
     }
 
     cmplx ins0c0, ins0c1, ins1c0, ins1c1;
@@ -1369,18 +1369,18 @@ void kernel ifulladd(global cmplx* stateVec, constant bitCapInt* bitCapIntPtr)
     iHigh = lcv;                                                                     \
     i = 0U;                                                                          \
     for (p = 0U; p < (controlLen + len); p++) {                                      \
-        iLow = iHigh & (controlPowers[p] - 1U);                                      \
+        iLow = iHigh & (controlPowers[p] - ONE);                                      \
         i |= iLow;                                                                   \
-        iHigh = (iHigh ^ iLow) << 1U;                                                \
+        iHigh = (iHigh ^ iLow) << ONE;                                                \
     }                                                                                \
     i |= iHigh;                                                                      \
 
 #define CMOD_FINISH()                                                                \
     nStateVec[i] = stateVec[i];                                                      \
-    for (j = 1U; j < ((1U << controlLen) - 1U); j++) {                               \
+    for (j = ONE; j < ((ONE << controlLen) - ONE); j++) {                               \
         partControlMask = 0U;                                                        \
         for (k = 0U; k < controlLen; k++) {                                          \
-            if (j & (1U << k)) {                                                     \
+            if (j & (ONE << k)) {                                                     \
                 partControlMask |= controlPowers[controlLen + len + k];              \
             }                                                                        \
         }                                                                            \
@@ -1400,7 +1400,7 @@ void kernel cmul(global cmplx* stateVec, constant bitCapInt* bitCapIntPtr, globa
     bitCapInt carryMask = bitCapIntPtr[5];
     bitCapInt otherMask = bitCapIntPtr[6];
     bitCapInt len = bitCapIntPtr[7];
-    bitCapInt lowMask = (1U << len) - 1U;
+    bitCapInt lowMask = (ONE << len) - ONE;
     bitCapInt highMask = lowMask << len;
     bitCapInt inOutStart = bitCapIntPtr[8];
     bitCapInt carryStart = bitCapIntPtr[9];
@@ -1432,7 +1432,7 @@ void kernel cdiv(global cmplx* stateVec, constant bitCapInt* bitCapIntPtr, globa
     bitCapInt carryMask = bitCapIntPtr[5];
     bitCapInt otherMask = bitCapIntPtr[6];
     bitCapInt len = bitCapIntPtr[7];
-    bitCapInt lowMask = (1 << len) - 1;
+    bitCapInt lowMask = (ONE << len) - ONE;
     bitCapInt highMask = lowMask << len;
     bitCapInt inOutStart = bitCapIntPtr[8];
     bitCapInt carryStart = bitCapIntPtr[9];
@@ -1464,11 +1464,11 @@ void kernel cmulmodnout(global cmplx* stateVec, constant bitCapInt* bitCapIntPtr
     bitCapInt outMask = bitCapIntPtr[5];
     bitCapInt modN = bitCapIntPtr[6];
     bitCapInt len = bitCapIntPtr[7];
-    bitCapInt lowMask = (1U << len) - 1U;
+    bitCapInt lowMask = (ONE << len) - ONE;
     bitCapInt inStart = bitCapIntPtr[8];
     bitCapInt outStart = bitCapIntPtr[9];
 
-    bitCapInt otherMask = (maxI - 1U) ^ (inMask | outMask | controlMask);
+    bitCapInt otherMask = (maxI - ONE) ^ (inMask | outMask | controlMask);
     maxI >>= (controlLen + len);
 
     bitCapInt otherRes, outRes, inRes;
@@ -1501,11 +1501,11 @@ void kernel cpowmodnout(global cmplx* stateVec, constant bitCapInt* bitCapIntPtr
     bitCapInt outMask = bitCapIntPtr[5];
     bitCapInt modN = bitCapIntPtr[6];
     bitCapInt len = bitCapIntPtr[7];
-    bitCapInt lowMask = (1U << len) - 1U;
+    bitCapInt lowMask = (ONE << len) - ONE;
     bitCapInt inStart = bitCapIntPtr[8];
     bitCapInt outStart = bitCapIntPtr[9];
 
-    bitCapInt otherMask = (maxI - 1U) ^ (inMask | outMask | controlMask);
+    bitCapInt otherMask = (maxI - ONE) ^ (inMask | outMask | controlMask);
     maxI >>= (controlLen + len);
 
     bitCapInt otherRes, outRes, inRes, inInt;
@@ -1547,7 +1547,7 @@ void kernel indexedLda(
     bitCapInt outputStart = bitCapIntPtr[3];
     bitCapInt valueBytes = bitCapIntPtr[4];
     bitCapInt valueLength = bitCapIntPtr[5];
-    bitCapInt lowMask = (1U << outputStart) - 1U;
+    bitCapInt lowMask = (ONE << outputStart) - ONE;
     bitCapInt inputRes, inputInt, outputRes, outputInt;
     bitCapInt i, iLow, iHigh, j;
     for (lcv = ID; lcv < maxI; lcv += Nthreads) {
@@ -1586,8 +1586,8 @@ void kernel indexedAdc(
     bitCapInt i, iLow, iHigh, j;
     for (lcv = ID; lcv < maxI; lcv += Nthreads) {
         iHigh = lcv;
-        iLow = iHigh & (carryMask - 1U);
-        i = iLow | ((iHigh ^ iLow) << 1U);
+        iLow = iHigh & (carryMask - ONE);
+        i = iLow | ((iHigh ^ iLow) << ONE);
 
         otherRes = i & otherMask;
         inputRes = i & inputMask;
@@ -1630,8 +1630,8 @@ void kernel indexedSbc(
     bitCapInt i, iLow, iHigh, j;
     for (lcv = ID; lcv < maxI; lcv += Nthreads) {
         iHigh = lcv;
-        iLow = iHigh & (carryMask - 1U);
-        i = iLow | ((iHigh ^ iLow) << 1U);
+        iLow = iHigh & (carryMask - ONE);
+        i = iLow | ((iHigh ^ iLow) << ONE);
 
         otherRes = i & otherMask;
         inputRes = i & inputMask;
@@ -1690,7 +1690,7 @@ void kernel updatenorm(global cmplx* stateVec, constant bitCapInt* bitCapIntPtr,
     locID = get_local_id(0);
     locNthreads = get_local_size(0);
     lProbBuffer[locID] = partNrm;
-    for (lcv = (locNthreads >> 1U); lcv > 0U; lcv >>= 1U) {
+    for (lcv = (locNthreads >> ONE); lcv > 0U; lcv >>= ONE) {
         barrier(CLK_LOCAL_MEM_FENCE);
         if (locID < lcv) {
             lProbBuffer[locID] += lProbBuffer[locID + lcv];
@@ -1740,7 +1740,7 @@ void kernel approxcompare(global cmplx* stateVec1, global cmplx* stateVec2, cons
         locNthreads = get_local_size(0);
         lProbBuffer[locID] = partNrm;
     
-        for (lcv = (locNthreads >> 1U); lcv > 0U; lcv >>= 1U) {
+        for (lcv = (locNthreads >> ONE); lcv > 0U; lcv >>= ONE) {
             barrier(CLK_LOCAL_MEM_FENCE);
             if (locID < lcv) {
                 lProbBuffer[locID] += lProbBuffer[locID + lcv];
@@ -1761,7 +1761,7 @@ void kernel applym(global cmplx* stateVec, constant bitCapInt* bitCapIntPtr, con
     Nthreads = get_global_size(0);
     bitCapInt maxI = bitCapIntPtr[0];
     bitCapInt qPower = bitCapIntPtr[1];
-    bitCapInt qMask = qPower - 1U;
+    bitCapInt qMask = qPower - ONE;
     bitCapInt savePower = bitCapIntPtr[2];
     bitCapInt discardPower = qPower ^ savePower;
     cmplx nrm = cmplx_ptr[0];
@@ -1770,7 +1770,7 @@ void kernel applym(global cmplx* stateVec, constant bitCapInt* bitCapIntPtr, con
     for (lcv = ID; lcv < maxI; lcv += Nthreads) {
         iHigh = lcv;
         iLow = iHigh & qMask;
-        i = iLow | ((iHigh ^ iLow) << 1U);
+        i = iLow | ((iHigh ^ iLow) << ONE);
 
         stateVec[i | savePower] = zmul(nrm, stateVec[i | savePower]);
         stateVec[i | discardPower] = (cmplx)(ZERO_R1, ZERO_R1);
@@ -1809,7 +1809,7 @@ void kernel zerophaseflip(global cmplx* stateVec, constant bitCapInt* bitCapIntP
     
     Nthreads = get_global_size(0);
     bitCapInt maxI = bitCapIntPtr[0];
-    bitCapInt skipMask = bitCapIntPtr[1] - 1U;
+    bitCapInt skipMask = bitCapIntPtr[1] - ONE;
     bitCapInt skipLength = bitCapIntPtr[2];
     for (lcv = ID; lcv < maxI; lcv += Nthreads) {
         iHigh = lcv;
@@ -1834,8 +1834,8 @@ void kernel cphaseflipifless(global cmplx* stateVec, constant bitCapInt* bitCapI
     cmplx amp;
     for (lcv = ID; lcv < maxI; lcv += Nthreads) {
         iHigh = lcv;
-        iLow = iHigh & (skipPower - 1U);
-        i = (iLow | ((iHigh ^ iLow) << 1U)) | skipPower;
+        iLow = iHigh & (skipPower - ONE);
+        i = (iLow | ((iHigh ^ iLow) << ONE)) | skipPower;
 
         if (((i & regMask) >> start) < greaterPerm)
             stateVec[i] = -stateVec[i];

--- a/src/common/qengine.cl
+++ b/src/common/qengine.cl
@@ -60,21 +60,21 @@ inline real1 arg(const cmplx cmp)
     iHigh = lcv;                                                                     \
     i = 0U;                                                                          \
     for (p = 0U; p < BITCOUNT_ARG; p++) {                                            \
-        iLow = iHigh & (qPowersSorted[p] - ONE);                                      \
+        iLow = iHigh & (qPowersSorted[p] - ONE_BCI);                                 \
         i |= iLow;                                                                   \
-        iHigh = (iHigh ^ iLow) << ONE;                                                \
+        iHigh = (iHigh ^ iLow) << ONE_BCI;                                           \
     }                                                                                \
     i |= iHigh
 
 #define PUSH_APART_1()                                                               \
     i = lcv & qMask;                                                                 \
-    i |= (lcv ^ i) << ONE
+    i |= (lcv ^ i) << ONE_BCI
 
 #define PUSH_APART_2()                                                               \
     i = lcv & qMask1;                                                                \
-    iHigh = (lcv ^ i) << ONE;                                                         \
+    iHigh = (lcv ^ i) << ONE_BCI;                                                    \
     iLow = iHigh & qMask2;                                                           \
-    i |= iLow | ((iHigh ^ iLow) << ONE)
+    i |= iLow | ((iHigh ^ iLow) << ONE_BCI)
 
 #define APPLY_AND_OUT()                                                              \
     mulRes.lo = stateVec[i | OFFSET1_ARG];                                           \
@@ -98,7 +98,7 @@ inline real1 arg(const cmplx cmp)
     locNthreads = get_local_size(0);                                                 \
     lProbBuffer[locID] = partNrm;                                                    \
                                                                                      \
-    for (lcv = (locNthreads >> ONE); lcv > 0U; lcv >>= ONE) {                          \
+    for (lcv = (locNthreads >> ONE_BCI); lcv > 0U; lcv >>= ONE_BCI) {                \
         barrier(CLK_LOCAL_MEM_FENCE);                                                \
         if (locID < lcv) {                                                           \
             lProbBuffer[locID] += lProbBuffer[locID + lcv];                          \
@@ -284,7 +284,7 @@ void kernel uniformlycontrolled(global cmplx* stateVec, constant bitCapInt* bitC
 
     bitCapInt maxI = bitCapIntPtr[0];
     bitCapInt targetPower = bitCapIntPtr[1];
-    bitCapInt targetMask = targetPower - ONE;
+    bitCapInt targetMask = targetPower - ONE_BCI;
     bitCapInt controlLen = bitCapIntPtr[2];
     bitCapInt mtrxSkipLen = bitCapIntPtr[3];
     bitCapInt mtrxSkipValueMask = bitCapIntPtr[4];
@@ -301,21 +301,21 @@ void kernel uniformlycontrolled(global cmplx* stateVec, constant bitCapInt* bitC
 
     for (lcv = ID; lcv < maxI; lcv += Nthreads) {
         i = lcv & targetMask;
-        i |= (lcv ^ i) << ONE;
+        i |= (lcv ^ i) << ONE_BCI;
 
         offset = 0;
         for (p = 0; p < controlLen; p++) {
             if (i & qPowers[p]) {
-                offset |= ONE << p;
+                offset |= ONE_BCI << p;
             }
         }
 
         jHigh = offset;
         j = 0;
         for (p = 0; p < mtrxSkipLen; p++) {
-            jLow = jHigh & (qPowers[controlLen + p] - ONE);
+            jLow = jHigh & (qPowers[controlLen + p] - ONE_BCI);
             j |= jLow;
-            jHigh = (jHigh ^ jLow) << ONE;
+            jHigh = (jHigh ^ jLow) << ONE_BCI;
         }
         j |= jHigh;
         offset = j | mtrxSkipValueMask;
@@ -335,7 +335,7 @@ void kernel uniformlycontrolled(global cmplx* stateVec, constant bitCapInt* bitC
     locNthreads = get_local_size(0);
     lProbBuffer[locID] = partNrm;
     
-    for (lcv = (locNthreads >> ONE); lcv > 0U; lcv >>= ONE) {
+    for (lcv = (locNthreads >> ONE_BCI); lcv > 0U; lcv >>= ONE_BCI) {
         barrier(CLK_LOCAL_MEM_FENCE);
         if (locID < lcv) {
             lProbBuffer[locID] += lProbBuffer[locID + lcv];
@@ -415,7 +415,7 @@ void kernel decomposeprob(global cmplx* stateVec, constant bitCapInt* bitCapIntP
     real1 partProb, nrm, firstAngle, currentAngle;
 
     for (lcv = ID; lcv < remainderPower; lcv += Nthreads) {
-        j = lcv & ((ONE << start) - ONE);
+        j = lcv & ((ONE_BCI << start) - ONE_BCI);
         j |= (lcv ^ j) << len;
 
         partProb = ZERO_R1;
@@ -447,7 +447,7 @@ void kernel decomposeprob(global cmplx* stateVec, constant bitCapInt* bitCapIntP
         firstAngle = -16 * PI_R1;
 
         for (k = 0U; k < remainderPower; k++) {
-            l = k & ((ONE << start) - ONE);
+            l = k & ((ONE_BCI << start) - ONE_BCI);
             l |= (k ^ l) << len;
             l = j | l;
             
@@ -490,7 +490,7 @@ void kernel prob(global cmplx* stateVec, constant bitCapInt* bitCapIntPtr, globa
     bitCapInt2 args = vload2(0, bitCapIntPtr);
     bitCapInt maxI = args.x;
     bitCapInt qPower = args.y;
-    bitCapInt qMask = qPower - ONE;
+    bitCapInt qMask = qPower - ONE_BCI;
 
     real1 oneChancePart = ZERO_R1;
     cmplx amp;
@@ -498,7 +498,7 @@ void kernel prob(global cmplx* stateVec, constant bitCapInt* bitCapIntPtr, globa
 
     for (lcv = ID; lcv < maxI; lcv += Nthreads) {
         i = lcv & qMask;
-        i |= ((lcv ^ i) << ONE) | qPower;
+        i |= ((lcv ^ i) << ONE_BCI) | qPower;
         amp = stateVec[i];
         oneChancePart += dot(amp, amp);
     }
@@ -507,7 +507,7 @@ void kernel prob(global cmplx* stateVec, constant bitCapInt* bitCapIntPtr, globa
     locNthreads = get_local_size(0);
     lProbBuffer[locID] = oneChancePart;
     
-    for (lcv = (locNthreads >> ONE); lcv > 0U; lcv >>= ONE) {
+    for (lcv = (locNthreads >> ONE_BCI); lcv > 0U; lcv >>= ONE_BCI) {
         barrier(CLK_LOCAL_MEM_FENCE);
         if (locID < lcv) {
             lProbBuffer[locID] += lProbBuffer[locID + lcv];
@@ -530,7 +530,7 @@ void kernel probreg(global cmplx* stateVec, constant bitCapInt* bitCapIntPtr, gl
     bitCapInt perm = args.y;
     bitCapInt start = args.z;
     bitCapInt len = args.w;
-    bitCapInt qMask = (ONE << start) - ONE;
+    bitCapInt qMask = (ONE_BCI << start) - ONE_BCI;
 
     real1 oneChancePart = ZERO_R1;
     cmplx amp;
@@ -547,7 +547,7 @@ void kernel probreg(global cmplx* stateVec, constant bitCapInt* bitCapIntPtr, gl
     locNthreads = get_local_size(0);
     lProbBuffer[locID] = oneChancePart;
     
-    for (lcv = (locNthreads >> ONE); lcv > 0U; lcv >>= ONE) {
+    for (lcv = (locNthreads >> ONE_BCI); lcv > 0U; lcv >>= ONE_BCI) {
         barrier(CLK_LOCAL_MEM_FENCE);
         if (locID < lcv) {
             lProbBuffer[locID] += lProbBuffer[locID + lcv];
@@ -570,7 +570,7 @@ void kernel probregall(global cmplx* stateVec, constant bitCapInt* bitCapIntPtr,
     bitCapInt maxJ = args.y;
     bitCapInt start = args.z;
     bitCapInt len = args.w;
-    bitCapInt qMask = (ONE << start) - ONE;
+    bitCapInt qMask = (ONE_BCI << start) - ONE_BCI;
 
     real1 oneChancePart;
     cmplx amp;
@@ -610,9 +610,9 @@ void kernel probmask(global cmplx* stateVec, constant bitCapInt* bitCapIntPtr, g
         iHigh = lcv;
         i = 0U;
         for (p = 0U; p < len; p++) {
-            iLow = iHigh & (qPowers[p] - ONE);
+            iLow = iHigh & (qPowers[p] - ONE_BCI);
             i |= iLow;
-            iHigh = (iHigh ^ iLow) << ONE;
+            iHigh = (iHigh ^ iLow) << ONE_BCI;
         }
         i |= iHigh;
 
@@ -624,7 +624,7 @@ void kernel probmask(global cmplx* stateVec, constant bitCapInt* bitCapIntPtr, g
     locNthreads = get_local_size(0);
     lProbBuffer[locID] = oneChancePart;
     
-    for (lcv = (locNthreads >> ONE); lcv > 0U; lcv >>= ONE) {
+    for (lcv = (locNthreads >> ONE_BCI); lcv > 0U; lcv >>= ONE_BCI) {
         barrier(CLK_LOCAL_MEM_FENCE);
         if (locID < lcv) {
             lProbBuffer[locID] += lProbBuffer[locID + lcv];
@@ -657,9 +657,9 @@ void kernel probmaskall(global cmplx* stateVec, constant bitCapInt* bitCapIntPtr
         iHigh = lcv1;
         perm = 0U;
         for (p = 0U; p < skipLen; p++) {
-            iLow = iHigh & (qPowersSkip[p] - ONE);
+            iLow = iHigh & (qPowersSkip[p] - ONE_BCI);
             perm |= iLow;
-            iHigh = (iHigh ^ iLow) << ONE;
+            iHigh = (iHigh ^ iLow) << ONE_BCI;
         }
         perm |= iHigh;
 
@@ -668,9 +668,9 @@ void kernel probmaskall(global cmplx* stateVec, constant bitCapInt* bitCapIntPtr
             iHigh = lcv2;
             i = 0U;
             for (p = 0U; p < maskLen; p++) {
-                iLow = iHigh & (qPowersMask[p] - ONE);
+                iLow = iHigh & (qPowersMask[p] - ONE_BCI);
                 i |= iLow;
-                iHigh = (iHigh ^ iLow) << ONE;
+                iHigh = (iHigh ^ iLow) << ONE_BCI;
             }
             i |= iHigh;
 
@@ -689,7 +689,7 @@ void kernel rol(global cmplx* stateVec, constant bitCapInt* bitCapIntPtr, global
     bitCapInt maxI = bitCapIntPtr[0];
     bitCapInt regMask = bitCapIntPtr[1];
     bitCapInt otherMask = bitCapIntPtr[2];
-    bitCapInt lengthMask = bitCapIntPtr[3] - ONE;
+    bitCapInt lengthMask = bitCapIntPtr[3] - ONE_BCI;
     bitCapInt start = bitCapIntPtr[4];
     bitCapInt shift = bitCapIntPtr[5];
     bitCapInt length = bitCapIntPtr[6];
@@ -711,7 +711,7 @@ void kernel inc(global cmplx* stateVec, constant bitCapInt* bitCapIntPtr, global
     bitCapInt maxI = bitCapIntPtr[0];
     bitCapInt inOutMask = bitCapIntPtr[1];
     bitCapInt otherMask = bitCapIntPtr[2];
-    bitCapInt lengthMask = bitCapIntPtr[3] - ONE;
+    bitCapInt lengthMask = bitCapIntPtr[3] - ONE_BCI;
     bitCapInt inOutStart = bitCapIntPtr[4];
     bitCapInt toAdd = bitCapIntPtr[5];
     for (i = ID; i < maxI; i += Nthreads) {
@@ -727,7 +727,7 @@ void kernel cinc(global cmplx* stateVec, constant bitCapInt* bitCapIntPtr, globa
     bitCapInt maxI = bitCapIntPtr[0];
     bitCapInt inOutMask = bitCapIntPtr[1];
     bitCapInt otherMask = bitCapIntPtr[2];
-    bitCapInt lengthMask = bitCapIntPtr[3] - ONE;
+    bitCapInt lengthMask = bitCapIntPtr[3] - ONE_BCI;
     bitCapInt inOutStart = bitCapIntPtr[4];
     bitCapInt toAdd = bitCapIntPtr[5];
     bitCapInt controlLen = bitCapIntPtr[6];
@@ -739,9 +739,9 @@ void kernel cinc(global cmplx* stateVec, constant bitCapInt* bitCapIntPtr, globa
         iHigh = lcv;
         i = 0U;
         for (p = 0U; p < controlLen; p++) {
-            iLow = iHigh & (controlPowers[p] - ONE);
+            iLow = iHigh & (controlPowers[p] - ONE_BCI);
             i |= iLow;
-            iHigh = (iHigh ^ iLow) << ONE;
+            iHigh = (iHigh ^ iLow) << ONE_BCI;
         }
         i |= iHigh;
 
@@ -758,14 +758,14 @@ void kernel incdecc(global cmplx* stateVec, constant bitCapInt* bitCapIntPtr, gl
     bitCapInt maxI = bitCapIntPtr[0];
     bitCapInt inOutMask = bitCapIntPtr[1];
     bitCapInt otherMask = bitCapIntPtr[2];
-    bitCapInt lengthMask = bitCapIntPtr[3] - ONE;
+    bitCapInt lengthMask = bitCapIntPtr[3] - ONE_BCI;
     bitCapInt carryMask = bitCapIntPtr[4];
     bitCapInt inOutStart = bitCapIntPtr[5];
     bitCapInt toMod = bitCapIntPtr[6];
     bitCapInt otherRes, inOutRes, outInt, outRes, i;
     for (lcv = ID; lcv < maxI; lcv += Nthreads) {
-        i = lcv & (carryMask - ONE);
-        i |= (lcv ^ i) << ONE;
+        i = lcv & (carryMask - ONE_BCI);
+        i |= (lcv ^ i) << ONE_BCI;
 
         otherRes = i & otherMask;
         inOutRes = i & inOutMask;
@@ -789,7 +789,7 @@ void kernel incs(global cmplx* stateVec, constant bitCapInt* bitCapIntPtr, globa
     bitCapInt inOutMask = bitCapIntPtr[1];
     bitCapInt otherMask = bitCapIntPtr[2];
     bitCapInt lengthPower = bitCapIntPtr[3];
-    bitCapInt signMask = lengthPower >> ONE;
+    bitCapInt signMask = lengthPower >> ONE_BCI;
     bitCapInt overflowMask = bitCapIntPtr[4];
     bitCapInt inOutStart = bitCapIntPtr[5];
     bitCapInt toAdd = bitCapIntPtr[6];
@@ -810,8 +810,8 @@ void kernel incs(global cmplx* stateVec, constant bitCapInt* bitCapIntPtr, globa
         isOverflow = false;
         // Both negative:
         if (inOutInt & inInt & signMask) {
-            inOutInt = ((~inOutInt) & (lengthPower - ONE)) + ONE;
-            inInt = ((~inInt) & (lengthPower - ONE)) + ONE;
+            inOutInt = ((~inOutInt) & (lengthPower - ONE_BCI)) + ONE_BCI;
+            inInt = ((~inInt) & (lengthPower - ONE_BCI)) + ONE_BCI;
             if ((inOutInt + inInt) > signMask) {
                 isOverflow = true;
             }
@@ -839,7 +839,7 @@ void kernel incdecsc1(global cmplx* stateVec, constant bitCapInt* bitCapIntPtr, 
     bitCapInt inOutMask = bitCapIntPtr[1];
     bitCapInt otherMask = bitCapIntPtr[2];
     bitCapInt lengthPower = bitCapIntPtr[3];
-    bitCapInt signMask = lengthPower >> ONE;
+    bitCapInt signMask = lengthPower >> ONE_BCI;
     bitCapInt overflowMask = bitCapIntPtr[4];
     bitCapInt carryMask = bitCapIntPtr[5];
     bitCapInt inOutStart = bitCapIntPtr[6];
@@ -848,8 +848,8 @@ void kernel incdecsc1(global cmplx* stateVec, constant bitCapInt* bitCapIntPtr, 
     cmplx amp;
     bool isOverflow;
     for (lcv = ID; lcv < maxI; lcv += Nthreads) {
-        i = lcv & (carryMask - ONE);
-        i |= (lcv ^ i) << ONE;
+        i = lcv & (carryMask - ONE_BCI);
+        i |= (lcv ^ i) << ONE_BCI;
 
         otherRes = i & otherMask;
         inOutRes = i & inOutMask;
@@ -864,8 +864,8 @@ void kernel incdecsc1(global cmplx* stateVec, constant bitCapInt* bitCapIntPtr, 
         bool isOverflow = false;
         // Both negative:
         if (inOutInt & inInt & signMask) {
-            inOutInt = ((~inOutInt) & (lengthPower - ONE)) + ONE;
-            inInt = ((~inInt) & (lengthPower - ONE)) + ONE;
+            inOutInt = ((~inOutInt) & (lengthPower - ONE_BCI)) + ONE_BCI;
+            inInt = ((~inInt) & (lengthPower - ONE_BCI)) + ONE_BCI;
             if ((inOutInt + inInt) > signMask)
                 isOverflow = true;
         }
@@ -891,7 +891,7 @@ void kernel incdecsc2(global cmplx* stateVec, constant bitCapInt* bitCapIntPtr, 
     bitCapInt inOutMask = bitCapIntPtr[1];
     bitCapInt otherMask = bitCapIntPtr[2];
     bitCapInt lengthPower = bitCapIntPtr[3];
-    bitCapInt signMask = lengthPower >> ONE;
+    bitCapInt signMask = lengthPower >> ONE_BCI;
     bitCapInt carryMask = bitCapIntPtr[4];
     bitCapInt inOutStart = bitCapIntPtr[5];
     bitCapInt toAdd = bitCapIntPtr[6];
@@ -899,8 +899,8 @@ void kernel incdecsc2(global cmplx* stateVec, constant bitCapInt* bitCapIntPtr, 
     cmplx amp;
     bool isOverflow;
     for (lcv = ID; lcv < maxI; lcv += Nthreads) {
-        i = lcv & (carryMask - ONE);
-        i |= (lcv ^ i) << ONE;
+        i = lcv & (carryMask - ONE_BCI);
+        i |= (lcv ^ i) << ONE_BCI;
 
         otherRes = i & otherMask;
         inOutRes = i & inOutMask;
@@ -915,8 +915,8 @@ void kernel incdecsc2(global cmplx* stateVec, constant bitCapInt* bitCapIntPtr, 
         bool isOverflow = false;
         // Both negative:
         if (inOutInt & inInt & (signMask)) {
-            inOutInt = ((~inOutInt) & (lengthPower - ONE)) + ONE;
-            inInt = ((~inInt) & (lengthPower - ONE)) + ONE;
+            inOutInt = ((~inOutInt) & (lengthPower - ONE_BCI)) + ONE_BCI;
+            inInt = ((~inInt) & (lengthPower - ONE_BCI)) + ONE_BCI;
             if ((inOutInt + inInt) > signMask)
                 isOverflow = true;
         }
@@ -1020,8 +1020,8 @@ void kernel incdecbcdc(global cmplx* stateVec, constant bitCapInt* bitCapIntPtr,
     bool isValid;
     cmplx amp1, amp2;
     for (lcv = ID; lcv < maxI; lcv += Nthreads) {
-        i = lcv & (carryMask - ONE);
-        i |= (lcv ^ i) << ONE;
+        i = lcv & (carryMask - ONE_BCI);
+        i |= (lcv ^ i) << ONE_BCI;
 
         otherRes = i & otherMask;
         partToAdd = toAdd;
@@ -1087,7 +1087,7 @@ void kernel mul(global cmplx* stateVec, constant bitCapInt* bitCapIntPtr, global
     bitCapInt carryMask = bitCapIntPtr[3];
     bitCapInt otherMask = bitCapIntPtr[4];
     bitCapInt len = bitCapIntPtr[5];
-    bitCapInt lowMask = (ONE << len) - ONE;
+    bitCapInt lowMask = (ONE_BCI << len) - ONE_BCI;
     bitCapInt highMask = lowMask << len;
     bitCapInt inOutStart = bitCapIntPtr[6];
     bitCapInt carryStart = bitCapIntPtr[7];
@@ -1116,7 +1116,7 @@ void kernel div(global cmplx* stateVec, constant bitCapInt* bitCapIntPtr, global
     bitCapInt carryMask = bitCapIntPtr[3];
     bitCapInt otherMask = bitCapIntPtr[4];
     bitCapInt len = bitCapIntPtr[5];
-    bitCapInt lowMask = (ONE << len) - ONE;
+    bitCapInt lowMask = (ONE_BCI << len) - ONE_BCI;
     bitCapInt highMask = lowMask << len;
     bitCapInt inOutStart = bitCapIntPtr[6];
     bitCapInt carryStart = bitCapIntPtr[7];
@@ -1145,7 +1145,7 @@ void kernel mulmodnout(global cmplx* stateVec, constant bitCapInt* bitCapIntPtr,
     bitCapInt outMask = bitCapIntPtr[3];
     bitCapInt otherMask = bitCapIntPtr[4];
     bitCapInt len = bitCapIntPtr[5];
-    bitCapInt lowMask = (ONE << len) - ONE;
+    bitCapInt lowMask = (ONE_BCI << len) - ONE_BCI;
     bitCapInt inStart = bitCapIntPtr[6];
     bitCapInt outStart = bitCapIntPtr[7];
     bitCapInt skipMask = bitCapIntPtr[8];
@@ -1175,7 +1175,7 @@ void kernel powmodnout(global cmplx* stateVec, constant bitCapInt* bitCapIntPtr,
     bitCapInt outMask = bitCapIntPtr[3];
     bitCapInt otherMask = bitCapIntPtr[4];
     bitCapInt len = bitCapIntPtr[5];
-    bitCapInt lowMask = (ONE << len) - ONE;
+    bitCapInt lowMask = (ONE_BCI << len) - ONE_BCI;
     bitCapInt inStart = bitCapIntPtr[6];
     bitCapInt outStart = bitCapIntPtr[7];
     bitCapInt skipMask = bitCapIntPtr[8];
@@ -1218,11 +1218,11 @@ void kernel fulladd(global cmplx* stateVec, constant bitCapInt* bitCapIntPtr)
 
     bitCapInt qMask1, qMask2;
     if (carryInSumOutMask < carryOutMask) {
-        qMask1 = carryInSumOutMask - ONE;
-        qMask2 = carryOutMask - ONE;
+        qMask1 = carryInSumOutMask - ONE_BCI;
+        qMask2 = carryOutMask - ONE_BCI;
     } else {
-        qMask1 = carryOutMask - ONE;
-        qMask2 = carryInSumOutMask - ONE;
+        qMask1 = carryOutMask - ONE_BCI;
+        qMask2 = carryInSumOutMask - ONE_BCI;
     }
 
     cmplx ins0c0, ins0c1, ins1c0, ins1c1;
@@ -1298,11 +1298,11 @@ void kernel ifulladd(global cmplx* stateVec, constant bitCapInt* bitCapIntPtr)
 
     bitCapInt qMask1, qMask2;
     if (carryInSumOutMask < carryOutMask) {
-        qMask1 = carryInSumOutMask - ONE;
-        qMask2 = carryOutMask - ONE;
+        qMask1 = carryInSumOutMask - ONE_BCI;
+        qMask2 = carryOutMask - ONE_BCI;
     } else {
-        qMask1 = carryOutMask - ONE;
-        qMask2 = carryInSumOutMask - ONE;
+        qMask1 = carryOutMask - ONE_BCI;
+        qMask2 = carryInSumOutMask - ONE_BCI;
     }
 
     cmplx ins0c0, ins0c1, ins1c0, ins1c1;
@@ -1369,18 +1369,18 @@ void kernel ifulladd(global cmplx* stateVec, constant bitCapInt* bitCapIntPtr)
     iHigh = lcv;                                                                     \
     i = 0U;                                                                          \
     for (p = 0U; p < (controlLen + len); p++) {                                      \
-        iLow = iHigh & (controlPowers[p] - ONE);                                      \
+        iLow = iHigh & (controlPowers[p] - ONE_BCI);                                 \
         i |= iLow;                                                                   \
-        iHigh = (iHigh ^ iLow) << ONE;                                                \
+        iHigh = (iHigh ^ iLow) << ONE_BCI;                                           \
     }                                                                                \
     i |= iHigh;                                                                      \
 
 #define CMOD_FINISH()                                                                \
     nStateVec[i] = stateVec[i];                                                      \
-    for (j = ONE; j < ((ONE << controlLen) - ONE); j++) {                               \
+    for (j = ONE_BCI; j < ((ONE_BCI << controlLen) - ONE_BCI); j++) {                \
         partControlMask = 0U;                                                        \
         for (k = 0U; k < controlLen; k++) {                                          \
-            if (j & (ONE << k)) {                                                     \
+            if (j & (ONE_BCI << k)) {                                                \
                 partControlMask |= controlPowers[controlLen + len + k];              \
             }                                                                        \
         }                                                                            \
@@ -1400,7 +1400,7 @@ void kernel cmul(global cmplx* stateVec, constant bitCapInt* bitCapIntPtr, globa
     bitCapInt carryMask = bitCapIntPtr[5];
     bitCapInt otherMask = bitCapIntPtr[6];
     bitCapInt len = bitCapIntPtr[7];
-    bitCapInt lowMask = (ONE << len) - ONE;
+    bitCapInt lowMask = (ONE_BCI << len) - ONE_BCI;
     bitCapInt highMask = lowMask << len;
     bitCapInt inOutStart = bitCapIntPtr[8];
     bitCapInt carryStart = bitCapIntPtr[9];
@@ -1432,7 +1432,7 @@ void kernel cdiv(global cmplx* stateVec, constant bitCapInt* bitCapIntPtr, globa
     bitCapInt carryMask = bitCapIntPtr[5];
     bitCapInt otherMask = bitCapIntPtr[6];
     bitCapInt len = bitCapIntPtr[7];
-    bitCapInt lowMask = (ONE << len) - ONE;
+    bitCapInt lowMask = (ONE_BCI << len) - ONE_BCI;
     bitCapInt highMask = lowMask << len;
     bitCapInt inOutStart = bitCapIntPtr[8];
     bitCapInt carryStart = bitCapIntPtr[9];
@@ -1464,11 +1464,11 @@ void kernel cmulmodnout(global cmplx* stateVec, constant bitCapInt* bitCapIntPtr
     bitCapInt outMask = bitCapIntPtr[5];
     bitCapInt modN = bitCapIntPtr[6];
     bitCapInt len = bitCapIntPtr[7];
-    bitCapInt lowMask = (ONE << len) - ONE;
+    bitCapInt lowMask = (ONE_BCI << len) - ONE_BCI;
     bitCapInt inStart = bitCapIntPtr[8];
     bitCapInt outStart = bitCapIntPtr[9];
 
-    bitCapInt otherMask = (maxI - ONE) ^ (inMask | outMask | controlMask);
+    bitCapInt otherMask = (maxI - ONE_BCI) ^ (inMask | outMask | controlMask);
     maxI >>= (controlLen + len);
 
     bitCapInt otherRes, outRes, inRes;
@@ -1501,11 +1501,11 @@ void kernel cpowmodnout(global cmplx* stateVec, constant bitCapInt* bitCapIntPtr
     bitCapInt outMask = bitCapIntPtr[5];
     bitCapInt modN = bitCapIntPtr[6];
     bitCapInt len = bitCapIntPtr[7];
-    bitCapInt lowMask = (ONE << len) - ONE;
+    bitCapInt lowMask = (ONE_BCI << len) - ONE_BCI;
     bitCapInt inStart = bitCapIntPtr[8];
     bitCapInt outStart = bitCapIntPtr[9];
 
-    bitCapInt otherMask = (maxI - ONE) ^ (inMask | outMask | controlMask);
+    bitCapInt otherMask = (maxI - ONE_BCI) ^ (inMask | outMask | controlMask);
     maxI >>= (controlLen + len);
 
     bitCapInt otherRes, outRes, inRes, inInt;
@@ -1547,7 +1547,7 @@ void kernel indexedLda(
     bitCapInt outputStart = bitCapIntPtr[3];
     bitCapInt valueBytes = bitCapIntPtr[4];
     bitCapInt valueLength = bitCapIntPtr[5];
-    bitCapInt lowMask = (ONE << outputStart) - ONE;
+    bitCapInt lowMask = (ONE_BCI << outputStart) - ONE_BCI;
     bitCapInt inputRes, inputInt, outputRes, outputInt;
     bitCapInt i, iLow, iHigh, j;
     for (lcv = ID; lcv < maxI; lcv += Nthreads) {
@@ -1586,8 +1586,8 @@ void kernel indexedAdc(
     bitCapInt i, iLow, iHigh, j;
     for (lcv = ID; lcv < maxI; lcv += Nthreads) {
         iHigh = lcv;
-        iLow = iHigh & (carryMask - ONE);
-        i = iLow | ((iHigh ^ iLow) << ONE);
+        iLow = iHigh & (carryMask - ONE_BCI);
+        i = iLow | ((iHigh ^ iLow) << ONE_BCI);
 
         otherRes = i & otherMask;
         inputRes = i & inputMask;
@@ -1630,8 +1630,8 @@ void kernel indexedSbc(
     bitCapInt i, iLow, iHigh, j;
     for (lcv = ID; lcv < maxI; lcv += Nthreads) {
         iHigh = lcv;
-        iLow = iHigh & (carryMask - ONE);
-        i = iLow | ((iHigh ^ iLow) << ONE);
+        iLow = iHigh & (carryMask - ONE_BCI);
+        i = iLow | ((iHigh ^ iLow) << ONE_BCI);
 
         otherRes = i & otherMask;
         inputRes = i & inputMask;
@@ -1690,7 +1690,7 @@ void kernel updatenorm(global cmplx* stateVec, constant bitCapInt* bitCapIntPtr,
     locID = get_local_id(0);
     locNthreads = get_local_size(0);
     lProbBuffer[locID] = partNrm;
-    for (lcv = (locNthreads >> ONE); lcv > 0U; lcv >>= ONE) {
+    for (lcv = (locNthreads >> ONE_BCI); lcv > 0U; lcv >>= ONE_BCI) {
         barrier(CLK_LOCAL_MEM_FENCE);
         if (locID < lcv) {
             lProbBuffer[locID] += lProbBuffer[locID + lcv];
@@ -1740,7 +1740,7 @@ void kernel approxcompare(global cmplx* stateVec1, global cmplx* stateVec2, cons
         locNthreads = get_local_size(0);
         lProbBuffer[locID] = partNrm;
     
-        for (lcv = (locNthreads >> ONE); lcv > 0U; lcv >>= ONE) {
+        for (lcv = (locNthreads >> ONE_BCI); lcv > 0U; lcv >>= ONE_BCI) {
             barrier(CLK_LOCAL_MEM_FENCE);
             if (locID < lcv) {
                 lProbBuffer[locID] += lProbBuffer[locID + lcv];
@@ -1761,7 +1761,7 @@ void kernel applym(global cmplx* stateVec, constant bitCapInt* bitCapIntPtr, con
     Nthreads = get_global_size(0);
     bitCapInt maxI = bitCapIntPtr[0];
     bitCapInt qPower = bitCapIntPtr[1];
-    bitCapInt qMask = qPower - ONE;
+    bitCapInt qMask = qPower - ONE_BCI;
     bitCapInt savePower = bitCapIntPtr[2];
     bitCapInt discardPower = qPower ^ savePower;
     cmplx nrm = cmplx_ptr[0];
@@ -1770,7 +1770,7 @@ void kernel applym(global cmplx* stateVec, constant bitCapInt* bitCapIntPtr, con
     for (lcv = ID; lcv < maxI; lcv += Nthreads) {
         iHigh = lcv;
         iLow = iHigh & qMask;
-        i = iLow | ((iHigh ^ iLow) << ONE);
+        i = iLow | ((iHigh ^ iLow) << ONE_BCI);
 
         stateVec[i | savePower] = zmul(nrm, stateVec[i | savePower]);
         stateVec[i | discardPower] = (cmplx)(ZERO_R1, ZERO_R1);
@@ -1809,7 +1809,7 @@ void kernel zerophaseflip(global cmplx* stateVec, constant bitCapInt* bitCapIntP
     
     Nthreads = get_global_size(0);
     bitCapInt maxI = bitCapIntPtr[0];
-    bitCapInt skipMask = bitCapIntPtr[1] - ONE;
+    bitCapInt skipMask = bitCapIntPtr[1] - ONE_BCI;
     bitCapInt skipLength = bitCapIntPtr[2];
     for (lcv = ID; lcv < maxI; lcv += Nthreads) {
         iHigh = lcv;
@@ -1834,8 +1834,8 @@ void kernel cphaseflipifless(global cmplx* stateVec, constant bitCapInt* bitCapI
     cmplx amp;
     for (lcv = ID; lcv < maxI; lcv += Nthreads) {
         iHigh = lcv;
-        iLow = iHigh & (skipPower - ONE);
-        i = (iLow | ((iHigh ^ iLow) << ONE)) | skipPower;
+        iLow = iHigh & (skipPower - ONE_BCI);
+        i = (iLow | ((iHigh ^ iLow) << ONE_BCI)) | skipPower;
 
         if (((i & regMask) >> start) < greaterPerm)
             stateVec[i] = -stateVec[i];

--- a/src/common/qheader32.cl
+++ b/src/common/qheader32.cl
@@ -23,4 +23,4 @@
 #define bitCapInt uint
 #define bitCapInt2 uint2
 #define bitCapInt4 uint4
-#define bitLenInt unsigned char
+#define bitLenInt uint

--- a/src/common/qheader32.cl
+++ b/src/common/qheader32.cl
@@ -23,4 +23,4 @@
 #define bitCapInt uint
 #define bitCapInt2 uint2
 #define bitCapInt4 uint4
-#define bitLenInt uint
+#define bitLenInt unsigned char

--- a/src/common/qheader32.cl
+++ b/src/common/qheader32.cl
@@ -16,7 +16,7 @@
 #define real1 float
 #define ZERO_R1 0.0f
 #define ONE_R1 1.0f
-#define ONE 1U
+#define ONE_BCI 1U
 #define SineShift M_PI_2_F
 #define PI_R1 M_PI_F
 #define min_norm 1e-13f

--- a/src/common/qheader32.cl
+++ b/src/common/qheader32.cl
@@ -16,6 +16,7 @@
 #define real1 float
 #define ZERO_R1 0.0f
 #define ONE_R1 1.0f
+#define ONE 1U
 #define SineShift M_PI_2_F
 #define PI_R1 M_PI_F
 #define min_norm 1e-13f

--- a/src/common/qheader_double.cl
+++ b/src/common/qheader_double.cl
@@ -24,5 +24,5 @@
 #define bitCapInt ulong
 #define bitCapInt2 ulong2
 #define bitCapInt4 ulong4
-#define bitLenInt unsigned char
+#define bitLenInt ulong
 

--- a/src/common/qheader_double.cl
+++ b/src/common/qheader_double.cl
@@ -17,7 +17,7 @@
 #define real1 double
 #define ZERO_R1 0.0
 #define ONE_R1 1.0
-#define ONE 1UL
+#define ONE_BCI 1UL
 #define SineShift M_PI_2
 #define PI_R1 M_PI
 #define min_norm 1e-30

--- a/src/common/qheader_double.cl
+++ b/src/common/qheader_double.cl
@@ -24,5 +24,5 @@
 #define bitCapInt ulong
 #define bitCapInt2 ulong2
 #define bitCapInt4 ulong4
-#define bitLenInt ulong
+#define bitLenInt unsigned char
 

--- a/src/common/qheader_double.cl
+++ b/src/common/qheader_double.cl
@@ -17,6 +17,7 @@
 #define real1 double
 #define ZERO_R1 0.0
 #define ONE_R1 1.0
+#define ONE 1UL
 #define SineShift M_PI_2
 #define PI_R1 M_PI
 #define min_norm 1e-30

--- a/src/common/qheader_float.cl
+++ b/src/common/qheader_float.cl
@@ -16,7 +16,7 @@
 #define real1 float
 #define ZERO_R1 0.0f
 #define ONE_R1 1.0f
-#define ONE 1UL
+#define ONE_BCI 1UL
 #define SineShift M_PI_2_F
 #define PI_R1 M_PI_F
 #define min_norm 1e-13f

--- a/src/common/qheader_float.cl
+++ b/src/common/qheader_float.cl
@@ -23,4 +23,4 @@
 #define bitCapInt ulong
 #define bitCapInt2 ulong2
 #define bitCapInt4 ulong4
-#define bitLenInt ulong
+#define bitLenInt unsigned char

--- a/src/common/qheader_float.cl
+++ b/src/common/qheader_float.cl
@@ -16,6 +16,7 @@
 #define real1 float
 #define ZERO_R1 0.0f
 #define ONE_R1 1.0f
+#define ONE 1UL
 #define SineShift M_PI_2_F
 #define PI_R1 M_PI_F
 #define min_norm 1e-13f

--- a/src/common/qheader_float.cl
+++ b/src/common/qheader_float.cl
@@ -23,4 +23,4 @@
 #define bitCapInt ulong
 #define bitCapInt2 ulong2
 #define bitCapInt4 ulong4
-#define bitLenInt unsigned char
+#define bitLenInt ulong

--- a/src/qengine/arithmetic.cpp
+++ b/src/qengine/arithmetic.cpp
@@ -571,7 +571,7 @@ void QEngineCPU::INCBCD(bitCapInt toAdd, bitLenInt inOutStart, bitLenInt length)
     }
 
     int nibbleCount = length / 4;
-    if (nibbleCount * 4 != length) {
+    if (nibbleCount * 4 != (int)length) {
         throw std::invalid_argument("BCD word bit length must be a multiple of 4.");
     }
 
@@ -635,7 +635,7 @@ void QEngineCPU::INCDECBCDC(
     }
 
     int nibbleCount = length / 4;
-    if (nibbleCount * 4 != length) {
+    if (nibbleCount * 4 != (int)length) {
         throw std::invalid_argument("BCD word bit length must be a multiple of 4.");
     }
 

--- a/src/qengine/arithmetic.cpp
+++ b/src/qengine/arithmetic.cpp
@@ -27,9 +27,9 @@ void QEngineCPU::ROL(bitLenInt shift, bitLenInt start, bitLenInt length)
     }
 
     bitCapInt lengthPower = pow2(length);
-    bitCapInt lengthMask = lengthPower - 1UL;
+    bitCapInt lengthMask = lengthPower - ONE_BCI;
     bitCapInt regMask = lengthMask << start;
-    bitCapInt otherMask = (maxQPower - 1UL) ^ regMask;
+    bitCapInt otherMask = (maxQPower - ONE_BCI) ^ regMask;
 
     StateVectorPtr nStateVec = AllocStateVec(maxQPower);
 
@@ -57,7 +57,7 @@ void QEngineCPU::INC(bitCapInt toAdd, bitLenInt inOutStart, bitLenInt length)
     }
 
     bitCapInt inOutMask = lengthMask << inOutStart;
-    bitCapInt otherMask = (maxQPower - 1UL) ^ inOutMask;
+    bitCapInt otherMask = (maxQPower - ONE_BCI) ^ inOutMask;
 
     StateVectorPtr nStateVec = AllocStateVec(maxQPower);
 
@@ -85,7 +85,7 @@ void QEngineCPU::CINC(
     }
 
     bitCapInt lengthPower = pow2(length);
-    bitCapInt lengthMask = lengthPower - 1UL;
+    bitCapInt lengthMask = lengthPower - ONE_BCI;
     toAdd &= lengthMask;
     if (toAdd == 0) {
         return;
@@ -100,7 +100,7 @@ void QEngineCPU::CINC(
     std::sort(controlPowers, controlPowers + controlLen);
 
     bitCapInt inOutMask = lengthMask << inOutStart;
-    bitCapInt otherMask = (maxQPower - 1UL) ^ (inOutMask | controlMask);
+    bitCapInt otherMask = (maxQPower - ONE_BCI) ^ (inOutMask | controlMask);
 
     StateVectorPtr nStateVec = AllocStateVec(maxQPower);
     nStateVec->copy(*stateVec);
@@ -127,7 +127,7 @@ void QEngineCPU::INCDECC(
     }
 
     bitCapInt lengthPower = pow2(length);
-    bitCapInt lengthMask = lengthPower - 1UL;
+    bitCapInt lengthMask = lengthPower - ONE_BCI;
     toMod &= lengthMask;
     if (toMod == 0) {
         return;
@@ -135,14 +135,14 @@ void QEngineCPU::INCDECC(
 
     bitCapInt carryMask = pow2(carryIndex);
     bitCapInt inOutMask = lengthMask << inOutStart;
-    bitCapInt otherMask = maxQPower - 1UL;
+    bitCapInt otherMask = maxQPower - ONE_BCI;
 
     otherMask ^= inOutMask | carryMask;
 
     StateVectorPtr nStateVec = AllocStateVec(maxQPower);
     nStateVec->clear();
 
-    par_for_skip(0, maxQPower, pow2(carryIndex), 1UL, [&](const bitCapInt lcv, const int cpu) {
+    par_for_skip(0, maxQPower, pow2(carryIndex), ONE_BCI, [&](const bitCapInt lcv, const int cpu) {
         bitCapInt otherRes = lcv & otherMask;
         bitCapInt inOutRes = lcv & inOutMask;
         bitCapInt inOutInt = inOutRes >> inOutStart;
@@ -172,16 +172,16 @@ void QEngineCPU::INCS(bitCapInt toAdd, bitLenInt inOutStart, bitLenInt length, b
     }
 
     bitCapInt lengthPower = pow2(length);
-    bitCapInt lengthMask = lengthPower - 1UL;
+    bitCapInt lengthMask = lengthPower - ONE_BCI;
     toAdd &= lengthMask;
     if (toAdd == 0) {
         return;
     }
 
     bitCapInt overflowMask = pow2(overflowIndex);
-    bitCapInt signMask = pow2(length - 1UL);
+    bitCapInt signMask = pow2(length - ONE_BCI);
     bitCapInt inOutMask = lengthMask << inOutStart;
-    bitCapInt otherMask = (maxQPower - 1UL) ^ inOutMask;
+    bitCapInt otherMask = (maxQPower - ONE_BCI) ^ inOutMask;
 
     StateVectorPtr nStateVec = AllocStateVec(maxQPower);
     nStateVec->clear();
@@ -216,15 +216,15 @@ void QEngineCPU::INCDECSC(
     }
 
     bitCapInt lengthPower = pow2(length);
-    bitCapInt lengthMask = lengthPower - 1UL;
+    bitCapInt lengthMask = lengthPower - ONE_BCI;
     toMod &= lengthMask;
     if (toMod == 0) {
         return;
     }
 
-    bitCapInt signMask = pow2(length - 1UL);
+    bitCapInt signMask = pow2(length - ONE_BCI);
     bitCapInt carryMask = pow2(carryIndex);
-    bitCapInt otherMask = maxQPower - 1UL;
+    bitCapInt otherMask = maxQPower - ONE_BCI;
     bitCapInt inOutMask = lengthMask << inOutStart;
 
     otherMask ^= inOutMask | carryMask;
@@ -232,7 +232,7 @@ void QEngineCPU::INCDECSC(
     StateVectorPtr nStateVec = AllocStateVec(maxQPower);
     nStateVec->clear();
 
-    par_for_skip(0, maxQPower, carryMask, 1UL, [&](const bitCapInt lcv, const int cpu) {
+    par_for_skip(0, maxQPower, carryMask, ONE_BCI, [&](const bitCapInt lcv, const int cpu) {
         bitCapInt otherRes = lcv & otherMask;
         bitCapInt inOutRes = lcv & inOutMask;
         bitCapInt inOutInt = inOutRes >> inOutStart;
@@ -262,22 +262,22 @@ void QEngineCPU::INCDECSC(bitCapInt toMod, const bitLenInt& inOutStart, const bi
     }
 
     bitCapInt lengthPower = pow2(length);
-    bitCapInt lengthMask = lengthPower - 1UL;
+    bitCapInt lengthMask = lengthPower - ONE_BCI;
     toMod &= lengthMask;
     if (toMod == 0) {
         return;
     }
 
     bitCapInt overflowMask = pow2(overflowIndex);
-    bitCapInt signMask = pow2(length - 1UL);
+    bitCapInt signMask = pow2(length - ONE_BCI);
     bitCapInt carryMask = pow2(carryIndex);
     bitCapInt inOutMask = lengthMask << inOutStart;
-    bitCapInt otherMask = (maxQPower - 1UL) ^ (inOutMask | carryMask);
+    bitCapInt otherMask = (maxQPower - ONE_BCI) ^ (inOutMask | carryMask);
 
     StateVectorPtr nStateVec = AllocStateVec(maxQPower);
     nStateVec->clear();
 
-    par_for_skip(0, maxQPower, carryMask, 1UL, [&](const bitCapInt lcv, const int cpu) {
+    par_for_skip(0, maxQPower, carryMask, ONE_BCI, [&](const bitCapInt lcv, const int cpu) {
         bitCapInt otherRes = lcv & otherMask;
         bitCapInt inOutRes = lcv & inOutMask;
         bitCapInt inOutInt = inOutRes >> inOutStart;
@@ -306,7 +306,7 @@ void QEngineCPU::MULDIV(const IOFn& inFn, const IOFn& outFn, const bitCapInt& to
     bitCapInt highMask = lowMask << length;
     bitCapInt inOutMask = lowMask << inOutStart;
     bitCapInt carryMask = lowMask << carryStart;
-    bitCapInt otherMask = (maxQPower - 1UL) ^ (inOutMask | carryMask);
+    bitCapInt otherMask = (maxQPower - ONE_BCI) ^ (inOutMask | carryMask);
 
     StateVectorPtr nStateVec = AllocStateVec(maxQPower);
     nStateVec->clear();
@@ -330,7 +330,7 @@ void QEngineCPU::MUL(bitCapInt toMul, bitLenInt inOutStart, bitLenInt carryStart
         SetReg(inOutStart, length, 0);
         return;
     }
-    if (toMul == 1UL) {
+    if (toMul == ONE_BCI) {
         return;
     }
 
@@ -343,7 +343,7 @@ void QEngineCPU::DIV(bitCapInt toDiv, bitLenInt inOutStart, bitLenInt carryStart
     if (toDiv == 0) {
         throw "DIV by zero";
     }
-    if (toDiv == 1UL) {
+    if (toDiv == ONE_BCI) {
         return;
     }
 
@@ -372,7 +372,7 @@ void QEngineCPU::CMULDIV(const IOFn& inFn, const IOFn& outFn, const bitCapInt& t
     }
     std::sort(skipPowers, skipPowers + controlLen + length);
 
-    bitCapInt otherMask = (maxQPower - 1UL) ^ (inOutMask | carryMask | controlMask);
+    bitCapInt otherMask = (maxQPower - ONE_BCI) ^ (inOutMask | carryMask | controlMask);
 
     StateVectorPtr nStateVec = AllocStateVec(maxQPower);
     nStateVec->clear();
@@ -387,10 +387,10 @@ void QEngineCPU::CMULDIV(const IOFn& inFn, const IOFn& outFn, const bitCapInt& t
 
         nStateVec->write(lcv, stateVec->read(lcv));
         bitCapInt partControlMask;
-        for (bitCapInt j = 1UL; j < pow2Mask(controlLen); j++) {
+        for (bitCapInt j = ONE_BCI; j < pow2Mask(controlLen); j++) {
             partControlMask = 0;
             for (bitLenInt k = 0; k < controlLen; k++) {
-                if ((j >> k) & 1UL) {
+                if ((j >> k) & ONE_BCI) {
                     partControlMask |= controlPowers[k];
                 }
             }
@@ -418,7 +418,7 @@ void QEngineCPU::CMUL(bitCapInt toMul, bitLenInt inOutStart, bitLenInt carryStar
         SetReg(inOutStart, length, 0);
         return;
     }
-    if (toMul == 1UL) {
+    if (toMul == ONE_BCI) {
         return;
     }
 
@@ -438,7 +438,7 @@ void QEngineCPU::CDIV(bitCapInt toDiv, bitLenInt inOutStart, bitLenInt carryStar
     if (toDiv == 0) {
         throw "DIV by zero";
     }
-    if (toDiv == 1UL) {
+    if (toDiv == ONE_BCI) {
         return;
     }
 
@@ -455,7 +455,7 @@ void QEngineCPU::ModNOut(const MFn& kernelFn, const bitCapInt& modN, const bitLe
     bitCapInt lowMask = pow2Mask(length);
     bitCapInt inMask = lowMask << inStart;
     bitCapInt outMask = lowMask << outStart;
-    bitCapInt otherMask = (maxQPower - 1UL) ^ (inMask | outMask);
+    bitCapInt otherMask = (maxQPower - ONE_BCI) ^ (inMask | outMask);
 
     StateVectorPtr nStateVec = AllocStateVec(maxQPower);
     nStateVec->clear();
@@ -491,7 +491,7 @@ void QEngineCPU::CModNOut(const MFn& kernelFn, const bitCapInt& modN, const bitL
     SetReg(outStart, length, 0);
 
     bitCapInt lowPower = pow2(length);
-    bitCapInt lowMask = lowPower - 1UL;
+    bitCapInt lowMask = lowPower - ONE_BCI;
     bitCapInt inMask = lowMask << inStart;
     bitCapInt outMask = lowMask << outStart;
 
@@ -508,7 +508,7 @@ void QEngineCPU::CModNOut(const MFn& kernelFn, const bitCapInt& modN, const bitL
     }
     std::sort(skipPowers, skipPowers + controlLen + length);
 
-    bitCapInt otherMask = (maxQPower - 1UL) ^ (inMask | outMask | controlMask);
+    bitCapInt otherMask = (maxQPower - ONE_BCI) ^ (inMask | outMask | controlMask);
 
     StateVectorPtr nStateVec = AllocStateVec(maxQPower);
     nStateVec->clear();
@@ -522,10 +522,10 @@ void QEngineCPU::CModNOut(const MFn& kernelFn, const bitCapInt& modN, const bitL
         nStateVec->write(lcv, stateVec->read(lcv));
 
         bitCapInt partControlMask;
-        for (bitCapInt j = 1UL; j < pow2Mask(controlLen); j++) {
+        for (bitCapInt j = ONE_BCI; j < pow2Mask(controlLen); j++) {
             partControlMask = 0;
             for (bitLenInt k = 0; k < controlLen; k++) {
-                if ((j >> k) & 1UL) {
+                if ((j >> k) & ONE_BCI) {
                     partControlMask |= controlPowers[k];
                 }
             }
@@ -615,7 +615,7 @@ void QEngineCPU::INCBCD(bitCapInt toAdd, bitLenInt inOutStart, bitLenInt length)
                         nibbles[j + 1]++;
                     }
                 }
-                outInt |= ((bitCapInt)nibbles[j]) << (j * 4UL);
+                outInt |= ((bitCapInt)nibbles[j]) << (j * 4U * ONE_BCI);
             }
             nStateVec->write((outInt << inOutStart) | otherRes, stateVec->read(lcv));
         } else {
@@ -646,7 +646,7 @@ void QEngineCPU::INCDECBCDC(
     }
 
     bitCapInt inOutMask = bitRegMask(inOutStart, length);
-    bitCapInt otherMask = maxQPower - 1UL;
+    bitCapInt otherMask = maxQPower - ONE_BCI;
     bitCapInt carryMask = pow2(carryIndex);
 
     otherMask ^= inOutMask | carryMask;
@@ -654,7 +654,7 @@ void QEngineCPU::INCDECBCDC(
     StateVectorPtr nStateVec = AllocStateVec(maxQPower);
     nStateVec->clear();
 
-    par_for_skip(0, maxQPower, pow2(carryIndex), 1UL, [&](const bitCapInt lcv, const int cpu) {
+    par_for_skip(0, maxQPower, pow2(carryIndex), ONE_BCI, [&](const bitCapInt lcv, const int cpu) {
         bitCapInt otherRes = lcv & otherMask;
         bitCapInt partToAdd = toMod;
         bitCapInt inOutRes = lcv & inOutMask;
@@ -665,7 +665,7 @@ void QEngineCPU::INCDECBCDC(
         bool isValid = true;
 
         test1 = inOutInt & 15UL;
-        inOutInt >>= 4UL;
+        inOutInt >>= 4U * ONE_BCI;
         test2 = partToAdd % 10;
         partToAdd /= 10;
         nibbles[0] = test1 + test2;
@@ -675,7 +675,7 @@ void QEngineCPU::INCDECBCDC(
 
         for (j = 1; j < nibbleCount; j++) {
             test1 = inOutInt & 15UL;
-            inOutInt >>= 4UL;
+            inOutInt >>= 4U * ONE_BCI;
             test2 = partToAdd % 10;
             partToAdd /= 10;
             nibbles[j] = test1 + test2;
@@ -696,7 +696,7 @@ void QEngineCPU::INCDECBCDC(
                         carryRes = carryMask;
                     }
                 }
-                outInt |= ((bitCapInt)nibbles[j]) << (j * 4UL);
+                outInt |= ((bitCapInt)nibbles[j]) << (j * 4U * ONE_BCI);
             }
             outRes = (outInt << inOutStart) | otherRes | carryRes;
             nStateVec->write(outRes, stateVec->read(lcv));
@@ -786,7 +786,7 @@ bitCapInt QEngineCPU::IndexedADC(bitLenInt indexStart, bitLenInt indexLength, bi
     bitCapInt carryMask = pow2(carryIndex);
     bitCapInt inputMask = bitRegMask(indexStart, indexLength);
     bitCapInt outputMask = bitRegMask(valueStart, valueLength);
-    bitCapInt otherMask = (maxQPower - 1UL) & (~(inputMask | outputMask | carryMask));
+    bitCapInt otherMask = (maxQPower - ONE_BCI) & (~(inputMask | outputMask | carryMask));
     bitCapInt skipPower = pow2(carryIndex);
 
     ParallelFunc fn = [&](const bitCapInt lcv, const int cpu) {
@@ -883,7 +883,7 @@ bitCapInt QEngineCPU::IndexedSBC(bitLenInt indexStart, bitLenInt indexLength, bi
     bitCapInt carryMask = pow2(carryIndex);
     bitCapInt inputMask = bitRegMask(indexStart, indexLength);
     bitCapInt outputMask = bitRegMask(valueStart, valueLength);
-    bitCapInt otherMask = (maxQPower - 1UL) & (~(inputMask | outputMask | carryMask));
+    bitCapInt otherMask = (maxQPower - ONE_BCI) & (~(inputMask | outputMask | carryMask));
     bitCapInt skipPower = pow2(carryIndex);
 
     ParallelFunc fn = [&](const bitCapInt lcv, const int cpu) {

--- a/src/qengine/arithmetic.cpp
+++ b/src/qengine/arithmetic.cpp
@@ -26,10 +26,10 @@ void QEngineCPU::ROL(bitLenInt shift, bitLenInt start, bitLenInt length)
         return;
     }
 
-    bitCapInt lengthPower = 1U << length;
-    bitCapInt lengthMask = lengthPower - 1U;
+    bitCapInt lengthPower = pow2(length);
+    bitCapInt lengthMask = lengthPower - 1UL;
     bitCapInt regMask = lengthMask << start;
-    bitCapInt otherMask = (maxQPower - 1U) ^ regMask;
+    bitCapInt otherMask = (maxQPower - 1UL) ^ regMask;
 
     StateVectorPtr nStateVec = AllocStateVec(maxQPower);
 
@@ -50,14 +50,14 @@ void QEngineCPU::INC(bitCapInt toAdd, bitLenInt inOutStart, bitLenInt length)
         return;
     }
 
-    bitCapInt lengthMask = (1U << length) - 1U;
+    bitCapInt lengthMask = pow2Mask(length);
     toAdd &= lengthMask;
     if (toAdd == 0) {
         return;
     }
 
     bitCapInt inOutMask = lengthMask << inOutStart;
-    bitCapInt otherMask = (maxQPower - 1U) ^ inOutMask;
+    bitCapInt otherMask = (maxQPower - 1UL) ^ inOutMask;
 
     StateVectorPtr nStateVec = AllocStateVec(maxQPower);
 
@@ -84,8 +84,8 @@ void QEngineCPU::CINC(
         return;
     }
 
-    bitCapInt lengthPower = 1U << length;
-    bitCapInt lengthMask = lengthPower - 1U;
+    bitCapInt lengthPower = pow2(length);
+    bitCapInt lengthMask = lengthPower - 1UL;
     toAdd &= lengthMask;
     if (toAdd == 0) {
         return;
@@ -94,13 +94,13 @@ void QEngineCPU::CINC(
     bitCapInt* controlPowers = new bitCapInt[controlLen];
     bitCapInt controlMask = 0;
     for (bitLenInt i = 0; i < controlLen; i++) {
-        controlPowers[i] = 1U << controls[i];
+        controlPowers[i] = pow2(controls[i]);
         controlMask |= controlPowers[i];
     }
     std::sort(controlPowers, controlPowers + controlLen);
 
     bitCapInt inOutMask = lengthMask << inOutStart;
-    bitCapInt otherMask = (maxQPower - 1U) ^ (inOutMask | controlMask);
+    bitCapInt otherMask = (maxQPower - 1UL) ^ (inOutMask | controlMask);
 
     StateVectorPtr nStateVec = AllocStateVec(maxQPower);
     nStateVec->copy(*stateVec);
@@ -126,23 +126,23 @@ void QEngineCPU::INCDECC(
         return;
     }
 
-    bitCapInt lengthPower = 1U << length;
-    bitCapInt lengthMask = lengthPower - 1U;
+    bitCapInt lengthPower = pow2(length);
+    bitCapInt lengthMask = lengthPower - 1UL;
     toMod &= lengthMask;
     if (toMod == 0) {
         return;
     }
 
-    bitCapInt carryMask = 1U << carryIndex;
+    bitCapInt carryMask = pow2(carryIndex);
     bitCapInt inOutMask = lengthMask << inOutStart;
-    bitCapInt otherMask = maxQPower - 1U;
+    bitCapInt otherMask = maxQPower - 1UL;
 
     otherMask ^= inOutMask | carryMask;
 
     StateVectorPtr nStateVec = AllocStateVec(maxQPower);
     nStateVec->clear();
 
-    par_for_skip(0, maxQPower, 1U << carryIndex, 1U, [&](const bitCapInt lcv, const int cpu) {
+    par_for_skip(0, maxQPower, pow2(carryIndex), 1UL, [&](const bitCapInt lcv, const int cpu) {
         bitCapInt otherRes = lcv & otherMask;
         bitCapInt inOutRes = lcv & inOutMask;
         bitCapInt inOutInt = inOutRes >> inOutStart;
@@ -171,17 +171,17 @@ void QEngineCPU::INCS(bitCapInt toAdd, bitLenInt inOutStart, bitLenInt length, b
         return;
     }
 
-    bitCapInt lengthPower = 1U << length;
-    bitCapInt lengthMask = lengthPower - 1U;
+    bitCapInt lengthPower = pow2(length);
+    bitCapInt lengthMask = lengthPower - 1UL;
     toAdd &= lengthMask;
     if (toAdd == 0) {
         return;
     }
 
-    bitCapInt overflowMask = 1U << overflowIndex;
-    bitCapInt signMask = 1U << (length - 1U);
+    bitCapInt overflowMask = pow2(overflowIndex);
+    bitCapInt signMask = pow2(length - 1UL);
     bitCapInt inOutMask = lengthMask << inOutStart;
-    bitCapInt otherMask = (maxQPower - 1U) ^ inOutMask;
+    bitCapInt otherMask = (maxQPower - 1UL) ^ inOutMask;
 
     StateVectorPtr nStateVec = AllocStateVec(maxQPower);
     nStateVec->clear();
@@ -198,21 +198,7 @@ void QEngineCPU::INCS(bitCapInt toAdd, bitLenInt inOutStart, bitLenInt length, b
         } else {
             outRes = ((outInt - lengthPower) << inOutStart) | otherRes;
         }
-        bool isOverflow = false;
-        // Both negative:
-        if (inOutInt & inInt & signMask) {
-            inOutInt = ((~inOutInt) & lengthMask) + 1U;
-            inInt = ((~inInt) & lengthMask) + 1U;
-            if ((inOutInt + inInt) > signMask) {
-                isOverflow = true;
-            }
-        }
-        // Both positive:
-        else if ((~inOutInt) & (~inInt) & signMask) {
-            if ((inOutInt + inInt) >= signMask) {
-                isOverflow = true;
-            }
-        }
+        bool isOverflow = isOverflowAdd(inOutInt, inInt, signMask, lengthPower);
         if (isOverflow && ((outRes & overflowMask) == overflowMask)) {
             nStateVec->write(outRes, -stateVec->read(lcv));
         } else {
@@ -229,16 +215,16 @@ void QEngineCPU::INCDECSC(
         return;
     }
 
-    bitCapInt lengthPower = 1U << length;
-    bitCapInt lengthMask = lengthPower - 1U;
+    bitCapInt lengthPower = pow2(length);
+    bitCapInt lengthMask = lengthPower - 1UL;
     toMod &= lengthMask;
     if (toMod == 0) {
         return;
     }
 
-    bitCapInt signMask = 1U << (length - 1U);
-    bitCapInt carryMask = 1U << carryIndex;
-    bitCapInt otherMask = maxQPower - 1U;
+    bitCapInt signMask = pow2(length - 1UL);
+    bitCapInt carryMask = pow2(carryIndex);
+    bitCapInt otherMask = maxQPower - 1UL;
     bitCapInt inOutMask = lengthMask << inOutStart;
 
     otherMask ^= inOutMask | carryMask;
@@ -246,7 +232,7 @@ void QEngineCPU::INCDECSC(
     StateVectorPtr nStateVec = AllocStateVec(maxQPower);
     nStateVec->clear();
 
-    par_for_skip(0, maxQPower, carryMask, 1U, [&](const bitCapInt lcv, const int cpu) {
+    par_for_skip(0, maxQPower, carryMask, 1UL, [&](const bitCapInt lcv, const int cpu) {
         bitCapInt otherRes = lcv & otherMask;
         bitCapInt inOutRes = lcv & inOutMask;
         bitCapInt inOutInt = inOutRes >> inOutStart;
@@ -258,19 +244,7 @@ void QEngineCPU::INCDECSC(
         } else {
             outRes = ((outInt - lengthPower) << inOutStart) | otherRes | carryMask;
         }
-        bool isOverflow = false;
-        // Both negative:
-        if (inOutInt & inInt & (signMask)) {
-            inOutInt = ((~inOutInt) & lengthMask) + 1U;
-            inInt = ((~inInt) & lengthMask) + 1U;
-            if ((inOutInt + inInt) > signMask)
-                isOverflow = true;
-        }
-        // Both positive:
-        else if ((~inOutInt) & (~inInt) & signMask) {
-            if ((inOutInt + inInt) >= signMask)
-                isOverflow = true;
-        }
+        bool isOverflow = isOverflowAdd(inOutInt, inInt, signMask, lengthPower);
         if (isOverflow) {
             nStateVec->write(outRes, -stateVec->read(lcv));
         } else {
@@ -287,23 +261,23 @@ void QEngineCPU::INCDECSC(bitCapInt toMod, const bitLenInt& inOutStart, const bi
         return;
     }
 
-    bitCapInt lengthPower = 1U << length;
-    bitCapInt lengthMask = lengthPower - 1U;
+    bitCapInt lengthPower = pow2(length);
+    bitCapInt lengthMask = lengthPower - 1UL;
     toMod &= lengthMask;
     if (toMod == 0) {
         return;
     }
 
-    bitCapInt overflowMask = 1U << overflowIndex;
-    bitCapInt signMask = 1U << (length - 1U);
-    bitCapInt carryMask = 1U << carryIndex;
+    bitCapInt overflowMask = pow2(overflowIndex);
+    bitCapInt signMask = pow2(length - 1UL);
+    bitCapInt carryMask = pow2(carryIndex);
     bitCapInt inOutMask = lengthMask << inOutStart;
-    bitCapInt otherMask = (maxQPower - 1U) ^ (inOutMask | carryMask);
+    bitCapInt otherMask = (maxQPower - 1UL) ^ (inOutMask | carryMask);
 
     StateVectorPtr nStateVec = AllocStateVec(maxQPower);
     nStateVec->clear();
 
-    par_for_skip(0, maxQPower, carryMask, 1U, [&](const bitCapInt lcv, const int cpu) {
+    par_for_skip(0, maxQPower, carryMask, 1UL, [&](const bitCapInt lcv, const int cpu) {
         bitCapInt otherRes = lcv & otherMask;
         bitCapInt inOutRes = lcv & inOutMask;
         bitCapInt inOutInt = inOutRes >> inOutStart;
@@ -315,19 +289,7 @@ void QEngineCPU::INCDECSC(bitCapInt toMod, const bitLenInt& inOutStart, const bi
         } else {
             outRes = ((outInt - lengthPower) << inOutStart) | otherRes | carryMask;
         }
-        bool isOverflow = false;
-        // Both negative:
-        if (inOutInt & inInt & (signMask)) {
-            inOutInt = ((~inOutInt) & lengthMask) + 1U;
-            inInt = ((~inInt) & lengthMask) + 1U;
-            if ((inOutInt + inInt) > signMask)
-                isOverflow = true;
-        }
-        // Both positive:
-        else if ((~inOutInt) & (~inInt) & signMask) {
-            if ((inOutInt + inInt) >= signMask)
-                isOverflow = true;
-        }
+        bool isOverflow = isOverflowAdd(inOutInt, inInt, signMask, lengthPower);
         if (isOverflow && ((outRes & overflowMask) == overflowMask)) {
             nStateVec->write(outRes, -stateVec->read(lcv));
         } else {
@@ -340,16 +302,16 @@ void QEngineCPU::INCDECSC(bitCapInt toMod, const bitLenInt& inOutStart, const bi
 void QEngineCPU::MULDIV(const IOFn& inFn, const IOFn& outFn, const bitCapInt& toMul, const bitLenInt& inOutStart,
     const bitLenInt& carryStart, const bitLenInt& length)
 {
-    bitCapInt lowMask = (1U << length) - 1U;
+    bitCapInt lowMask = pow2Mask(length);
     bitCapInt highMask = lowMask << length;
     bitCapInt inOutMask = lowMask << inOutStart;
     bitCapInt carryMask = lowMask << carryStart;
-    bitCapInt otherMask = (maxQPower - 1U) ^ (inOutMask | carryMask);
+    bitCapInt otherMask = (maxQPower - 1UL) ^ (inOutMask | carryMask);
 
     StateVectorPtr nStateVec = AllocStateVec(maxQPower);
     nStateVec->clear();
 
-    par_for_skip(0, maxQPower, 1U << carryStart, length, [&](const bitCapInt lcv, const int cpu) {
+    par_for_skip(0, maxQPower, pow2(carryStart), length, [&](const bitCapInt lcv, const int cpu) {
         bitCapInt otherRes = lcv & otherMask;
         bitCapInt mulInt = ((lcv & inOutMask) >> inOutStart) * toMul;
         bitCapInt mulRes =
@@ -368,7 +330,7 @@ void QEngineCPU::MUL(bitCapInt toMul, bitLenInt inOutStart, bitLenInt carryStart
         SetReg(inOutStart, length, 0);
         return;
     }
-    if (toMul == 1U) {
+    if (toMul == 1UL) {
         return;
     }
 
@@ -381,7 +343,7 @@ void QEngineCPU::DIV(bitCapInt toDiv, bitLenInt inOutStart, bitLenInt carryStart
     if (toDiv == 0) {
         throw "DIV by zero";
     }
-    if (toDiv == 1U) {
+    if (toDiv == 1UL) {
         return;
     }
 
@@ -392,7 +354,7 @@ void QEngineCPU::DIV(bitCapInt toDiv, bitLenInt inOutStart, bitLenInt carryStart
 void QEngineCPU::CMULDIV(const IOFn& inFn, const IOFn& outFn, const bitCapInt& toMul, const bitLenInt& inOutStart,
     const bitLenInt& carryStart, const bitLenInt& length, const bitLenInt* controls, const bitLenInt controlLen)
 {
-    bitCapInt lowMask = (1U << length) - 1U;
+    bitCapInt lowMask = pow2Mask(length);
     bitCapInt highMask = lowMask << length;
     bitCapInt inOutMask = lowMask << inOutStart;
     bitCapInt carryMask = lowMask << carryStart;
@@ -401,16 +363,16 @@ void QEngineCPU::CMULDIV(const IOFn& inFn, const IOFn& outFn, const bitCapInt& t
     bitCapInt* controlPowers = new bitCapInt[controlLen];
     bitCapInt controlMask = 0;
     for (bitLenInt i = 0; i < controlLen; i++) {
-        controlPowers[i] = 1U << controls[i];
+        controlPowers[i] = pow2(controls[i]);
         skipPowers[i] = controlPowers[i];
         controlMask |= controlPowers[i];
     }
     for (bitLenInt i = 0; i < length; i++) {
-        skipPowers[i + controlLen] = 1U << (carryStart + i);
+        skipPowers[i + controlLen] = pow2(carryStart + i);
     }
     std::sort(skipPowers, skipPowers + controlLen + length);
 
-    bitCapInt otherMask = (maxQPower - 1U) ^ (inOutMask | carryMask | controlMask);
+    bitCapInt otherMask = (maxQPower - 1UL) ^ (inOutMask | carryMask | controlMask);
 
     StateVectorPtr nStateVec = AllocStateVec(maxQPower);
     nStateVec->clear();
@@ -425,10 +387,10 @@ void QEngineCPU::CMULDIV(const IOFn& inFn, const IOFn& outFn, const bitCapInt& t
 
         nStateVec->write(lcv, stateVec->read(lcv));
         bitCapInt partControlMask;
-        for (bitCapInt j = 1U; j < ((1U << controlLen) - 1U); j++) {
+        for (bitCapInt j = 1UL; j < pow2Mask(controlLen); j++) {
             partControlMask = 0;
             for (bitLenInt k = 0; k < controlLen; k++) {
-                if (j & (1U << k)) {
+                if ((j >> k) & 1UL) {
                     partControlMask |= controlPowers[k];
                 }
             }
@@ -456,7 +418,7 @@ void QEngineCPU::CMUL(bitCapInt toMul, bitLenInt inOutStart, bitLenInt carryStar
         SetReg(inOutStart, length, 0);
         return;
     }
-    if (toMul == 1U) {
+    if (toMul == 1UL) {
         return;
     }
 
@@ -476,7 +438,7 @@ void QEngineCPU::CDIV(bitCapInt toDiv, bitLenInt inOutStart, bitLenInt carryStar
     if (toDiv == 0) {
         throw "DIV by zero";
     }
-    if (toDiv == 1U) {
+    if (toDiv == 1UL) {
         return;
     }
 
@@ -490,15 +452,15 @@ void QEngineCPU::ModNOut(const MFn& kernelFn, const bitCapInt& modN, const bitLe
 {
     SetReg(outStart, length, 0);
 
-    bitCapInt lowMask = (1U << length) - 1U;
+    bitCapInt lowMask = pow2Mask(length);
     bitCapInt inMask = lowMask << inStart;
     bitCapInt outMask = lowMask << outStart;
-    bitCapInt otherMask = (maxQPower - 1U) ^ (inMask | outMask);
+    bitCapInt otherMask = (maxQPower - 1UL) ^ (inMask | outMask);
 
     StateVectorPtr nStateVec = AllocStateVec(maxQPower);
     nStateVec->clear();
 
-    par_for_skip(0, maxQPower, 1U << outStart, length, [&](const bitCapInt lcv, const int cpu) {
+    par_for_skip(0, maxQPower, pow2(outStart), length, [&](const bitCapInt lcv, const int cpu) {
         bitCapInt otherRes = lcv & otherMask;
         bitCapInt inRes = lcv & inMask;
         bitCapInt outRes = (kernelFn(inRes >> inStart) % modN) << outStart;
@@ -528,8 +490,8 @@ void QEngineCPU::CModNOut(const MFn& kernelFn, const bitCapInt& modN, const bitL
 {
     SetReg(outStart, length, 0);
 
-    bitCapInt lowPower = 1U << length;
-    bitCapInt lowMask = lowPower - 1U;
+    bitCapInt lowPower = pow2(length);
+    bitCapInt lowMask = lowPower - 1UL;
     bitCapInt inMask = lowMask << inStart;
     bitCapInt outMask = lowMask << outStart;
 
@@ -537,16 +499,16 @@ void QEngineCPU::CModNOut(const MFn& kernelFn, const bitCapInt& modN, const bitL
     bitCapInt* controlPowers = new bitCapInt[controlLen];
     bitCapInt controlMask = 0;
     for (bitLenInt i = 0; i < controlLen; i++) {
-        controlPowers[i] = 1U << controls[i];
+        controlPowers[i] = pow2(controls[i]);
         skipPowers[i] = controlPowers[i];
         controlMask |= controlPowers[i];
     }
     for (bitLenInt i = 0; i < length; i++) {
-        skipPowers[i + controlLen] = 1U << (outStart + i);
+        skipPowers[i + controlLen] = pow2(outStart + i);
     }
     std::sort(skipPowers, skipPowers + controlLen + length);
 
-    bitCapInt otherMask = (maxQPower - 1U) ^ (inMask | outMask | controlMask);
+    bitCapInt otherMask = (maxQPower - 1UL) ^ (inMask | outMask | controlMask);
 
     StateVectorPtr nStateVec = AllocStateVec(maxQPower);
     nStateVec->clear();
@@ -560,10 +522,10 @@ void QEngineCPU::CModNOut(const MFn& kernelFn, const bitCapInt& modN, const bitL
         nStateVec->write(lcv, stateVec->read(lcv));
 
         bitCapInt partControlMask;
-        for (bitCapInt j = 1U; j < ((1U << controlLen) - 1U); j++) {
+        for (bitCapInt j = 1UL; j < pow2Mask(controlLen); j++) {
             partControlMask = 0;
             for (bitLenInt k = 0; k < controlLen; k++) {
-                if (j & (1U << k)) {
+                if ((j >> k) & 1UL) {
                     partControlMask |= controlPowers[k];
                 }
             }
@@ -635,8 +597,8 @@ void QEngineCPU::INCBCD(bitCapInt toAdd, bitLenInt inOutStart, bitLenInt length)
         int* nibbles = new int[nibbleCount];
         bool isValid = true;
         for (j = 0; j < nibbleCount; j++) {
-            test1 = inOutInt & 15U;
-            inOutInt >>= 4U;
+            test1 = inOutInt & 15UL;
+            inOutInt >>= 4UL;
             test2 = (partToAdd % 10);
             partToAdd /= 10;
             nibbles[j] = test1 + test2;
@@ -653,7 +615,7 @@ void QEngineCPU::INCBCD(bitCapInt toAdd, bitLenInt inOutStart, bitLenInt length)
                         nibbles[j + 1]++;
                     }
                 }
-                outInt |= ((bitCapInt)nibbles[j]) << (j * 4U);
+                outInt |= ((bitCapInt)nibbles[j]) << (j * 4UL);
             }
             nStateVec->write((outInt << inOutStart) | otherRes, stateVec->read(lcv));
         } else {
@@ -684,15 +646,15 @@ void QEngineCPU::INCDECBCDC(
     }
 
     bitCapInt inOutMask = bitRegMask(inOutStart, length);
-    bitCapInt otherMask = maxQPower - 1U;
-    bitCapInt carryMask = 1U << carryIndex;
+    bitCapInt otherMask = maxQPower - 1UL;
+    bitCapInt carryMask = pow2(carryIndex);
 
     otherMask ^= inOutMask | carryMask;
 
     StateVectorPtr nStateVec = AllocStateVec(maxQPower);
     nStateVec->clear();
 
-    par_for_skip(0, maxQPower, 1U << carryIndex, 1U, [&](const bitCapInt lcv, const int cpu) {
+    par_for_skip(0, maxQPower, pow2(carryIndex), 1UL, [&](const bitCapInt lcv, const int cpu) {
         bitCapInt otherRes = lcv & otherMask;
         bitCapInt partToAdd = toMod;
         bitCapInt inOutRes = lcv & inOutMask;
@@ -702,8 +664,8 @@ void QEngineCPU::INCDECBCDC(
         int* nibbles = new int[nibbleCount];
         bool isValid = true;
 
-        test1 = inOutInt & 15U;
-        inOutInt >>= 4U;
+        test1 = inOutInt & 15UL;
+        inOutInt >>= 4UL;
         test2 = partToAdd % 10;
         partToAdd /= 10;
         nibbles[0] = test1 + test2;
@@ -712,8 +674,8 @@ void QEngineCPU::INCDECBCDC(
         }
 
         for (j = 1; j < nibbleCount; j++) {
-            test1 = inOutInt & 15U;
-            inOutInt >>= 4U;
+            test1 = inOutInt & 15UL;
+            inOutInt >>= 4UL;
             test2 = partToAdd % 10;
             partToAdd /= 10;
             nibbles[j] = test1 + test2;
@@ -734,7 +696,7 @@ void QEngineCPU::INCDECBCDC(
                         carryRes = carryMask;
                     }
                 }
-                outInt |= ((bitCapInt)nibbles[j]) << (j * 4U);
+                outInt |= ((bitCapInt)nibbles[j]) << (j * 4UL);
             }
             outRes = (outInt << inOutStart) | otherRes | carryRes;
             nStateVec->write(outRes, stateVec->read(lcv));
@@ -757,7 +719,7 @@ bitCapInt QEngineCPU::IndexedLDA(
 
     bitLenInt valueBytes = (valueLength + 7U) / 8U;
     bitCapInt inputMask = bitRegMask(indexStart, indexLength);
-    bitCapInt skipPower = 1U << valueStart;
+    bitCapInt skipPower = pow2(valueStart);
 
     StateVectorPtr nStateVec = AllocStateVec(maxQPower);
     nStateVec->clear();
@@ -767,7 +729,7 @@ bitCapInt QEngineCPU::IndexedLDA(
         bitCapInt inputInt = inputRes >> indexStart;
         bitCapInt outputInt = 0;
         for (bitLenInt j = 0; j < valueBytes; j++) {
-            outputInt |= values[inputInt * valueBytes + j] << (8U * j);
+            outputInt |= values[inputInt * valueBytes + j] << (8UL * j);
         }
         bitCapInt outputRes = outputInt << valueStart;
         nStateVec->write(outputRes | lcv, stateVec->read(lcv));
@@ -820,12 +782,12 @@ bitCapInt QEngineCPU::IndexedADC(bitLenInt indexStart, bitLenInt indexLength, bi
     // distinguish the different values of the input register, output register,
     // carry, and other bits that aren't involved in the operation.
     bitLenInt valueBytes = (valueLength + 7U) / 8U;
-    bitCapInt lengthPower = 1U << valueLength;
-    bitCapInt carryMask = 1U << carryIndex;
+    bitCapInt lengthPower = pow2(valueLength);
+    bitCapInt carryMask = pow2(carryIndex);
     bitCapInt inputMask = bitRegMask(indexStart, indexLength);
     bitCapInt outputMask = bitRegMask(valueStart, valueLength);
-    bitCapInt otherMask = (maxQPower - 1U) & (~(inputMask | outputMask | carryMask));
-    bitCapInt skipPower = 1U << carryIndex;
+    bitCapInt otherMask = (maxQPower - 1UL) & (~(inputMask | outputMask | carryMask));
+    bitCapInt skipPower = pow2(carryIndex);
 
     ParallelFunc fn = [&](const bitCapInt lcv, const int cpu) {
         // These are qubits that are not directly involved in the
@@ -849,7 +811,7 @@ bitCapInt QEngineCPU::IndexedADC(bitLenInt indexStart, bitLenInt indexLength, bi
         // iteration of the loop.
         bitCapInt outputInt = 0;
         for (bitLenInt j = 0; j < valueBytes; j++) {
-            outputInt |= values[inputInt * valueBytes + j] << (8U * j);
+            outputInt |= values[inputInt * valueBytes + j] << (8UL * j);
         }
         outputInt += (outputRes >> valueStart) + carryIn;
 
@@ -917,12 +879,12 @@ bitCapInt QEngineCPU::IndexedSBC(bitLenInt indexStart, bitLenInt indexLength, bi
     // This bit masks let us quickly distinguish the different values of the input register, output register, carry, and
     // other bits that aren't involved in the operation.
     bitLenInt valueBytes = (valueLength + 7U) / 8U;
-    bitCapInt lengthPower = 1U << valueLength;
-    bitCapInt carryMask = 1U << carryIndex;
+    bitCapInt lengthPower = pow2(valueLength);
+    bitCapInt carryMask = pow2(carryIndex);
     bitCapInt inputMask = bitRegMask(indexStart, indexLength);
     bitCapInt outputMask = bitRegMask(valueStart, valueLength);
-    bitCapInt otherMask = (maxQPower - 1U) & (~(inputMask | outputMask | carryMask));
-    bitCapInt skipPower = 1U << carryIndex;
+    bitCapInt otherMask = (maxQPower - 1UL) & (~(inputMask | outputMask | carryMask));
+    bitCapInt skipPower = pow2(carryIndex);
 
     ParallelFunc fn = [&](const bitCapInt lcv, const int cpu) {
         // These are qubits that are not directly involved in the
@@ -946,7 +908,7 @@ bitCapInt QEngineCPU::IndexedSBC(bitLenInt indexStart, bitLenInt indexLength, bi
         // iteration of the loop.
         bitCapInt outputInt = 0;
         for (bitLenInt j = 0; j < valueBytes; j++) {
-            outputInt |= values[inputInt * valueBytes + j] << (8U * j);
+            outputInt |= values[inputInt * valueBytes + j] << (8UL * j);
         }
         outputInt = (outputRes >> valueStart) + (lengthPower - (outputInt + carryIn));
 
@@ -990,10 +952,10 @@ bitCapInt QEngineCPU::IndexedSBC(bitLenInt indexStart, bitLenInt indexLength, bi
 
 void QEngineCPU::FullAdd(bitLenInt inputBit1, bitLenInt inputBit2, bitLenInt carryInSumOut, bitLenInt carryOut)
 {
-    bitCapInt input1Mask = 1U << inputBit1;
-    bitCapInt input2Mask = 1U << inputBit2;
-    bitCapInt carryInSumOutMask = 1U << carryInSumOut;
-    bitCapInt carryOutMask = 1U << carryOut;
+    bitCapInt input1Mask = pow2(inputBit1);
+    bitCapInt input2Mask = pow2(inputBit2);
+    bitCapInt carryInSumOutMask = pow2(carryInSumOut);
+    bitCapInt carryOutMask = pow2(carryOut);
 
     bitCapInt qPowers[2] = { carryInSumOutMask, carryOutMask };
     std::sort(qPowers, qPowers + 2);
@@ -1055,10 +1017,10 @@ void QEngineCPU::FullAdd(bitLenInt inputBit1, bitLenInt inputBit2, bitLenInt car
 
 void QEngineCPU::IFullAdd(bitLenInt inputBit1, bitLenInt inputBit2, bitLenInt carryInSumOut, bitLenInt carryOut)
 {
-    bitCapInt input1Mask = 1U << inputBit1;
-    bitCapInt input2Mask = 1U << inputBit2;
-    bitCapInt carryInSumOutMask = 1U << carryInSumOut;
-    bitCapInt carryOutMask = 1U << carryOut;
+    bitCapInt input1Mask = pow2(inputBit1);
+    bitCapInt input2Mask = pow2(inputBit2);
+    bitCapInt carryInSumOutMask = pow2(carryInSumOut);
+    bitCapInt carryOutMask = pow2(carryOut);
 
     bitCapInt qPowers[2] = { carryInSumOutMask, carryOutMask };
     std::sort(qPowers, qPowers + 2);

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -1127,7 +1127,7 @@ real1 QEngineOCL::Prob(bitLenInt qubit)
 
     bitCapInt qPower = pow2(qubit);
 
-    bitCapInt bciArgs[BCI_ARG_LEN] = { maxQPower >> 1U, qPower, 0, 0, 0, 0, 0, 0, 0, 0 };
+    bitCapInt bciArgs[BCI_ARG_LEN] = { maxQPower >> ONE_BCI, qPower, 0, 0, 0, 0, 0, 0, 0, 0 };
 
     return Probx(OCL_API_PROB, bciArgs);
 }
@@ -1912,7 +1912,7 @@ bitCapInt QEngineOCL::OpIndexed(OCLAPI api_call, bitCapInt carryIn, bitLenInt in
          * If the carry is set, we flip the carry bit. We always initially
          * clear the carry after testing for carry in.
          */
-        carryIn ^= 1U;
+        carryIn ^= ONE_BCI;
         X(carryIndex);
     }
 

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -139,10 +139,10 @@ size_t QEngineOCL::FixWorkItemCount(size_t maxI, size_t wic)
         // Otherwise, clamp to a power of two
         size_t power = 2;
         while (power < wic) {
-            power <<= 1U;
+            power <<= 1UL;
         }
         if (power > wic) {
-            power >>= 1U;
+            power >>= 1UL;
         }
         wic = power;
     }
@@ -334,16 +334,16 @@ void QEngineOCL::SetDevice(const int& dID, const bool& forceReInit)
     // constrain to a power of two
     size_t procElemPow = 1;
     while (procElemPow < procElemCount) {
-        procElemPow <<= 1U;
+        procElemPow <<= 1UL;
     }
     procElemCount = procElemPow;
     maxWorkItems = device_context->device.getInfo<CL_DEVICE_MAX_WORK_ITEM_SIZES>()[0];
     nrmGroupCount = maxWorkItems;
     size_t nrmGroupPow = 2;
     while (nrmGroupPow <= nrmGroupCount) {
-        nrmGroupPow <<= 1U;
+        nrmGroupPow <<= 1UL;
     }
-    nrmGroupCount = nrmGroupPow >> 1U;
+    nrmGroupCount = nrmGroupPow >> 1UL;
     if (nrmGroupSize > (nrmGroupCount / procElemCount)) {
         nrmGroupSize = (nrmGroupCount / procElemCount);
         if (nrmGroupSize == 0) {
@@ -522,7 +522,7 @@ void QEngineOCL::X(bitLenInt qubit)
     const complex pauliX[4] = { complex(ZERO_R1, ZERO_R1), complex(ONE_R1, ZERO_R1), complex(ONE_R1, ZERO_R1),
         complex(ZERO_R1, ZERO_R1) };
     bitCapInt qPowers[1];
-    qPowers[0] = 1 << qubit;
+    qPowers[0] = pow2(qubit);
     Apply2x2(0, qPowers[0], pauliX, 1, qPowers, false, SPECIAL_2X2::PAULIX);
 }
 
@@ -534,7 +534,7 @@ void QEngineOCL::Z(bitLenInt qubit)
     const complex pauliZ[4] = { complex(ONE_R1, ZERO_R1), complex(ZERO_R1, ZERO_R1), complex(ZERO_R1, ZERO_R1),
         complex(-ONE_R1, ZERO_R1) };
     bitCapInt qPowers[1];
-    qPowers[0] = 1 << qubit;
+    qPowers[0] = pow2(qubit);
     Apply2x2(0, qPowers[0], pauliZ, 1, qPowers, false, SPECIAL_2X2::PAULIZ);
 }
 
@@ -738,22 +738,22 @@ void QEngineOCL::UniformlyControlledSingleBit(const bitLenInt* controls, const b
 
     // Load the integer kernel arguments buffer.
     bitCapInt maxI = maxQPower >> 1;
-    bitCapInt bciArgs[BCI_ARG_LEN] = { maxI, (bitCapInt)(1 << qubitIndex), controlLen, mtrxSkipLen, mtrxSkipValueMask,
-        0, 0, 0, 0, 0 };
+    bitCapInt bciArgs[BCI_ARG_LEN] = { maxI, pow2(qubitIndex), controlLen, mtrxSkipLen, mtrxSkipValueMask, 0, 0, 0, 0,
+        0 };
     DISPATCH_WRITE(waitVec, *(poolItem->ulongBuffer), sizeof(bitCapInt) * 5, bciArgs);
 
     BufferPtr nrmInBuffer = std::make_shared<cl::Buffer>(context, CL_MEM_READ_ONLY, sizeof(real1));
     real1 nrm = (real1)(ONE_R1 / std::sqrt(runningNorm));
     DISPATCH_WRITE(waitVec, *nrmInBuffer, sizeof(real1), &nrm);
 
-    BufferPtr uniformBuffer = std::make_shared<cl::Buffer>(
-        context, CL_MEM_READ_ONLY, sizeof(complex) * 4U * (1U << (controlLen + mtrxSkipLen)));
+    BufferPtr uniformBuffer =
+        std::make_shared<cl::Buffer>(context, CL_MEM_READ_ONLY, sizeof(complex) * 4UL * pow2(controlLen + mtrxSkipLen));
 
-    DISPATCH_WRITE(waitVec, *uniformBuffer, sizeof(complex) * 4 * (1U << (controlLen + mtrxSkipLen)), mtrxs);
+    DISPATCH_WRITE(waitVec, *uniformBuffer, sizeof(complex) * 4UL * pow2(controlLen + mtrxSkipLen), mtrxs);
 
     bitCapInt* qPowers = new bitCapInt[controlLen + mtrxSkipLen];
     for (bitLenInt i = 0; i < controlLen; i++) {
-        qPowers[i] = 1U << controls[i];
+        qPowers[i] = pow2(controls[i]);
     }
     for (bitLenInt i = 0; i < mtrxSkipLen; i++) {
         qPowers[controlLen + i] = mtrxSkipPowers[i];
@@ -888,9 +888,9 @@ bitLenInt QEngineOCL::Compose(QEngineOCLPtr toCopy)
 
     bitCapInt oQubitCount = toCopy->qubitCount;
     bitCapInt nQubitCount = qubitCount + oQubitCount;
-    bitCapInt nMaxQPower = 1U << nQubitCount;
-    bitCapInt startMask = maxQPower - 1U;
-    bitCapInt endMask = (toCopy->maxQPower - 1U) << qubitCount;
+    bitCapInt nMaxQPower = pow2(nQubitCount);
+    bitCapInt startMask = maxQPower - 1UL;
+    bitCapInt endMask = (toCopy->maxQPower - 1UL) << qubitCount;
     bitCapInt bciArgs[BCI_ARG_LEN] = { nMaxQPower, qubitCount, startMask, endMask, 0, 0, 0, 0, 0, 0 };
 
     OCLAPI api_call;
@@ -911,10 +911,10 @@ bitLenInt QEngineOCL::Compose(QEngineOCLPtr toCopy, bitLenInt start)
 
     bitLenInt oQubitCount = toCopy->qubitCount;
     bitLenInt nQubitCount = qubitCount + oQubitCount;
-    bitCapInt nMaxQPower = 1U << nQubitCount;
-    bitCapInt startMask = (1U << start) - 1U;
+    bitCapInt nMaxQPower = pow2(nQubitCount);
+    bitCapInt startMask = pow2(start) - 1UL;
     bitCapInt midMask = bitRegMask(start, oQubitCount);
-    bitCapInt endMask = ((1U << (qubitCount + oQubitCount)) - 1U) & ~(startMask | midMask);
+    bitCapInt endMask = pow2Mask(qubitCount + oQubitCount) & ~(startMask | midMask);
     bitCapInt bciArgs[BCI_ARG_LEN] = { nMaxQPower, qubitCount, oQubitCount, startMask, midMask, endMask, start, 0, 0,
         0 };
 
@@ -959,8 +959,8 @@ void QEngineOCL::DecomposeDispose(bitLenInt start, bitLenInt length, QEngineOCLP
 
     OCLAPI api_call = OCL_API_DECOMPOSEPROB;
 
-    bitCapInt partPower = 1U << length;
-    bitCapInt remainderPower = 1U << (qubitCount - length);
+    bitCapInt partPower = pow2(length);
+    bitCapInt remainderPower = pow2(qubitCount - length);
     bitCapInt bciArgs[BCI_ARG_LEN] = { partPower, remainderPower, start, length, 0, 0, 0, 0, 0, 0 };
 
     EventVecPtr waitVec = ResetWaitEvents();
@@ -1125,7 +1125,7 @@ real1 QEngineOCL::Prob(bitLenInt qubit)
         return ProbAll(1);
     }
 
-    bitCapInt qPower = 1U << qubit;
+    bitCapInt qPower = pow2(qubit);
 
     bitCapInt bciArgs[BCI_ARG_LEN] = { maxQPower >> 1U, qPower, 0, 0, 0, 0, 0, 0, 0, 0 };
 
@@ -1148,7 +1148,7 @@ real1 QEngineOCL::ProbReg(const bitLenInt& start, const bitLenInt& length, const
 
 void QEngineOCL::ProbRegAll(const bitLenInt& start, const bitLenInt& length, real1* probsArray)
 {
-    bitCapInt lengthPower = 1U << length;
+    bitCapInt lengthPower = pow2(length);
     bitCapInt maxJ = maxQPower >> length;
 
     if (doNormalize) {
@@ -1236,11 +1236,11 @@ void QEngineOCL::ProbMaskAll(const bitCapInt& mask, real1* probsArray)
     std::vector<bitCapInt> powersVec;
     for (length = 0; v; length++) {
         oldV = v;
-        v &= v - 1U; // clear the least significant bit set
+        v &= v - 1UL; // clear the least significant bit set
         powersVec.push_back((v ^ oldV) & oldV);
     }
 
-    bitCapInt lengthPower = 1U << length;
+    bitCapInt lengthPower = pow2(length);
     bitCapInt maxJ = maxQPower >> length;
 
     if (doNormalize) {
@@ -1254,13 +1254,13 @@ void QEngineOCL::ProbMaskAll(const bitCapInt& mask, real1* probsArray)
         return;
     }
 
-    v = (~mask) & (maxQPower - 1U); // count the number of bits set in v
+    v = (~mask) & (maxQPower - 1UL); // count the number of bits set in v
     bitCapInt skipPower;
     bitLenInt skipLength = 0; // c accumulates the total bits set in v
     std::vector<bitCapInt> skipPowersVec;
     for (skipLength = 0; v; skipLength++) {
         oldV = v;
-        v &= v - 1U; // clear the least significant bit set
+        v &= v - 1UL; // clear the least significant bit set
         skipPower = (v ^ oldV) & oldV;
         skipPowersVec.push_back(skipPower);
     }
@@ -1312,9 +1312,9 @@ void QEngineOCL::ROx(OCLAPI api_call, bitLenInt shift, bitLenInt start, bitLenIn
         return;
     }
 
-    bitCapInt lengthPower = 1U << length;
-    bitCapInt regMask = (lengthPower - 1U) << start;
-    bitCapInt otherMask = (maxQPower - 1U) & (~regMask);
+    bitCapInt lengthPower = pow2(length);
+    bitCapInt regMask = (lengthPower - 1UL) << start;
+    bitCapInt otherMask = (maxQPower - 1UL) & (~regMask);
     bitCapInt bciArgs[BCI_ARG_LEN] = { maxQPower, regMask, otherMask, lengthPower, start, shift, length, 0, 0, 0 };
 
     ArithmeticCall(api_call, bciArgs);
@@ -1330,15 +1330,15 @@ void QEngineOCL::INT(OCLAPI api_call, bitCapInt toMod, const bitLenInt start, co
         return;
     }
 
-    bitCapInt lengthPower = 1U << length;
-    bitCapInt lengthMask = lengthPower - 1U;
+    bitCapInt lengthPower = pow2(length);
+    bitCapInt lengthMask = lengthPower - 1UL;
     toMod &= lengthMask;
     if (toMod == 0) {
         return;
     }
 
     bitCapInt regMask = lengthMask << start;
-    bitCapInt otherMask = (maxQPower - 1U) & ~(regMask);
+    bitCapInt otherMask = (maxQPower - 1UL) & ~(regMask);
 
     bitCapInt bciArgs[BCI_ARG_LEN] = { maxQPower, regMask, otherMask, lengthPower, start, toMod, 0, 0, 0, 0 };
 
@@ -1353,8 +1353,8 @@ void QEngineOCL::CINT(OCLAPI api_call, bitCapInt toMod, const bitLenInt start, c
         return;
     }
 
-    bitCapInt lengthPower = 1U << length;
-    bitCapInt lengthMask = lengthPower - 1U;
+    bitCapInt lengthPower = pow2(length);
+    bitCapInt lengthMask = lengthPower - 1UL;
     toMod &= lengthMask;
     if (toMod == 0) {
         return;
@@ -1365,12 +1365,12 @@ void QEngineOCL::CINT(OCLAPI api_call, bitCapInt toMod, const bitLenInt start, c
     bitCapInt controlMask = 0;
     bitCapInt* controlPowers = new bitCapInt[controlLen];
     for (bitLenInt i = 0; i < controlLen; i++) {
-        controlPowers[i] = 1U << controls[i];
+        controlPowers[i] = pow2(controls[i]);
         controlMask |= controlPowers[i];
     }
     std::sort(controlPowers, controlPowers + controlLen);
 
-    bitCapInt otherMask = (maxQPower - 1U) ^ (regMask | controlMask);
+    bitCapInt otherMask = (maxQPower - 1UL) ^ (regMask | controlMask);
 
     bitCapInt bciArgs[BCI_ARG_LEN] = { maxQPower >> controlLen, regMask, otherMask, lengthPower, start, toMod,
         controlLen, controlMask, 0, 0 };
@@ -1405,18 +1405,18 @@ void QEngineOCL::INTC(
         return;
     }
 
-    bitCapInt lengthPower = 1U << length;
-    bitCapInt lengthMask = lengthPower - 1U;
+    bitCapInt lengthPower = pow2(length);
+    bitCapInt lengthMask = lengthPower - 1UL;
     toMod &= lengthMask;
     if (toMod == 0) {
         return;
     }
 
-    bitCapInt carryMask = 1U << carryIndex;
-    bitCapInt regMask = (lengthPower - 1U) << start;
-    bitCapInt otherMask = (maxQPower - 1U) & (~(regMask | carryMask));
+    bitCapInt carryMask = pow2(carryIndex);
+    bitCapInt regMask = (lengthPower - 1UL) << start;
+    bitCapInt otherMask = (maxQPower - 1UL) & (~(regMask | carryMask));
 
-    bitCapInt bciArgs[BCI_ARG_LEN] = { maxQPower >> 1U, regMask, otherMask, lengthPower, carryMask, start, toMod, 0, 0,
+    bitCapInt bciArgs[BCI_ARG_LEN] = { maxQPower >> 1UL, regMask, otherMask, lengthPower, carryMask, start, toMod, 0, 0,
         0 };
 
     ArithmeticCall(api_call, bciArgs);
@@ -1437,16 +1437,16 @@ void QEngineOCL::INTS(
         return;
     }
 
-    bitCapInt lengthPower = 1U << length;
-    bitCapInt lengthMask = lengthPower - 1U;
+    bitCapInt lengthPower = pow2(length);
+    bitCapInt lengthMask = lengthPower - 1UL;
     toMod &= lengthMask;
     if (toMod == 0) {
         return;
     }
 
-    bitCapInt overflowMask = 1U << overflowIndex;
+    bitCapInt overflowMask = pow2(overflowIndex);
     bitCapInt regMask = lengthMask << start;
-    bitCapInt otherMask = (maxQPower - 1U) ^ regMask;
+    bitCapInt otherMask = (maxQPower - 1UL) ^ regMask;
 
     bitCapInt bciArgs[BCI_ARG_LEN] = { maxQPower, regMask, otherMask, lengthPower, overflowMask, start, toMod, 0, 0,
         0 };
@@ -1468,19 +1468,19 @@ void QEngineOCL::INTSC(OCLAPI api_call, bitCapInt toMod, const bitLenInt start, 
         return;
     }
 
-    bitCapInt lengthPower = 1U << length;
-    bitCapInt lengthMask = lengthPower - 1U;
+    bitCapInt lengthPower = pow2(length);
+    bitCapInt lengthMask = lengthPower - 1UL;
     toMod &= lengthMask;
     if (toMod == 0) {
         return;
     }
 
-    bitCapInt overflowMask = 1U << overflowIndex;
-    bitCapInt carryMask = 1U << carryIndex;
+    bitCapInt overflowMask = pow2(overflowIndex);
+    bitCapInt carryMask = pow2(carryIndex);
     bitCapInt inOutMask = lengthMask << start;
-    bitCapInt otherMask = (maxQPower - 1U) ^ (inOutMask | carryMask);
+    bitCapInt otherMask = (maxQPower - 1UL) ^ (inOutMask | carryMask);
 
-    bitCapInt bciArgs[BCI_ARG_LEN] = { maxQPower >> 1U, inOutMask, otherMask, lengthPower, overflowMask, carryMask,
+    bitCapInt bciArgs[BCI_ARG_LEN] = { maxQPower >> 1UL, inOutMask, otherMask, lengthPower, overflowMask, carryMask,
         start, toMod, 0, 0 };
 
     ArithmeticCall(api_call, bciArgs);
@@ -1497,12 +1497,12 @@ void QEngineOCL::INCDECSC(bitCapInt toAdd, const bitLenInt& start, const bitLenI
 void QEngineOCL::INTSC(
     OCLAPI api_call, bitCapInt toMod, const bitLenInt start, const bitLenInt length, const bitLenInt carryIndex)
 {
-    bitCapInt carryMask = 1U << carryIndex;
-    bitCapInt lengthPower = 1U << length;
-    bitCapInt inOutMask = (lengthPower - 1U) << start;
-    bitCapInt otherMask = ((1U << qubitCount) - 1U) ^ (inOutMask | carryMask);
+    bitCapInt carryMask = pow2(carryIndex);
+    bitCapInt lengthPower = pow2(length);
+    bitCapInt inOutMask = (lengthPower - 1UL) << start;
+    bitCapInt otherMask = pow2Mask(qubitCount) ^ (inOutMask | carryMask);
 
-    bitCapInt bciArgs[BCI_ARG_LEN] = { maxQPower >> 1U, inOutMask, otherMask, lengthPower, carryMask, start, toMod, 0,
+    bitCapInt bciArgs[BCI_ARG_LEN] = { maxQPower >> 1UL, inOutMask, otherMask, lengthPower, carryMask, start, toMod, 0,
         0, 0 };
 
     ArithmeticCall(api_call, bciArgs);
@@ -1533,7 +1533,7 @@ void QEngineOCL::INTBCD(OCLAPI api_call, bitCapInt toMod, const bitLenInt start,
     }
 
     bitCapInt inOutMask = bitRegMask(start, length);
-    bitCapInt otherMask = (maxQPower - 1U) ^ inOutMask;
+    bitCapInt otherMask = (maxQPower - 1UL) ^ inOutMask;
 
     bitCapInt bciArgs[BCI_ARG_LEN] = { maxQPower, inOutMask, otherMask, start, toMod, nibbleCount, 0, 0, 0, 0 };
 
@@ -1566,10 +1566,10 @@ void QEngineOCL::INTBCDC(
     }
 
     bitCapInt inOutMask = bitRegMask(start, length);
-    bitCapInt carryMask = 1U << carryIndex;
-    bitCapInt otherMask = (maxQPower - 1U) ^ (inOutMask | carryMask);
+    bitCapInt carryMask = pow2(carryIndex);
+    bitCapInt otherMask = (maxQPower - 1UL) ^ (inOutMask | carryMask);
 
-    bitCapInt bciArgs[BCI_ARG_LEN] = { maxQPower >> 1U, inOutMask, otherMask, carryMask, start, toMod, nibbleCount, 0,
+    bitCapInt bciArgs[BCI_ARG_LEN] = { maxQPower >> 1UL, inOutMask, otherMask, carryMask, start, toMod, nibbleCount, 0,
         0, 0 };
 
     ArithmeticCall(api_call, bciArgs);
@@ -1587,8 +1587,8 @@ void QEngineOCL::MUL(bitCapInt toMul, bitLenInt inOutStart, bitLenInt carryStart
 {
     SetReg(carryStart, length, 0);
 
-    bitCapInt lowPower = 1U << length;
-    toMul &= (lowPower - 1U);
+    bitCapInt lowPower = pow2(length);
+    toMul &= (lowPower - 1UL);
     if (toMul == 0) {
         SetReg(inOutStart, length, 0);
         return;
@@ -1639,8 +1639,8 @@ void QEngineOCL::IFullAdd(bitLenInt inputBit1, bitLenInt inputBit2, bitLenInt ca
 void QEngineOCL::FullAdx(
     bitLenInt inputBit1, bitLenInt inputBit2, bitLenInt carryInSumOut, bitLenInt carryOut, OCLAPI api_call)
 {
-    bitCapInt bciArgs[BCI_ARG_LEN] = { maxQPower >> 2U, 1U << inputBit1, 1U << inputBit2, 1U << carryInSumOut,
-        1U << carryOut, 0, 0, 0, 0, 0 };
+    bitCapInt bciArgs[BCI_ARG_LEN] = { maxQPower >> 2UL, pow2(inputBit1), pow2(inputBit2), pow2(carryInSumOut),
+        pow2(carryOut), 0, 0, 0, 0, 0 };
 
     EventVecPtr waitVec = ResetWaitEvents();
     PoolItemPtr poolItem = GetFreePoolItem();
@@ -1669,8 +1669,8 @@ void QEngineOCL::CMUL(bitCapInt toMul, bitLenInt inOutStart, bitLenInt carryStar
 
     SetReg(carryStart, length, 0);
 
-    bitCapInt lowPower = 1U << length;
-    toMul &= (lowPower - 1U);
+    bitCapInt lowPower = pow2(length);
+    toMul &= (lowPower - 1UL);
     if (toMul == 1) {
         return;
     }
@@ -1709,8 +1709,8 @@ void QEngineOCL::CMULModNOut(bitCapInt toMul, bitCapInt modN, bitLenInt inStart,
 
     SetReg(outStart, length, 0);
 
-    bitCapInt lowPower = 1U << length;
-    toMul &= (lowPower - 1U);
+    bitCapInt lowPower = pow2(length);
+    toMul &= (lowPower - 1UL);
     if (toMul == 0) {
         return;
     }
@@ -1764,11 +1764,11 @@ void QEngineOCL::xMULx(OCLAPI api_call, bitCapInt* bciArgs, BufferPtr controlBuf
 void QEngineOCL::MULx(
     OCLAPI api_call, bitCapInt toMod, const bitLenInt inOutStart, const bitLenInt carryStart, const bitLenInt length)
 {
-    bitCapInt lowMask = (1U << length) - 1U;
+    bitCapInt lowMask = pow2Mask(length);
     bitCapInt inOutMask = lowMask << inOutStart;
     bitCapInt carryMask = lowMask << carryStart;
-    bitCapInt skipMask = (1U << carryStart) - 1U;
-    bitCapInt otherMask = (maxQPower - 1U) ^ (inOutMask | carryMask);
+    bitCapInt skipMask = pow2Mask(carryStart);
+    bitCapInt otherMask = (maxQPower - 1UL) ^ (inOutMask | carryMask);
 
     bitCapInt bciArgs[BCI_ARG_LEN] = { maxQPower >> length, toMod, inOutMask, carryMask, otherMask, length, inOutStart,
         carryStart, skipMask, 0 };
@@ -1781,11 +1781,11 @@ void QEngineOCL::MULModx(OCLAPI api_call, bitCapInt toMod, bitCapInt modN, const
 {
     SetReg(outStart, length, 0);
 
-    bitCapInt lowMask = (1U << length) - 1U;
+    bitCapInt lowMask = pow2Mask(length);
     bitCapInt inMask = lowMask << inStart;
     bitCapInt outMask = lowMask << outStart;
-    bitCapInt skipMask = (1U << outStart) - 1U;
-    bitCapInt otherMask = (maxQPower - 1U) ^ (inMask | outMask);
+    bitCapInt skipMask = pow2Mask(outStart);
+    bitCapInt otherMask = (maxQPower - 1UL) ^ (inMask | outMask);
 
     bitCapInt bciArgs[BCI_ARG_LEN] = { maxQPower >> length, toMod, inMask, outMask, otherMask, length, inStart,
         outStart, skipMask, modN };
@@ -1796,7 +1796,7 @@ void QEngineOCL::MULModx(OCLAPI api_call, bitCapInt toMod, bitCapInt modN, const
 void QEngineOCL::CMULx(OCLAPI api_call, bitCapInt toMod, const bitLenInt inOutStart, const bitLenInt carryStart,
     const bitLenInt length, const bitLenInt* controls, const bitLenInt controlLen)
 {
-    bitCapInt lowMask = (1U << length) - 1U;
+    bitCapInt lowMask = pow2Mask(length);
     bitCapInt inOutMask = lowMask << inOutStart;
     bitCapInt carryMask = lowMask << carryStart;
 
@@ -1804,16 +1804,16 @@ void QEngineOCL::CMULx(OCLAPI api_call, bitCapInt toMod, const bitLenInt inOutSt
     bitCapInt* controlPowers = new bitCapInt[controlLen];
     bitCapInt controlMask = 0;
     for (bitLenInt i = 0; i < controlLen; i++) {
-        controlPowers[i] = 1U << controls[i];
+        controlPowers[i] = pow2(controls[i]);
         skipPowers[i] = controlPowers[i];
         controlMask |= controlPowers[i];
     }
     for (bitLenInt i = 0; i < length; i++) {
-        skipPowers[i + controlLen] = 1U << (carryStart + i);
+        skipPowers[i + controlLen] = pow2(carryStart + i);
     }
     std::sort(skipPowers, skipPowers + controlLen + length);
 
-    bitCapInt otherMask = (maxQPower - 1U) ^ (inOutMask | carryMask | controlMask);
+    bitCapInt otherMask = (maxQPower - 1UL) ^ (inOutMask | carryMask | controlMask);
 
     bitCapInt bciArgs[BCI_ARG_LEN] = { maxQPower >> (controlLen + length), toMod, controlLen, controlMask, inOutMask,
         carryMask, otherMask, length, inOutStart, carryStart };
@@ -1830,7 +1830,7 @@ void QEngineOCL::CMULx(OCLAPI api_call, bitCapInt toMod, const bitLenInt inOutSt
 void QEngineOCL::CMULModx(OCLAPI api_call, bitCapInt toMod, bitCapInt modN, const bitLenInt inOutStart,
     const bitLenInt carryStart, const bitLenInt length, const bitLenInt* controls, const bitLenInt controlLen)
 {
-    bitCapInt lowMask = (1U << length) - 1U;
+    bitCapInt lowMask = pow2Mask(length);
     bitCapInt inOutMask = lowMask << inOutStart;
     bitCapInt carryMask = lowMask << carryStart;
 
@@ -1838,12 +1838,12 @@ void QEngineOCL::CMULModx(OCLAPI api_call, bitCapInt toMod, bitCapInt modN, cons
     bitCapInt* controlPowers = new bitCapInt[controlLen];
     bitCapInt controlMask = 0;
     for (bitLenInt i = 0; i < controlLen; i++) {
-        controlPowers[i] = 1U << controls[i];
+        controlPowers[i] = pow2(controls[i]);
         skipPowers[i] = controlPowers[i];
         controlMask |= controlPowers[i];
     }
     for (bitLenInt i = 0; i < length; i++) {
-        skipPowers[i + controlLen] = 1U << (carryStart + i);
+        skipPowers[i + controlLen] = pow2(carryStart + i);
     }
     std::sort(skipPowers, skipPowers + controlLen + length);
 
@@ -1891,7 +1891,7 @@ bitCapInt QEngineOCL::IndexedLDA(
     bitCapInt bciArgs[BCI_ARG_LEN] = { maxQPower >> valueLength, indexStart, inputMask, valueStart, valueBytes,
         valueLength, 0, 0, 0, 0 };
 
-    ArithmeticCall(OCL_API_INDEXEDLDA, bciArgs, values, (1 << indexLength) * valueBytes);
+    ArithmeticCall(OCL_API_INDEXEDLDA, bciArgs, values, pow2(indexLength) * valueBytes);
 
     real1 average = ZERO_R1;
 #if ENABLE_VM6502Q_DEBUG
@@ -1917,15 +1917,15 @@ bitCapInt QEngineOCL::OpIndexed(OCLAPI api_call, bitCapInt carryIn, bitLenInt in
     }
 
     bitLenInt valueBytes = (valueLength + 7) / 8;
-    bitCapInt lengthPower = 1 << valueLength;
-    bitCapInt carryMask = 1 << carryIndex;
+    bitCapInt lengthPower = pow2(valueLength);
+    bitCapInt carryMask = pow2(carryIndex);
     bitCapInt inputMask = bitRegMask(indexStart, indexLength);
     bitCapInt outputMask = bitRegMask(valueStart, valueLength);
-    bitCapInt otherMask = (maxQPower - 1) & (~(inputMask | outputMask | carryMask));
-    bitCapInt bciArgs[BCI_ARG_LEN] = { maxQPower >> 1, indexStart, inputMask, valueStart, outputMask, otherMask,
+    bitCapInt otherMask = (maxQPower - 1UL) & (~(inputMask | outputMask | carryMask));
+    bitCapInt bciArgs[BCI_ARG_LEN] = { maxQPower >> 1UL, indexStart, inputMask, valueStart, outputMask, otherMask,
         carryIn, carryMask, lengthPower, valueBytes };
 
-    ArithmeticCall(api_call, bciArgs, values, (1 << indexLength) * valueBytes);
+    ArithmeticCall(api_call, bciArgs, values, pow2(indexLength) * valueBytes);
 
     real1 average = ZERO_R1;
 #if ENABLE_VM6502Q_DEBUG
@@ -1981,14 +1981,14 @@ void QEngineOCL::PhaseFlip()
 /// For chips with a zero flag, flip the phase of the state where the register equals zero.
 void QEngineOCL::ZeroPhaseFlip(bitLenInt start, bitLenInt length)
 {
-    bitCapInt bciArgs[BCI_ARG_LEN] = { maxQPower >> length, (1U << start), length, 0, 0, 0, 0, 0, 0, 0 };
+    bitCapInt bciArgs[BCI_ARG_LEN] = { maxQPower >> length, pow2(start), length, 0, 0, 0, 0, 0, 0, 0 };
 
     PhaseFlipX(OCL_API_ZEROPHASEFLIP, bciArgs);
 }
 
 void QEngineOCL::CPhaseFlipIfLess(bitCapInt greaterPerm, bitLenInt start, bitLenInt length, bitLenInt flagIndex)
 {
-    bitCapInt bciArgs[BCI_ARG_LEN] = { maxQPower >> 1, bitRegMask(start, length), 1U << flagIndex, greaterPerm, start,
+    bitCapInt bciArgs[BCI_ARG_LEN] = { maxQPower >> 1UL, bitRegMask(start, length), pow2(flagIndex), greaterPerm, start,
         0, 0, 0, 0, 0 };
 
     PhaseFlipX(OCL_API_CPHASEFLIPIFLESS, bciArgs);

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -325,7 +325,9 @@ void QEngineOCL::SetDevice(const int& dID, const bool& forceReInit)
     size_t stateVecSize = maxQPower * sizeof(complex);
     bool usingHostRam;
     // Device RAM should be large enough for 2 times the size of the stateVec, plus some excess.
-    if (useHostRam && !(stateVecSize > maxAlloc || (3 * stateVecSize) > maxMem)) {
+    if (stateVecSize > maxAlloc) {
+        throw "Error: State vector exceeds device maximum OpenCL allocation";
+    } else if (useHostRam || ((3 * stateVecSize) > maxMem)) {
         usingHostRam = true;
     } else {
         usingHostRam = false;

--- a/src/qengine/qengine.cpp
+++ b/src/qengine/qengine.cpp
@@ -191,7 +191,7 @@ void QEngine::ApplySingleBit(const complex* mtrx, bool doCalcNorm, bitLenInt qub
     }
 
     bitCapInt qPowers[1];
-    qPowers[0] = 1 << qubit;
+    qPowers[0] = pow2(qubit);
     Apply2x2(0, qPowers[0], mtrx, 1, qPowers, doCalcNorm);
 }
 
@@ -241,13 +241,13 @@ void QEngine::CSwap(
     bitCapInt skipMask = 0;
     bitCapInt* qPowersSorted = new bitCapInt[controlLen + 2];
     for (bitLenInt i = 0; i < controlLen; i++) {
-        qPowersSorted[i] = 1U << controls[i];
+        qPowersSorted[i] = pow2(controls[i]);
         skipMask |= qPowersSorted[i];
     }
-    qPowersSorted[controlLen] = 1U << qubit1;
-    qPowersSorted[controlLen + 1] = 1U << qubit2;
+    qPowersSorted[controlLen] = pow2(qubit1);
+    qPowersSorted[controlLen + 1] = pow2(qubit2);
     std::sort(qPowersSorted, qPowersSorted + controlLen + 2);
-    Apply2x2(skipMask | (1U << qubit1), skipMask | (1U << qubit2), pauliX, 2 + controlLen, qPowersSorted, false);
+    Apply2x2(skipMask | pow2(qubit1), skipMask | pow2(qubit2), pauliX, 2 + controlLen, qPowersSorted, false);
     delete[] qPowersSorted;
 }
 
@@ -262,12 +262,12 @@ void QEngine::AntiCSwap(
         complex(ZERO_R1, ZERO_R1) };
     bitCapInt* qPowersSorted = new bitCapInt[controlLen + 2];
     for (bitLenInt i = 0; i < controlLen; i++) {
-        qPowersSorted[i] = 1U << controls[i];
+        qPowersSorted[i] = pow2(controls[i]);
     }
-    qPowersSorted[controlLen] = 1U << qubit1;
-    qPowersSorted[controlLen + 1] = 1U << qubit2;
+    qPowersSorted[controlLen] = pow2(qubit1);
+    qPowersSorted[controlLen + 1] = pow2(qubit2);
     std::sort(qPowersSorted, qPowersSorted + controlLen + 2);
-    Apply2x2(1U << qubit1, 1U << qubit2, pauliX, 2 + controlLen, qPowersSorted, false);
+    Apply2x2(pow2(qubit1), pow2(qubit2), pauliX, 2 + controlLen, qPowersSorted, false);
     delete[] qPowersSorted;
 }
 
@@ -283,13 +283,13 @@ void QEngine::CSqrtSwap(
     bitCapInt skipMask = 0;
     bitCapInt* qPowersSorted = new bitCapInt[controlLen + 2];
     for (bitLenInt i = 0; i < controlLen; i++) {
-        qPowersSorted[i] = 1U << controls[i];
+        qPowersSorted[i] = pow2(controls[i]);
         skipMask |= qPowersSorted[i];
     }
-    qPowersSorted[controlLen] = 1U << qubit1;
-    qPowersSorted[controlLen + 1] = 1U << qubit2;
+    qPowersSorted[controlLen] = pow2(qubit1);
+    qPowersSorted[controlLen + 1] = pow2(qubit2);
     std::sort(qPowersSorted, qPowersSorted + controlLen + 2);
-    Apply2x2(skipMask | (1U << qubit1), skipMask | (1U << qubit2), sqrtX, 2 + controlLen, qPowersSorted, false);
+    Apply2x2(skipMask | pow2(qubit1), skipMask | pow2(qubit2), sqrtX, 2 + controlLen, qPowersSorted, false);
     delete[] qPowersSorted;
 }
 
@@ -304,12 +304,12 @@ void QEngine::AntiCSqrtSwap(
         complex(ONE_R1 / 2, -ONE_R1 / 2), complex(ONE_R1 / 2, ONE_R1 / 2) };
     bitCapInt* qPowersSorted = new bitCapInt[controlLen + 2];
     for (bitLenInt i = 0; i < controlLen; i++) {
-        qPowersSorted[i] = 1U << controls[i];
+        qPowersSorted[i] = pow2(controls[i]);
     }
-    qPowersSorted[controlLen] = 1U << qubit1;
-    qPowersSorted[controlLen + 1] = 1U << qubit2;
+    qPowersSorted[controlLen] = pow2(qubit1);
+    qPowersSorted[controlLen + 1] = pow2(qubit2);
     std::sort(qPowersSorted, qPowersSorted + controlLen + 2);
-    Apply2x2(1U << qubit1, 1U << qubit2, sqrtX, 2 + controlLen, qPowersSorted, false);
+    Apply2x2(pow2(qubit1), pow2(qubit2), sqrtX, 2 + controlLen, qPowersSorted, false);
     delete[] qPowersSorted;
 }
 
@@ -325,13 +325,13 @@ void QEngine::CISqrtSwap(
     bitCapInt skipMask = 0;
     bitCapInt* qPowersSorted = new bitCapInt[controlLen + 2];
     for (bitLenInt i = 0; i < controlLen; i++) {
-        qPowersSorted[i] = 1U << controls[i];
+        qPowersSorted[i] = pow2(controls[i]);
         skipMask |= qPowersSorted[i];
     }
-    qPowersSorted[controlLen] = 1U << qubit1;
-    qPowersSorted[controlLen + 1] = 1U << qubit2;
+    qPowersSorted[controlLen] = pow2(qubit1);
+    qPowersSorted[controlLen + 1] = pow2(qubit2);
     std::sort(qPowersSorted, qPowersSorted + controlLen + 2);
-    Apply2x2(skipMask | (1U << qubit1), skipMask | (1U << qubit2), iSqrtX, 2 + controlLen, qPowersSorted, false);
+    Apply2x2(skipMask | pow2(qubit1), skipMask | pow2(qubit2), iSqrtX, 2 + controlLen, qPowersSorted, false);
     delete[] qPowersSorted;
 }
 
@@ -346,12 +346,12 @@ void QEngine::AntiCISqrtSwap(
         complex(ONE_R1 / 2, ONE_R1 / 2), complex(ONE_R1 / 2, -ONE_R1 / 2) };
     bitCapInt* qPowersSorted = new bitCapInt[controlLen + 2];
     for (bitLenInt i = 0; i < controlLen; i++) {
-        qPowersSorted[i] = 1U << controls[i];
+        qPowersSorted[i] = pow2(controls[i]);
     }
-    qPowersSorted[controlLen] = 1U << qubit1;
-    qPowersSorted[controlLen + 1] = 1U << qubit2;
+    qPowersSorted[controlLen] = pow2(qubit1);
+    qPowersSorted[controlLen + 1] = pow2(qubit2);
     std::sort(qPowersSorted, qPowersSorted + controlLen + 2);
-    Apply2x2(1U << qubit1, 1U << qubit2, iSqrtX, 2 + controlLen, qPowersSorted, false);
+    Apply2x2(pow2(qubit1), pow2(qubit2), iSqrtX, 2 + controlLen, qPowersSorted, false);
     delete[] qPowersSorted;
 }
 
@@ -362,12 +362,12 @@ void QEngine::ApplyControlled2x2(const bitLenInt* controls, const bitLenInt& con
     bitCapInt fullMask = 0U;
     bitCapInt controlMask;
     for (bitLenInt i = 0U; i < controlLen; i++) {
-        qPowersSorted[i] = 1U << controls[i];
+        qPowersSorted[i] = pow2(controls[i]);
         fullMask |= qPowersSorted[i];
     }
     controlMask = fullMask;
-    qPowersSorted[controlLen] = 1U << target;
-    fullMask |= 1U << target;
+    qPowersSorted[controlLen] = pow2(target);
+    fullMask |= pow2(target);
     std::sort(qPowersSorted, qPowersSorted + controlLen + 1U);
     Apply2x2(controlMask, fullMask, mtrx, controlLen + 1U, qPowersSorted, doCalcNorm);
     delete[] qPowersSorted;
@@ -378,11 +378,11 @@ void QEngine::ApplyAntiControlled2x2(const bitLenInt* controls, const bitLenInt&
 {
     bitCapInt* qPowersSorted = new bitCapInt[controlLen + 1U];
     for (bitLenInt i = 0U; i < controlLen; i++) {
-        qPowersSorted[i] = 1U << controls[i];
+        qPowersSorted[i] = pow2(controls[i]);
     }
-    qPowersSorted[controlLen] = 1U << target;
+    qPowersSorted[controlLen] = pow2(target);
     std::sort(qPowersSorted, qPowersSorted + controlLen + 1U);
-    Apply2x2(0U, 1U << target, mtrx, controlLen + 1U, qPowersSorted, doCalcNorm);
+    Apply2x2(0U, pow2(target), mtrx, controlLen + 1U, qPowersSorted, doCalcNorm);
     delete[] qPowersSorted;
 }
 
@@ -396,8 +396,8 @@ void QEngine::Swap(bitLenInt qubit1, bitLenInt qubit2)
     const complex pauliX[4] = { complex(ZERO_R1, ZERO_R1), complex(ONE_R1, ZERO_R1), complex(ONE_R1, ZERO_R1),
         complex(ZERO_R1, ZERO_R1) };
     bitCapInt qPowersSorted[2];
-    qPowersSorted[0] = 1 << qubit1;
-    qPowersSorted[1] = 1 << qubit2;
+    qPowersSorted[0] = pow2(qubit1);
+    qPowersSorted[1] = pow2(qubit2);
     std::sort(qPowersSorted, qPowersSorted + 2);
     Apply2x2(qPowersSorted[0], qPowersSorted[1], pauliX, 2, qPowersSorted, false);
 }
@@ -412,8 +412,8 @@ void QEngine::SqrtSwap(bitLenInt qubit1, bitLenInt qubit2)
     const complex sqrtX[4] = { complex(ONE_R1 / 2, ONE_R1 / 2), complex(ONE_R1 / 2, -ONE_R1 / 2),
         complex(ONE_R1 / 2, -ONE_R1 / 2), complex(ONE_R1 / 2, ONE_R1 / 2) };
     bitCapInt qPowersSorted[2];
-    qPowersSorted[0] = 1 << qubit1;
-    qPowersSorted[1] = 1 << qubit2;
+    qPowersSorted[0] = pow2(qubit1);
+    qPowersSorted[1] = pow2(qubit2);
     std::sort(qPowersSorted, qPowersSorted + 2);
     Apply2x2(qPowersSorted[0], qPowersSorted[1], sqrtX, 2, qPowersSorted, false);
 }
@@ -428,15 +428,15 @@ void QEngine::ISqrtSwap(bitLenInt qubit1, bitLenInt qubit2)
     const complex iSqrtX[4] = { complex(ONE_R1 / 2, -ONE_R1 / 2), complex(ONE_R1 / 2, ONE_R1 / 2),
         complex(ONE_R1 / 2, ONE_R1 / 2), complex(ONE_R1 / 2, -ONE_R1 / 2) };
     bitCapInt qPowersSorted[2];
-    qPowersSorted[0] = 1 << qubit1;
-    qPowersSorted[1] = 1 << qubit2;
+    qPowersSorted[0] = pow2(qubit1);
+    qPowersSorted[1] = pow2(qubit2);
     std::sort(qPowersSorted, qPowersSorted + 2);
     Apply2x2(qPowersSorted[0], qPowersSorted[1], iSqrtX, 2, qPowersSorted, false);
 }
 
 void QEngine::ProbRegAll(const bitLenInt& start, const bitLenInt& length, real1* probsArray)
 {
-    bitCapInt lengthPower = 1U << length;
+    bitCapInt lengthPower = pow2(length);
     for (bitCapInt lcv = 0; lcv < lengthPower; lcv++) {
         probsArray[lcv] = ProbReg(start, length, lcv);
     }
@@ -450,21 +450,21 @@ void QEngine::ProbMaskAll(const bitCapInt& mask, real1* probsArray)
     std::vector<bitCapInt> powersVec;
     for (length = 0; v; length++) {
         oldV = v;
-        v &= v - 1U; // clear the least significant bit set
+        v &= v - 1UL; // clear the least significant bit set
     }
 
-    v = (~mask) & (maxQPower - 1U); // count the number of bits set in v
+    v = (~mask) & (maxQPower - 1UL); // count the number of bits set in v
     bitCapInt power;
     bitLenInt len; // c accumulates the total bits set in v
     std::vector<bitCapInt> skipPowersVec;
     for (len = 0; v; len++) {
         oldV = v;
-        v &= v - 1U; // clear the least significant bit set
+        v &= v - 1UL; // clear the least significant bit set
         power = (v ^ oldV) & oldV;
         skipPowersVec.push_back(power);
     }
 
-    bitCapInt lengthPower = 1U << length;
+    bitCapInt lengthPower = pow2(length);
     bitCapInt lcv;
 
     bitLenInt p;
@@ -473,9 +473,9 @@ void QEngine::ProbMaskAll(const bitCapInt& mask, real1* probsArray)
         iHigh = lcv;
         i = 0;
         for (p = 0; p < (skipPowersVec.size()); p++) {
-            iLow = iHigh & (skipPowersVec[p] - 1U);
+            iLow = iHigh & (skipPowersVec[p] - 1UL);
             i |= iLow;
-            iHigh = (iHigh ^ iLow) << 1U;
+            iHigh = (iHigh ^ iLow) << 1UL;
             if (iHigh == 0) {
                 break;
             }
@@ -503,8 +503,8 @@ bitCapInt QEngine::ForceMReg(bitLenInt start, bitLenInt length, bitCapInt result
 
     real1 prob = Rand();
     complex phase = GetNonunitaryPhase();
-    bitCapInt lengthPower = 1U << length;
-    bitCapInt regMask = (lengthPower - 1U) << start;
+    bitCapInt lengthPower = pow2(length);
+    bitCapInt regMask = (lengthPower - 1UL) << start;
     real1* probArray = new real1[lengthPower]();
     bitCapInt lcv;
     real1 nrmlzr = ONE_R1;
@@ -515,7 +515,7 @@ bitCapInt QEngine::ForceMReg(bitLenInt start, bitLenInt length, bitCapInt result
         lcv = 0;
         real1 lowerProb = ZERO_R1;
         real1 largestProb = ZERO_R1;
-        result = lengthPower - 1U;
+        result = lengthPower - 1UL;
 
         /*
          * The value of 'lcv' should not exceed lengthPower unless the stateVec is
@@ -570,7 +570,7 @@ void QEngine::DECC(bitCapInt toSub, const bitLenInt inOutStart, const bitLenInt 
         toSub++;
     }
 
-    bitCapInt invToSub = (1U << length) - toSub;
+    bitCapInt invToSub = pow2(length) - toSub;
     INCDECC(invToSub, inOutStart, length, carryIndex);
 }
 
@@ -606,7 +606,7 @@ void QEngine::DECSC(bitCapInt toSub, bitLenInt inOutStart, bitLenInt length, bit
         toSub++;
     }
 
-    bitCapInt invToSub = (1U << length) - toSub;
+    bitCapInt invToSub = pow2(length) - toSub;
     INCDECSC(invToSub, inOutStart, length, carryIndex);
 }
 
@@ -644,7 +644,7 @@ void QEngine::DECSC(
         toSub++;
     }
 
-    bitCapInt invToSub = (1U << length) - toSub;
+    bitCapInt invToSub = pow2(length) - toSub;
     INCDECSC(invToSub, inOutStart, length, overflowIndex, carryIndex);
 }
 

--- a/src/qengine/qengine.cpp
+++ b/src/qengine/qengine.cpp
@@ -411,16 +411,16 @@ void QEngine::ProbMaskAll(const bitCapInt& mask, real1* probsArray)
     std::vector<bitCapInt> powersVec;
     for (length = 0; v; length++) {
         oldV = v;
-        v &= v - 1UL; // clear the least significant bit set
+        v &= v - ONE_BCI; // clear the least significant bit set
     }
 
-    v = (~mask) & (maxQPower - 1UL); // count the number of bits set in v
+    v = (~mask) & (maxQPower - ONE_BCI); // count the number of bits set in v
     bitCapInt power;
     bitLenInt len; // c accumulates the total bits set in v
     std::vector<bitCapInt> skipPowersVec;
     for (len = 0; v; len++) {
         oldV = v;
-        v &= v - 1UL; // clear the least significant bit set
+        v &= v - ONE_BCI; // clear the least significant bit set
         power = (v ^ oldV) & oldV;
         skipPowersVec.push_back(power);
     }
@@ -434,9 +434,9 @@ void QEngine::ProbMaskAll(const bitCapInt& mask, real1* probsArray)
         iHigh = lcv;
         i = 0;
         for (p = 0; p < (skipPowersVec.size()); p++) {
-            iLow = iHigh & (skipPowersVec[p] - 1UL);
+            iLow = iHigh & (skipPowersVec[p] - ONE_BCI);
             i |= iLow;
-            iHigh = (iHigh ^ iLow) << 1UL;
+            iHigh = (iHigh ^ iLow) << ONE_BCI;
             if (iHigh == 0) {
                 break;
             }
@@ -465,7 +465,7 @@ bitCapInt QEngine::ForceMReg(bitLenInt start, bitLenInt length, bitCapInt result
     real1 prob = Rand();
     complex phase = GetNonunitaryPhase();
     bitCapInt lengthPower = pow2(length);
-    bitCapInt regMask = (lengthPower - 1UL) << start;
+    bitCapInt regMask = (lengthPower - ONE_BCI) << start;
     real1* probArray = new real1[lengthPower]();
     bitCapInt lcv;
     real1 nrmlzr = ONE_R1;
@@ -476,7 +476,7 @@ bitCapInt QEngine::ForceMReg(bitLenInt start, bitLenInt length, bitCapInt result
         lcv = 0;
         real1 lowerProb = ZERO_R1;
         real1 largestProb = ZERO_R1;
-        result = lengthPower - 1UL;
+        result = lengthPower - ONE_BCI;
 
         /*
          * The value of 'lcv' should not exceed lengthPower unless the stateVec is

--- a/src/qengine/state.cpp
+++ b/src/qengine/state.cpp
@@ -308,9 +308,9 @@ void QEngineCPU::UniformlyControlledSingleBit(const bitLenInt* controls, const b
         iHigh = offset;
         i = 0;
         for (p = 0; p < mtrxSkipLen; p++) {
-            iLow = iHigh & (mtrxSkipPowers[p] - 1UL);
+            iLow = iHigh & (mtrxSkipPowers[p] - ONE_BCI);
             i |= iLow;
-            iHigh = (iHigh ^ iLow) << 1UL;
+            iHigh = (iHigh ^ iLow) << ONE_BCI;
         }
         i |= iHigh;
 
@@ -361,8 +361,8 @@ bitLenInt QEngineCPU::Compose(QEngineCPUPtr toCopy)
 
     bitCapInt nQubitCount = qubitCount + toCopy->qubitCount;
     bitCapInt nMaxQPower = pow2(nQubitCount);
-    bitCapInt startMask = maxQPower - 1UL;
-    bitCapInt endMask = (toCopy->maxQPower - 1UL) << qubitCount;
+    bitCapInt startMask = maxQPower - ONE_BCI;
+    bitCapInt endMask = (toCopy->maxQPower - ONE_BCI) << qubitCount;
 
     StateVectorPtr nStateVec = AllocStateVec(nMaxQPower);
 
@@ -430,7 +430,7 @@ std::map<QInterfacePtr, bitLenInt> QEngineCPU::Compose(std::vector<QInterfacePtr
     std::vector<bitLenInt> offset(toComposeCount);
     std::vector<bitCapInt> mask(toComposeCount);
 
-    bitCapInt startMask = maxQPower - 1UL;
+    bitCapInt startMask = maxQPower - ONE_BCI;
     bitCapInt nQubitCount = qubitCount;
     bitCapInt nMaxQPower;
 
@@ -443,7 +443,7 @@ std::map<QInterfacePtr, bitLenInt> QEngineCPU::Compose(std::vector<QInterfacePtr
         if ((src->doNormalize) && (src->runningNorm != ONE_R1)) {
             src->NormalizeState();
         }
-        mask[i] = (src->GetMaxQPower() - 1UL) << nQubitCount;
+        mask[i] = (src->GetMaxQPower() - ONE_BCI) << nQubitCount;
         offset[i] = nQubitCount;
         ret[toCopy[i]] = nQubitCount;
         nQubitCount += src->GetQubitCount();
@@ -591,15 +591,15 @@ real1 QEngineCPU::Prob(bitLenInt qubit)
     }
 
     bitCapInt qPower = pow2(qubit);
-    bitCapInt qMask = qPower - 1UL;
+    bitCapInt qMask = qPower - ONE_BCI;
     real1 oneChance = 0;
 
     int numCores = GetConcurrencyLevel();
     real1* oneChanceBuff = new real1[numCores]();
 
-    par_for(0, maxQPower >> 1UL, [&](const bitCapInt lcv, const int cpu) {
+    par_for(0, maxQPower >> ONE_BCI, [&](const bitCapInt lcv, const int cpu) {
         bitCapInt i = lcv & qMask;
-        i |= ((lcv ^ i) << 1UL) | qPower;
+        i |= ((lcv ^ i) << ONE_BCI) | qPower;
         oneChanceBuff[cpu] += norm(stateVec->read(i));
     });
 
@@ -660,7 +660,7 @@ real1 QEngineCPU::ProbMask(const bitCapInt& mask, const bitCapInt& permutation)
     std::vector<bitCapInt> skipPowersVec;
     for (length = 0; v; length++) {
         oldV = v;
-        v &= v - 1UL; // clear the least significant bit set
+        v &= v - ONE_BCI; // clear the least significant bit set
         skipPowersVec.push_back((v ^ oldV) & oldV);
     }
 

--- a/src/qengine/state.cpp
+++ b/src/qengine/state.cpp
@@ -283,13 +283,13 @@ void QEngineCPU::UniformlyControlledSingleBit(const bitLenInt* controls, const b
         return;
     }
 
-    bitCapInt targetPower = 1 << qubitIndex;
+    bitCapInt targetPower = pow2(qubitIndex);
 
     real1 nrm = ONE_R1 / std::sqrt(runningNorm);
 
     bitCapInt* qPowers = new bitCapInt[controlLen];
     for (bitLenInt i = 0; i < controlLen; i++) {
-        qPowers[i] = 1 << controls[i];
+        qPowers[i] = pow2(controls[i]);
     }
 
     int numCores = GetConcurrencyLevel();
@@ -300,7 +300,7 @@ void QEngineCPU::UniformlyControlledSingleBit(const bitLenInt* controls, const b
         bitCapInt offset = 0;
         for (bitLenInt j = 0; j < controlLen; j++) {
             if (lcv & qPowers[j]) {
-                offset |= 1 << j;
+                offset |= pow2(j);
             }
         }
 
@@ -308,9 +308,9 @@ void QEngineCPU::UniformlyControlledSingleBit(const bitLenInt* controls, const b
         iHigh = offset;
         i = 0;
         for (p = 0; p < mtrxSkipLen; p++) {
-            iLow = iHigh & (mtrxSkipPowers[p] - 1U);
+            iLow = iHigh & (mtrxSkipPowers[p] - 1UL);
             i |= iLow;
-            iHigh = (iHigh ^ iLow) << 1U;
+            iHigh = (iHigh ^ iLow) << 1UL;
         }
         i |= iHigh;
 
@@ -360,9 +360,9 @@ bitLenInt QEngineCPU::Compose(QEngineCPUPtr toCopy)
     }
 
     bitCapInt nQubitCount = qubitCount + toCopy->qubitCount;
-    bitCapInt nMaxQPower = 1U << nQubitCount;
-    bitCapInt startMask = maxQPower - 1U;
-    bitCapInt endMask = (toCopy->maxQPower - 1U) << qubitCount;
+    bitCapInt nMaxQPower = pow2(nQubitCount);
+    bitCapInt startMask = maxQPower - 1UL;
+    bitCapInt endMask = (toCopy->maxQPower - 1UL) << qubitCount;
 
     StateVectorPtr nStateVec = AllocStateVec(nMaxQPower);
 
@@ -393,10 +393,10 @@ bitLenInt QEngineCPU::Compose(QEngineCPUPtr toCopy, bitLenInt start)
 
     bitLenInt oQubitCount = toCopy->qubitCount;
     bitLenInt nQubitCount = qubitCount + oQubitCount;
-    bitCapInt nMaxQPower = 1U << nQubitCount;
-    bitCapInt startMask = (1U << start) - 1U;
+    bitCapInt nMaxQPower = pow2(nQubitCount);
+    bitCapInt startMask = pow2Mask(start);
     bitCapInt midMask = bitRegMask(start, oQubitCount);
-    bitCapInt endMask = ((1U << (qubitCount + oQubitCount)) - 1U) & ~(startMask | midMask);
+    bitCapInt endMask = pow2Mask(qubitCount + oQubitCount) & ~(startMask | midMask);
 
     StateVectorPtr nStateVec = AllocStateVec(nMaxQPower);
 
@@ -430,7 +430,7 @@ std::map<QInterfacePtr, bitLenInt> QEngineCPU::Compose(std::vector<QInterfacePtr
     std::vector<bitLenInt> offset(toComposeCount);
     std::vector<bitCapInt> mask(toComposeCount);
 
-    bitCapInt startMask = maxQPower - 1U;
+    bitCapInt startMask = maxQPower - 1UL;
     bitCapInt nQubitCount = qubitCount;
     bitCapInt nMaxQPower;
 
@@ -443,13 +443,13 @@ std::map<QInterfacePtr, bitLenInt> QEngineCPU::Compose(std::vector<QInterfacePtr
         if ((src->doNormalize) && (src->runningNorm != ONE_R1)) {
             src->NormalizeState();
         }
-        mask[i] = (src->GetMaxQPower() - 1U) << nQubitCount;
+        mask[i] = (src->GetMaxQPower() - 1UL) << nQubitCount;
         offset[i] = nQubitCount;
         ret[toCopy[i]] = nQubitCount;
         nQubitCount += src->GetQubitCount();
     }
 
-    nMaxQPower = 1 << nQubitCount;
+    nMaxQPower = pow2(nQubitCount);
 
     StateVectorPtr nStateVec = AllocStateVec(nMaxQPower);
 
@@ -487,8 +487,8 @@ void QEngineCPU::DecomposeDispose(bitLenInt start, bitLenInt length, QEngineCPUP
         NormalizeState();
     }
 
-    bitCapInt partPower = 1U << length;
-    bitCapInt remainderPower = 1U << (qubitCount - length);
+    bitCapInt partPower = pow2(length);
+    bitCapInt remainderPower = pow2(qubitCount - length);
 
     real1* remainderStateProb = new real1[remainderPower]();
     real1* remainderStateAngle = new real1[remainderPower]();
@@ -497,7 +497,7 @@ void QEngineCPU::DecomposeDispose(bitLenInt start, bitLenInt length, QEngineCPUP
 
     par_for(0, remainderPower, [&](const bitCapInt lcv, const int cpu) {
         bitCapInt j, k, l;
-        j = lcv & ((1U << start) - 1U);
+        j = lcv & pow2Mask(start);
         j |= (lcv ^ j) << length;
 
         real1 firstAngle = -16 * M_PI;
@@ -529,7 +529,7 @@ void QEngineCPU::DecomposeDispose(bitLenInt start, bitLenInt length, QEngineCPUP
         real1 nrm;
 
         for (k = 0; k < remainderPower; k++) {
-            l = k & ((1U << start) - 1U);
+            l = k & pow2Mask(start);
             l |= (k ^ l) << length;
             l = j | l;
 
@@ -590,16 +590,16 @@ real1 QEngineCPU::Prob(bitLenInt qubit)
         NormalizeState();
     }
 
-    bitCapInt qPower = 1U << qubit;
-    bitCapInt qMask = qPower - 1U;
+    bitCapInt qPower = pow2(qubit);
+    bitCapInt qMask = qPower - 1UL;
     real1 oneChance = 0;
 
     int numCores = GetConcurrencyLevel();
     real1* oneChanceBuff = new real1[numCores]();
 
-    par_for(0, maxQPower >> 1U, [&](const bitCapInt lcv, const int cpu) {
+    par_for(0, maxQPower >> 1UL, [&](const bitCapInt lcv, const int cpu) {
         bitCapInt i = lcv & qMask;
-        i |= ((lcv ^ i) << 1U) | qPower;
+        i |= ((lcv ^ i) << 1UL) | qPower;
         oneChanceBuff[cpu] += norm(stateVec->read(i));
     });
 
@@ -634,7 +634,7 @@ real1 QEngineCPU::ProbReg(const bitLenInt& start, const bitLenInt& length, const
 
     bitCapInt perm = permutation << start;
 
-    par_for_skip(0, maxQPower, (1U << start), length,
+    par_for_skip(0, maxQPower, pow2(start), length,
         [&](const bitCapInt lcv, const int cpu) { probs[cpu] += norm(stateVec->read(lcv | perm)); });
 
     real1 prob = ZERO_R1;
@@ -660,7 +660,7 @@ real1 QEngineCPU::ProbMask(const bitCapInt& mask, const bitCapInt& permutation)
     std::vector<bitCapInt> skipPowersVec;
     for (length = 0; v; length++) {
         oldV = v;
-        v &= v - 1U; // clear the least significant bit set
+        v &= v - 1UL; // clear the least significant bit set
         skipPowersVec.push_back((v ^ oldV) & oldV);
     }
 
@@ -740,7 +740,7 @@ bool QEngineCPU::ApproxCompare(QEngineCPUPtr toCompare)
 /// For chips with a zero flag, flip the phase of the state where the register equals zero.
 void QEngineCPU::ZeroPhaseFlip(bitLenInt start, bitLenInt length)
 {
-    par_for_skip(0, maxQPower, 1U << start, length,
+    par_for_skip(0, maxQPower, pow2(start), length,
         [&](const bitCapInt lcv, const int cpu) { stateVec->write(lcv, -stateVec->read(lcv)); });
 }
 
@@ -748,7 +748,7 @@ void QEngineCPU::ZeroPhaseFlip(bitLenInt start, bitLenInt length)
 void QEngineCPU::CPhaseFlipIfLess(bitCapInt greaterPerm, bitLenInt start, bitLenInt length, bitLenInt flagIndex)
 {
     bitCapInt regMask = bitRegMask(start, length);
-    bitCapInt flagMask = 1U << flagIndex;
+    bitCapInt flagMask = pow2(flagIndex);
 
     par_for(0, maxQPower, [&](const bitCapInt lcv, const int cpu) {
         if ((((lcv & regMask) >> start) < greaterPerm) & ((lcv & flagMask) == flagMask))

--- a/src/qfusion.cpp
+++ b/src/qfusion.cpp
@@ -719,7 +719,7 @@ void QFusion::MUL(bitCapInt toMul, bitLenInt inOutStart, bitLenInt carryStart, b
         DiscardReg(carryStart, length);
         SetReg(inOutStart, length, 0U);
         SetReg(carryStart, length, 0U);
-    } else if (toMul > 1U) {
+    } else if (toMul > ONE_BCI) {
         FlushReg(inOutStart, length);
         FlushReg(carryStart, length);
         qReg->MUL(toMul, inOutStart, carryStart, length);
@@ -728,7 +728,7 @@ void QFusion::MUL(bitCapInt toMul, bitLenInt inOutStart, bitLenInt carryStart, b
 
 void QFusion::DIV(bitCapInt toDiv, bitLenInt inOutStart, bitLenInt carryStart, bitLenInt length)
 {
-    if (toDiv != 1U) {
+    if (toDiv != ONE_BCI) {
         FlushReg(inOutStart, length);
         FlushReg(carryStart, length);
         qReg->DIV(toDiv, inOutStart, carryStart, length);
@@ -792,7 +792,7 @@ void QFusion::CIFullAdd(bitLenInt* controls, bitLenInt controlLen, bitLenInt inp
 void QFusion::CMUL(bitCapInt toMul, bitLenInt inOutStart, bitLenInt carryStart, bitLenInt length, bitLenInt* controls,
     bitLenInt controlLen)
 {
-    if (toMul != 1U) {
+    if (toMul != ONE_BCI) {
         FlushArray(controls, controlLen);
         FlushReg(inOutStart, length);
         FlushReg(carryStart, length);
@@ -803,7 +803,7 @@ void QFusion::CMUL(bitCapInt toMul, bitLenInt inOutStart, bitLenInt carryStart, 
 void QFusion::CDIV(bitCapInt toDiv, bitLenInt inOutStart, bitLenInt carryStart, bitLenInt length, bitLenInt* controls,
     bitLenInt controlLen)
 {
-    if (toDiv != 1U) {
+    if (toDiv != ONE_BCI) {
         FlushArray(controls, controlLen);
         FlushReg(inOutStart, length);
         FlushReg(carryStart, length);

--- a/src/qinterface/arithmetic.cpp
+++ b/src/qinterface/arithmetic.cpp
@@ -39,7 +39,7 @@ void QInterface::INC(bitCapInt toAdd, bitLenInt inOutStart, bitLenInt length)
 /// Subtract integer (without sign)
 void QInterface::DEC(bitCapInt toSub, bitLenInt inOutStart, bitLenInt length)
 {
-    bitCapInt invToSub = (1U << length) - toSub;
+    bitCapInt invToSub = pow2(length) - toSub;
     INC(invToSub, inOutStart, length);
 }
 
@@ -50,7 +50,7 @@ void QInterface::DEC(bitCapInt toSub, bitLenInt inOutStart, bitLenInt length)
  */
 void QInterface::DECS(bitCapInt toSub, bitLenInt inOutStart, bitLenInt length, bitLenInt overflowIndex)
 {
-    bitCapInt invToSub = (1U << length) - toSub;
+    bitCapInt invToSub = pow2(length) - toSub;
     INCS(invToSub, inOutStart, length, overflowIndex);
 }
 
@@ -58,7 +58,7 @@ void QInterface::DECS(bitCapInt toSub, bitLenInt inOutStart, bitLenInt length, b
 void QInterface::CDEC(
     bitCapInt toSub, bitLenInt inOutStart, bitLenInt length, bitLenInt* controls, bitLenInt controlLen)
 {
-    bitCapInt invToSub = (1U << length) - toSub;
+    bitCapInt invToSub = pow2(length) - toSub;
     CINC(invToSub, inOutStart, length, controls, controlLen);
 }
 

--- a/src/qinterface/gates.cpp
+++ b/src/qinterface/gates.cpp
@@ -178,7 +178,7 @@ void QInterface::UniformlyControlledSingleBit(const bitLenInt* controls, const b
     const bitCapInt& mtrxSkipValueMask)
 {
     bitCapInt index;
-    for (bitCapInt lcv = 0; lcv < (1U << controlLen); lcv++) {
+    for (bitCapInt lcv = 0; lcv < pow2(controlLen); lcv++) {
         index = pushApartBits(lcv, mtrxSkipPowers, mtrxSkipLen) | mtrxSkipValueMask;
         for (bitLenInt bit_pos = 0; bit_pos < controlLen; bit_pos++) {
             if (!((lcv >> bit_pos) & 1)) {
@@ -208,7 +208,7 @@ void QInterface::TimeEvolve(Hamiltonian h, real1 timeDiff)
 
         bitCapInt maxJ = 4;
         if (op->uniform) {
-            maxJ *= 1U << op->controlLen;
+            maxJ *= pow2(op->controlLen);
         }
         mtrx = new complex[maxJ];
 
@@ -226,7 +226,7 @@ void QInterface::TimeEvolve(Hamiltonian h, real1 timeDiff)
 
         if (op->uniform) {
             complex* expMtrx = new complex[maxJ];
-            for (bitCapInt j = 0; j < (1U << op->controlLen); j++) {
+            for (bitCapInt j = 0; j < pow2(op->controlLen); j++) {
                 exp2x2(mtrx + (j * 4U), expMtrx + (j * 4U));
             }
             UniformlyControlledSingleBit(op->controls, op->controlLen, op->targetBit, expMtrx);

--- a/src/qinterface/protected.cpp
+++ b/src/qinterface/protected.cpp
@@ -153,8 +153,8 @@ bool isOverflowAdd(bitCapInt inOutInt, bitCapInt inInt, const bitCapInt& signMas
 {
     // Both negative:
     if (inOutInt & inInt & signMask) {
-        inOutInt = ((~inOutInt) & (lengthPower - 1UL)) + 1UL;
-        inInt = ((~inInt) & (lengthPower - 1UL)) + 1UL;
+        inOutInt = ((~inOutInt) & (lengthPower - ONE_BCI)) + ONE_BCI;
+        inInt = ((~inInt) & (lengthPower - ONE_BCI)) + ONE_BCI;
         if ((inOutInt + inInt) > signMask) {
             return true;
         }
@@ -174,13 +174,13 @@ bool isOverflowSub(bitCapInt inOutInt, bitCapInt inInt, const bitCapInt& signMas
 {
     // First negative:
     if (inOutInt & (~inInt) & (signMask)) {
-        inOutInt = ((~inOutInt) & (lengthPower - 1UL)) + 1UL;
+        inOutInt = ((~inOutInt) & (lengthPower - ONE_BCI)) + ONE_BCI;
         if ((inOutInt + inInt) > signMask)
             return true;
     }
     // First positive:
     else if ((~inOutInt) & inInt & (signMask)) {
-        inInt = ((~inInt) & (lengthPower - 1UL)) + 1UL;
+        inInt = ((~inInt) & (lengthPower - ONE_BCI)) + ONE_BCI;
         if ((inOutInt + inInt) >= signMask)
             return true;
     }
@@ -198,7 +198,7 @@ bitCapInt pushApartBits(const bitCapInt& perm, const bitCapInt* skipPowers, cons
     iHigh = perm;
     i = 0;
     for (p = 0; p < skipPowersCount; p++) {
-        iLow = iHigh & (skipPowers[p] - 1UL);
+        iLow = iHigh & (skipPowers[p] - ONE_BCI);
         i |= iLow;
         iHigh = (iHigh ^ iLow) << 1U;
     }

--- a/src/qinterface/protected.cpp
+++ b/src/qinterface/protected.cpp
@@ -153,8 +153,8 @@ bool isOverflowAdd(bitCapInt inOutInt, bitCapInt inInt, const bitCapInt& signMas
 {
     // Both negative:
     if (inOutInt & inInt & signMask) {
-        inOutInt = ((~inOutInt) & (lengthPower - 1U)) + 1U;
-        inInt = ((~inInt) & (lengthPower - 1U)) + 1U;
+        inOutInt = ((~inOutInt) & (lengthPower - 1UL)) + 1UL;
+        inInt = ((~inInt) & (lengthPower - 1UL)) + 1UL;
         if ((inOutInt + inInt) > signMask) {
             return true;
         }
@@ -174,13 +174,13 @@ bool isOverflowSub(bitCapInt inOutInt, bitCapInt inInt, const bitCapInt& signMas
 {
     // First negative:
     if (inOutInt & (~inInt) & (signMask)) {
-        inOutInt = ((~inOutInt) & (lengthPower - 1U)) + 1U;
+        inOutInt = ((~inOutInt) & (lengthPower - 1UL)) + 1UL;
         if ((inOutInt + inInt) > signMask)
             return true;
     }
     // First positive:
     else if ((~inOutInt) & inInt & (signMask)) {
-        inInt = ((~inInt) & (lengthPower - 1U)) + 1U;
+        inInt = ((~inInt) & (lengthPower - 1UL)) + 1UL;
         if ((inOutInt + inInt) >= signMask)
             return true;
     }
@@ -198,7 +198,7 @@ bitCapInt pushApartBits(const bitCapInt& perm, const bitCapInt* skipPowers, cons
     iHigh = perm;
     i = 0;
     for (p = 0; p < skipPowersCount; p++) {
-        iLow = iHigh & (skipPowers[p] - 1U);
+        iLow = iHigh & (skipPowers[p] - 1UL);
         i |= iLow;
         iHigh = (iHigh ^ iLow) << 1U;
     }

--- a/src/qinterface/qinterface.cpp
+++ b/src/qinterface/qinterface.cpp
@@ -606,7 +606,7 @@ real1 QInterface::ProbReg(const bitLenInt& start, const bitLenInt& length, const
 {
     real1 prob = ONE_R1;
     for (bitLenInt i = 0; i < length; i++) {
-        if ((permutation >> i) & 1UL) {
+        if ((permutation >> i) & 1U) {
             prob *= Prob(start + i);
         } else {
             prob *= (ONE_R1 - Prob(start + i));

--- a/src/qinterface/qinterface.cpp
+++ b/src/qinterface/qinterface.cpp
@@ -174,7 +174,7 @@ void QInterface::CLAND(bitLenInt qInputStart, bitCapInt classicalInput, bitLenIn
 {
     bool cBit;
     for (bitLenInt i = 0; i < length; i++) {
-        cBit = (1 << i) & classicalInput;
+        cBit = bitSlice(i, classicalInput);
         CLAND(qInputStart + i, cBit, outputStart + i);
     }
 }
@@ -185,7 +185,7 @@ void QInterface::CLOR(bitLenInt qInputStart, bitCapInt classicalInput, bitLenInt
 {
     bool cBit;
     for (bitLenInt i = 0; i < length; i++) {
-        cBit = (1 << i) & classicalInput;
+        cBit = bitSlice(i, classicalInput);
         CLOR(qInputStart + i, cBit, outputStart + i);
     }
 }
@@ -196,7 +196,7 @@ void QInterface::CLXOR(bitLenInt qInputStart, bitCapInt classicalInput, bitLenIn
 {
     bool cBit;
     for (bitLenInt i = 0; i < length; i++) {
-        cBit = (1 << i) & classicalInput;
+        cBit = bitSlice(i, classicalInput);
         CLXOR(qInputStart + i, cBit, outputStart + i);
     }
 }
@@ -312,8 +312,8 @@ void QInterface::SetReg(bitLenInt start, bitLenInt length, bitCapInt value)
         bool bitVal;
         bitCapInt regVal = MReg(start, length);
         for (bitLenInt i = 0; i < length; i++) {
-            bitVal = regVal & (1 << i);
-            if ((bitVal && !(value & (1 << i))) || (!bitVal && (value & (1 << i))))
+            bitVal = bitSlice(i, regVal);
+            if ((bitVal && !bitSlice(i, value)) || (!bitVal && bitSlice(i, value)))
                 X(start + i);
         }
     }
@@ -579,7 +579,7 @@ bitCapInt QInterface::ForceMReg(bitLenInt start, bitLenInt length, bitCapInt res
     bitCapInt res = 0;
     bitCapInt power;
     for (bitLenInt bit = 0; bit < length; bit++) {
-        power = 1U << bit;
+        power = pow2(bit);
         res |= ForceM(start + bit, !(!(power & result)), doForce) ? power : 0;
     }
     return res;
@@ -591,11 +591,11 @@ bitCapInt QInterface::ForceM(const bitLenInt* bits, const bitLenInt& length, con
     bitCapInt result = 0;
     if (values == NULL) {
         for (bitLenInt bit = 0; bit < length; bit++) {
-            result |= M(bits[bit]) ? (1U << (bits[bit])) : 0;
+            result |= M(bits[bit]) ? pow2(bits[bit]) : 0;
         }
     } else {
         for (bitLenInt bit = 0; bit < length; bit++) {
-            result |= ForceM(bits[bit], values[bit]) ? (1U << (bits[bit])) : 0;
+            result |= ForceM(bits[bit], values[bit]) ? pow2(bits[bit]) : 0;
         }
     }
     return result;
@@ -606,7 +606,7 @@ real1 QInterface::ProbReg(const bitLenInt& start, const bitLenInt& length, const
 {
     real1 prob = ONE_R1;
     for (bitLenInt i = 0; i < length; i++) {
-        if (permutation & (1U << i)) {
+        if ((permutation >> i) & 1UL) {
             prob *= Prob(start + i);
         } else {
             prob *= (ONE_R1 - Prob(start + i));

--- a/src/qinterface/rotational.cpp
+++ b/src/qinterface/rotational.cpp
@@ -55,7 +55,7 @@ void QInterface::RZ(real1 radians, bitLenInt qubit)
 void QInterface::UniformlyControlledRY(
     const bitLenInt* controls, const bitLenInt& controlLen, bitLenInt qubitIndex, const real1* angles)
 {
-    bitCapInt permCount = 1U << controlLen;
+    bitCapInt permCount = pow2(controlLen);
     complex* pauliRYs = new complex[4U * permCount];
 
     real1 cosine, sine;
@@ -79,7 +79,7 @@ void QInterface::UniformlyControlledRY(
 void QInterface::UniformlyControlledRZ(
     const bitLenInt* controls, const bitLenInt& controlLen, bitLenInt qubitIndex, const real1* angles)
 {
-    bitCapInt permCount = 1U << controlLen;
+    bitCapInt permCount = pow2(controlLen);
     complex* pauliRZs = new complex[4U * permCount];
 
     real1 cosine, sine;

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -54,7 +54,7 @@ QUnit::QUnit(QInterfaceEngine eng, QInterfaceEngine subEng, bitLenInt qBitCount,
     bool bitState;
 
     for (bitLenInt i = 0; i < qubitCount; i++) {
-        bitState = (initState >> i) & 1UL;
+        bitState = (initState >> i) & ONE_BCI;
         shards[i] = QEngineShard(MakeEngine(1, bitState ? 1 : 0), bitState);
     }
 }
@@ -72,7 +72,7 @@ void QUnit::SetPermutation(bitCapInt perm, complex phaseFac)
     Finish();
 
     for (bitLenInt i = 0; i < qubitCount; i++) {
-        bitState = (perm >> i) & 1UL;
+        bitState = (perm >> i) & ONE_BCI;
         shards[i] = QEngineShard(MakeEngine(1, bitState ? 1 : 0), bitState);
     }
 }
@@ -118,7 +118,7 @@ complex QUnit::GetAmplitude(bitCapInt perm)
         if (perms.find(shards[i].unit) == perms.end()) {
             perms[shards[i].unit] = 0U;
         }
-        if ((perm >> i) & 1UL) {
+        if ((perm >> i) & ONE_BCI) {
             perms[shards[i].unit] |= pow2(shards[i].mapped);
         }
     }
@@ -623,7 +623,7 @@ real1 QUnit::ProbAll(bitCapInt perm)
         if (perms.find(shards[i].unit) == perms.end()) {
             perms[shards[i].unit] = 0U;
         }
-        if ((perm >> i) & 1UL) {
+        if ((perm >> i) & ONE_BCI) {
             perms[shards[i].unit] |= pow2(shards[i].mapped);
         }
     }
@@ -698,7 +698,7 @@ void QUnit::SetReg(bitLenInt start, bitLenInt length, bitCapInt value)
 
     bool bitState;
     for (bitLenInt i = 0; i < length; i++) {
-        bitState = (value >> i) & 1UL;
+        bitState = (value >> i) & ONE_BCI;
         shards[i + start] = QEngineShard(shards[i + start].unit, bitState);
         shards[i + start].isEmulated = true;
     }
@@ -795,7 +795,7 @@ void QUnit::UniformlyControlledSingleBit(const bitLenInt* controls, const bitLen
     if (trimmedControls.size() == 0) {
         bitCapInt controlPerm = GetCachedPermutation(controls, controlLen);
         complex mtrx[4];
-        std::copy(mtrxs + (controlPerm * 4UL), mtrxs + ((controlPerm + 1UL) * 4UL), mtrx);
+        std::copy(mtrxs + (controlPerm * 4UL), mtrxs + ((controlPerm + ONE_BCI) * 4U), mtrx);
         ApplySingleBit(mtrx, true, qubitIndex);
         return;
     }
@@ -1584,7 +1584,7 @@ bool QUnit::INTSCOptimize(
     }
 
     bitCapInt lengthPower = pow2(length);
-    bitCapInt signMask = pow2(length - 1UL);
+    bitCapInt signMask = pow2(length - 1U);
     bitCapInt inOutInt = GetCachedPermutation(start, length);
     bitCapInt inInt = toMod;
 
@@ -1600,7 +1600,7 @@ bool QUnit::INTSCOptimize(
 
     bool carryOut = (outInt >= lengthPower);
     if (carryOut) {
-        outInt &= (lengthPower - 1UL);
+        outInt &= (lengthPower - ONE_BCI);
     }
     if (carry && (carryIn != carryOut)) {
         X(carryIndex);
@@ -1630,10 +1630,10 @@ void QUnit::INT(bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt ca
     bitLenInt origLength = length;
     bitLenInt i = 0;
     while (i < origLength) {
-        toAdd = toMod & 1UL;
+        toAdd = toMod & ONE_BCI;
 
         if (toAdd == carry) {
-            toMod >>= 1UL;
+            toMod >>= ONE_BCI;
             start++;
             length--;
             i++;
@@ -1649,7 +1649,7 @@ void QUnit::INT(bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt ca
             }
             carry = (total > 1);
 
-            toMod >>= 1UL;
+            toMod >>= ONE_BCI;
             start++;
             length--;
             i++;
@@ -1670,9 +1670,9 @@ void QUnit::INT(bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt ca
             // not to be superposed.
 
             // Load the first bit:
-            bitCapInt bitMask = 1UL;
+            bitCapInt bitMask = ONE_BCI;
             bitCapInt partMod = toMod & bitMask;
-            bitLenInt partLength = 1;
+            bitLenInt partLength = 1U;
             bitLenInt partStart;
             i++;
 
@@ -1680,12 +1680,12 @@ void QUnit::INT(bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt ca
                 // Guaranteed to need to load the second bit
                 partLength++;
                 i++;
-                bitMask <<= 1UL;
+                bitMask <<= ONE_BCI;
 
                 toAdd = toMod & bitMask;
                 partMod |= toMod & bitMask;
 
-                partStart = start + partLength - 1UL;
+                partStart = start + partLength - ONE_BCI;
                 if (!CheckBitPermutation(partStart)) {
                     // If the quantum bit at this position is superposed, then we can't determine that the carry won't
                     // be superposed. Advance the loop.
@@ -1769,7 +1769,7 @@ void QUnit::INTS(
         return;
     }
 
-    bitLenInt signBit = start + length - 1UL;
+    bitLenInt signBit = start + length - 1U;
     bool knewFlagSet = CheckBitPermutation(overflowIndex);
     bool flagSet = SHARD_STATE(shards[overflowIndex]);
 
@@ -1779,7 +1779,7 @@ void QUnit::INTS(
         return;
     }
 
-    bool addendNeg = toMod & pow2(length - 1UL);
+    bool addendNeg = toMod & pow2(length - 1U);
     bool knewSign = CheckBitPermutation(signBit);
     bool quantumNeg = SHARD_STATE(shards[signBit]);
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -939,9 +939,9 @@ void QUnit::TransformInvert(const complex& topRight, const complex& bottomLeft, 
         [&]() { bare; });
 
 #define CTRLED_PHASE_WRAP(ctrld, ctrldgen, bare, anti)                                                                 \
-    ApplyEitherControlled(controls, controlLen, { target }, anti,                                                      \
+    ApplyEitherControlled(lcontrols, controlLen, { ltarget }, anti,                                                    \
         [&](QInterfacePtr unit, std::vector<bitLenInt> mappedControls) {                                               \
-            if (!shards[target].isPlusMinus) {                                                                         \
+            if (!shards[ltarget].isPlusMinus) {                                                                        \
                 unit->ctrld;                                                                                           \
             } else {                                                                                                   \
                 complex trnsMtrx[4];                                                                                   \
@@ -1132,8 +1132,20 @@ void QUnit::ApplyControlledSinglePhase(const bitLenInt* controls, const bitLenIn
             return;
         }
 
+        bitLenInt* lcontrols = new bitLenInt[controlLen];
+        bitLenInt ltarget;
+        if (controlLen == 1 && CACHED_CLASSICAL(shards[target]) && !CACHED_CLASSICAL(shards[controls[0]])) {
+            ltarget = controls[0];
+            lcontrols[0] = target;
+        } else {
+            ltarget = target;
+            std::copy(controls, controls + controlLen, lcontrols);
+        }
+
         CTRLED_PHASE_WRAP(ApplyControlledSinglePhase(CTRL_P_ARGS), ApplyControlledSingleBit(CTRL_GEN_ARGS),
             ApplySinglePhase(topLeft, bottomRight, true, target), false);
+
+        delete[] lcontrols;
     }
 }
 
@@ -1155,8 +1167,20 @@ void QUnit::ApplyAntiControlledSinglePhase(const bitLenInt* controls, const bitL
             return;
         }
 
+        bitLenInt* lcontrols = new bitLenInt[controlLen];
+        bitLenInt ltarget;
+        if (controlLen == 1 && CACHED_CLASSICAL(shards[target]) && !CACHED_CLASSICAL(shards[controls[0]])) {
+            ltarget = controls[0];
+            lcontrols[0] = target;
+        } else {
+            ltarget = target;
+            std::copy(controls, controls + controlLen, lcontrols);
+        }
+
         CTRLED_PHASE_WRAP(ApplyControlledSinglePhase(CTRL_P_ARGS), ApplyControlledSingleBit(CTRL_GEN_ARGS),
             ApplySinglePhase(topLeft, bottomRight, true, target), false);
+
+        delete[] lcontrols;
     }
 }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -269,7 +269,7 @@ QInterfacePtr QUnit::EntangleRange(bitLenInt start, bitLenInt length)
 
     std::vector<bitLenInt> bits(length);
     std::vector<bitLenInt*> ebits(length);
-    for (auto i = 0; i < length; i++) {
+    for (bitLenInt i = 0; i < length; i++) {
         bits[i] = i + start;
         ebits[i] = &bits[i];
     }
@@ -292,12 +292,12 @@ QInterfacePtr QUnit::EntangleRange(bitLenInt start1, bitLenInt length1, bitLenIn
         std::swap(length1, length2);
     }
 
-    for (auto i = 0; i < length1; i++) {
+    for (bitLenInt i = 0; i < length1; i++) {
         bits[i] = i + start1;
         ebits[i] = &bits[i];
     }
 
-    for (auto i = 0; i < length2; i++) {
+    for (bitLenInt i = 0; i < length2; i++) {
         bits[i + length1] = i + start2;
         ebits[i + length1] = &bits[i + length1];
     }
@@ -332,17 +332,17 @@ QInterfacePtr QUnit::EntangleRange(
         std::swap(length2, length3);
     }
 
-    for (auto i = 0; i < length1; i++) {
+    for (bitLenInt i = 0; i < length1; i++) {
         bits[i] = i + start1;
         ebits[i] = &bits[i];
     }
 
-    for (auto i = 0; i < length2; i++) {
+    for (bitLenInt i = 0; i < length2; i++) {
         bits[i + length1] = i + start2;
         ebits[i + length1] = &bits[i + length1];
     }
 
-    for (auto i = 0; i < length3; i++) {
+    for (bitLenInt i = 0; i < length3; i++) {
         bits[i + length1 + length2] = i + start3;
         ebits[i + length1 + length2] = &bits[i + length1 + length2];
     }
@@ -473,8 +473,8 @@ void QUnit::OrderContiguous(QInterfacePtr unit)
     /* Create a sortable collection of all of the bits that are in the unit. */
     std::vector<QSortEntry> bits(unit->GetQubitCount());
 
-    int j = 0;
-    for (int i = 0; i < qubitCount; i++) {
+    bitLenInt j = 0;
+    for (bitLenInt i = 0; i < qubitCount; i++) {
         if (shards[i].unit == unit) {
             bits[j].mapped = shards[i].mapped;
             bits[j].bit = i;
@@ -580,7 +580,7 @@ void QUnit::DumpShards()
 {
     int i = 0;
     for (auto shard : shards) {
-        printf("%2d.\t%p[%d]\n", i++, shard.unit.get(), shard.mapped);
+        printf("%2d.\t%p[%d]\n", i++, shard.unit.get(), (int)shard.mapped);
     }
 }
 
@@ -1341,7 +1341,7 @@ void QUnit::CLXOR(bitLenInt qInputStart, bitCapInt classicalInput, bitLenInt out
 bool QUnit::CArithmeticOptimize(
     bitLenInt start, bitLenInt length, bitLenInt* controls, bitLenInt controlLen, std::vector<bitLenInt>* controlVec)
 {
-    for (auto i = 0; i < controlLen; i++) {
+    for (bitLenInt i = 0; i < controlLen; i++) {
         // If any control has a cached zero probability, this gate will do nothing, and we can avoid basically all
         // overhead.
         if (!shards[controls[i]].isProbDirty && (Prob(controls[i]) < min_norm)) {
@@ -1356,7 +1356,7 @@ bool QUnit::CArithmeticOptimize(
     std::copy(controls, controls + controlLen, controlVec->begin());
     bitLenInt controlIndex = 0;
 
-    for (auto i = 0; i < controlLen; i++) {
+    for (bitLenInt i = 0; i < controlLen; i++) {
         if (shards[controls[i]].isProbDirty && (shards[controls[i]].unit == shards[start].unit)) {
             continue;
         }

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -21,7 +21,7 @@
 #define CACHED_CLASSICAL(shard)                                                                                        \
     ((!shard.isPlusMinus) && !shard.isProbDirty && ((norm(shard.amp0) < min_norm) || (norm(shard.amp1) < min_norm)))
 #define PHASE_MATTERS(shard)                                                                                           \
-    (!randGlobalPhase || shard.isPlusMinus || shard.isProbDirty || shard.isPhaseDirty ||                               \
+    (!randGlobalPhase || shard.isPlusMinus || shard.isProbDirty ||                                                     \
         !((norm(shard.amp0) < min_norm) || (norm(shard.amp1) < min_norm)))
 #define DIRTY(shard) (shard.isProbDirty || shard.isPhaseDirty)
 
@@ -1134,7 +1134,7 @@ void QUnit::ApplyControlledSinglePhase(const bitLenInt* controls, const bitLenIn
 
         bitLenInt* lcontrols = new bitLenInt[controlLen];
         bitLenInt ltarget;
-        if (controlLen == 1 && CACHED_CLASSICAL(shards[target]) && !CACHED_CLASSICAL(shards[controls[0]])) {
+        if (controlLen == 1 && CACHED_CLASSICAL(shard) && !CACHED_CLASSICAL(shards[controls[0]])) {
             ltarget = controls[0];
             lcontrols[0] = target;
         } else {
@@ -1169,16 +1169,11 @@ void QUnit::ApplyAntiControlledSinglePhase(const bitLenInt* controls, const bitL
 
         bitLenInt* lcontrols = new bitLenInt[controlLen];
         bitLenInt ltarget;
-        if (controlLen == 1 && CACHED_CLASSICAL(shards[target]) && !CACHED_CLASSICAL(shards[controls[0]])) {
-            ltarget = controls[0];
-            lcontrols[0] = target;
-        } else {
-            ltarget = target;
-            std::copy(controls, controls + controlLen, lcontrols);
-        }
 
-        CTRLED_PHASE_WRAP(ApplyControlledSinglePhase(CTRL_P_ARGS), ApplyControlledSingleBit(CTRL_GEN_ARGS),
-            ApplySinglePhase(topLeft, bottomRight, true, target), false);
+        ltarget = target;
+        std::copy(controls, controls + controlLen, lcontrols);
+        CTRLED_PHASE_WRAP(ApplyAntiControlledSinglePhase(CTRL_P_ARGS), ApplyAntiControlledSingleBit(CTRL_GEN_ARGS),
+            ApplySinglePhase(topLeft, bottomRight, true, target), true);
 
         delete[] lcontrols;
     }

--- a/test/accuracy.cpp
+++ b/test/accuracy.cpp
@@ -55,7 +55,8 @@ void benchmarkLoopVariable(std::function<void(QInterfacePtr, int)> fn, bitLenInt
     double err;
     double trialErrors[ITERATIONS];
 
-    int i, numBits;
+    int i;
+    bitLenInt numBits;
 
     double avge, stdee;
 

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -32,8 +32,6 @@ using namespace Qrack;
         REQUIRE(__tmp_b > (__tmp_b - EPSILON));                                                                        \
     } while (0);
 
-const bitLenInt MaxQubits = 24;
-
 const double clockFactor = 1000.0 / CLOCKS_PER_SEC; // Report in ms
 
 double formatTime(double t, bool logNormal)
@@ -70,7 +68,14 @@ void benchmarkLoopVariable(std::function<void(QInterfacePtr, int)> fn, bitLenInt
 
     double avgt, stdet;
 
-    for (numBits = 4; numBits <= mxQbts; numBits++) {
+    bitLenInt mnQbts;
+    if (single_qubit_run) {
+        mnQbts = mxQbts;
+    } else {
+        mnQbts = 4;
+    }
+
+    for (numBits = mnQbts; numBits <= mxQbts; numBits++) {
         QInterfacePtr qftReg = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, numBits,
             0, rng, complex(ONE_R1, ZERO_R1), enable_normalization, true, false, device_id, !disable_hardware_rng);
         avgt = 0.0;
@@ -153,150 +158,150 @@ void benchmarkLoopVariable(std::function<void(QInterfacePtr, int)> fn, bitLenInt
 void benchmarkLoop(std::function<void(QInterfacePtr, int)> fn, bool resetRandomPerm = true,
     bool hadamardRandomBits = false, bool logNormal = false)
 {
-    benchmarkLoopVariable(fn, MaxQubits, resetRandomPerm, hadamardRandomBits, logNormal);
+    benchmarkLoopVariable(fn, max_qubits, resetRandomPerm, hadamardRandomBits, logNormal);
 }
 
-TEST_CASE("test_cnot_single")
+TEST_CASE("test_cnot_single", "[gates]")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->CNOT(0, 1); });
 }
 
-TEST_CASE("test_x_single")
+TEST_CASE("test_x_single", "[gates]")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->X(0); });
 }
 
-TEST_CASE("test_y_single")
+TEST_CASE("test_y_single", "[gates]")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->Y(0); });
 }
 
-TEST_CASE("test_z_single")
+TEST_CASE("test_z_single", "[gates]")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->Z(0); });
 }
 
-TEST_CASE("test_swap_single")
+TEST_CASE("test_swap_single", "[gates]")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->Swap(0, 1); });
 }
 
-TEST_CASE("test_cnot_all")
+TEST_CASE("test_cnot_all", "[gates]")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->CNOT(0, n / 2, n / 2); });
 }
 
-TEST_CASE("test_x_all")
+TEST_CASE("test_x_all", "[gates]")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->X(0, n); });
 }
 
-TEST_CASE("test_y_all")
+TEST_CASE("test_y_all", "[gates]")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->Y(0, n); });
 }
 
-TEST_CASE("test_z_all")
+TEST_CASE("test_z_all", "[gates]")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->Z(0, n); });
 }
 
-TEST_CASE("test_swap_all")
+TEST_CASE("test_swap_all", "[gates]")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->Swap(0, n / 2, n / 2); });
 }
 
-TEST_CASE("test_ccnot_all")
+TEST_CASE("test_ccnot_all", "[gates]")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->CCNOT(0, n / 3, (2 * n) / 3, n / 3); });
 }
 
-TEST_CASE("test_and_all")
+TEST_CASE("test_and_all", "[gates]")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->AND(0, n / 3, (2 * n) / 3, n / 3); });
 }
 
-TEST_CASE("test_or_all")
+TEST_CASE("test_or_all", "[gates]")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->OR(0, n / 3, (2 * n) / 3, n / 3); });
 }
 
-TEST_CASE("test_xor_all")
+TEST_CASE("test_xor_all", "[gates]")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->XOR(0, n / 3, (2 * n) / 3, n / 3); });
 }
 
-TEST_CASE("test_cland_all")
+TEST_CASE("test_cland_all", "[gates]")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->CLAND(0, 0x0c, 0, n); });
 }
 
-TEST_CASE("test_clor_all")
+TEST_CASE("test_clor_all", "[gates]")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->CLOR(0, 0x0d, 0, n); });
 }
 
-TEST_CASE("test_clxor_all")
+TEST_CASE("test_clxor_all", "[gates]")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->CLXOR(0, 0x0d, 0, n); });
 }
 
-TEST_CASE("test_rt_all")
+TEST_CASE("test_rt_all", "[gates]")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->RT(M_PI, 0, n); });
 }
 
-TEST_CASE("test_crt_all")
+TEST_CASE("test_crt_all", "[gates]")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->CRT(M_PI, 0, n / 2, n / 2); });
 }
 
-TEST_CASE("test_rol")
+TEST_CASE("test_rol", "[gates]")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->ROL(1, 0, n); });
 }
 
-TEST_CASE("test_inc")
+TEST_CASE("test_inc", "[arithmetic]")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->INC(1, 0, n); });
 }
 
-TEST_CASE("test_incs")
+TEST_CASE("test_incs", "[arithmetic]")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->INCS(1, 0, n - 1, n - 1); });
 }
 
-TEST_CASE("test_incc")
+TEST_CASE("test_incc", "[arithmetic]")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->INCC(1, 0, n - 1, n - 1); });
 }
 
-TEST_CASE("test_incsc")
+TEST_CASE("test_incsc", "[arithmetic]")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->INCSC(1, 0, n - 2, n - 2, n - 1); });
 }
 
-TEST_CASE("test_zero_phase_flip")
+TEST_CASE("test_zero_phase_flip", "[phaseflip]")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->ZeroPhaseFlip(0, n); });
 }
 
-TEST_CASE("test_c_phase_flip_if_less")
+TEST_CASE("test_c_phase_flip_if_less", "[phaseflip]")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->CPhaseFlipIfLess(1, 0, n - 1, n - 1); });
 }
 
-TEST_CASE("test_phase_flip")
+TEST_CASE("test_phase_flip", "[phaseflip]")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->PhaseFlip(); });
 }
 
-TEST_CASE("test_m")
+TEST_CASE("test_m", "[measure]")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->M(n - 1); });
 }
 
-TEST_CASE("test_mreg")
+TEST_CASE("test_mreg", "[measure]")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->MReg(0, n); });
 }
@@ -305,8 +310,8 @@ void benchmarkSuperpose(std::function<void(QInterfacePtr, int, unsigned char*)> 
 {
     bitCapInt i, j;
 
-    bitCapInt wordLength = (MaxQubits / 16 + 1);
-    bitCapInt indexLength = (1 << (MaxQubits / 2));
+    bitCapInt wordLength = (max_qubits / 16 + 1);
+    bitCapInt indexLength = (1 << (max_qubits / 2));
     unsigned char* testPage = new unsigned char[wordLength * indexLength];
     for (j = 0; j < indexLength; j++) {
         for (i = 0; i < wordLength; i++) {
@@ -317,90 +322,88 @@ void benchmarkSuperpose(std::function<void(QInterfacePtr, int, unsigned char*)> 
     delete[] testPage;
 }
 
-TEST_CASE("test_superposition_reg")
+TEST_CASE("test_superposition_reg", "[indexed]")
 {
     benchmarkSuperpose([](QInterfacePtr qftReg, int n, unsigned char* testPage) {
         qftReg->IndexedLDA(0, n / 2, n / 2, n / 2, testPage);
     });
 }
 
-TEST_CASE("test_adc_superposition_reg")
+TEST_CASE("test_adc_superposition_reg", "[indexed]")
 {
     benchmarkSuperpose([](QInterfacePtr qftReg, int n, unsigned char* testPage) {
         qftReg->IndexedADC(0, (n - 1) / 2, (n - 1) / 2, (n - 1) / 2, (n - 1), testPage);
     });
 }
 
-TEST_CASE("test_sbc_superposition_reg")
+TEST_CASE("test_sbc_superposition_reg", "[indexed]")
 {
     benchmarkSuperpose([](QInterfacePtr qftReg, int n, unsigned char* testPage) {
         qftReg->IndexedSBC(0, (n - 1) / 2, (n - 1) / 2, (n - 1) / 2, (n - 1), testPage);
     });
 }
 
-TEST_CASE("test_setbit")
+TEST_CASE("test_setbit", "[aux]")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->SetBit(0, true); });
 }
 
-TEST_CASE("test_proball")
+TEST_CASE("test_proball", "[aux]")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->ProbAll(0x02); });
 }
 
-TEST_CASE("test_set_reg")
+TEST_CASE("test_set_reg", "[aux]")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->SetReg(0, n, 1); });
 }
 
-TEST_CASE("test_grover")
+TEST_CASE("test_grover", "[grover]")
 {
 
     // Grover's search inverts the function of a black box subroutine.
     // Our subroutine returns true only for an input of 3.
 
-    benchmarkLoopVariable(
-        [](QInterfacePtr qftReg, int n) {
-            int i;
-            // Twelve iterations maximizes the probablity for 256 searched elements, for example.
-            // For an arbitrary number of qubits, this gives the number of iterations for optimal probability.
-            int optIter = M_PI / (4.0 * asin(1.0 / sqrt(1 << n)));
+    benchmarkLoop([](QInterfacePtr qftReg, int n) {
+        int i;
+        // Twelve iterations maximizes the probablity for 256 searched elements, for example.
+        // For an arbitrary number of qubits, this gives the number of iterations for optimal probability.
+        int optIter = M_PI / (4.0 * asin(1.0 / sqrt(1 << n)));
 
-            // Our input to the subroutine "oracle" is 8 bits.
-            qftReg->SetPermutation(0);
+        // Our input to the subroutine "oracle" is 8 bits.
+        qftReg->SetPermutation(0);
+        qftReg->H(0, n);
+
+        for (i = 0; i < optIter; i++) {
+            // Our "oracle" is true for an input of "3" and false for all other inputs.
+            qftReg->DEC(3, 0, n);
+            qftReg->ZeroPhaseFlip(0, n);
+            qftReg->INC(3, 0, n);
+            // This ends the "oracle."
             qftReg->H(0, n);
+            qftReg->ZeroPhaseFlip(0, n);
+            qftReg->H(0, n);
+            qftReg->PhaseFlip();
+        }
 
-            for (i = 0; i < optIter; i++) {
-                // Our "oracle" is true for an input of "3" and false for all other inputs.
-                qftReg->DEC(3, 0, n);
-                qftReg->ZeroPhaseFlip(0, n);
-                qftReg->INC(3, 0, n);
-                // This ends the "oracle."
-                qftReg->H(0, n);
-                qftReg->ZeroPhaseFlip(0, n);
-                qftReg->H(0, n);
-                qftReg->PhaseFlip();
-            }
+        REQUIRE_THAT(qftReg, HasProbability(0x3));
 
-            REQUIRE_THAT(qftReg, HasProbability(0x3));
-
-            qftReg->MReg(0, n);
-        },
-        16);
+        qftReg->MReg(0, n);
+    });
 }
 
-TEST_CASE("test_qft_ideal_init")
+TEST_CASE("test_qft_ideal_init", "[qft]")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->QFT(0, n, false); }, false, false);
 }
 
-TEST_CASE("test_qft_permutation_init")
+TEST_CASE("test_qft_permutation_init", "[qft]")
 {
     benchmarkLoop(
         [](QInterfacePtr qftReg, int n) { qftReg->QFT(0, n, false); }, true, false, testEngineType == QINTERFACE_QUNIT);
 }
 
-TEST_CASE("test_qft_permutation_round_trip_entangled")
+TEST_CASE("test_qft_permutation_round_trip_entangled", "[qft]")
 {
     benchmarkLoop(
         [](QInterfacePtr qftReg, int n) {
@@ -410,7 +413,7 @@ TEST_CASE("test_qft_permutation_round_trip_entangled")
         true, false, testEngineType == QINTERFACE_QUNIT);
 }
 
-TEST_CASE("test_qft_superposition_round_trip")
+TEST_CASE("test_qft_superposition_round_trip", "[qft]")
 {
     benchmarkLoop(
         [](QInterfacePtr qftReg, int n) {

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -64,7 +64,7 @@ void benchmarkLoopVariable(std::function<void(QInterfacePtr, int)> fn, bitLenInt
     clock_t tClock, iterClock;
     real1 trialClocks[ITERATIONS];
 
-    int i, j, numBits;
+    bitLenInt i, j, numBits;
 
     double avgt, stdet;
 

--- a/test/benchmarks_main.cpp
+++ b/test/benchmarks_main.cpp
@@ -231,6 +231,5 @@ QInterfaceTestFixture::QInterfaceTestFixture()
     qrack_rand_gen_ptr rng = std::make_shared<qrack_rand_gen>();
     rng->seed(rngSeed);
 
-    qftReg = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 1, 0, rng,
-        complex(ONE_R1, ZERO_R1), enable_normalization, true, false, -1, !disable_hardware_rng);
+    qftReg = NULL;
 }

--- a/test/benchmarks_main.cpp
+++ b/test/benchmarks_main.cpp
@@ -119,7 +119,7 @@ int main(int argc, char* argv[])
 
             // Device RAM should be large enough for 2 times the size of the stateVec, plus some excess.
             max_qubits = log2(maxAlloc);
-            if ((3 * (1U << max_qubits)) > maxMem ) {
+            if ((3 * (1U << max_qubits)) > maxMem) {
                 max_qubits = log2(maxMem / 3);
             }
 #else

--- a/test/benchmarks_main.cpp
+++ b/test/benchmarks_main.cpp
@@ -119,8 +119,8 @@ int main(int argc, char* argv[])
 
             // Device RAM should be large enough for 2 times the size of the stateVec, plus some excess.
             max_qubits = log2(maxAlloc);
-            if ((3 * (1U << max_qubits)) > maxMem) {
-                max_qubits = log2(maxMem / 3);
+            if ((3U * pow2(max_qubits)) > maxMem) {
+                max_qubits = log2(maxMem / 3U);
             }
 #else
         // With OpenCL tests disabled, it's ambiguous what device we want to set the limit by.

--- a/test/benchmarks_main.cpp
+++ b/test/benchmarks_main.cpp
@@ -30,6 +30,8 @@ bool enable_normalization = false;
 bool disable_hardware_rng = false;
 bool async_time = false;
 int device_id = -1;
+bitLenInt max_qubits = 24;
+bool single_qubit_run = false;
 
 int main(int argc, char* argv[])
 {
@@ -41,6 +43,8 @@ int main(int argc, char* argv[])
     bool qunit_qfusion = false;
     bool cpu = false;
     bool opencl_single = false;
+
+    int mxQbts = 24;
 
     using namespace Catch::clara;
 
@@ -60,7 +64,10 @@ int main(int argc, char* argv[])
         Opt(disable_hardware_rng)["--disable-hardware-rng"]("Modern Intel chips provide an instruction for hardware "
                                                             "random number generation, which this option turns off. "
                                                             "(Hardware generation is on by default, if available.)") |
-        Opt(device_id, "device-id")["-d"]["--device-id"]("Opencl device ID (\"-1\" for default device)");
+        Opt(device_id, "device-id")["-d"]["--device-id"]("Opencl device ID (\"-1\" for default device)") |
+        Opt(mxQbts, "max-qubits")["-m"]["--max-qubits"](
+            "Maximum qubits for test (default value 24, enter \"-1\" for automatic selection)") |
+        Opt(single_qubit_run)["--single"]("Only run single (maximum) qubit count for tests");
 
     session.cli(cli);
 
@@ -95,6 +102,35 @@ int main(int argc, char* argv[])
     if (!cpu && !opencl_single) {
         cpu = true;
         opencl_single = true;
+    }
+
+    if (mxQbts == -1) {
+        // If we're talking about a particular OpenCL device,
+        // we have an API designed to tell us device capabilities and limitations,
+        // like maximum RAM allocation.
+        if (opencl_single) {
+#if ENABLE_OPENCL
+            // Make sure the context singleton is initialized.
+            CreateQuantumInterface(QINTERFACE_OPENCL, 1, 0).reset();
+
+            DeviceContextPtr device_context = OCLEngine::Instance()->GetDeviceContextPtr(device_id);
+            size_t maxMem = device_context->device.getInfo<CL_DEVICE_GLOBAL_MEM_SIZE>() / sizeof(complex);
+            size_t maxAlloc = device_context->device.getInfo<CL_DEVICE_MAX_MEM_ALLOC_SIZE>() / sizeof(complex);
+
+            // Device RAM should be large enough for 2 times the size of the stateVec, plus some excess.
+            max_qubits = log2(maxAlloc);
+            if ((3 * (1U << max_qubits)) > maxMem ) {
+                max_qubits = log2(maxMem / 3);
+            }
+#else
+        // With OpenCL tests disabled, it's ambiguous what device we want to set the limit by.
+        // If we're not talking about the OpenCL resources of a single device,
+        // maximum allocation becomes a notoriously thorny matter.
+        // For any case besides the above, we just use the default.
+#endif
+        }
+    } else {
+        max_qubits = mxQbts;
     }
 
     int num_failed = 0;

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -2950,7 +2950,7 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_fast_grover")
     // Our subroutine returns true only for an input of 100.
     const bitLenInt length = 10;
     const int TARGET_PROB = 100;
-    int i;
+    bitLenInt i;
     bitLenInt partStart;
     // Start in a superposition of all inputs.
     qftReg->SetPermutation(0);
@@ -3352,19 +3352,19 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_basis_change")
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_entanglement")
 {
     REQUIRE_THAT(qftReg, HasProbability(0, 20, 0x0));
-    for (int i = 0; i < qftReg->GetQubitCount(); i += 2) {
+    for (bitLenInt i = 0; i < qftReg->GetQubitCount(); i += 2) {
         qftReg->X(i);
     }
     REQUIRE_THAT(qftReg, HasProbability(0, 20, 0x55555));
-    for (int i = 0; i < (qftReg->GetQubitCount() - 1); i += 2) {
+    for (bitLenInt i = 0; i < (qftReg->GetQubitCount() - 1); i += 2) {
         qftReg->CNOT(i, i + 1);
     }
     REQUIRE_THAT(qftReg, HasProbability(0, 20, 0xfffff));
-    for (int i = qftReg->GetQubitCount() - 2; i > 0; i -= 2) {
+    for (bitLenInt i = qftReg->GetQubitCount() - 2; i > 0; i -= 2) {
         qftReg->CNOT(i - 1, i);
     }
     REQUIRE_THAT(qftReg, HasProbability(0, 20, 0xAAAAB));
-    for (int i = 1; i < qftReg->GetQubitCount(); i += 2) {
+    for (bitLenInt i = 1; i < qftReg->GetQubitCount(); i += 2) {
         qftReg->X(i);
     }
     REQUIRE_THAT(qftReg, HasProbability(0, 20, 0x1));

--- a/test/tests.hpp
+++ b/test/tests.hpp
@@ -133,10 +133,10 @@ public:
 class ProbPattern : public Catch::MatcherBase<Qrack::QInterfacePtr> {
     bitLenInt start;
     bitLenInt length;
-    uint64_t mask;
+    bitCapInt mask;
 
 public:
-    ProbPattern(bitLenInt s, bitLenInt l, uint64_t m)
+    ProbPattern(bitLenInt s, bitLenInt l, bitCapInt m)
         : start(s)
         , length(l)
         , mask(m)
@@ -154,7 +154,7 @@ public:
             return false;
         }
 
-        for (uint8_t j = 0; j < length; j++) {
+        for (bitCapInt j = 0; j < length; j++) {
             /* Consider anything more than a 50% probability as a '1'. */
             bool bit = (qftReg->Prob(j + start) > QRACK_TEST_EPSILON);
             if (bit != !!(mask & (1U << j))) {

--- a/test/tests.hpp
+++ b/test/tests.hpp
@@ -32,6 +32,8 @@ extern bool enable_normalization;
 extern bool disable_hardware_rng;
 extern bool async_time;
 extern int device_id;
+extern bitLenInt max_qubits;
+extern bool single_qubit_run;
 
 /* Declare the stream-to-probability prior to including catch.hpp. */
 namespace Qrack {

--- a/test/tests.hpp
+++ b/test/tests.hpp
@@ -67,15 +67,14 @@ inline std::ostream& outputPerBitProbs(std::ostream& os, Qrack::QInterfacePtr qf
 
 inline std::ostream& outputProbableResult(std::ostream& os, Qrack::QInterfacePtr qftReg)
 {
-    int i;
+    bitCapInt i;
 
     double maxProb = 0;
-    int maxProbIdx = 0;
+    bitCapInt maxProbIdx = 0;
     double totalProb = 0;
 
-    // Iterate through all possible values of the bit array, starting at the
-    // max.
-    for (i = qftReg->GetMaxQPower() - 1; i >= 0; i--) {
+    // Iterate through all possible values of the bit array
+    for (i = 0; i < qftReg->GetMaxQPower(); i++) {
         double prob = qftReg->ProbAll(i);
         totalProb += prob;
         if (prob > maxProb) {
@@ -90,7 +89,7 @@ inline std::ostream& outputProbableResult(std::ostream& os, Qrack::QInterfacePtr
     os << qftReg->GetQubitCount() << "/";
 
     // Print the resulting maximum probability bit pattern.
-    for (i = qftReg->GetMaxQPower() >> 1; i > 0; i >>= 1) {
+    for (i = qftReg->GetMaxQPower() >> 1UL; i > 0; i >>= 1UL) {
         if (i & maxProbIdx) {
             os << "1";
         } else {


### PR DESCRIPTION
This can still be generalized further, but, at least in the case of a single control bit and single target, phase gates are symmetric under swap of the bits. Swapping target and control as convenient for optimization can make a huge difference to more general cases of the QFT.