### PR TITLE
CNOT Optimization and Cleanup

### DIFF
--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -447,6 +447,9 @@ protected:
         }
     }
 
+    bool TryCnotOptimize(const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& target,
+        const complex& bottomLeft, const complex& topRight, const bool& anti);
+
     /* Debugging and diagnostic routines. */
     void DumpShards();
     QInterfacePtr GetUnit(bitLenInt bit) { return shards[bit].unit; }

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1074,7 +1074,7 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
             CNOT(target, control);
         } else if (norm(tShard.amp0) < min_norm) {
             std::swap(cShard.amp0, cShard.amp1);
-            if (cShard.unit->GetQubitCount() == 1) {
+            if (cShard.unit->GetQubitCount() == 1U) {
                 cShard.isEmulated = true;
             } else {
                 cShard.unit->X(cShard.mapped);
@@ -1097,7 +1097,7 @@ void QUnit::AntiCNOT(bitLenInt control, bitLenInt target)
             AntiCNOT(target, control);
         } else if (norm(tShard.amp0) < min_norm) {
             std::swap(cShard.amp0, cShard.amp1);
-            if (cShard.unit->GetQubitCount() == 1) {
+            if (cShard.unit->GetQubitCount() == 1U) {
                 cShard.isEmulated = true;
             } else {
                 cShard.unit->X(cShard.mapped);
@@ -1137,11 +1137,6 @@ void QUnit::CZ(bitLenInt control, bitLenInt target)
 
 void QUnit::ApplySinglePhase(const complex topLeft, const complex bottomRight, bool doCalcNorm, bitLenInt target)
 {
-    complex iTest[4] = { topLeft, 0, 0, bottomRight };
-    if (IsIdentity(iTest)) {
-        return;
-    }
-
     QEngineShard& shard = shards[target];
 
     if (!shard.isPlusMinus) {
@@ -1221,12 +1216,6 @@ void QUnit::ApplyControlledSinglePhase(const bitLenInt* controls, const bitLenIn
         return;
     }
 
-    // Identity operator has no effect.
-    complex iTest[4] = { topLeft, 0, 0, bottomRight };
-    if (IsIdentity(iTest)) {
-        return;
-    }
-
     bitLenInt* lcontrols = new bitLenInt[controlLen];
     bitLenInt ltarget;
     if (controlLen == 1 && CACHED_CLASSICAL(shard) && !CACHED_CLASSICAL(shards[controls[0]])) {
@@ -1258,11 +1247,6 @@ void QUnit::ApplyAntiControlledSinglePhase(const bitLenInt* controls, const bitL
     QEngineShard& shard = shards[target];
     // If the target bit is in a |0>/|1> eigenstate, this gate has no effect.
     if (PHASE_MATTERS(shard)) {
-        complex iTest[4] = { topLeft, 0, 0, bottomRight };
-        if (IsIdentity(iTest)) {
-            return;
-        }
-
         bitLenInt* lcontrols = new bitLenInt[controlLen];
         bitLenInt ltarget;
 
@@ -1286,10 +1270,6 @@ void QUnit::ApplyAntiControlledSingleInvert(const bitLenInt* controls, const bit
 
 void QUnit::ApplySingleBit(const complex* mtrx, bool doCalcNorm, bitLenInt target)
 {
-    if (IsIdentity(mtrx)) {
-        return;
-    }
-
     QEngineShard& shard = shards[target];
 
     complex trnsMtrx[4];
@@ -1366,7 +1346,6 @@ void QUnit::AntiCISqrtSwap(
 
 #define CHECK_BREAK_AND_TRIM()                                                                                         \
     /* Check whether the bit probability is 0, (or 1, if "anti"). */                                                   \
-    CheckShardSeparable(controls[i]);                                                                                  \
     bitProb = Prob(controls[i]);                                                                                       \
     if (bitProb < min_norm) {                                                                                          \
         if (!anti) {                                                                                                   \

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -600,8 +600,8 @@ real1 QUnit::ProbBase(const bitLenInt& qubit)
             } else if (norm(shard.amp1) < min_norm) {
                 SeparateBit(false, qubit);
             }
-        } else {
-            // 1 qubit, therefore phase is unimportant to Hermitian eigenvalues
+        } else if (CACHED_CLASSICAL(shard)) {
+            // 1 qubit, therefore |0>/|1> eigenstate phase is unimportant to Hermitian eigenvalues
             shard.isPhaseDirty = false;
         }
     }
@@ -2524,8 +2524,11 @@ void QUnit::CheckShardSeparable(const bitLenInt& target)
         if (abs(ProbBase(target) - (ONE_R1 / 2)) < min_norm) {
             TransformBasis(!shard.isPlusMinus, target);
         }
-        // Since the probability cache is correct, and we have one separated qubit, phase is clean.
-        shard.isPhaseDirty = false;
+        // Since the probability cache is correct, and we have one separated qubit, phase is clean if we are in a
+        // natural basis eigenstate.
+        if (CACHED_CLASSICAL(shard)) {
+            shard.isPhaseDirty = false;
+        }
 
         // The shard is already separated.
         return;

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -6,6 +6,17 @@
 // See https://arxiv.org/abs/1710.05867
 // (The makers of Qrack have no affiliation with the authors of that paper.)
 //
+// When we allocate a quantum register, all bits are in a (re)set state. At this point,
+// we know they are separable, in the sense of full Schmidt decomposability into qubits
+// in the "natural" or "permutation" basis of the register. Many operations can be
+// traced in terms of fewer qubits that the full "Schr\{"o}dinger representation."
+//
+// Based on experimentation, QUnit is designed to avoid increasing representational
+// entanglement for its primary action, and only try to decrease it when inquiries
+// about probability need to be made otherwise anyway. Avoiding introducing the cost of
+// any basically any entanglement whatsoever, rather than exponentially costly "garbage
+// collection," should be the first and ultimate concern, in the authors' experience.
+//
 // Licensed under the GNU Lesser General Public License V3.
 // See LICENSE.md in the project root or https://www.gnu.org/licenses/lgpl-3.0.en.html
 // for details.
@@ -735,10 +746,15 @@ void QUnit::SqrtSwap(bitLenInt qubit1, bitLenInt qubit2)
         return;
     }
 
-    EntangleAndCallMember(PTR2(SqrtSwap), qubit1, qubit2);
-
     QEngineShard& shard1 = shards[qubit1];
     QEngineShard& shard2 = shards[qubit2];
+
+    if (CACHED_CLASSICAL(shard1) && CACHED_CLASSICAL(shard2) && (SHARD_STATE(shard1) == SHARD_STATE(shard2))) {
+        // We can avoid dirtying the cache and entangling, since this gate doesn't swap identical classical bits.
+        return;
+    }
+
+    EntangleAndCallMember(PTR2(SqrtSwap), qubit1, qubit2);
 
     // TODO: If we multiply out cached amplitudes, we can optimize this.
 
@@ -754,10 +770,15 @@ void QUnit::ISqrtSwap(bitLenInt qubit1, bitLenInt qubit2)
         return;
     }
 
-    EntangleAndCallMember(PTR2(ISqrtSwap), qubit1, qubit2);
-
     QEngineShard& shard1 = shards[qubit1];
     QEngineShard& shard2 = shards[qubit2];
+
+    if (CACHED_CLASSICAL(shard1) && CACHED_CLASSICAL(shard2) && (SHARD_STATE(shard1) == SHARD_STATE(shard2))) {
+        // We can avoid dirtying the cache and entangling, since this gate doesn't swap identical classical bits.
+        return;
+    }
+
+    EntangleAndCallMember(PTR2(ISqrtSwap), qubit1, qubit2);
 
     // TODO: If we multiply out cached amplitudes, we can optimize this.
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -31,9 +31,7 @@
 #define SHARD_STATE(shard) (norm(shard.amp0) < (ONE_R1 / 2))
 #define UNSAFE_CACHED_CLASSICAL(shard) ((norm(shard.amp0) < min_norm) || (norm(shard.amp1) < min_norm))
 #define CACHED_CLASSICAL(shard) ((!shard.isPlusMinus) && !shard.isProbDirty && UNSAFE_CACHED_CLASSICAL(shard))
-#define PHASE_MATTERS(shard)                                                                                           \
-    (!randGlobalPhase || shard.isPlusMinus || shard.isProbDirty ||                                                     \
-        !((norm(shard.amp0) < min_norm) || (norm(shard.amp1) < min_norm)))
+#define PHASE_MATTERS(shard) (!randGlobalPhase || !CACHED_CLASSICAL(shard))
 #define DIRTY(shard) (shard.isProbDirty || shard.isPhaseDirty)
 
 namespace Qrack {

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -2510,12 +2510,11 @@ void QUnit::TransformBasis(const bool& toPlusMinus, const bitLenInt& i)
     }
 
     freezeBasis = true;
-
     H(i);
     shards[i].isPlusMinus = toPlusMinus;
-    TrySeparate(i);
-
     freezeBasis = false;
+
+    TrySeparate(i);
 }
 
 bool QUnit::CheckRangeInBasis(const bitLenInt& start, const bitLenInt& length, const bitLenInt& plusMinus)
@@ -2534,7 +2533,7 @@ void QUnit::CheckShardSeparable(const bitLenInt& target)
 {
     QEngineShard& shard = shards[target];
 
-    if (shard.isProbDirty || shard.unit->GetQubitCount() == 1U) {
+    if (shard.isProbDirty || (shard.unit->GetQubitCount() == 1U)) {
         return;
     }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -2517,10 +2517,14 @@ void QUnit::CheckShardSeparable(const bitLenInt& target)
 
     if (shard.unit->GetQubitCount() == 1) {
         // Now is the perfect time to execute deferred (or preferential) basis change:
+        // We also update the probability cache, with ProbBase();
         if (abs(ProbBase(target) - (ONE_R1 / 2)) < min_norm) {
             TransformBasis(!shard.isPlusMinus, target);
         }
-        // Otherwise, we were already done.
+        // Since the probability cache is correct, and we have one separated qubit, phase is clean.
+        shard.isPhaseDirty = false;
+
+        // The shard is already separated.
         return;
     }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -600,6 +600,9 @@ real1 QUnit::ProbBase(const bitLenInt& qubit)
             } else if (norm(shard.amp1) < min_norm) {
                 SeparateBit(false, qubit);
             }
+        } else {
+            // 1 qubit, therefore phase is unimportant to Hermitian eigenvalues
+            shard.isPhaseDirty = false;
         }
     }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -14,7 +14,7 @@
 // Based on experimentation, QUnit is designed to avoid increasing representational
 // entanglement for its primary action, and only try to decrease it when inquiries
 // about probability need to be made otherwise anyway. Avoiding introducing the cost of
-// any basically any entanglement whatsoever, rather than exponentially costly "garbage
+// basically any entanglement whatsoever, rather than exponentially costly "garbage
 // collection," should be the first and ultimate concern, in the authors' experience.
 //
 // Licensed under the GNU Lesser General Public License V3.
@@ -1013,6 +1013,7 @@ void QUnit::TransformInvert(const complex& topRight, const complex& bottomLeft, 
 bool QUnit::TryCnotOptimize(const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& target,
     const complex& bottomLeft, const complex& topRight, const bool& anti)
 {
+    // Returns:
     // "true" if successfully handled/consumed,
     // "false" if needs general handling
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -594,10 +594,12 @@ real1 QUnit::ProbBase(const bitLenInt& qubit)
         shard.amp0 = complex(sqrt(ONE_R1 - prob), ZERO_R1);
         shard.isProbDirty = false;
 
-        if (norm(shard.amp0) < min_norm) {
-            SeparateBit(true, qubit);
-        } else if (norm(shard.amp1) < min_norm) {
-            SeparateBit(false, qubit);
+        if (shard.unit->GetQubitCount() > 1U) {
+            if (norm(shard.amp0) < min_norm) {
+                SeparateBit(true, qubit);
+            } else if (norm(shard.amp1) < min_norm) {
+                SeparateBit(false, qubit);
+            }
         }
     }
 
@@ -2513,16 +2515,16 @@ void QUnit::CheckShardSeparable(const bitLenInt& target)
 {
     QEngineShard& shard = shards[target];
 
-    if (shard.isProbDirty) {
-        return;
-    }
-
     if (shard.unit->GetQubitCount() == 1) {
         // Now is the perfect time to execute deferred (or preferential) basis change:
-        if (abs(norm(shard.amp1) - (ONE_R1 / 2)) < min_norm) {
+        if (abs(ProbBase(target) - (ONE_R1 / 2)) < min_norm) {
             TransformBasis(!shard.isPlusMinus, target);
         }
         // Otherwise, we were already done.
+        return;
+    }
+
+    if (shard.isProbDirty) {
         return;
     }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1345,6 +1345,7 @@ void QUnit::AntiCISqrtSwap(
 
 #define CHECK_BREAK_AND_TRIM()                                                                                         \
     /* Check whether the bit probability is 0, (or 1, if "anti"). */                                                   \
+    CheckShardSeparable(controls[i]);                                                                                  \
     bitProb = Prob(controls[i]);                                                                                       \
     if (bitProb < min_norm) {                                                                                          \
         if (!anti) {                                                                                                   \
@@ -2512,7 +2513,16 @@ void QUnit::CheckShardSeparable(const bitLenInt& target)
 {
     QEngineShard& shard = shards[target];
 
-    if (shard.isProbDirty || (shard.unit->GetQubitCount() == 1)) {
+    if (shard.isProbDirty) {
+        return;
+    }
+
+    if (shard.unit->GetQubitCount() == 1) {
+        // Now is the perfect time to execute deferred (or preferential) basis change:
+        if (abs(norm(shard.amp1) - (ONE_R1 / 2)) < min_norm) {
+            TransformBasis(!shard.isPlusMinus, target);
+        }
+        // Otherwise, we were already done.
         return;
     }
 

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -392,6 +392,7 @@ TEST_CASE("test_grover", "[grover]")
     });
 }
 
+#if 0
 TEST_CASE("test_qft_ideal_init", "[qft]")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->QFT(0, n, false); }, false, false);
@@ -421,4 +422,11 @@ TEST_CASE("test_qft_superposition_round_trip", "[qft]")
             qftReg->IQFT(0, n, false);
         },
         true, true, testEngineType == QINTERFACE_QUNIT);
+}
+#endif
+
+TEST_CASE("test_qft_superposition", "[qft]")
+{
+    benchmarkLoop(
+        [](QInterfacePtr qftReg, int n) { qftReg->QFT(0, n, false); }, true, true, testEngineType == QINTERFACE_QUNIT);
 }

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -392,7 +392,6 @@ TEST_CASE("test_grover", "[grover]")
     });
 }
 
-#if 0
 TEST_CASE("test_qft_ideal_init", "[qft]")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->QFT(0, n, false); }, false, false);
@@ -422,11 +421,4 @@ TEST_CASE("test_qft_superposition_round_trip", "[qft]")
             qftReg->IQFT(0, n, false);
         },
         true, true, testEngineType == QINTERFACE_QUNIT);
-}
-#endif
-
-TEST_CASE("test_qft_superposition", "[qft]")
-{
-    benchmarkLoop(
-        [](QInterfacePtr qftReg, int n) { qftReg->QFT(0, n, false); }, true, true, testEngineType == QINTERFACE_QUNIT);
 }


### PR DESCRIPTION
Per #200, managing to maintain separability in cases of CNOT with H gates (per line 2819 in the [unit tests](https://github.com/vm6502q/qrack/commit/fa76fc899af04823cef884a2c78adf3517c78604)), I wanted to support this optimization for generally controlled single bit gates, as other projects would and do use for a Qrack API.

Checks for identity should be (almost) entirely removed from QUnit, as attempts at optimization. If anywhere, this should go in QFusion. Further, if all I know is that a bit is in "50/50" superposition, it's relatively unlikely that a check that tries a basis conversion with H will place it into |0>/|1>. (Although, it's obvious that it will handle the first two roots of unity, and we might have reason to suspect first roots in particular.)

This is basically just housekeeping, but I wanted to finish the thought before moving onto #232.