### PR TITLE
ProbMask and isEmulated debugging (for ProjectQ)

### DIFF
--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -412,7 +412,8 @@ protected:
     void EndEmulation(QEngineShard& shard)
     {
         if (shard.isEmulated) {
-            shard.unit->SetBit(shard.mapped, norm(shard.amp0) < (ONE_R1 / 2));
+            complex bitState[2] = { shard.amp0, shard.amp1 };
+            shard.unit->SetQuantumState(bitState);
             shard.isEmulated = false;
         }
     }
@@ -439,10 +440,9 @@ protected:
 
     template <typename F> void ApplyOrEmulate(QEngineShard& shard, F payload)
     {
-        if (shard.unit->GetQubitCount() == 1) {
+        if ((shard.unit->GetQubitCount() == 1) && !shard.isProbDirty && !shard.isPhaseDirty) {
             shard.isEmulated = true;
         } else {
-            EndEmulation(shard);
             payload(shard);
         }
     }

--- a/src/qinterface/qinterface.cpp
+++ b/src/qinterface/qinterface.cpp
@@ -618,27 +618,13 @@ real1 QInterface::ProbReg(const bitLenInt& start, const bitLenInt& length, const
 // Returns probability of permutation of the mask
 real1 QInterface::ProbMask(const bitCapInt& mask, const bitCapInt& permutation)
 {
-    real1 prob = ONE_R1;
-    bitCapInt v = mask; // count the number of bits set in v
-    bitCapInt oldV;
-    bitLenInt length; // c accumulates the total bits set in v
-    bitCapInt power;
-    std::vector<bitLenInt> bits;
-    std::vector<bool> bitsSet;
-    for (length = 0; v; length++) {
-        oldV = v;
-        v &= v - 1; // clear the least significant bit set
-        power = (v ^ oldV) & oldV;
-        bits.push_back(log2(power));
-        bitsSet.push_back(!(!(power & permutation)));
-    }
-    for (bitLenInt bit = 0; bit < length; bit++) {
-        if (bitsSet[bit]) {
-            prob *= Prob(bits[bit]);
-        } else {
-            prob *= (ONE_R1 - Prob(bits[bit]));
+    real1 prob = ZERO_R1;
+    for (bitCapInt lcv = 0; lcv < maxQPower; lcv++) {
+        if ((lcv & mask) == permutation) {
+            prob += ProbAll(lcv);
         }
     }
+
     return prob;
 }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1406,6 +1406,10 @@ void QUnit::ApplyEitherControlled(const bitLenInt* controls, const bitLenInt& co
         return;
     }
 
+    // TODO: If controls that survive the "first order" check above start out entangled,
+    // then it might be worth checking whether there is any intra-unit chance of control bits
+    // being conditionally all 0 or all 1, in any unit, due to entanglement.
+
     // If we've made it this far, we have to form the entangled representation and apply the gate.
     std::vector<bitLenInt> allBits(controlVec.size() + targets.size());
     std::copy(controlVec.begin(), controlVec.end(), allBits.begin());
@@ -1417,15 +1421,9 @@ void QUnit::ApplyEitherControlled(const bitLenInt* controls, const bitLenInt& co
         ebits[i] = &allBits[i];
     }
 
-    QInterfacePtr unit;
-    if (targets.size() == 1) {
-        // Avoid changing basis, if unnecessary
-        unit = EntangleInCurrentBasis(ebits.begin(), ebits.end());
-    } else {
-        unit = Entangle(ebits);
-    }
+    QInterfacePtr unit = Entangle(ebits);
 
-    std::vector<bitLenInt> controlsMapped(controlVec.size() == 0 ? 1 : controlVec.size());
+    std::vector<bitLenInt> controlsMapped(controlVec.size());
     for (i = 0; i < controlVec.size(); i++) {
         controlsMapped[i] = shards[controlVec[i]].mapped;
         shards[controlVec[i]].isPhaseDirty = true;

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -871,7 +871,7 @@ void QUnit::H(bitLenInt target)
     shard.amp0 = ((real1)M_SQRT1_2) * (shard.amp0 + shard.amp1);
     shard.amp1 = tempAmp1;
 
-    if (shard.unit->GetQubitCount() > 1) {
+    if (shard.unit->GetQubitCount() > 1U) {
         if (norm(shard.amp0) < min_norm) {
             SeparateBit(true, target);
         } else if (norm(shard.amp1) < min_norm) {
@@ -895,7 +895,7 @@ void QUnit::X(bitLenInt target)
 {
     QEngineShard& shard = shards[target];
     if (!shard.isPlusMinus) {
-        if (shard.unit->GetQubitCount() == 1) {
+        if (shard.unit->GetQubitCount() == 1U) {
             shard.isEmulated = true;
         } else {
             shard.unit->X(shard.mapped);
@@ -2252,9 +2252,11 @@ void QUnit::CPhaseFlipIfLess(bitCapInt greaterPerm, bitLenInt start, bitLenInt l
 
 void QUnit::PhaseFlip()
 {
-    if (PHASE_MATTERS(shards[0])) {
+    QEngineShard& shard = shards[0];
+    if (PHASE_MATTERS(shard)) {
         TransformBasis(false, 0);
-        shards[0].unit->PhaseFlip();
+        shard.unit->PhaseFlip();
+        shard.amp1 = -shard.amp1;
     }
 }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -107,6 +107,7 @@ void QUnit::GetQuantumState(complex* outputState)
 
 void QUnit::GetProbs(real1* outputProbs)
 {
+    TransformBasisAll(false);
     EndAllEmulation();
 
     QUnitPtr clone = std::dynamic_pointer_cast<QUnit>(Clone());

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -3397,8 +3397,6 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_amplitude_amplification")
     qftReg->SetPermutation(0);
     qftReg->H(0, 8);
 
-    // std::cout << "Iterations:" << std::endl;
-    // Twelve iterations maximizes the probablity for 256 searched elements.
     for (i = 0; i < optIter; i++) {
         // Our "oracle" is true for an input of "000..." or "110..." and false for all other inputs.
         qftReg->CNOT(0, 1);

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -3384,6 +3384,41 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_quaternary_search_alt")
     cl_free(toLoad);
 }
 
+TEST_CASE_METHOD(QInterfaceTestFixture, "test_amplitude_amplification")
+{
+    int i;
+
+    // Grover's search inverts the function of a black box subroutine.
+    // Our subroutine returns true for an input of 000... or 110...
+
+    int optIter = M_PI / (4.0 * asin(2.0 / sqrt(1U << 8U)));
+
+    // Our input to the subroutine "oracle" is 8 bits.
+    qftReg->SetPermutation(0);
+    qftReg->H(0, 8);
+
+    // std::cout << "Iterations:" << std::endl;
+    // Twelve iterations maximizes the probablity for 256 searched elements.
+    for (i = 0; i < optIter; i++) {
+        // Our "oracle" is true for an input of "000..." or "110..." and false for all other inputs.
+        qftReg->CNOT(0, 1);
+        qftReg->H(0);
+        qftReg->ZeroPhaseFlip(0, 8);
+        qftReg->H(0);
+        qftReg->CNOT(0, 1);
+        // This ends the "oracle."
+        qftReg->H(0, 8);
+        qftReg->ZeroPhaseFlip(0, 8);
+        qftReg->H(0, 8);
+        qftReg->PhaseFlip();
+    }
+
+    qftReg->CNOT(0, 1);
+    qftReg->H(0);
+
+    REQUIRE_THAT(qftReg, HasProbability(0, 16, 0));
+}
+
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_set_reg")
 {
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0));


### PR DESCRIPTION
We were failing new ProjectQ unit tests, specifically for amplitude amplification. The reason was that `QInterface::ProbMask` implicitly assumed that there was no conditional dependence between bits, (i.e. entanglement). `ProbMask` is significantly slower, now, but I would have already suggested avoiding this method in the first place; try to treat `QInterface` types like you would an actual quantum computer, for the most part. The equivalent method, if even available, would likely come at a similar premium for overhead.

In the process, I noticed I had confused myself on how `isEmulated` should be used for "shards" in QUnit. At this point, the purpose of `isEmulated` is to take single separated bits that have totally "clean" caches and handle them with "host"/CPU code only, in order to avoid dispatching a GPU for many un-batched, 2 amplitude gates.

This works with all new ProjectQ unit tests, now.