### PR TITLE
Phase gate bit symmetry optimization and debugging (and API extension)

### DIFF
--- a/include/common/qrack_types.hpp
+++ b/include/common/qrack_types.hpp
@@ -57,6 +57,10 @@ typedef double real1;
 #define min_norm 1e-30
 #endif
 
+#define ONE_CMPLX complex(ONE_R1, ZERO_R1)
+#define ZERO_CMPLX complex(ZERO_R1, ZERO_R1)
+#define I_CMPLX complex(ZERO_R1, ONE_R1)
+
 // approxcompare_error is the maximum acceptable sum of probability amplitude difference for ApproxCompare to return
 // "true." When TrySeparate or TryDecohere is applied after the QFT followed by its inverse on a permutation, the sum of
 // square errors of probability is generally less than 10^-11, for float accuracy. (A small number of trials return many

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -663,6 +663,20 @@ public:
     virtual void IT(bitLenInt qubitIndex);
 
     /**
+     * "PhaseRootN" gate
+     *
+     * Applies a 1/(2^N) phase rotation to the qubit at "qubitIndex."
+     */
+    virtual void PhaseRootN(bitLenInt n, bitLenInt qubitIndex);
+
+    /**
+     * Inverse "PhaseRootN" gate
+     *
+     * Applies an inverse 1/(2^N) phase rotation to the qubit at "qubitIndex."
+     */
+    virtual void IPhaseRootN(bitLenInt n, bitLenInt qubitIndex);
+
+    /**
      * X gate
      *
      * Applies the Pauli "X" operator to the qubit at "qubitIndex." The Pauli
@@ -768,6 +782,22 @@ public:
      * to "target."
      */
     virtual void CIT(bitLenInt control, bitLenInt target);
+
+    /**
+     * Controlled "PhaseRootN" gate
+     *
+     * If the "control" bit is set to 1, then the "PhaseRootN" gate is applied
+     * to "target."
+     */
+    virtual void CPhaseRootN(bitLenInt n, bitLenInt control, bitLenInt target);
+
+    /**
+     * Controlled inverse "PhaseRootN" gate
+     *
+     * If the "control" bit is set to 1, then the inverse "PhaseRootN" gate is applied
+     * to "target."
+     */
+    virtual void CIPhaseRootN(bitLenInt n, bitLenInt control, bitLenInt target);
 
     /** @} */
 
@@ -1079,6 +1109,12 @@ public:
     /** Bitwise inverse T operator (1/8 phase rotation) */
     virtual void IT(bitLenInt start, bitLenInt length);
 
+    /** Bitwise "PhaseRootN" operator (1/(2^N) phase rotation) */
+    virtual void PhaseRootN(bitLenInt n, bitLenInt start, bitLenInt length);
+
+    /** Bitwise inverse "PhaseRootN" operator (1/(2^N) phase rotation) */
+    virtual void IPhaseRootN(bitLenInt n, bitLenInt start, bitLenInt length);
+
     /** Bitwise Pauli X (or logical "NOT") operator */
     virtual void X(bitLenInt start, bitLenInt length);
 
@@ -1367,6 +1403,22 @@ public:
      * to "target."
      */
     virtual void CIT(bitLenInt control, bitLenInt target, bitLenInt length);
+
+    /**
+     * Bitwise controlled "PhaseRootN" gate
+     *
+     * If the "control" bit is set to 1, then the "PhaseRootN" gate is applied
+     * to "target."
+     */
+    virtual void CPhaseRootN(bitLenInt n, bitLenInt control, bitLenInt target, bitLenInt length);
+
+    /**
+     * Bitwise controlled inverse "PhaseRootN" gate
+     *
+     * If the "control" bit is set to 1, then the inverse "PhaseRootN" gate is applied
+     * to "target."
+     */
+    virtual void CIPhaseRootN(bitLenInt n, bitLenInt control, bitLenInt target, bitLenInt length);
 
     /** @} */
 

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -753,6 +753,22 @@ public:
      */
     virtual void CIS(bitLenInt control, bitLenInt target);
 
+    /**
+     * Controlled T gate
+     *
+     * If the "control" bit is set to 1, then the T gate is applied
+     * to "target."
+     */
+    virtual void CT(bitLenInt control, bitLenInt target);
+
+    /**
+     * Controlled inverse T gate
+     *
+     * If the "control" bit is set to 1, then the inverse T gate is applied
+     * to "target."
+     */
+    virtual void CIT(bitLenInt control, bitLenInt target);
+
     /** @} */
 
     /**
@@ -1335,6 +1351,22 @@ public:
      * to "target."
      */
     virtual void CIS(bitLenInt control, bitLenInt target, bitLenInt length);
+
+    /**
+     * Bitwise controlled T gate
+     *
+     * If the "control" bit is set to 1, then the T gate is applied
+     * to "target."
+     */
+    virtual void CT(bitLenInt control, bitLenInt target, bitLenInt length);
+
+    /**
+     * Bitwise controlled inverse T gate
+     *
+     * If the "control" bit is set to 1, then the inverse T gate is applied
+     * to "target."
+     */
+    virtual void CIT(bitLenInt control, bitLenInt target, bitLenInt length);
 
     /** @} */
 

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -737,6 +737,22 @@ public:
      */
     virtual void CZ(bitLenInt control, bitLenInt target);
 
+    /**
+     * Controlled S gate
+     *
+     * If the "control" bit is set to 1, then the S gate is applied
+     * to "target."
+     */
+    virtual void CS(bitLenInt control, bitLenInt target);
+
+    /**
+     * Controlled inverse S gate
+     *
+     * If the "control" bit is set to 1, then the inverse S gate is applied
+     * to "target."
+     */
+    virtual void CIS(bitLenInt control, bitLenInt target);
+
     /** @} */
 
     /**
@@ -1303,6 +1319,22 @@ public:
      * to "target."
      */
     virtual void CZ(bitLenInt control, bitLenInt target, bitLenInt length);
+
+    /**
+     * Bitwise controlled S gate
+     *
+     * If the "control" bit is set to 1, then the S gate is applied
+     * to "target."
+     */
+    virtual void CS(bitLenInt control, bitLenInt target, bitLenInt length);
+
+    /**
+     * Bitwise controlled inverse S gate
+     *
+     * If the "control" bit is set to 1, then the inverse S gate is applied
+     * to "target."
+     */
+    virtual void CIS(bitLenInt control, bitLenInt target, bitLenInt length);
 
     /** @} */
 

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -572,6 +572,13 @@ public:
     virtual void H(bitLenInt qubitIndex);
 
     /**
+     * Square root of Hadamard gate
+     *
+     * Applies the square root of the Hadamard gate on qubit at "qubitIndex."
+     */
+    virtual void SqrtH(bitLenInt qubitIndex);
+
+    /**
      * Measurement gate
      *
      * Measures the qubit at "qubitIndex" and returns either "true" or "false."
@@ -679,6 +686,40 @@ public:
      * "Z" operator reverses the phase of |1> and leaves |0> unchanged.
      */
     virtual void Z(bitLenInt qubitIndex);
+
+    /**
+     * Square root of X gate
+     *
+     * Applies the square root of the Pauli "X" operator to the qubit at "qubitIndex." The Pauli
+     * "X" operator is equivalent to a logical "NOT."
+     */
+    virtual void SqrtX(bitLenInt qubitIndex);
+
+    /**
+     * Inverse square root of X gate
+     *
+     * Applies the (by convention) inverse square root of the Pauli "X" operator to the qubit at "qubitIndex." The Pauli
+     * "X" operator is equivalent to a logical "NOT."
+     */
+    virtual void ISqrtX(bitLenInt qubitIndex);
+
+    /**
+     * Square root of Y gate
+     *
+     * Applies the square root of the Pauli "Y" operator to the qubit at "qubitIndex." The Pauli
+     * "Y" operator is similar to a logical "NOT" with permutation phase
+     * effects.
+     */
+    virtual void SqrtY(bitLenInt qubitIndex);
+
+    /**
+     * Square root of Y gate
+     *
+     * Applies the (by convention) inverse square root of the Pauli "Y" operator to the qubit at "qubitIndex." The Pauli
+     * "Y" operator is similar to a logical "NOT" with permutation phase
+     * effects.
+     */
+    virtual void ISqrtY(bitLenInt qubitIndex);
 
     /**
      * Controlled Y gate
@@ -991,6 +1032,9 @@ public:
     /** Bitwise Hadamard */
     virtual void H(bitLenInt start, bitLenInt length);
 
+    /** Bitwise square root of Hadamard */
+    virtual void SqrtH(bitLenInt start, bitLenInt length);
+
     /** Bitwise S operator (1/4 phase rotation) */
     virtual void S(bitLenInt start, bitLenInt length);
 
@@ -1008,6 +1052,18 @@ public:
 
     /** Bitwise Pauli Y operator */
     virtual void Y(bitLenInt start, bitLenInt length);
+
+    /** Bitwise square root of Pauli X operator */
+    virtual void SqrtX(bitLenInt start, bitLenInt length);
+
+    /** Bitwise inverse square root of Pauli X operator */
+    virtual void ISqrtX(bitLenInt start, bitLenInt length);
+
+    /** Bitwise square root of Pauli Y operator */
+    virtual void SqrtY(bitLenInt start, bitLenInt length);
+
+    /** Bitwise inverse square root of Pauli Y operator */
+    virtual void ISqrtY(bitLenInt start, bitLenInt length);
 
     /** Bitwise Pauli Z operator */
     virtual void Z(bitLenInt start, bitLenInt length);

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -148,14 +148,10 @@ public:
     virtual void AntiCCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target);
     using QInterface::CZ;
     virtual void CZ(bitLenInt control, bitLenInt target);
-    using QInterface::CS;
-    virtual void CS(bitLenInt control, bitLenInt target);
-    using QInterface::CIS;
-    virtual void CIS(bitLenInt control, bitLenInt target);
-    using QInterface::CT;
-    virtual void CT(bitLenInt control, bitLenInt target);
-    using QInterface::CIT;
-    virtual void CIT(bitLenInt control, bitLenInt target);
+    using QInterface::CPhaseRootN;
+    virtual void CPhaseRootN(bitLenInt n, bitLenInt control, bitLenInt target);
+    using QInterface::CIPhaseRootN;
+    virtual void CIPhaseRootN(bitLenInt n, bitLenInt control, bitLenInt target);
 
     virtual void ApplySinglePhase(
         const complex topLeft, const complex bottomRight, bool doCalcNorm, bitLenInt qubitIndex);

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -148,10 +148,6 @@ public:
     virtual void AntiCCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target);
     using QInterface::CZ;
     virtual void CZ(bitLenInt control, bitLenInt target);
-    using QInterface::CPhaseRootN;
-    virtual void CPhaseRootN(bitLenInt n, bitLenInt control, bitLenInt target);
-    using QInterface::CIPhaseRootN;
-    virtual void CIPhaseRootN(bitLenInt n, bitLenInt control, bitLenInt target);
 
     virtual void ApplySinglePhase(
         const complex topLeft, const complex bottomRight, bool doCalcNorm, bitLenInt qubitIndex);
@@ -329,7 +325,6 @@ protected:
     bool INTSOptimize(bitCapInt toMod, bitLenInt start, bitLenInt length, bool isAdd, bitLenInt overflowIndex);
     bool INTSCOptimize(
         bitCapInt toMod, bitLenInt start, bitLenInt length, bool isAdd, bitLenInt carryIndex, bitLenInt overflowIndex);
-    void CGenPhaseRootN(bitLenInt n, bitLenInt control, bitLenInt target, bool isNegExp);
 
     virtual QInterfacePtr Entangle(std::vector<bitLenInt*> bits);
     virtual QInterfacePtr EntangleRange(bitLenInt start, bitLenInt length);

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -286,6 +286,8 @@ public:
     virtual void Finish();
     virtual bool isFinished();
 
+    virtual bool TrySeparate(bitLenInt start, bitLenInt length = 1);
+
     virtual QInterfacePtr Clone();
 
     /** @} */
@@ -353,8 +355,6 @@ protected:
 
     virtual void SeparateBit(bool value, bitLenInt qubit);
 
-    virtual bool TrySeparate(bitLenInt start, bitLenInt length = 1);
-
     void OrderContiguous(QInterfacePtr unit);
 
     virtual void Detach(bitLenInt start, bitLenInt length, QUnitPtr dest);
@@ -369,7 +369,7 @@ protected:
 
     template <typename CF, typename F>
     void ApplyEitherControlled(const bitLenInt* controls, const bitLenInt& controlLen,
-        const std::vector<bitLenInt> targets, const bool& anti, CF cfn, F f);
+        const std::vector<bitLenInt> targets, const bool& anti, CF cfn, F f, const bool& inCurrentBasis = false);
 
     bitCapInt GetIndexedEigenstate(bitLenInt indexStart, bitLenInt indexLength, bitLenInt valueStart,
         bitLenInt valueLength, unsigned char* values);

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -329,7 +329,7 @@ protected:
     bool INTSOptimize(bitCapInt toMod, bitLenInt start, bitLenInt length, bool isAdd, bitLenInt overflowIndex);
     bool INTSCOptimize(
         bitCapInt toMod, bitLenInt start, bitLenInt length, bool isAdd, bitLenInt carryIndex, bitLenInt overflowIndex);
-    void CPRN(bitLenInt n, bitLenInt control, bitLenInt target, bool isNegExp);
+    void CGenPhaseRootN(bitLenInt n, bitLenInt control, bitLenInt target, bool isNegExp);
 
     virtual QInterfacePtr Entangle(std::vector<bitLenInt*> bits);
     virtual QInterfacePtr EntangleRange(bitLenInt start, bitLenInt length);
@@ -369,7 +369,7 @@ protected:
 
     template <typename CF, typename F>
     void ApplyEitherControlled(const bitLenInt* controls, const bitLenInt& controlLen,
-        const std::vector<bitLenInt> targets, const bool& anti, CF cfn, F f, const bool& inCurrentBasis = false);
+        const std::vector<bitLenInt> targets, const bool& anti, CF cfn, F f);
 
     bitCapInt GetIndexedEigenstate(bitLenInt indexStart, bitLenInt indexLength, bitLenInt valueStart,
         bitLenInt valueLength, unsigned char* values);

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -152,6 +152,10 @@ public:
     virtual void CS(bitLenInt control, bitLenInt target);
     using QInterface::CIS;
     virtual void CIS(bitLenInt control, bitLenInt target);
+    using QInterface::CT;
+    virtual void CT(bitLenInt control, bitLenInt target);
+    using QInterface::CIT;
+    virtual void CIT(bitLenInt control, bitLenInt target);
 
     virtual void ApplySinglePhase(
         const complex topLeft, const complex bottomRight, bool doCalcNorm, bitLenInt qubitIndex);

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -148,6 +148,10 @@ public:
     virtual void AntiCCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target);
     using QInterface::CZ;
     virtual void CZ(bitLenInt control, bitLenInt target);
+    using QInterface::CS;
+    virtual void CS(bitLenInt control, bitLenInt target);
+    using QInterface::CIS;
+    virtual void CIS(bitLenInt control, bitLenInt target);
 
     virtual void ApplySinglePhase(
         const complex topLeft, const complex bottomRight, bool doCalcNorm, bitLenInt qubitIndex);

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -349,7 +349,7 @@ protected:
     template <typename F, typename... B> void EntangleAndCallMember(F fn, B... bits);
     template <typename F, typename... B> void EntangleAndCall(F fn, B... bits);
     template <typename F, typename... B> void EntangleAndCallMemberRot(F fn, real1 radians, B... bits);
-    template <typename F> void ParallelUnitApply(F fn);
+    template <typename F> bool ParallelUnitApply(F fn);
 
     virtual void SeparateBit(bool value, bitLenInt qubit);
 

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -326,6 +326,10 @@ protected:
     bool INTSCOptimize(
         bitCapInt toMod, bitLenInt start, bitLenInt length, bool isAdd, bitLenInt carryIndex, bitLenInt overflowIndex);
 
+    template <typename F>
+    void CBoolReg(const bitLenInt& qInputStart, const bitCapInt& classicalInput, const bitLenInt& outputStart,
+        const bitLenInt& length, F fn);
+
     virtual QInterfacePtr Entangle(std::vector<bitLenInt*> bits);
     virtual QInterfacePtr EntangleRange(bitLenInt start, bitLenInt length);
     virtual QInterfacePtr EntangleRange(bitLenInt start, bitLenInt length, bitLenInt start2, bitLenInt length2);
@@ -345,6 +349,7 @@ protected:
     template <typename F, typename... B> void EntangleAndCallMember(F fn, B... bits);
     template <typename F, typename... B> void EntangleAndCall(F fn, B... bits);
     template <typename F, typename... B> void EntangleAndCallMemberRot(F fn, real1 radians, B... bits);
+    template <typename F> void ParallelUnitApply(F fn);
 
     virtual void SeparateBit(bool value, bitLenInt qubit);
 

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -351,7 +351,9 @@ protected:
     template <typename F, typename... B> void EntangleAndCallMember(F fn, B... bits);
     template <typename F, typename... B> void EntangleAndCall(F fn, B... bits);
     template <typename F, typename... B> void EntangleAndCallMemberRot(F fn, real1 radians, B... bits);
-    template <typename F> bool ParallelUnitApply(F fn);
+
+    typedef bool (*ParallelUnitFn)(QInterfacePtr unit, real1 param);
+    bool ParallelUnitApply(ParallelUnitFn fn, real1 param = ZERO_R1);
 
     virtual void SeparateBit(bool value, bitLenInt qubit);
 

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -329,6 +329,7 @@ protected:
     bool INTSOptimize(bitCapInt toMod, bitLenInt start, bitLenInt length, bool isAdd, bitLenInt overflowIndex);
     bool INTSCOptimize(
         bitCapInt toMod, bitLenInt start, bitLenInt length, bool isAdd, bitLenInt carryIndex, bitLenInt overflowIndex);
+    void CPRN(bitLenInt n, bitLenInt control, bitLenInt target, bool isNegExp);
 
     virtual QInterfacePtr Entangle(std::vector<bitLenInt*> bits);
     virtual QInterfacePtr EntangleRange(bitLenInt start, bitLenInt length);

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -364,7 +364,7 @@ protected:
 
     template <typename CF, typename F>
     void ApplyEitherControlled(const bitLenInt* controls, const bitLenInt& controlLen,
-        const std::vector<bitLenInt> targets, const bool& anti, CF cfn, F f);
+        const std::vector<bitLenInt> targets, const bool& anti, CF cfn, F f, const bool& inCurrentBasis = false);
 
     bitCapInt GetIndexedEigenstate(bitLenInt indexStart, bitLenInt indexLength, bitLenInt valueStart,
         bitLenInt valueLength, unsigned char* values);

--- a/src/qinterface/gates.cpp
+++ b/src/qinterface/gates.cpp
@@ -12,18 +12,22 @@
 
 #include "qinterface.hpp"
 
-#define SINGLE_PHASE(gate, topLeft, bottomRight, doNorm)                                                               \
-    void QInterface::gate(bitLenInt qubit) { ApplySinglePhase(topLeft, bottomRight, doNorm, qubit); }
+#define C_SQRT1_2 complex(M_SQRT1_2, ZERO_R1)
+#define ONE_PLUS_I_DIV_2 complex(ONE_R1 / 2, ONE_R1 / 2)
+#define ONE_MINUS_I_DIV_2 complex(ONE_R1 / 2, -ONE_R1 / 2)
 
-#define SINGLE_INVERT(gate, topRight, bottomLeft, doNorm)                                                              \
-    void QInterface::gate(bitLenInt qubit) { ApplySingleInvert(topRight, bottomLeft, doNorm, qubit); }
-
-#define SINGLE_BIT(gate, mtrx00, mtrx01, mtrx10, mtrx11, doNorm)                                                       \
+#define GATE_1_BIT(gate, mtrx00, mtrx01, mtrx10, mtrx11)                                                               \
     void QInterface::gate(bitLenInt qubit)                                                                             \
     {                                                                                                                  \
         const complex mtrx[4] = { mtrx00, mtrx01, mtrx10, mtrx11 };                                                    \
-        ApplySingleBit(mtrx, doNorm, qubit);                                                                           \
+        ApplySingleBit(mtrx, true, qubit);                                                                             \
     }
+
+#define GATE_1_PHASE(gate, topLeft, bottomRight)                                                                       \
+    void QInterface::gate(bitLenInt qubit) { ApplySinglePhase(topLeft, bottomRight, false, qubit); }
+
+#define GATE_1_INVERT(gate, topRight, bottomLeft)                                                                      \
+    void QInterface::gate(bitLenInt qubit) { ApplySingleInvert(topRight, bottomLeft, false, qubit); }
 
 namespace Qrack {
 
@@ -39,7 +43,7 @@ void QInterface::SetBit(bitLenInt qubit1, bool value)
 void QInterface::ApplySinglePhase(
     const complex topLeft, const complex bottomRight, bool doCalcNorm, bitLenInt qubitIndex)
 {
-    const complex mtrx[4] = { topLeft, complex(ZERO_R1, ZERO_R1), complex(ZERO_R1, ZERO_R1), bottomRight };
+    const complex mtrx[4] = { topLeft, ZERO_CMPLX, ZERO_CMPLX, bottomRight };
     ApplySingleBit(mtrx, doCalcNorm, qubitIndex);
 }
 
@@ -47,7 +51,7 @@ void QInterface::ApplySinglePhase(
 void QInterface::ApplySingleInvert(
     const complex topRight, const complex bottomLeft, bool doCalcNorm, bitLenInt qubitIndex)
 {
-    const complex mtrx[4] = { complex(ZERO_R1, ZERO_R1), topRight, bottomLeft, complex(ZERO_R1, ZERO_R1) };
+    const complex mtrx[4] = { ZERO_CMPLX, topRight, bottomLeft, ZERO_CMPLX };
     ApplySingleBit(mtrx, doCalcNorm, qubitIndex);
 }
 
@@ -55,7 +59,7 @@ void QInterface::ApplySingleInvert(
 void QInterface::ApplyControlledSinglePhase(const bitLenInt* controls, const bitLenInt& controlLen,
     const bitLenInt& target, const complex topLeft, const complex bottomRight)
 {
-    const complex mtrx[4] = { topLeft, complex(ZERO_R1, ZERO_R1), complex(ZERO_R1, ZERO_R1), bottomRight };
+    const complex mtrx[4] = { topLeft, ZERO_CMPLX, ZERO_CMPLX, bottomRight };
     ApplyControlledSingleBit(controls, controlLen, target, mtrx);
 }
 
@@ -63,7 +67,7 @@ void QInterface::ApplyControlledSinglePhase(const bitLenInt* controls, const bit
 void QInterface::ApplyControlledSingleInvert(const bitLenInt* controls, const bitLenInt& controlLen,
     const bitLenInt& target, const complex topRight, const complex bottomLeft)
 {
-    const complex mtrx[4] = { complex(ZERO_R1, ZERO_R1), topRight, bottomLeft, complex(ZERO_R1, ZERO_R1) };
+    const complex mtrx[4] = { ZERO_CMPLX, topRight, bottomLeft, ZERO_CMPLX };
     ApplyControlledSingleBit(controls, controlLen, target, mtrx);
 }
 
@@ -71,7 +75,7 @@ void QInterface::ApplyControlledSingleInvert(const bitLenInt* controls, const bi
 void QInterface::ApplyAntiControlledSinglePhase(const bitLenInt* controls, const bitLenInt& controlLen,
     const bitLenInt& target, const complex topLeft, const complex bottomRight)
 {
-    const complex mtrx[4] = { topLeft, complex(ZERO_R1, ZERO_R1), complex(ZERO_R1, ZERO_R1), bottomRight };
+    const complex mtrx[4] = { topLeft, ZERO_CMPLX, ZERO_CMPLX, bottomRight };
     ApplyAntiControlledSingleBit(controls, controlLen, target, mtrx);
 }
 
@@ -80,7 +84,7 @@ void QInterface::ApplyAntiControlledSinglePhase(const bitLenInt* controls, const
 void QInterface::ApplyAntiControlledSingleInvert(const bitLenInt* controls, const bitLenInt& controlLen,
     const bitLenInt& target, const complex topRight, const complex bottomLeft)
 {
-    const complex mtrx[4] = { complex(ZERO_R1, ZERO_R1), topRight, bottomLeft, complex(ZERO_R1, ZERO_R1) };
+    const complex mtrx[4] = { ZERO_CMPLX, topRight, bottomLeft, ZERO_CMPLX };
     ApplyAntiControlledSingleBit(controls, controlLen, target, mtrx);
 }
 
@@ -94,14 +98,60 @@ void QInterface::U(bitLenInt target, real1 theta, real1 phi, real1 lambda)
     ApplySingleBit(uGate, true, target);
 }
 
+/// Apply 1/(2^N) phase rotation
+void QInterface::PhaseRootN(bitLenInt n, bitLenInt qubit)
+{
+    if (n == 0) {
+        return;
+    }
+    if (n == 1) {
+        Z(qubit);
+    }
+
+    ApplySinglePhase(ONE_CMPLX, pow(-ONE_CMPLX, ONE_R1 / (ONE_BCI << (n - 1U))), true, qubit);
+}
+
+/// Apply inverse 1/(2^N) phase rotation
+void QInterface::IPhaseRootN(bitLenInt n, bitLenInt qubit)
+{
+    if (n == 0) {
+        return;
+    }
+    if (n == 1) {
+        Z(qubit);
+    }
+
+    ApplySinglePhase(ONE_CMPLX, pow(-ONE_CMPLX, -ONE_R1 / (ONE_BCI << (n - 1U))), true, qubit);
+}
+
+/// NOT gate, which is also Pauli x matrix
+GATE_1_INVERT(X, ONE_CMPLX, ONE_CMPLX);
+
+/// Apply Pauli Y matrix to bit
+GATE_1_INVERT(Y, -I_CMPLX, I_CMPLX);
+
+/// Apply Pauli Z matrix to bit
+GATE_1_PHASE(Z, ONE_CMPLX, -ONE_CMPLX);
+
 /// Hadamard gate
-SINGLE_BIT(H, complex(M_SQRT1_2, ZERO_R1), complex(M_SQRT1_2, ZERO_R1), complex(M_SQRT1_2, ZERO_R1),
-    complex(-M_SQRT1_2, ZERO_R1), true);
+GATE_1_BIT(H, C_SQRT1_2, C_SQRT1_2, C_SQRT1_2, -C_SQRT1_2);
 
 /// Square root of Hadamard gate
-SINGLE_BIT(SqrtH, complex((ONE_R1 + M_SQRT2) / (2 * M_SQRT2), (-ONE_R1 + M_SQRT2) / (2 * M_SQRT2)),
+GATE_1_BIT(SqrtH, complex((ONE_R1 + M_SQRT2) / (2 * M_SQRT2), (-ONE_R1 + M_SQRT2) / (2 * M_SQRT2)),
     complex(M_SQRT1_2 / 2, -M_SQRT1_2 / 2), complex(M_SQRT1_2 / 2, -M_SQRT1_2 / 2),
-    complex((-ONE_R1 + M_SQRT2) / (2 * M_SQRT2), (ONE_R1 + M_SQRT2) / (2 * M_SQRT2)), true);
+    complex((-ONE_R1 + M_SQRT2) / (2 * M_SQRT2), (ONE_R1 + M_SQRT2) / (2 * M_SQRT2)));
+
+/// Square root of NOT gate
+GATE_1_BIT(SqrtX, ONE_PLUS_I_DIV_2, ONE_MINUS_I_DIV_2, ONE_MINUS_I_DIV_2, ONE_PLUS_I_DIV_2);
+
+/// Inverse square root of NOT gate
+GATE_1_BIT(ISqrtX, ONE_MINUS_I_DIV_2, ONE_PLUS_I_DIV_2, ONE_PLUS_I_DIV_2, ONE_MINUS_I_DIV_2);
+
+/// Apply Pauli Y matrix to bit
+GATE_1_BIT(SqrtY, ONE_PLUS_I_DIV_2, -ONE_PLUS_I_DIV_2, ONE_PLUS_I_DIV_2, ONE_PLUS_I_DIV_2);
+
+/// Apply Pauli Y matrix to bit
+GATE_1_BIT(ISqrtY, ONE_MINUS_I_DIV_2, ONE_MINUS_I_DIV_2, -ONE_MINUS_I_DIV_2, ONE_MINUS_I_DIV_2);
 
 /// Apply 1/4 phase rotation
 void QInterface::S(bitLenInt qubit) { PhaseRootN(2U, qubit); }
@@ -115,143 +165,72 @@ void QInterface::T(bitLenInt qubit) { PhaseRootN(3U, qubit); }
 /// Apply inverse 1/8 phase rotation
 void QInterface::IT(bitLenInt qubit) { IPhaseRootN(3U, qubit); }
 
-/// Apply 1/(2^N) phase rotation
-void QInterface::PhaseRootN(bitLenInt n, bitLenInt qubit)
-{
-    if (n == 0) {
-        return;
-    }
-    if (n == 1) {
-        Z(qubit);
-    }
+/// Apply controlled S gate to bit
+void QInterface::CS(bitLenInt control, bitLenInt target) { CPhaseRootN(2U, control, target); }
 
-    ApplySinglePhase(
-        complex(ONE_R1, ZERO_R1), pow(complex(-ONE_R1, ZERO_R1), ONE_R1 / (ONE_BCI << (n - 1U))), true, qubit);
-}
+/// Apply controlled IS gate to bit
+void QInterface::CIS(bitLenInt control, bitLenInt target) { CIPhaseRootN(2U, control, target); }
 
-/// Apply inverse 1/(2^N) phase rotation
-void QInterface::IPhaseRootN(bitLenInt n, bitLenInt qubit)
-{
-    if (n == 0) {
-        return;
-    }
-    if (n == 1) {
-        Z(qubit);
-    }
+/// Apply controlled T gate to bit
+void QInterface::CT(bitLenInt control, bitLenInt target) { CPhaseRootN(3U, control, target); }
 
-    ApplySinglePhase(
-        complex(ONE_R1, ZERO_R1), pow(complex(-ONE_R1, ZERO_R1), -ONE_R1 / (ONE_BCI << (n - 1U))), true, qubit);
-}
-
-/// NOT gate, which is also Pauli x matrix
-SINGLE_INVERT(X, complex(ONE_R1, ZERO_R1), complex(ONE_R1, ZERO_R1), false);
-
-/// Apply Pauli Y matrix to bit
-SINGLE_INVERT(Y, complex(ZERO_R1, -ONE_R1), complex(ZERO_R1, ONE_R1), false);
-
-/// Square root of NOT gate
-SINGLE_BIT(SqrtX, complex(ONE_R1 / 2, ONE_R1 / 2), complex(ONE_R1 / 2, -ONE_R1 / 2), complex(ONE_R1 / 2, -ONE_R1 / 2),
-    complex(ONE_R1 / 2, ONE_R1 / 2), true);
-
-/// Inverse square root of NOT gate
-SINGLE_BIT(ISqrtX, complex(ONE_R1 / 2, -ONE_R1 / 2), complex(ONE_R1 / 2, ONE_R1 / 2), complex(ONE_R1 / 2, ONE_R1 / 2),
-    complex(ONE_R1 / 2, -ONE_R1 / 2), true);
-
-/// Apply Pauli Y matrix to bit
-SINGLE_BIT(SqrtY, complex(ONE_R1 / 2, ONE_R1 / 2), complex(-ONE_R1 / 2, -ONE_R1 / 2), complex(ONE_R1 / 2, ONE_R1 / 2),
-    complex(ONE_R1 / 2, ONE_R1 / 2), true);
-
-/// Apply Pauli Y matrix to bit
-SINGLE_BIT(ISqrtY, complex(ONE_R1 / 2, -ONE_R1 / 2), complex(ONE_R1 / 2, -ONE_R1 / 2), complex(-ONE_R1 / 2, ONE_R1 / 2),
-    complex(ONE_R1 / 2, -ONE_R1 / 2), true);
-
-/// Apply Pauli Z matrix to bit
-SINGLE_PHASE(Z, complex(ONE_R1, ZERO_R1), complex(-ONE_R1, ZERO_R1), false);
-
-/// Doubly-controlled not
-void QInterface::CCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target)
-{
-    bitLenInt controls[2] = { control1, control2 };
-    ApplyControlledSingleInvert(controls, 2, target, complex(ONE_R1, ZERO_R1), complex(ONE_R1, ZERO_R1));
-}
-
-/// "Anti-doubly-controlled not" - Apply "not" if control bits are both zero, do not apply if either control bit is one.
-void QInterface::AntiCCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target)
-{
-    bitLenInt controls[2] = { control1, control2 };
-    ApplyAntiControlledSingleInvert(controls, 2, target, complex(ONE_R1, ZERO_R1), complex(ONE_R1, ZERO_R1));
-}
+/// Apply controlled IT gate to bit
+void QInterface::CIT(bitLenInt control, bitLenInt target) { CIPhaseRootN(3U, control, target); }
 
 /// Controlled not
 void QInterface::CNOT(bitLenInt control, bitLenInt target)
 {
     bitLenInt controls[1] = { control };
-    ApplyControlledSingleInvert(controls, 1, target, complex(ONE_R1, ZERO_R1), complex(ONE_R1, ZERO_R1));
-}
-
-/// "Anti-controlled not" - Apply "not" if control bit is zero, do not apply if control bit is one.
-void QInterface::AntiCNOT(bitLenInt control, bitLenInt target)
-{
-    bitLenInt controls[1] = { control };
-    ApplyAntiControlledSingleInvert(controls, 1, target, complex(ONE_R1, ZERO_R1), complex(ONE_R1, ZERO_R1));
+    ApplyControlledSingleInvert(controls, 1, target, ONE_CMPLX, ONE_CMPLX);
 }
 
 /// Apply controlled Pauli Y matrix to bit
 void QInterface::CY(bitLenInt control, bitLenInt target)
 {
     bitLenInt controls[1] = { control };
-    ApplyControlledSingleInvert(controls, 1, target, complex(ZERO_R1, -ONE_R1), complex(ZERO_R1, ONE_R1));
+    ApplyControlledSingleInvert(controls, 1, target, -I_CMPLX, I_CMPLX);
 }
 
 /// Apply controlled Pauli Z matrix to bit
 void QInterface::CZ(bitLenInt control, bitLenInt target)
 {
     bitLenInt controls[1] = { control };
-    ApplyControlledSinglePhase(controls, 1, target, complex(ONE_R1, ZERO_R1), complex(-ONE_R1, ZERO_R1));
+    ApplyControlledSinglePhase(controls, 1, target, ONE_CMPLX, -ONE_CMPLX);
 }
 
-/// Apply controlled S gate to bit
-void QInterface::CS(bitLenInt control, bitLenInt target)
+/// Doubly-controlled not
+void QInterface::CCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target)
 {
-    bitLenInt controls[1] = { control };
-    ApplyControlledSinglePhase(controls, 1, target, complex(ONE_R1, ZERO_R1), complex(ZERO_R1, ONE_R1));
+    bitLenInt controls[2] = { control1, control2 };
+    ApplyControlledSingleInvert(controls, 2, target, ONE_CMPLX, ONE_CMPLX);
 }
 
-/// Apply controlled IS gate to bit
-void QInterface::CIS(bitLenInt control, bitLenInt target)
+/// "Anti-doubly-controlled not" - Apply "not" if control bits are both zero, do not apply if either control bit is one.
+void QInterface::AntiCCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target)
 {
-    bitLenInt controls[1] = { control };
-    ApplyControlledSinglePhase(controls, 1, target, complex(ONE_R1, ZERO_R1), complex(ZERO_R1, -ONE_R1));
+    bitLenInt controls[2] = { control1, control2 };
+    ApplyAntiControlledSingleInvert(controls, 2, target, ONE_CMPLX, ONE_CMPLX);
 }
 
-/// Apply controlled T gate to bit
-void QInterface::CT(bitLenInt control, bitLenInt target)
+/// "Anti-controlled not" - Apply "not" if control bit is zero, do not apply if control bit is one.
+void QInterface::AntiCNOT(bitLenInt control, bitLenInt target)
 {
     bitLenInt controls[1] = { control };
-    ApplyControlledSinglePhase(controls, 1, target, complex(ONE_R1, ZERO_R1), complex(M_SQRT1_2, M_SQRT1_2));
-}
-
-/// Apply controlled IT gate to bit
-void QInterface::CIT(bitLenInt control, bitLenInt target)
-{
-    bitLenInt controls[1] = { control };
-    ApplyControlledSinglePhase(controls, 1, target, complex(ONE_R1, ZERO_R1), complex(M_SQRT1_2, -M_SQRT1_2));
+    ApplyAntiControlledSingleInvert(controls, 1, target, ONE_CMPLX, ONE_CMPLX);
 }
 
 /// Apply controlled "PhaseRootN" gate to bit
 void QInterface::CPhaseRootN(bitLenInt n, bitLenInt control, bitLenInt target)
 {
     bitLenInt controls[1] = { control };
-    ApplyControlledSinglePhase(
-        controls, 1, target, complex(ONE_R1, ZERO_R1), pow(complex(-ONE_R1, ZERO_R1), ONE_R1 / (ONE_BCI << (n - 1U))));
+    ApplyControlledSinglePhase(controls, 1, target, ONE_CMPLX, pow(-ONE_CMPLX, ONE_R1 / (ONE_BCI << (n - 1U))));
 }
 
 /// Apply controlled "IPhaseRootN" gate to bit
 void QInterface::CIPhaseRootN(bitLenInt n, bitLenInt control, bitLenInt target)
 {
     bitLenInt controls[1] = { control };
-    ApplyControlledSinglePhase(
-        controls, 1, target, complex(ONE_R1, ZERO_R1), pow(complex(-ONE_R1, ZERO_R1), -ONE_R1 / (ONE_BCI << (n - 1U))));
+    ApplyControlledSinglePhase(controls, 1, target, ONE_CMPLX, pow(-ONE_CMPLX, -ONE_R1 / (ONE_BCI << (n - 1U))));
 }
 
 void QInterface::UniformlyControlledSingleBit(const bitLenInt* controls, const bitLenInt& controlLen,

--- a/src/qinterface/gates.cpp
+++ b/src/qinterface/gates.cpp
@@ -237,15 +237,15 @@ void QInterface::CPhaseRootN(bitLenInt n, bitLenInt control, bitLenInt target)
 {
     bitLenInt controls[1] = { control };
     ApplyControlledSinglePhase(
-        controls, 1, target, complex(ONE_R1, ZERO_R1), complex(cos(M_PI / (ONE_BCI << n)), sin(M_PI / (ONE_BCI << n))));
+        controls, 1, target, complex(ONE_R1, ZERO_R1), pow(complex(-ONE_R1, ZERO_R1), ONE_R1 / (ONE_BCI << (n - 1U))));
 }
 
 /// Apply controlled "IPhaseRootN" gate to bit
 void QInterface::CIPhaseRootN(bitLenInt n, bitLenInt control, bitLenInt target)
 {
     bitLenInt controls[1] = { control };
-    ApplyControlledSinglePhase(controls, 1, target, complex(ONE_R1, ZERO_R1),
-        complex(cos(M_PI / (ONE_BCI << n)), -sin(M_PI / (ONE_BCI << n))));
+    ApplyControlledSinglePhase(
+        controls, 1, target, complex(ONE_R1, ZERO_R1), pow(complex(-ONE_R1, ZERO_R1), -ONE_R1 / (ONE_BCI << (n - 1U))));
 }
 
 void QInterface::UniformlyControlledSingleBit(const bitLenInt* controls, const bitLenInt& controlLen,

--- a/src/qinterface/gates.cpp
+++ b/src/qinterface/gates.cpp
@@ -122,7 +122,8 @@ void QInterface::PhaseRootN(bitLenInt n, bitLenInt qubit)
         return;
     }
 
-    ApplySinglePhase(complex(ONE_R1, ZERO_R1), pow(complex(-ONE_R1, ZERO_R1), ONE_R1 / (1U << (n - 1U))), true, qubit);
+    ApplySinglePhase(
+        complex(ONE_R1, ZERO_R1), pow(complex(-ONE_R1, ZERO_R1), ONE_R1 / (ONE_BCI << (n - 1U))), true, qubit);
 }
 
 /// Apply inverse 1/(2^N) phase rotation
@@ -132,7 +133,8 @@ void QInterface::IPhaseRootN(bitLenInt n, bitLenInt qubit)
         return;
     }
 
-    ApplySinglePhase(complex(ONE_R1, ZERO_R1), pow(complex(-ONE_R1, ZERO_R1), -ONE_R1 / (1U << (n - 1U))), true, qubit);
+    ApplySinglePhase(
+        complex(ONE_R1, ZERO_R1), pow(complex(-ONE_R1, ZERO_R1), -ONE_R1 / (ONE_BCI << (n - 1U))), true, qubit);
 }
 
 /// NOT gate, which is also Pauli x matrix

--- a/src/qinterface/gates.cpp
+++ b/src/qinterface/gates.cpp
@@ -121,6 +121,9 @@ void QInterface::PhaseRootN(bitLenInt n, bitLenInt qubit)
     if (n == 0) {
         return;
     }
+    if (n == 1) {
+        Z(qubit);
+    }
 
     ApplySinglePhase(
         complex(ONE_R1, ZERO_R1), pow(complex(-ONE_R1, ZERO_R1), ONE_R1 / (ONE_BCI << (n - 1U))), true, qubit);
@@ -131,6 +134,9 @@ void QInterface::IPhaseRootN(bitLenInt n, bitLenInt qubit)
 {
     if (n == 0) {
         return;
+    }
+    if (n == 1) {
+        Z(qubit);
     }
 
     ApplySinglePhase(

--- a/src/qinterface/gates.cpp
+++ b/src/qinterface/gates.cpp
@@ -89,6 +89,15 @@ void QInterface::H(bitLenInt qubit)
     ApplySingleBit(had, true, qubit);
 }
 
+/// Square root of Hadamard gate
+void QInterface::SqrtH(bitLenInt qubit)
+{
+    const complex sqrtHad[4] = { complex((ONE_R1 + M_SQRT2) / (2 * M_SQRT2), (-ONE_R1 + M_SQRT2) / (2 * M_SQRT2)),
+        complex(M_SQRT1_2 / 2, -M_SQRT1_2 / 2), complex(M_SQRT1_2 / 2, -M_SQRT1_2 / 2),
+        complex((-ONE_R1 + M_SQRT2) / (2 * M_SQRT2), (ONE_R1 + M_SQRT2) / (2 * M_SQRT2)) };
+    ApplySingleBit(sqrtHad, true, qubit);
+}
+
 /// Apply 1/4 phase rotation
 void QInterface::S(bitLenInt qubit)
 {
@@ -123,6 +132,38 @@ void QInterface::X(bitLenInt qubit)
 void QInterface::Y(bitLenInt qubit)
 {
     ApplySingleInvert(complex(ZERO_R1, -ONE_R1), complex(ZERO_R1, ONE_R1), false, qubit);
+}
+
+/// Square root of NOT gate
+void QInterface::SqrtX(bitLenInt qubit)
+{
+    const complex mtrx[4] = { complex(ONE_R1 / 2, ONE_R1 / 2), complex(ONE_R1 / 2, -ONE_R1 / 2),
+        complex(ONE_R1 / 2, -ONE_R1 / 2), complex(ONE_R1 / 2, ONE_R1 / 2) };
+    ApplySingleBit(mtrx, true, qubit);
+}
+
+/// Inverse square root of NOT gate
+void QInterface::ISqrtX(bitLenInt qubit)
+{
+    const complex mtrx[4] = { complex(ONE_R1 / 2, -ONE_R1 / 2), complex(ONE_R1 / 2, ONE_R1 / 2),
+        complex(ONE_R1 / 2, ONE_R1 / 2), complex(ONE_R1 / 2, -ONE_R1 / 2) };
+    ApplySingleBit(mtrx, true, qubit);
+}
+
+/// Apply Pauli Y matrix to bit
+void QInterface::SqrtY(bitLenInt qubit)
+{
+    const complex mtrx[4] = { complex(ONE_R1 / 2, ONE_R1 / 2), complex(-ONE_R1 / 2, -ONE_R1 / 2),
+        complex(ONE_R1 / 2, ONE_R1 / 2), complex(ONE_R1 / 2, ONE_R1 / 2) };
+    ApplySingleBit(mtrx, true, qubit);
+}
+
+/// Apply Pauli Y matrix to bit
+void QInterface::ISqrtY(bitLenInt qubit)
+{
+    const complex mtrx[4] = { complex(ONE_R1 / 2, -ONE_R1 / 2), complex(ONE_R1 / 2, -ONE_R1 / 2),
+        complex(-ONE_R1 / 2, ONE_R1 / 2), complex(ONE_R1 / 2, -ONE_R1 / 2) };
+    ApplySingleBit(mtrx, true, qubit);
 }
 
 /// Apply Pauli Z matrix to bit

--- a/src/qinterface/gates.cpp
+++ b/src/qinterface/gates.cpp
@@ -118,13 +118,21 @@ void QInterface::IT(bitLenInt qubit) { IPhaseRootN(3U, qubit); }
 /// Apply 1/(2^N) phase rotation
 void QInterface::PhaseRootN(bitLenInt n, bitLenInt qubit)
 {
-    ApplySinglePhase(complex(ONE_R1, ZERO_R1), pow(complex(-ONE_R1, ZERO_R1), ONE_R1 / n), true, qubit);
+    if (n == 0) {
+        return;
+    }
+
+    ApplySinglePhase(complex(ONE_R1, ZERO_R1), pow(complex(-ONE_R1, ZERO_R1), ONE_R1 / (1U << (n - 1U))), true, qubit);
 }
 
 /// Apply inverse 1/(2^N) phase rotation
 void QInterface::IPhaseRootN(bitLenInt n, bitLenInt qubit)
 {
-    ApplySinglePhase(complex(ONE_R1, ZERO_R1), pow(complex(-ONE_R1, ZERO_R1), ONE_R1 / n), true, qubit);
+    if (n == 0) {
+        return;
+    }
+
+    ApplySinglePhase(complex(ONE_R1, ZERO_R1), pow(complex(-ONE_R1, ZERO_R1), -ONE_R1 / (1U << (n - 1U))), true, qubit);
 }
 
 /// NOT gate, which is also Pauli x matrix

--- a/src/qinterface/gates.cpp
+++ b/src/qinterface/gates.cpp
@@ -12,6 +12,19 @@
 
 #include "qinterface.hpp"
 
+#define SINGLE_PHASE(gate, topLeft, bottomRight, doNorm)                                                               \
+    void QInterface::gate(bitLenInt qubit) { ApplySinglePhase(topLeft, bottomRight, doNorm, qubit); }
+
+#define SINGLE_INVERT(gate, topRight, bottomLeft, doNorm)                                                              \
+    void QInterface::gate(bitLenInt qubit) { ApplySingleInvert(topRight, bottomLeft, doNorm, qubit); }
+
+#define SINGLE_BIT(gate, mtrx00, mtrx01, mtrx10, mtrx11, doNorm)                                                       \
+    void QInterface::gate(bitLenInt qubit)                                                                             \
+    {                                                                                                                  \
+        const complex mtrx[4] = { mtrx00, mtrx01, mtrx10, mtrx11 };                                                    \
+        ApplySingleBit(mtrx, doNorm, qubit);                                                                           \
+    }
+
 namespace Qrack {
 
 /// Set individual bit to pure |0> (false) or |1> (true) state
@@ -82,95 +95,50 @@ void QInterface::U(bitLenInt target, real1 theta, real1 phi, real1 lambda)
 }
 
 /// Hadamard gate
-void QInterface::H(bitLenInt qubit)
-{
-    const complex had[4] = { complex(M_SQRT1_2, ZERO_R1), complex(M_SQRT1_2, ZERO_R1), complex(M_SQRT1_2, ZERO_R1),
-        complex(-M_SQRT1_2, ZERO_R1) };
-    ApplySingleBit(had, true, qubit);
-}
+SINGLE_BIT(H, complex(M_SQRT1_2, ZERO_R1), complex(M_SQRT1_2, ZERO_R1), complex(M_SQRT1_2, ZERO_R1),
+    complex(-M_SQRT1_2, ZERO_R1), true);
 
 /// Square root of Hadamard gate
-void QInterface::SqrtH(bitLenInt qubit)
-{
-    const complex sqrtHad[4] = { complex((ONE_R1 + M_SQRT2) / (2 * M_SQRT2), (-ONE_R1 + M_SQRT2) / (2 * M_SQRT2)),
-        complex(M_SQRT1_2 / 2, -M_SQRT1_2 / 2), complex(M_SQRT1_2 / 2, -M_SQRT1_2 / 2),
-        complex((-ONE_R1 + M_SQRT2) / (2 * M_SQRT2), (ONE_R1 + M_SQRT2) / (2 * M_SQRT2)) };
-    ApplySingleBit(sqrtHad, true, qubit);
-}
+SINGLE_BIT(SqrtH, complex((ONE_R1 + M_SQRT2) / (2 * M_SQRT2), (-ONE_R1 + M_SQRT2) / (2 * M_SQRT2)),
+    complex(M_SQRT1_2 / 2, -M_SQRT1_2 / 2), complex(M_SQRT1_2 / 2, -M_SQRT1_2 / 2),
+    complex((-ONE_R1 + M_SQRT2) / (2 * M_SQRT2), (ONE_R1 + M_SQRT2) / (2 * M_SQRT2)), true);
 
 /// Apply 1/4 phase rotation
-void QInterface::S(bitLenInt qubit)
-{
-    ApplySinglePhase(complex(ONE_R1, ZERO_R1), complex(ZERO_R1, ONE_R1), false, qubit);
-}
+SINGLE_PHASE(S, complex(ONE_R1, ZERO_R1), complex(ZERO_R1, ONE_R1), false);
 
 /// Apply inverse 1/4 phase rotation
-void QInterface::IS(bitLenInt qubit)
-{
-    ApplySinglePhase(complex(ONE_R1, ZERO_R1), complex(ZERO_R1, -ONE_R1), false, qubit);
-}
+SINGLE_PHASE(IS, complex(ONE_R1, ZERO_R1), complex(ZERO_R1, -ONE_R1), false);
 
 /// Apply 1/8 phase rotation
-void QInterface::T(bitLenInt qubit)
-{
-    ApplySinglePhase(complex(ONE_R1, ZERO_R1), complex(M_SQRT1_2, M_SQRT1_2), true, qubit);
-}
+SINGLE_PHASE(T, complex(ONE_R1, ZERO_R1), complex(M_SQRT1_2, M_SQRT1_2), true);
 
 /// Apply inverse 1/8 phase rotation
-void QInterface::IT(bitLenInt qubit)
-{
-    ApplySinglePhase(complex(ONE_R1, ZERO_R1), complex(M_SQRT1_2, -M_SQRT1_2), true, qubit);
-}
+SINGLE_PHASE(IT, complex(ONE_R1, ZERO_R1), complex(M_SQRT1_2, -M_SQRT1_2), true);
 
 /// NOT gate, which is also Pauli x matrix
-void QInterface::X(bitLenInt qubit)
-{
-    ApplySingleInvert(complex(ONE_R1, ZERO_R1), complex(ONE_R1, ZERO_R1), false, qubit);
-}
+SINGLE_INVERT(X, complex(ONE_R1, ZERO_R1), complex(ONE_R1, ZERO_R1), false);
 
 /// Apply Pauli Y matrix to bit
-void QInterface::Y(bitLenInt qubit)
-{
-    ApplySingleInvert(complex(ZERO_R1, -ONE_R1), complex(ZERO_R1, ONE_R1), false, qubit);
-}
+SINGLE_INVERT(Y, complex(ZERO_R1, -ONE_R1), complex(ZERO_R1, ONE_R1), false);
 
 /// Square root of NOT gate
-void QInterface::SqrtX(bitLenInt qubit)
-{
-    const complex mtrx[4] = { complex(ONE_R1 / 2, ONE_R1 / 2), complex(ONE_R1 / 2, -ONE_R1 / 2),
-        complex(ONE_R1 / 2, -ONE_R1 / 2), complex(ONE_R1 / 2, ONE_R1 / 2) };
-    ApplySingleBit(mtrx, true, qubit);
-}
+SINGLE_BIT(SqrtX, complex(ONE_R1 / 2, ONE_R1 / 2), complex(ONE_R1 / 2, -ONE_R1 / 2), complex(ONE_R1 / 2, -ONE_R1 / 2),
+    complex(ONE_R1 / 2, ONE_R1 / 2), true);
 
 /// Inverse square root of NOT gate
-void QInterface::ISqrtX(bitLenInt qubit)
-{
-    const complex mtrx[4] = { complex(ONE_R1 / 2, -ONE_R1 / 2), complex(ONE_R1 / 2, ONE_R1 / 2),
-        complex(ONE_R1 / 2, ONE_R1 / 2), complex(ONE_R1 / 2, -ONE_R1 / 2) };
-    ApplySingleBit(mtrx, true, qubit);
-}
+SINGLE_BIT(ISqrtX, complex(ONE_R1 / 2, -ONE_R1 / 2), complex(ONE_R1 / 2, ONE_R1 / 2), complex(ONE_R1 / 2, ONE_R1 / 2),
+    complex(ONE_R1 / 2, -ONE_R1 / 2), true);
 
 /// Apply Pauli Y matrix to bit
-void QInterface::SqrtY(bitLenInt qubit)
-{
-    const complex mtrx[4] = { complex(ONE_R1 / 2, ONE_R1 / 2), complex(-ONE_R1 / 2, -ONE_R1 / 2),
-        complex(ONE_R1 / 2, ONE_R1 / 2), complex(ONE_R1 / 2, ONE_R1 / 2) };
-    ApplySingleBit(mtrx, true, qubit);
-}
+SINGLE_BIT(SqrtY, complex(ONE_R1 / 2, ONE_R1 / 2), complex(-ONE_R1 / 2, -ONE_R1 / 2), complex(ONE_R1 / 2, ONE_R1 / 2),
+    complex(ONE_R1 / 2, ONE_R1 / 2), true);
 
 /// Apply Pauli Y matrix to bit
-void QInterface::ISqrtY(bitLenInt qubit)
-{
-    const complex mtrx[4] = { complex(ONE_R1 / 2, -ONE_R1 / 2), complex(ONE_R1 / 2, -ONE_R1 / 2),
-        complex(-ONE_R1 / 2, ONE_R1 / 2), complex(ONE_R1 / 2, -ONE_R1 / 2) };
-    ApplySingleBit(mtrx, true, qubit);
-}
+SINGLE_BIT(ISqrtY, complex(ONE_R1 / 2, -ONE_R1 / 2), complex(ONE_R1 / 2, -ONE_R1 / 2), complex(-ONE_R1 / 2, ONE_R1 / 2),
+    complex(ONE_R1 / 2, -ONE_R1 / 2), true);
 
 /// Apply Pauli Z matrix to bit
-void QInterface::Z(bitLenInt qubit)
-{
-    ApplySinglePhase(complex(ONE_R1, ZERO_R1), complex(-ONE_R1, ZERO_R1), false, qubit);
-}
+SINGLE_PHASE(Z, complex(ONE_R1, ZERO_R1), complex(-ONE_R1, ZERO_R1), false);
 
 /// Doubly-controlled not
 void QInterface::CCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target)
@@ -226,6 +194,20 @@ void QInterface::CIS(bitLenInt control, bitLenInt target)
 {
     bitLenInt controls[1] = { control };
     ApplyControlledSinglePhase(controls, 1, target, complex(ONE_R1, ZERO_R1), complex(ZERO_R1, -ONE_R1));
+}
+
+/// Apply controlled T gate to bit
+void QInterface::CT(bitLenInt control, bitLenInt target)
+{
+    bitLenInt controls[1] = { control };
+    ApplyControlledSinglePhase(controls, 1, target, complex(ONE_R1, ZERO_R1), complex(M_SQRT1_2, M_SQRT1_2));
+}
+
+/// Apply controlled IT gate to bit
+void QInterface::CIT(bitLenInt control, bitLenInt target)
+{
+    bitLenInt controls[1] = { control };
+    ApplyControlledSinglePhase(controls, 1, target, complex(ONE_R1, ZERO_R1), complex(M_SQRT1_2, -M_SQRT1_2));
 }
 
 void QInterface::UniformlyControlledSingleBit(const bitLenInt* controls, const bitLenInt& controlLen,

--- a/src/qinterface/gates.cpp
+++ b/src/qinterface/gates.cpp
@@ -104,16 +104,28 @@ SINGLE_BIT(SqrtH, complex((ONE_R1 + M_SQRT2) / (2 * M_SQRT2), (-ONE_R1 + M_SQRT2
     complex((-ONE_R1 + M_SQRT2) / (2 * M_SQRT2), (ONE_R1 + M_SQRT2) / (2 * M_SQRT2)), true);
 
 /// Apply 1/4 phase rotation
-SINGLE_PHASE(S, complex(ONE_R1, ZERO_R1), complex(ZERO_R1, ONE_R1), false);
+void QInterface::S(bitLenInt qubit) { PhaseRootN(2U, qubit); }
 
 /// Apply inverse 1/4 phase rotation
-SINGLE_PHASE(IS, complex(ONE_R1, ZERO_R1), complex(ZERO_R1, -ONE_R1), false);
+void QInterface::IS(bitLenInt qubit) { IPhaseRootN(2U, qubit); }
 
 /// Apply 1/8 phase rotation
-SINGLE_PHASE(T, complex(ONE_R1, ZERO_R1), complex(M_SQRT1_2, M_SQRT1_2), true);
+void QInterface::T(bitLenInt qubit) { PhaseRootN(3U, qubit); }
 
 /// Apply inverse 1/8 phase rotation
-SINGLE_PHASE(IT, complex(ONE_R1, ZERO_R1), complex(M_SQRT1_2, -M_SQRT1_2), true);
+void QInterface::IT(bitLenInt qubit) { IPhaseRootN(3U, qubit); }
+
+/// Apply 1/(2^N) phase rotation
+void QInterface::PhaseRootN(bitLenInt n, bitLenInt qubit)
+{
+    ApplySinglePhase(complex(ONE_R1, ZERO_R1), pow(complex(-ONE_R1, ZERO_R1), ONE_R1 / n), true, qubit);
+}
+
+/// Apply inverse 1/(2^N) phase rotation
+void QInterface::IPhaseRootN(bitLenInt n, bitLenInt qubit)
+{
+    ApplySinglePhase(complex(ONE_R1, ZERO_R1), pow(complex(-ONE_R1, ZERO_R1), ONE_R1 / n), true, qubit);
+}
 
 /// NOT gate, which is also Pauli x matrix
 SINGLE_INVERT(X, complex(ONE_R1, ZERO_R1), complex(ONE_R1, ZERO_R1), false);
@@ -208,6 +220,22 @@ void QInterface::CIT(bitLenInt control, bitLenInt target)
 {
     bitLenInt controls[1] = { control };
     ApplyControlledSinglePhase(controls, 1, target, complex(ONE_R1, ZERO_R1), complex(M_SQRT1_2, -M_SQRT1_2));
+}
+
+/// Apply controlled "PhaseRootN" gate to bit
+void QInterface::CPhaseRootN(bitLenInt n, bitLenInt control, bitLenInt target)
+{
+    bitLenInt controls[1] = { control };
+    ApplyControlledSinglePhase(
+        controls, 1, target, complex(ONE_R1, ZERO_R1), complex(cos(M_PI / (ONE_BCI << n)), sin(M_PI / (ONE_BCI << n))));
+}
+
+/// Apply controlled "IPhaseRootN" gate to bit
+void QInterface::CIPhaseRootN(bitLenInt n, bitLenInt control, bitLenInt target)
+{
+    bitLenInt controls[1] = { control };
+    ApplyControlledSinglePhase(controls, 1, target, complex(ONE_R1, ZERO_R1),
+        complex(cos(M_PI / (ONE_BCI << n)), -sin(M_PI / (ONE_BCI << n))));
 }
 
 void QInterface::UniformlyControlledSingleBit(const bitLenInt* controls, const bitLenInt& controlLen,

--- a/src/qinterface/gates.cpp
+++ b/src/qinterface/gates.cpp
@@ -214,6 +214,20 @@ void QInterface::CZ(bitLenInt control, bitLenInt target)
     ApplyControlledSinglePhase(controls, 1, target, complex(ONE_R1, ZERO_R1), complex(-ONE_R1, ZERO_R1));
 }
 
+/// Apply controlled S gate to bit
+void QInterface::CS(bitLenInt control, bitLenInt target)
+{
+    bitLenInt controls[1] = { control };
+    ApplyControlledSinglePhase(controls, 1, target, complex(ONE_R1, ZERO_R1), complex(ZERO_R1, ONE_R1));
+}
+
+/// Apply controlled IS gate to bit
+void QInterface::CIS(bitLenInt control, bitLenInt target)
+{
+    bitLenInt controls[1] = { control };
+    ApplyControlledSinglePhase(controls, 1, target, complex(ONE_R1, ZERO_R1), complex(ZERO_R1, -ONE_R1));
+}
+
 void QInterface::UniformlyControlledSingleBit(const bitLenInt* controls, const bitLenInt& controlLen,
     bitLenInt qubitIndex, const complex* mtrxs, const bitCapInt* mtrxSkipPowers, const bitLenInt mtrxSkipLen,
     const bitCapInt& mtrxSkipValueMask)

--- a/src/qinterface/qinterface.cpp
+++ b/src/qinterface/qinterface.cpp
@@ -466,7 +466,7 @@ void QInterface::QFT(bitLenInt start, bitLenInt length, bool trySeparate)
     for (i = 0; i < length; i++) {
         H(end - i);
         for (j = 0; j < ((length - 1U) - i); j++) {
-            CIPhaseRootN(j + 2U, (end - i) - (j + 1U), end - i);
+            CPhaseRootN(j + 2U, (end - i) - (j + 1U), end - i);
         }
 
         if (trySeparate) {
@@ -485,7 +485,7 @@ void QInterface::IQFT(bitLenInt start, bitLenInt length, bool trySeparate)
     bitLenInt i, j;
     for (i = 0; i < length; i++) {
         for (j = 0; j < i; j++) {
-            CPhaseRootN(j + 2U, (start + i) - (j + 1U), start + i);
+            CIPhaseRootN(j + 2U, (start + i) - (j + 1U), start + i);
         }
         H(start + i);
 

--- a/src/qinterface/qinterface.cpp
+++ b/src/qinterface/qinterface.cpp
@@ -189,20 +189,7 @@ REG_GATE_3B(CLXOR);
 REG_GATE_1R(RT);
 
 /// Dyadic fraction "phase shift gate" - Rotates as e^(i*(M_PI * numerator) / 2^denomPower) around |1> state.
-void QInterface::RTDyad(int numerator, int denomPower, bitLenInt qubit)
-{
-    if (denomPower > 0) {
-        if (numerator == 1) {
-            PhaseRootN(denomPower + 1, qubit);
-            return;
-        } else if (numerator == -1) {
-            IPhaseRootN(denomPower + 1, qubit);
-            return;
-        }
-    }
-
-    RT(dyadAngle(numerator, denomPower), qubit);
-}
+void QInterface::RTDyad(int numerator, int denomPower, bitLenInt qubit) { RT(dyadAngle(numerator, denomPower), qubit); }
 
 /// Dyadic fraction "phase shift gate" - Rotates each bit as e^(i*(M_PI * numerator) / denominator) around |1> state.
 REG_GATE_1D(RTDyad);

--- a/src/qinterface/qinterface.cpp
+++ b/src/qinterface/qinterface.cpp
@@ -182,6 +182,18 @@ void QInterface::CIS(bitLenInt control, bitLenInt target, bitLenInt length)
     ControlledLoopFixture(length, [&](bitLenInt bit) { CIS(control + bit, target + bit); });
 }
 
+/// Apply controlled T gate to each bit
+void QInterface::CT(bitLenInt control, bitLenInt target, bitLenInt length)
+{
+    ControlledLoopFixture(length, [&](bitLenInt bit) { CT(control + bit, target + bit); });
+}
+
+/// Apply controlled IT gate to each bit
+void QInterface::CIT(bitLenInt control, bitLenInt target, bitLenInt length)
+{
+    ControlledLoopFixture(length, [&](bitLenInt bit) { CIT(control + bit, target + bit); });
+}
+
 /// "AND" compare a bit range in QInterface with a classical unsigned integer, and store result in range starting at
 /// output
 REG_GATE_3B(CLAND);

--- a/src/qinterface/qinterface.cpp
+++ b/src/qinterface/qinterface.cpp
@@ -14,6 +14,46 @@
 
 namespace Qrack {
 
+#define REG_GATE_1(gate)                                                                                               \
+    void QInterface::gate(bitLenInt start, bitLenInt length)                                                           \
+    {                                                                                                                  \
+        for (bitLenInt bit = 0; bit < length; bit++) {                                                                 \
+            gate(start + bit);                                                                                         \
+        }                                                                                                              \
+    }
+
+#define REG_GATE_2(gate)                                                                                               \
+    void QInterface::gate(bitLenInt qubit1, bitLenInt qubit2, bitLenInt length)                                        \
+    {                                                                                                                  \
+        for (bitLenInt bit = 0; bit < length; bit++) {                                                                 \
+            gate(qubit1 + bit, qubit2 + bit);                                                                          \
+        }                                                                                                              \
+    }
+
+#define REG_GATE_3B(gate)                                                                                              \
+    void QInterface::gate(bitLenInt qInputStart, bitCapInt classicalInput, bitLenInt outputStart, bitLenInt length)    \
+    {                                                                                                                  \
+        for (bitLenInt i = 0; i < length; i++) {                                                                       \
+            gate(qInputStart + i, bitSlice(i, classicalInput), outputStart + i);                                       \
+        }                                                                                                              \
+    }
+
+#define REG_GATE_1R(gate)                                                                                              \
+    void QInterface::gate(real1 radians, bitLenInt start, bitLenInt length)                                            \
+    {                                                                                                                  \
+        for (bitLenInt bit = 0; bit < length; bit++) {                                                                 \
+            gate(radians, start + bit);                                                                                \
+        }                                                                                                              \
+    }
+
+#define REG_GATE_1D(gate)                                                                                              \
+    void QInterface::gate(int numerator, int denominator, bitLenInt start, bitLenInt length)                           \
+    {                                                                                                                  \
+        for (bitLenInt bit = 0; bit < length; bit++) {                                                                 \
+            gate(numerator, denominator, start + bit);                                                                 \
+        }                                                                                                              \
+    }
+
 template <typename GateFunc> void QInterface::ControlledLoopFixture(bitLenInt length, GateFunc gate)
 {
     // For length-wise application of controlled gates, there's no point in having normalization on, up to the last
@@ -29,28 +69,13 @@ template <typename GateFunc> void QInterface::ControlledLoopFixture(bitLenInt le
 }
 
 // Bit-wise apply swap to two registers
-void QInterface::Swap(bitLenInt qubit1, bitLenInt qubit2, bitLenInt length)
-{
-    for (bitLenInt bit = 0; bit < length; bit++) {
-        Swap(qubit1 + bit, qubit2 + bit);
-    }
-}
+REG_GATE_2(Swap);
 
 // Bit-wise apply square root of swap to two registers
-void QInterface::SqrtSwap(bitLenInt qubit1, bitLenInt qubit2, bitLenInt length)
-{
-    for (bitLenInt bit = 0; bit < length; bit++) {
-        SqrtSwap(qubit1 + bit, qubit2 + bit);
-    }
-}
+REG_GATE_2(SqrtSwap);
 
 // Bit-wise apply inverse square root of swap to two registers
-void QInterface::ISqrtSwap(bitLenInt qubit1, bitLenInt qubit2, bitLenInt length)
-{
-    for (bitLenInt bit = 0; bit < length; bit++) {
-        ISqrtSwap(qubit1 + bit, qubit2 + bit);
-    }
-}
+REG_GATE_2(ISqrtSwap);
 
 // Bit-wise apply "anti-"controlled-not to three registers
 void QInterface::AntiCCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target, bitLenInt length)
@@ -74,45 +99,28 @@ void QInterface::CNOT(bitLenInt control, bitLenInt target, bitLenInt length)
 }
 
 // Apply S gate (1/4 phase rotation) to each bit in "length," starting from bit index "start"
-void QInterface::S(bitLenInt start, bitLenInt length)
-{
-    for (bitLenInt bit = 0; bit < length; bit++) {
-        S(start + bit);
-    }
-}
+REG_GATE_1(S);
 
 // Apply inverse S gate (1/4 phase rotation) to each bit in "length," starting from bit index "start"
-void QInterface::IS(bitLenInt start, bitLenInt length)
-{
-    for (bitLenInt bit = 0; bit < length; bit++) {
-        IS(start + bit);
-    }
-}
+REG_GATE_1(IS);
 
 // Apply T gate (1/8 phase rotation)  to each bit in "length," starting from bit index "start"
-void QInterface::T(bitLenInt start, bitLenInt length)
-{
-    for (bitLenInt bit = 0; bit < length; bit++) {
-        T(start + bit);
-    }
-}
+REG_GATE_1(T);
 
 // Apply inverse T gate (1/8 phase rotation)  to each bit in "length," starting from bit index "start"
-void QInterface::IT(bitLenInt start, bitLenInt length)
-{
-    for (bitLenInt bit = 0; bit < length; bit++) {
-        IT(start + bit);
-    }
-}
+REG_GATE_1(IT);
 
 // Apply X ("not") gate to each bit in "length," starting from bit index
 // "start"
-void QInterface::X(bitLenInt start, bitLenInt length)
-{
-    for (bitLenInt bit = 0; bit < length; bit++) {
-        X(start + bit);
-    }
-}
+REG_GATE_1(X);
+
+// Apply square root of X gate to each bit in "length," starting from bit index
+// "start"
+REG_GATE_1(SqrtX);
+
+// Apply inverse square root of X gate to each bit in "length," starting from bit index
+// "start"
+REG_GATE_1(ISqrtX);
 
 // Single register instructions:
 
@@ -133,28 +141,22 @@ void QInterface::U2(bitLenInt start, bitLenInt length, real1 phi, real1 lambda)
 }
 
 /// Apply Hadamard gate to each bit in "length," starting from bit index "start"
-void QInterface::H(bitLenInt start, bitLenInt length)
-{
-    for (bitLenInt bit = 0; bit < length; bit++) {
-        H(start + bit);
-    }
-}
+REG_GATE_1(H);
+
+/// Apply square root of Hadamard gate to each bit in "length," starting from bit index "start"
+REG_GATE_1(SqrtH);
 
 /// Apply Pauli Y matrix to each bit
-void QInterface::Y(bitLenInt start, bitLenInt length)
-{
-    for (bitLenInt bit = 0; bit < length; bit++) {
-        Y(start + bit);
-    }
-}
+REG_GATE_1(Y);
+
+/// Apply square root of Pauli Y matrix to each bit
+REG_GATE_1(SqrtY);
+
+/// Apply square root of Pauli Y matrix to each bit
+REG_GATE_1(ISqrtY);
 
 /// Apply Pauli Z matrix to each bit
-void QInterface::Z(bitLenInt start, bitLenInt length)
-{
-    for (bitLenInt bit = 0; bit < length; bit++) {
-        Z(start + bit);
-    }
-}
+REG_GATE_1(Z);
 
 /// Apply controlled Pauli Y matrix to each bit
 void QInterface::CY(bitLenInt control, bitLenInt target, bitLenInt length)
@@ -170,36 +172,15 @@ void QInterface::CZ(bitLenInt control, bitLenInt target, bitLenInt length)
 
 /// "AND" compare a bit range in QInterface with a classical unsigned integer, and store result in range starting at
 /// output
-void QInterface::CLAND(bitLenInt qInputStart, bitCapInt classicalInput, bitLenInt outputStart, bitLenInt length)
-{
-    bool cBit;
-    for (bitLenInt i = 0; i < length; i++) {
-        cBit = bitSlice(i, classicalInput);
-        CLAND(qInputStart + i, cBit, outputStart + i);
-    }
-}
+REG_GATE_3B(CLAND);
 
 /// "OR" compare a bit range in QInterface with a classical unsigned integer, and store result in range starting at
 /// output
-void QInterface::CLOR(bitLenInt qInputStart, bitCapInt classicalInput, bitLenInt outputStart, bitLenInt length)
-{
-    bool cBit;
-    for (bitLenInt i = 0; i < length; i++) {
-        cBit = bitSlice(i, classicalInput);
-        CLOR(qInputStart + i, cBit, outputStart + i);
-    }
-}
+REG_GATE_3B(CLOR);
 
 /// "XOR" compare a bit range in QInterface with a classical unsigned integer, and store result in range starting at
 /// output
-void QInterface::CLXOR(bitLenInt qInputStart, bitCapInt classicalInput, bitLenInt outputStart, bitLenInt length)
-{
-    bool cBit;
-    for (bitLenInt i = 0; i < length; i++) {
-        cBit = bitSlice(i, classicalInput);
-        CLXOR(qInputStart + i, cBit, outputStart + i);
-    }
-}
+REG_GATE_3B(CLXOR);
 
 /// Arithmetic shift left, with last 2 bits as sign and carry
 void QInterface::ASL(bitLenInt shift, bitLenInt start, bitLenInt length)
@@ -320,12 +301,7 @@ void QInterface::SetReg(bitLenInt start, bitLenInt length, bitCapInt value)
 }
 
 ///"Phase shift gate" - Rotates each bit as e^(-i*\theta/2) around |1> state
-void QInterface::RT(real1 radians, bitLenInt start, bitLenInt length)
-{
-    for (bitLenInt bit = 0; bit < length; bit++) {
-        RT(radians, start + bit);
-    }
-}
+REG_GATE_1R(RT);
 
 /// Dyadic fraction "phase shift gate" - Rotates as e^(i*(M_PI * numerator) / 2^denomPower) around |1> state.
 void QInterface::RTDyad(int numerator, int denomPower, bitLenInt qubit)
@@ -334,20 +310,10 @@ void QInterface::RTDyad(int numerator, int denomPower, bitLenInt qubit)
 }
 
 /// Dyadic fraction "phase shift gate" - Rotates each bit as e^(i*(M_PI * numerator) / denominator) around |1> state.
-void QInterface::RTDyad(int numerator, int denominator, bitLenInt start, bitLenInt length)
-{
-    for (bitLenInt bit = 0; bit < length; bit++) {
-        RTDyad(numerator, denominator, start + bit);
-    }
-}
+REG_GATE_1D(RTDyad)
 
 /// Bitwise (identity) exponentiation gate - Applies exponentiation of the identity operator
-void QInterface::Exp(real1 radians, bitLenInt start, bitLenInt length)
-{
-    for (bitLenInt bit = 0; bit < length; bit++) {
-        Exp(radians, start + bit);
-    }
-}
+REG_GATE_1R(Exp)
 
 /// Dyadic fraction (identity) exponentiation gate - Applies exponentiation of the identity operator
 void QInterface::ExpDyad(int numerator, int denomPower, bitLenInt qubit)
@@ -356,20 +322,10 @@ void QInterface::ExpDyad(int numerator, int denomPower, bitLenInt qubit)
 }
 
 /// Dyadic fraction (identity) exponentiation gate - Applies \f$ e^{-i * \pi * numerator * I / 2^denomPower} \f$,
-void QInterface::ExpDyad(int numerator, int denominator, bitLenInt start, bitLenInt length)
-{
-    for (bitLenInt bit = 0; bit < length; bit++) {
-        ExpDyad(numerator, denominator, start + bit);
-    }
-}
+REG_GATE_1D(ExpDyad)
 
 /// Bitwise Pauli X exponentiation gate - Applies \f$ e^{-i*\theta*\sigma_x} \f$, exponentiation of the Pauli X operator
-void QInterface::ExpX(real1 radians, bitLenInt start, bitLenInt length)
-{
-    for (bitLenInt bit = 0; bit < length; bit++) {
-        ExpX(radians, start + bit);
-    }
-}
+REG_GATE_1R(ExpX)
 
 /// Dyadic fraction Pauli X exponentiation gate - Applies exponentiation of the Pauli X operator
 void QInterface::ExpXDyad(int numerator, int denomPower, bitLenInt qubit)
@@ -378,20 +334,10 @@ void QInterface::ExpXDyad(int numerator, int denomPower, bitLenInt qubit)
 }
 
 /// Dyadic fraction Pauli X exponentiation gate - Applies exponentiation of the Pauli X operator
-void QInterface::ExpXDyad(int numerator, int denominator, bitLenInt start, bitLenInt length)
-{
-    for (bitLenInt bit = 0; bit < length; bit++) {
-        ExpXDyad(numerator, denominator, start + bit);
-    }
-}
+REG_GATE_1D(ExpXDyad)
 
 /// Bitwise Pauli Y exponentiation gate - Applies \f$ e^{-i*\theta*\sigma_y} \f$, exponentiation of the Pauli Y operator
-void QInterface::ExpY(real1 radians, bitLenInt start, bitLenInt length)
-{
-    for (bitLenInt bit = 0; bit < length; bit++) {
-        ExpY(radians, start + bit);
-    }
-}
+REG_GATE_1R(ExpY)
 
 /// Dyadic fraction Pauli Y exponentiation gate - Applies exponentiation of the Pauli Y operator
 void QInterface::ExpYDyad(int numerator, int denomPower, bitLenInt qubit)
@@ -400,12 +346,7 @@ void QInterface::ExpYDyad(int numerator, int denomPower, bitLenInt qubit)
 }
 
 /// Dyadic fraction Pauli Y exponentiation gate - Applies exponentiation of the Pauli Y operator
-void QInterface::ExpYDyad(int numerator, int denominator, bitLenInt start, bitLenInt length)
-{
-    for (bitLenInt bit = 0; bit < length; bit++) {
-        ExpYDyad(numerator, denominator, start + bit);
-    }
-}
+REG_GATE_1D(ExpYDyad)
 
 /// Dyadic fraction Pauli Z exponentiation gate - Applies exponentiation of the Pauli Z operator
 void QInterface::ExpZDyad(int numerator, int denomPower, bitLenInt qubit)
@@ -416,28 +357,13 @@ void QInterface::ExpZDyad(int numerator, int denomPower, bitLenInt qubit)
 /**
  * Bitwise Pauli Z exponentiation gate - Applies \f$ e^{-i*\theta*\sigma_z} \f$, exponentiation of the Pauli Z operator
  */
-void QInterface::ExpZ(real1 radians, bitLenInt start, bitLenInt length)
-{
-    for (bitLenInt bit = 0; bit < length; bit++) {
-        ExpZ(radians, start + bit);
-    }
-}
+REG_GATE_1R(ExpZ)
 
 /// Dyadic fraction Pauli Z exponentiation gate - Applies exponentiation of the Pauli Z operator
-void QInterface::ExpZDyad(int numerator, int denominator, bitLenInt start, bitLenInt length)
-{
-    for (bitLenInt bit = 0; bit < length; bit++) {
-        ExpZDyad(numerator, denominator, start + bit);
-    }
-}
+REG_GATE_1D(ExpZDyad)
 
 /// x axis rotation gate - Rotates each bit as e^(-i*\theta/2) around Pauli x axis
-void QInterface::RX(real1 radians, bitLenInt start, bitLenInt length)
-{
-    for (bitLenInt bit = 0; bit < length; bit++) {
-        RX(radians, start + bit);
-    }
-}
+REG_GATE_1R(RX)
 
 /// Dyadic fraction x axis rotation gate - Rotates around Pauli x axis.
 void QInterface::RXDyad(int numerator, int denomPower, bitLenInt qubit)
@@ -446,20 +372,10 @@ void QInterface::RXDyad(int numerator, int denomPower, bitLenInt qubit)
 }
 
 /// Dyadic fraction x axis rotation gate - Rotates around Pauli x
-void QInterface::RXDyad(int numerator, int denominator, bitLenInt start, bitLenInt length)
-{
-    for (bitLenInt bit = 0; bit < length; bit++) {
-        RXDyad(numerator, denominator, start + bit);
-    }
-}
+REG_GATE_1D(RXDyad)
 
 /// y axis rotation gate - Rotates each bit as e^(-i*\theta/2) around Pauli y axis
-void QInterface::RY(real1 radians, bitLenInt start, bitLenInt length)
-{
-    for (bitLenInt bit = 0; bit < length; bit++) {
-        RY(radians, start + bit);
-    }
-}
+REG_GATE_1R(RY)
 
 /// Dyadic fraction y axis rotation gate - Rotates around Pauli y axis.
 void QInterface::RYDyad(int numerator, int denomPower, bitLenInt qubit)
@@ -468,20 +384,10 @@ void QInterface::RYDyad(int numerator, int denomPower, bitLenInt qubit)
 }
 
 /// Dyadic fraction y axis rotation gate - Rotates each bit around Pauli y axis.
-void QInterface::RYDyad(int numerator, int denominator, bitLenInt start, bitLenInt length)
-{
-    for (bitLenInt bit = 0; bit < length; bit++) {
-        RYDyad(numerator, denominator, start + bit);
-    }
-}
+REG_GATE_1D(RYDyad)
 
 /// z axis rotation gate - Rotates each bit around Pauli z axis
-void QInterface::RZ(real1 radians, bitLenInt start, bitLenInt length)
-{
-    for (bitLenInt bit = 0; bit < length; bit++) {
-        RZ(radians, start + bit);
-    }
-}
+REG_GATE_1R(RZ)
 
 /// Dyadic fraction y axis rotation gate - Rotates around Pauli y axis.
 void QInterface::RZDyad(int numerator, int denomPower, bitLenInt qubit)
@@ -490,12 +396,7 @@ void QInterface::RZDyad(int numerator, int denomPower, bitLenInt qubit)
 }
 
 /// Dyadic fraction z axis rotation gate - Rotates each bit around Pauli y axis.
-void QInterface::RZDyad(int numerator, int denominator, bitLenInt start, bitLenInt length)
-{
-    for (bitLenInt bit = 0; bit < length; bit++) {
-        RZDyad(numerator, denominator, start + bit);
-    }
-}
+REG_GATE_1D(RZDyad)
 
 /// Controlled "phase shift gate"
 void QInterface::CRT(real1 radians, bitLenInt control, bitLenInt target, bitLenInt length)

--- a/src/qinterface/qinterface.cpp
+++ b/src/qinterface/qinterface.cpp
@@ -79,7 +79,7 @@ namespace Qrack {
             length, [&](bitLenInt bit) { gate(numerator, denominator, control + bit, target + bit); });                \
     }
 
-inline real1 dyadAngle(int numerator, int denomPower) { return (-M_PI * numerator * 2) / pow(2, denomPower); };
+inline real1 dyadAngle(int numerator, int denomPower) { return (M_PI * numerator * 2) / pow(2, denomPower); };
 
 template <typename GateFunc> void QInterface::ControlledLoopFixture(bitLenInt length, GateFunc gate)
 {
@@ -216,10 +216,10 @@ void QInterface::ExpDyad(int numerator, int denomPower, bitLenInt qubit)
     Exp(dyadAngle(numerator, denomPower), qubit);
 }
 
-/// Dyadic fraction (identity) exponentiation gate - Applies \f$ e^{-i * \pi * numerator * I / 2^denomPower} \f$,
+/// Dyadic fraction (identity) exponentiation gate - Applies \f$ e^{i * \pi * numerator * I / 2^denomPower} \f$,
 REG_GATE_1D(ExpDyad);
 
-/// Bitwise Pauli X exponentiation gate - Applies \f$ e^{-i*\theta*\sigma_x} \f$, exponentiation of the Pauli X operator
+/// Bitwise Pauli X exponentiation gate - Applies \f$ e^{i*\theta*\sigma_x} \f$, exponentiation of the Pauli X operator
 REG_GATE_1R(ExpX);
 
 /// Dyadic fraction Pauli X exponentiation gate - Applies exponentiation of the Pauli X operator
@@ -231,7 +231,7 @@ void QInterface::ExpXDyad(int numerator, int denomPower, bitLenInt qubit)
 /// Dyadic fraction Pauli X exponentiation gate - Applies exponentiation of the Pauli X operator
 REG_GATE_1D(ExpXDyad);
 
-/// Bitwise Pauli Y exponentiation gate - Applies \f$ e^{-i*\theta*\sigma_y} \f$, exponentiation of the Pauli Y operator
+/// Bitwise Pauli Y exponentiation gate - Applies \f$ e^{i*\theta*\sigma_y} \f$, exponentiation of the Pauli Y operator
 REG_GATE_1R(ExpY);
 
 /// Dyadic fraction Pauli Y exponentiation gate - Applies exponentiation of the Pauli Y operator
@@ -250,7 +250,7 @@ void QInterface::ExpZDyad(int numerator, int denomPower, bitLenInt qubit)
 }
 
 /**
- * Bitwise Pauli Z exponentiation gate - Applies \f$ e^{-i*\theta*\sigma_z} \f$, exponentiation of the Pauli Z operator
+ * Bitwise Pauli Z exponentiation gate - Applies \f$ e^{i*\theta*\sigma_z} \f$, exponentiation of the Pauli Z operator
  */
 REG_GATE_1R(ExpZ);
 

--- a/src/qinterface/qinterface.cpp
+++ b/src/qinterface/qinterface.cpp
@@ -214,12 +214,26 @@ void QInterface::CIT(bitLenInt control, bitLenInt target, bitLenInt length)
 /// Apply controlled "PhaseRootN" gate to each bit
 void QInterface::CPhaseRootN(bitLenInt n, bitLenInt control, bitLenInt target, bitLenInt length)
 {
+    if (n == 0) {
+        return;
+    } else if (n == 1) {
+        CZ(control, target);
+        return;
+    }
+
     ControlledLoopFixture(length, [&](bitLenInt bit) { CPhaseRootN(n, control + bit, target + bit); });
 }
 
 /// Apply controlled IT gate to each bit
 void QInterface::CIPhaseRootN(bitLenInt n, bitLenInt control, bitLenInt target, bitLenInt length)
 {
+    if (n == 0) {
+        return;
+    } else if (n == 1) {
+        CZ(control, target);
+        return;
+    }
+
     ControlledLoopFixture(length, [&](bitLenInt bit) { CIPhaseRootN(n, control + bit, target + bit); });
 }
 

--- a/src/qinterface/qinterface.cpp
+++ b/src/qinterface/qinterface.cpp
@@ -217,7 +217,7 @@ void QInterface::CPhaseRootN(bitLenInt n, bitLenInt control, bitLenInt target, b
     if (n == 0) {
         return;
     } else if (n == 1) {
-        CZ(control, target);
+        CZ(control, target, length);
         return;
     }
 
@@ -230,7 +230,7 @@ void QInterface::CIPhaseRootN(bitLenInt n, bitLenInt control, bitLenInt target, 
     if (n == 0) {
         return;
     } else if (n == 1) {
-        CZ(control, target);
+        CZ(control, target, length);
         return;
     }
 

--- a/src/qinterface/qinterface.cpp
+++ b/src/qinterface/qinterface.cpp
@@ -191,12 +191,12 @@ REG_GATE_1R(RT);
 /// Dyadic fraction "phase shift gate" - Rotates as e^(i*(M_PI * numerator) / 2^denomPower) around |1> state.
 void QInterface::RTDyad(int numerator, int denomPower, bitLenInt qubit)
 {
-    if (denomPower > 1) {
+    if (denomPower > 0) {
         if (numerator == 1) {
-            IPhaseRootN(denomPower - 1, qubit);
+            PhaseRootN(denomPower + 1, qubit);
             return;
         } else if (numerator == -1) {
-            PhaseRootN(denomPower - 1, qubit);
+            IPhaseRootN(denomPower + 1, qubit);
             return;
         }
     }

--- a/src/qinterface/qinterface.cpp
+++ b/src/qinterface/qinterface.cpp
@@ -170,6 +170,18 @@ void QInterface::CZ(bitLenInt control, bitLenInt target, bitLenInt length)
     ControlledLoopFixture(length, [&](bitLenInt bit) { CZ(control + bit, target + bit); });
 }
 
+/// Apply controlled S gate to each bit
+void QInterface::CS(bitLenInt control, bitLenInt target, bitLenInt length)
+{
+    ControlledLoopFixture(length, [&](bitLenInt bit) { CS(control + bit, target + bit); });
+}
+
+/// Apply controlled IS gate to each bit
+void QInterface::CIS(bitLenInt control, bitLenInt target, bitLenInt length)
+{
+    ControlledLoopFixture(length, [&](bitLenInt bit) { CIS(control + bit, target + bit); });
+}
+
 /// "AND" compare a bit range in QInterface with a classical unsigned integer, and store result in range starting at
 /// output
 REG_GATE_3B(CLAND);

--- a/src/qinterface/qinterface.cpp
+++ b/src/qinterface/qinterface.cpp
@@ -79,7 +79,7 @@ namespace Qrack {
             length, [&](bitLenInt bit) { gate(numerator, denominator, control + bit, target + bit); });                \
     }
 
-inline real1 dyadAngle(int numerator, int denomPower) { return (M_PI * numerator * 2) / pow(2, denomPower); };
+inline real1 dyadAngle(int numerator, int denomPower) { return (-M_PI * numerator * 2) / pow(2, denomPower); };
 
 template <typename GateFunc> void QInterface::ControlledLoopFixture(bitLenInt length, GateFunc gate)
 {
@@ -193,10 +193,10 @@ void QInterface::RTDyad(int numerator, int denomPower, bitLenInt qubit)
 {
     if (denomPower > 1) {
         if (numerator == 1) {
-            PhaseRootN(denomPower - 1, qubit);
+            IPhaseRootN(denomPower - 1, qubit);
             return;
         } else if (numerator == -1) {
-            IPhaseRootN(denomPower - 1, qubit);
+            PhaseRootN(denomPower - 1, qubit);
             return;
         }
     }
@@ -216,10 +216,10 @@ void QInterface::ExpDyad(int numerator, int denomPower, bitLenInt qubit)
     Exp(dyadAngle(numerator, denomPower), qubit);
 }
 
-/// Dyadic fraction (identity) exponentiation gate - Applies \f$ e^{i * \pi * numerator * I / 2^denomPower} \f$,
+/// Dyadic fraction (identity) exponentiation gate - Applies \f$ e^{-i * \pi * numerator * I / 2^denomPower} \f$,
 REG_GATE_1D(ExpDyad);
 
-/// Bitwise Pauli X exponentiation gate - Applies \f$ e^{i*\theta*\sigma_x} \f$, exponentiation of the Pauli X operator
+/// Bitwise Pauli X exponentiation gate - Applies \f$ e^{-i*\theta*\sigma_x} \f$, exponentiation of the Pauli X operator
 REG_GATE_1R(ExpX);
 
 /// Dyadic fraction Pauli X exponentiation gate - Applies exponentiation of the Pauli X operator
@@ -231,7 +231,7 @@ void QInterface::ExpXDyad(int numerator, int denomPower, bitLenInt qubit)
 /// Dyadic fraction Pauli X exponentiation gate - Applies exponentiation of the Pauli X operator
 REG_GATE_1D(ExpXDyad);
 
-/// Bitwise Pauli Y exponentiation gate - Applies \f$ e^{i*\theta*\sigma_y} \f$, exponentiation of the Pauli Y operator
+/// Bitwise Pauli Y exponentiation gate - Applies \f$ e^{-i*\theta*\sigma_y} \f$, exponentiation of the Pauli Y operator
 REG_GATE_1R(ExpY);
 
 /// Dyadic fraction Pauli Y exponentiation gate - Applies exponentiation of the Pauli Y operator
@@ -250,7 +250,7 @@ void QInterface::ExpZDyad(int numerator, int denomPower, bitLenInt qubit)
 }
 
 /**
- * Bitwise Pauli Z exponentiation gate - Applies \f$ e^{i*\theta*\sigma_z} \f$, exponentiation of the Pauli Z operator
+ * Bitwise Pauli Z exponentiation gate - Applies \f$ e^{-i*\theta*\sigma_z} \f$, exponentiation of the Pauli Z operator
  */
 REG_GATE_1R(ExpZ);
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1175,7 +1175,7 @@ void QUnit::CPhaseRootN(bitLenInt n, bitLenInt control, bitLenInt target)
         bitLenInt controlLen = 1;
 
         complex cOne = complex(ONE_R1, ZERO_R1);
-        complex iRoot = pow(complex(-ONE_R1, ZERO_R1), ONE_R1 / (1U << n));
+        complex iRoot = pow(complex(-ONE_R1, ZERO_R1), ONE_R1 / (ONE_BCI << n));
         complex p = (ONE_R1 / 2) * (cOne + iRoot);
         complex m = (ONE_R1 / 2) * (cOne - iRoot);
         complex mtrx[4] = { p, m, m, p };
@@ -1215,7 +1215,7 @@ void QUnit::CIPhaseRootN(bitLenInt n, bitLenInt control, bitLenInt target)
         bitLenInt controlLen = 1;
 
         complex cOne = complex(ONE_R1, ZERO_R1);
-        complex iRoot = pow(complex(-ONE_R1, ZERO_R1), -ONE_R1 / (1U << n));
+        complex iRoot = pow(complex(-ONE_R1, ZERO_R1), -ONE_R1 / (ONE_BCI << n));
         complex p = (ONE_R1 / 2) * (cOne + iRoot);
         complex m = (ONE_R1 / 2) * (cOne - iRoot);
         complex mtrx[4] = { p, m, m, p };

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1214,10 +1214,10 @@ void QUnit::CIPhaseRootN(bitLenInt n, bitLenInt control, bitLenInt target)
         bitLenInt controlLen = 1;
 
         complex cOne = complex(ONE_R1, ZERO_R1);
-        complex iRoot = pow(complex(-ONE_R1, ONE_R1), ONE_R1 / n);
+        complex iRoot = pow(complex(-ONE_R1, ONE_R1), -ONE_R1 / n);
         complex p = (ONE_R1 / 2) * (cOne + iRoot);
         complex m = (ONE_R1 / 2) * (cOne - iRoot);
-        complex mtrx[4] = { m, p, p, m };
+        complex mtrx[4] = { p, m, m, p };
 
         CTRLED_GEN_WRAP(ApplyControlledSingleBit(CTRL_GEN_ARGS), ApplySingleBit(mtrx, true, target), false, true);
         return;

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1072,15 +1072,7 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
     // optional "true" argument in the call.
     if (cShard.isPlusMinus && tShard.isPlusMinus) {
         ApplyEitherControlled(controls, controlLen, { target }, false,
-            [&](QInterfacePtr unit, std::vector<bitLenInt> mappedControls) {
-                if (!shards[target].isPlusMinus) {
-                    unit->CNOT(CTRL_1_ARGS);
-                } else {
-                    complex trnsMtrx[4];
-                    TransformInvert(topRight, bottomLeft, trnsMtrx);
-                    unit->ApplyControlledSingleBit(CTRL_GEN_ARGS);
-                }
-            },
+            [&](QInterfacePtr unit, std::vector<bitLenInt> mappedControls) { unit->CNOT(CTRL_1_ARGS); },
             [&]() { X(target); }, true);
         return;
     }

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1130,7 +1130,6 @@ void QUnit::CZ(bitLenInt control, bitLenInt target)
         return;
     }
 
-    // TODO: Apply commutation rules for H.
     if (tShard.isPlusMinus != cShard.isPlusMinus) {
         if (cShard.isPlusMinus) {
             std::swap(control, target);
@@ -1230,20 +1229,22 @@ void QUnit::ApplyControlledSinglePhase(const bitLenInt* controls, const bitLenIn
     bitLenInt* lcontrols = new bitLenInt[controlLen];
     bitLenInt ltarget;
 
-    if (controlLen == 1U && CACHED_CLASSICAL(shard) && !CACHED_CLASSICAL(shards[controls[0]])) {
-        ltarget = controls[0];
-        lcontrols[0] = target;
-    } else {
-
+    if (controlLen == 1U) {
         bool isZ = (real(topLeft) > (ONE_R1 - min_norm)) && (abs(imag(topLeft)) < min_norm) &&
             (real(bottomRight) < -(ONE_R1 - min_norm)) && (abs(imag(bottomRight)) < min_norm);
-        if (isZ && controlLen == 1U) {
+        if (isZ) {
             // Optimized case
             CZ(controls[0], target);
             delete[] lcontrols;
             return;
+        } else if (CACHED_CLASSICAL(shard) && !CACHED_CLASSICAL(shards[controls[0]])) {
+            ltarget = controls[0];
+            lcontrols[0] = target;
+        } else {
+            ltarget = target;
+            lcontrols[0] = controls[0];
         }
-
+    } else {
         ltarget = target;
         std::copy(controls, controls + controlLen, lcontrols);
     }

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1082,23 +1082,6 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
 
 void QUnit::AntiCNOT(bitLenInt control, bitLenInt target)
 {
-    QEngineShard& cShard = shards[control];
-    QEngineShard& tShard = shards[target];
-    if (cShard.isPlusMinus && !DIRTY(cShard) && !DIRTY(tShard)) {
-        if (!tShard.isPlusMinus) {
-            AntiCNOT(target, control);
-        } else if (norm(tShard.amp0) < min_norm) {
-            ApplyOrEmulate(cShard, [&](QEngineShard& shard) {
-                shard.unit->X(shard.mapped);
-                shard.unit->PhaseFlip();
-            });
-            std::swap(cShard.amp0, cShard.amp1);
-            tShard.amp0 *= -1;
-            tShard.amp1 *= -1;
-        }
-        return;
-    }
-
     bitLenInt controls[1] = { control };
     bitLenInt controlLen = 1;
     complex topRight = ONE_R1;

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -2281,7 +2281,7 @@ void QUnit::PhaseFlip()
     QEngineShard& shard = shards[0];
     if (PHASE_MATTERS(shard)) {
         TransformBasis(false, 0);
-        shard.unit->PhaseFlip();
+        ApplyOrEmulate(shard, [&](QEngineShard& shard) { shard.unit->PhaseFlip(); });
         shard.amp1 = -shard.amp1;
     }
 }

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -104,6 +104,7 @@ void QUnit::SetQuantumState(const complex* inputState)
 
 void QUnit::GetQuantumState(complex* outputState)
 {
+    TransformBasisAll(false);
     EndAllEmulation();
 
     QUnitPtr clone = std::dynamic_pointer_cast<QUnit>(Clone());

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1175,15 +1175,16 @@ void QUnit::CPhaseRootN(bitLenInt n, bitLenInt control, bitLenInt target)
         bitLenInt controlLen = 1;
 
         complex cOne = complex(ONE_R1, ZERO_R1);
-        complex iRoot = pow(complex(-ONE_R1, ONE_R1), ONE_R1 / n);
+        complex iRoot = pow(complex(-ONE_R1, ZERO_R1), ONE_R1 / (1U << n));
         complex p = (ONE_R1 / 2) * (cOne + iRoot);
         complex m = (ONE_R1 / 2) * (cOne - iRoot);
         complex mtrx[4] = { p, m, m, p };
 
-        CTRLED_GEN_WRAP(ApplyControlledSingleBit(CTRL_GEN_ARGS), ApplySingleBit(mtrx, true, target), false, true);
+        CTRLED_GEN_WRAP(ApplyControlledSingleBit(CTRL_GEN_ARGS), ApplySingleBit(mtrx, true, target), false, false);
         return;
     }
 
+    // TODO: Handle both bits |+>/|-> case
     bitLenInt controls[1] = { control };
     bitLenInt controlLen = 1;
     CTRLED_CALL_WRAP(CPhaseRootN(CTRL_N_ARGS), PhaseRootN(n, target), false, true);
@@ -1214,7 +1215,7 @@ void QUnit::CIPhaseRootN(bitLenInt n, bitLenInt control, bitLenInt target)
         bitLenInt controlLen = 1;
 
         complex cOne = complex(ONE_R1, ZERO_R1);
-        complex iRoot = pow(complex(-ONE_R1, ONE_R1), -ONE_R1 / n);
+        complex iRoot = pow(complex(-ONE_R1, ZERO_R1), -ONE_R1 / (1U << n));
         complex p = (ONE_R1 / 2) * (cOne + iRoot);
         complex m = (ONE_R1 / 2) * (cOne - iRoot);
         complex mtrx[4] = { p, m, m, p };
@@ -1223,9 +1224,10 @@ void QUnit::CIPhaseRootN(bitLenInt n, bitLenInt control, bitLenInt target)
         return;
     }
 
+    // TODO: Handle both bits |+>/|-> case
     bitLenInt controls[1] = { control };
     bitLenInt controlLen = 1;
-    CTRLED_CALL_WRAP(CIPhaseRootN(CTRL_N_ARGS), IPhaseRootN(n, target), false, true);
+    CTRLED_CALL_WRAP(CIPhaseRootN(CTRL_N_ARGS), IPhaseRootN(n, target), false, false);
 }
 
 void QUnit::ApplySinglePhase(const complex topLeft, const complex bottomRight, bool doCalcNorm, bitLenInt target)

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1152,6 +1152,13 @@ void QUnit::CZ(bitLenInt control, bitLenInt target)
 
 void QUnit::CPhaseRootN(bitLenInt n, bitLenInt control, bitLenInt target)
 {
+    if (n == 0) {
+        return;
+    } else if (n == 1) {
+        CZ(control, target);
+        return;
+    }
+
     QEngineShard& tShard = shards[target];
     QEngineShard& cShard = shards[control];
 
@@ -1169,7 +1176,9 @@ void QUnit::CPhaseRootN(bitLenInt n, bitLenInt control, bitLenInt target)
 
         complex cOne = complex(ONE_R1, ZERO_R1);
         complex iRoot = pow(complex(-ONE_R1, ONE_R1), ONE_R1 / n);
-        complex mtrx[4] = { cOne + iRoot, cOne - iRoot, cOne - iRoot, cOne + iRoot };
+        complex p = (ONE_R1 / 2) * (cOne + iRoot);
+        complex m = (ONE_R1 / 2) * (cOne - iRoot);
+        complex mtrx[4] = { p, m, m, p };
 
         CTRLED_GEN_WRAP(ApplyControlledSingleBit(CTRL_GEN_ARGS), ApplySingleBit(mtrx, true, target), false, true);
         return;
@@ -1182,6 +1191,13 @@ void QUnit::CPhaseRootN(bitLenInt n, bitLenInt control, bitLenInt target)
 
 void QUnit::CIPhaseRootN(bitLenInt n, bitLenInt control, bitLenInt target)
 {
+    if (n == 0) {
+        return;
+    } else if (n == 1) {
+        CZ(control, target);
+        return;
+    }
+
     QEngineShard& tShard = shards[target];
     QEngineShard& cShard = shards[control];
 
@@ -1199,7 +1215,9 @@ void QUnit::CIPhaseRootN(bitLenInt n, bitLenInt control, bitLenInt target)
 
         complex cOne = complex(ONE_R1, ZERO_R1);
         complex iRoot = pow(complex(-ONE_R1, ONE_R1), ONE_R1 / n);
-        complex mtrx[4] = { cOne - iRoot, cOne + iRoot, cOne + iRoot, cOne - iRoot };
+        complex p = (ONE_R1 / 2) * (cOne + iRoot);
+        complex m = (ONE_R1 / 2) * (cOne - iRoot);
+        complex mtrx[4] = { m, p, p, m };
 
         CTRLED_GEN_WRAP(ApplyControlledSingleBit(CTRL_GEN_ARGS), ApplySingleBit(mtrx, true, target), false, true);
         return;
@@ -1213,6 +1231,10 @@ void QUnit::CIPhaseRootN(bitLenInt n, bitLenInt control, bitLenInt target)
 void QUnit::ApplySinglePhase(const complex topLeft, const complex bottomRight, bool doCalcNorm, bitLenInt target)
 {
     QEngineShard& shard = shards[target];
+
+    if (!PHASE_MATTERS(shard)) {
+        return;
+    }
 
     if (!shard.isPlusMinus) {
         // If the target bit is in a |0>/|1> eigenstate, this gate has no effect.

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1061,6 +1061,15 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
 
     QEngineShard& cShard = shards[control];
     QEngineShard& tShard = shards[target];
+    // We're free to transform gates to any orthonormal basis of the Hilbert space.
+    // For a 2 qubit system, if the control is the lefthand bit, it's easy to verify the following truth table for CNOT:
+    // |++> -> |++>
+    // |+-> -> |+->
+    // |-+> -> |-->
+    // |--> -> |-+>
+    // Under the Jacobian transformation between these two bases for defining the truth table, the matrix representation
+    // is invariant. We just let ApplyEitherControlled() know to leave the current basis alone, by way of the last
+    // optional "true" argument in the call.
     if (cShard.isPlusMinus && tShard.isPlusMinus) {
         ApplyEitherControlled(controls, controlLen, { target }, false,
             [&](QInterfacePtr unit, std::vector<bitLenInt> mappedControls) {

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1136,10 +1136,6 @@ void QUnit::CZ(bitLenInt control, bitLenInt target)
             std::swap(control, target);
         }
 
-        if (UNSAFE_CACHED_ZERO(cShard)) {
-            return;
-        }
-
         bitLenInt controls[1] = { control };
         bitLenInt controlLen = 1;
         complex topRight = complex(ONE_R1, ZERO_R1);

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -29,8 +29,10 @@
 #include "qunit.hpp"
 
 #define SHARD_STATE(shard) (norm(shard.amp0) < (ONE_R1 / 2))
-#define UNSAFE_CACHED_CLASSICAL(shard) ((norm(shard.amp0) < min_norm) || (norm(shard.amp1) < min_norm))
-#define CACHED_CLASSICAL(shard) (!shard.isPlusMinus && !shard.isProbDirty && UNSAFE_CACHED_CLASSICAL(shard))
+/* "UNSAFE" variants here do not check whether the bit is in |0>/|1> rather than |+>/|-> basis. */
+#define UNSAFE_CACHED_CLASSICAL(shard)                                                                                 \
+    (!shard.isProbDirty && ((norm(shard.amp0) < min_norm) || (norm(shard.amp1) < min_norm)))
+#define CACHED_CLASSICAL(shard) (!shard.isPlusMinus && UNSAFE_CACHED_CLASSICAL(shard))
 #define CACHED_ONE(shard) (CACHED_CLASSICAL(shard) && SHARD_STATE(shard))
 #define CACHED_ZERO(shard) (CACHED_CLASSICAL(shard) && !SHARD_STATE(shard))
 #define UNSAFE_CACHED_ONE(shard) (UNSAFE_CACHED_CLASSICAL(shard) && SHARD_STATE(shard))
@@ -1231,6 +1233,7 @@ void QUnit::ApplyControlledSinglePhase(const bitLenInt* cControls, const bitLenI
 
     if ((imag(topLeft) < min_norm) && (real(topLeft) > (ONE_R1 - min_norm))) {
         if (CACHED_ZERO(shards[target])) {
+            delete[] controls;
             return;
         }
 
@@ -1245,6 +1248,7 @@ void QUnit::ApplyControlledSinglePhase(const bitLenInt* cControls, const bitLenI
     }
 
     if ((imag(bottomRight) < min_norm) && (real(bottomRight) > (ONE_R1 - min_norm)) && CACHED_ONE(shards[target])) {
+        delete[] controls;
         return;
     }
 
@@ -1273,9 +1277,11 @@ void QUnit::ApplyAntiControlledSinglePhase(const bitLenInt* cControls, const bit
     bitLenInt target = cTarget;
 
     if ((imag(topLeft) < min_norm) && (real(topLeft) > (ONE_R1 - min_norm)) && CACHED_ZERO(shard)) {
+        delete[] controls;
         return;
     }
     if ((imag(bottomRight) < min_norm) && (real(bottomRight) > (ONE_R1 - min_norm)) && CACHED_ONE(shard)) {
+        delete[] controls;
         return;
     }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1128,7 +1128,11 @@ void QUnit::CZ(bitLenInt control, bitLenInt target)
     }
 
     // TODO: Apply commutation rules for H.
-    if (tShard.isPlusMinus) {
+    if (tShard.isPlusMinus != cShard.isPlusMinus) {
+        if (cShard.isPlusMinus) {
+            std::swap(control, target);
+        }
+
         bitLenInt controls[1] = { control };
         bitLenInt controlLen = 1;
         complex topRight = complex(ONE_R1, ZERO_R1);

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1070,21 +1070,11 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
     // Under the Jacobian transformation between these two bases for defining the truth table, the matrix representation
     // is invariant. We just let ApplyEitherControlled() know to leave the current basis alone, by way of the last
     // optional "true" argument in the call.
-    if (cShard.isPlusMinus) {
-        if (tShard.isPlusMinus) {
-            ApplyEitherControlled(controls, controlLen, { target }, false,
-                [&](QInterfacePtr unit, std::vector<bitLenInt> mappedControls) { unit->CNOT(CTRL_1_ARGS); },
-                [&]() { X(target); }, true);
-            return;
-        }// else {
-            // If tShard is in |0>/|1> basis, though, we can use the truth table in yet a third basis.
-            // You can check by hand, if we flip the bit phase and reverse the control and target,
-            // we get the same result. This is cheaper, given our controlled gate optimizations.
-            // std::swap(controls[0], target);
-            // ApplyControlledSinglePhase(controls, 1U, target, -ONE_CMPLX, -ONE_CMPLX);
-            // CNOT(controls[0], target);
-            // return;
-        //}    
+    if (cShard.isPlusMinus && tShard.isPlusMinus) {
+        ApplyEitherControlled(controls, controlLen, { target }, false,
+            [&](QInterfacePtr unit, std::vector<bitLenInt> mappedControls) { unit->CNOT(CTRL_1_ARGS); },
+            [&]() { X(target); }, true);
+        return;
     }
 
     CTRLED_INVERT_WRAP(CNOT(CTRL_1_ARGS), ApplyControlledSingleBit(CTRL_GEN_ARGS), X(target), false);

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -550,7 +550,7 @@ bool QUnit::CheckBitPermutation(const bitLenInt& qubitIndex, const bool& inCurre
     if (!inCurrentBasis) {
         TransformBasis(false, qubitIndex);
     }
-    if (CACHED_CLASSICAL(shards[qubitIndex])) {
+    if (UNSAFE_CACHED_CLASSICAL(shards[qubitIndex])) {
         return true;
     } else {
         return false;

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -33,6 +33,8 @@
 #define CACHED_CLASSICAL(shard) (!shard.isPlusMinus && !shard.isProbDirty && UNSAFE_CACHED_CLASSICAL(shard))
 #define CACHED_ONE(shard) (CACHED_CLASSICAL(shard) && SHARD_STATE(shard))
 #define CACHED_ZERO(shard) (CACHED_CLASSICAL(shard) && !SHARD_STATE(shard))
+#define UNSAFE_CACHED_ONE(shard) (UNSAFE_CACHED_CLASSICAL(shard) && SHARD_STATE(shard))
+#define UNSAFE_CACHED_ZERO(shard) (UNSAFE_CACHED_CLASSICAL(shard) && !SHARD_STATE(shard))
 #define PHASE_MATTERS(shard) (!randGlobalPhase || !CACHED_CLASSICAL(shard))
 #define DIRTY(shard) (shard.isPhaseDirty || shard.isProbDirty)
 
@@ -1132,6 +1134,10 @@ void QUnit::CZ(bitLenInt control, bitLenInt target)
     if (tShard.isPlusMinus != cShard.isPlusMinus) {
         if (cShard.isPlusMinus) {
             std::swap(control, target);
+        }
+
+        if (UNSAFE_CACHED_ZERO(cShard)) {
+            return;
         }
 
         bitLenInt controls[1] = { control };

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1246,6 +1246,10 @@ void QUnit::ApplyControlledSinglePhase(const bitLenInt* cControls, const bitLenI
         }
     }
 
+    if ((imag(bottomRight) < min_norm) && (real(bottomRight) > (ONE_R1 - min_norm)) && CACHED_ONE(shard)) {
+        return;
+    }
+
     CTRLED_PHASE_WRAP(ApplyControlledSinglePhase(CTRL_P_ARGS), ApplyControlledSingleBit(CTRL_GEN_ARGS),
         ApplySinglePhase(topLeft, bottomRight, true, target), false);
 
@@ -1270,10 +1274,11 @@ void QUnit::ApplyAntiControlledSinglePhase(const bitLenInt* cControls, const bit
     std::copy(cControls, cControls + controlLen, controls);
     bitLenInt target = cTarget;
 
-    if ((imag(topLeft) < min_norm) && (real(topLeft) > (ONE_R1 - min_norm))) {
-        if (CACHED_ZERO(shard)) {
-            return;
-        }
+    if ((imag(topLeft) < min_norm) && (real(topLeft) > (ONE_R1 - min_norm)) && CACHED_ZERO(shard)) {
+        return;
+    }
+    if ((imag(bottomRight) < min_norm) && (real(bottomRight) > (ONE_R1 - min_norm)) && CACHED_ONE(shard)) {
+        return;
     }
 
     CTRLED_PHASE_WRAP(ApplyAntiControlledSinglePhase(CTRL_P_ARGS), ApplyAntiControlledSingleBit(CTRL_GEN_ARGS),

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1231,11 +1231,17 @@ void QUnit::ApplyControlledSinglePhase(const bitLenInt* cControls, const bitLenI
     std::copy(cControls, cControls + controlLen, controls);
     bitLenInt target = cTarget;
 
-    if (!shard.isPlusMinus && (imag(topLeft) < min_norm) && (real(topLeft) > (ONE_R1 - min_norm))) {
-        for (bitLenInt i = 0; i < controlLen; i++) {
-            if (shards[controls[i]].isPlusMinus) {
-                std::swap(controls[i], target);
-                break;
+    if ((imag(topLeft) < min_norm) && (real(topLeft) > (ONE_R1 - min_norm))) {
+        if (CACHED_ZERO(shard)) {
+            return;
+        }
+
+        if (!shard.isPlusMinus) {
+            for (bitLenInt i = 0; i < controlLen; i++) {
+                if (shards[controls[i]].isPlusMinus) {
+                    std::swap(controls[i], target);
+                    break;
+                }
             }
         }
     }
@@ -1264,12 +1270,9 @@ void QUnit::ApplyAntiControlledSinglePhase(const bitLenInt* cControls, const bit
     std::copy(cControls, cControls + controlLen, controls);
     bitLenInt target = cTarget;
 
-    if (!shard.isPlusMinus && (imag(topLeft) < min_norm) && (real(topLeft) > (ONE_R1 - min_norm))) {
-        for (bitLenInt i = 0; i < controlLen; i++) {
-            if (shards[controls[i]].isPlusMinus) {
-                std::swap(controls[i], target);
-                break;
-            }
+    if ((imag(topLeft) < min_norm) && (real(topLeft) > (ONE_R1 - min_norm))) {
+        if (CACHED_ZERO(shard)) {
+            return;
         }
     }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1225,18 +1225,16 @@ void QUnit::ApplySingleInvert(const complex topRight, const complex bottomLeft, 
 void QUnit::ApplyControlledSinglePhase(const bitLenInt* cControls, const bitLenInt& controlLen,
     const bitLenInt& cTarget, const complex topLeft, const complex bottomRight)
 {
-    QEngineShard& shard = shards[cTarget];
-
     bitLenInt* controls = new bitLenInt[controlLen];
     std::copy(cControls, cControls + controlLen, controls);
     bitLenInt target = cTarget;
 
     if ((imag(topLeft) < min_norm) && (real(topLeft) > (ONE_R1 - min_norm))) {
-        if (CACHED_ZERO(shard)) {
+        if (CACHED_ZERO(shards[target])) {
             return;
         }
 
-        if (!shard.isPlusMinus) {
+        if (!shards[target].isPlusMinus) {
             for (bitLenInt i = 0; i < controlLen; i++) {
                 if (shards[controls[i]].isPlusMinus) {
                     std::swap(controls[i], target);
@@ -1246,7 +1244,7 @@ void QUnit::ApplyControlledSinglePhase(const bitLenInt* cControls, const bitLenI
         }
     }
 
-    if ((imag(bottomRight) < min_norm) && (real(bottomRight) > (ONE_R1 - min_norm)) && CACHED_ONE(shard)) {
+    if ((imag(bottomRight) < min_norm) && (real(bottomRight) > (ONE_R1 - min_norm)) && CACHED_ONE(shards[target])) {
         return;
     }
 

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -416,10 +416,7 @@ TEST_CASE("test_qft_permutation_round_trip_entangled", "[qft]")
 TEST_CASE("test_qft_superposition_one_way", "[qft]")
 {
     benchmarkLoop(
-        [](QInterfacePtr qftReg, int n) {
-            qftReg->QFT(0, n, false);
-        },
-        true, true, testEngineType == QINTERFACE_QUNIT);
+        [](QInterfacePtr qftReg, int n) { qftReg->QFT(0, n, false); }, true, true, testEngineType == QINTERFACE_QUNIT);
 }
 
 TEST_CASE("test_qft_superposition_round_trip", "[qft]")

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -413,6 +413,15 @@ TEST_CASE("test_qft_permutation_round_trip_entangled", "[qft]")
         true, false, testEngineType == QINTERFACE_QUNIT);
 }
 
+TEST_CASE("test_qft_superposition_one_way", "[qft]")
+{
+    benchmarkLoop(
+        [](QInterfacePtr qftReg, int n) {
+            qftReg->QFT(0, n, false);
+        },
+        true, true, testEngineType == QINTERFACE_QUNIT);
+}
+
 TEST_CASE("test_qft_superposition_round_trip", "[qft]")
 {
     benchmarkLoop(

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -391,7 +391,7 @@ TEST_CASE("test_grover", "[grover]")
         qftReg->MReg(0, n);
     });
 }
-#if 0
+
 TEST_CASE("test_qft_ideal_init", "[qft]")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->QFT(0, n, false); }, false, false);
@@ -412,7 +412,7 @@ TEST_CASE("test_qft_permutation_round_trip_entangled", "[qft]")
         },
         true, false, testEngineType == QINTERFACE_QUNIT);
 }
-#endif
+
 TEST_CASE("test_qft_superposition_round_trip", "[qft]")
 {
     benchmarkLoop(

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -391,7 +391,7 @@ TEST_CASE("test_grover", "[grover]")
         qftReg->MReg(0, n);
     });
 }
-
+#if 0
 TEST_CASE("test_qft_ideal_init", "[qft]")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) { qftReg->QFT(0, n, false); }, false, false);
@@ -412,7 +412,7 @@ TEST_CASE("test_qft_permutation_round_trip_entangled", "[qft]")
         },
         true, false, testEngineType == QINTERFACE_QUNIT);
 }
-
+#endif
 TEST_CASE("test_qft_superposition_round_trip", "[qft]")
 {
     benchmarkLoop(

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -1643,7 +1643,7 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_add_1")
     qftReg->SetPermutation(0);
     qftReg->QFT(0, 2);
     qftReg->RTDyad(1, 0, 0);
-    qftReg->RTDyad(1, 1, 1);
+    qftReg->RTDyad(1, 0, 1);
     qftReg->IQFT(0, 2);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 1));
 

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -733,6 +733,52 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_x_reg")
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x1d));
 }
 
+TEST_CASE_METHOD(QInterfaceTestFixture, "test_sqrtx")
+{
+    qftReg->SetPermutation(0x80001);
+    REQUIRE_THAT(qftReg, HasProbability(0, 20, 0x80001));
+    qftReg->SqrtX(19);
+    qftReg->SqrtX(19);
+    REQUIRE_THAT(qftReg, HasProbability(0, 20, 1));
+    qftReg->SqrtX(19);
+    qftReg->SqrtX(19);
+    REQUIRE_THAT(qftReg, HasProbability(0, 20, 0x80001));
+
+    qftReg->SqrtX(19);
+    qftReg->ISqrtX(19);
+    REQUIRE_THAT(qftReg, HasProbability(0, 20, 0x80001));
+
+    qftReg->ISqrtX(19);
+    qftReg->ISqrtX(19);
+    REQUIRE_THAT(qftReg, HasProbability(0, 20, 1));
+    qftReg->ISqrtX(19);
+    qftReg->ISqrtX(19);
+    REQUIRE_THAT(qftReg, HasProbability(0, 20, 0x80001));
+}
+
+TEST_CASE_METHOD(QInterfaceTestFixture, "test_sqrtx_reg")
+{
+    qftReg->SetPermutation(0x13);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x13));
+    qftReg->SqrtX(1, 4);
+    qftReg->SqrtX(1, 4);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x0d));
+    qftReg->SqrtX(4, 1);
+    qftReg->SqrtX(4, 1);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x1d));
+
+    qftReg->SqrtX(0, 4);
+    qftReg->ISqrtX(0, 4);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x1d));
+
+    qftReg->ISqrtX(4, 1);
+    qftReg->ISqrtX(4, 1);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x0d));
+    qftReg->ISqrtX(1, 4);
+    qftReg->ISqrtX(1, 4);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x13));
+}
+
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_y")
 {
     qftReg->SetReg(0, 8, 0x03);
@@ -761,6 +807,68 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_y_reg")
     qftReg->Y(1, 2);
     qftReg->H(1, 2);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x04));
+}
+
+TEST_CASE_METHOD(QInterfaceTestFixture, "test_sqrty")
+{
+    qftReg->SetReg(0, 8, 0x03);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x03));
+    qftReg->SqrtY(1);
+    qftReg->SqrtY(1);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x01));
+
+    qftReg->SetReg(0, 8, 0);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x00));
+    qftReg->SqrtH(1);
+    qftReg->SqrtH(1);
+    qftReg->SqrtY(1);
+    qftReg->SqrtY(1);
+    qftReg->SqrtH(1);
+    qftReg->SqrtH(1);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x02));
+
+    qftReg->SqrtY(1);
+    qftReg->ISqrtY(1);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x02));
+
+    qftReg->SqrtH(1);
+    qftReg->SqrtH(1);
+    qftReg->SqrtY(1);
+    qftReg->SqrtY(1);
+    qftReg->SqrtH(1);
+    qftReg->SqrtH(1);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x00));
+}
+
+TEST_CASE_METHOD(QInterfaceTestFixture, "test_sqrty_reg")
+{
+    qftReg->SetReg(0, 8, 0x13);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x13));
+    qftReg->SqrtY(1, 4);
+    qftReg->SqrtY(1, 4);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x0d));
+
+    qftReg->SetReg(0, 8, 0x02);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x02));
+    qftReg->SqrtH(1, 2);
+    qftReg->SqrtH(1, 2);
+    qftReg->SqrtY(1, 2);
+    qftReg->SqrtY(1, 2);
+    qftReg->SqrtH(1, 2);
+    qftReg->SqrtH(1, 2);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x04));
+
+    qftReg->SqrtY(0, 2);
+    qftReg->ISqrtY(0, 2);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x04));
+
+    qftReg->SqrtH(1, 2);
+    qftReg->SqrtH(1, 2);
+    qftReg->SqrtY(1, 2);
+    qftReg->SqrtY(1, 2);
+    qftReg->SqrtH(1, 2);
+    qftReg->SqrtH(1, 2);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x02));
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_z")

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -2924,7 +2924,7 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_trydecompose")
     qftReg->SetPermutation(0xb);
     qftReg->H(0, 4);
     qftReg->CNOT(0, 4, 4);
-    REQUIRE(qftReg->TryDecompose(0, 4, qftReg2) == (testEngineType == QINTERFACE_QUNIT));
+    REQUIRE(qftReg->TryDecompose(0, 4, qftReg2) == false);
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_setbit")

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -2543,9 +2543,9 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_tryseparate")
 
     qftReg->IQFT(0, 8);
 
-    for (i = 0; i < 8; i++) {
-        qftReg->TrySeparate(i);
-    }
+    // for (i = 0; i < 8; i++) {
+    //    qftReg->TrySeparate(i);
+    //}
 
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 85));
 }

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -2543,9 +2543,9 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_tryseparate")
 
     qftReg->IQFT(0, 8);
 
-    // for (i = 0; i < 8; i++) {
-    //    qftReg->TrySeparate(i);
-    //}
+    for (i = 0; i < 8; i++) {
+        qftReg->TrySeparate(i);
+    }
 
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 85));
 }

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -1643,7 +1643,7 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_add_1")
     qftReg->SetPermutation(0);
     qftReg->QFT(0, 2);
     qftReg->RTDyad(1, 0, 0);
-    qftReg->RTDyad(1, 0, 1);
+    qftReg->RTDyad(1, 1, 1);
     qftReg->IQFT(0, 2);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 1));
 


### PR DESCRIPTION
QUnit converts freely between |0>/|1> and |+>/|-> bases, by tracking a Boolean for each gate, and commuting applied gates with H where feasible. In this PR, we have implemented commutation with H for CZ, controlled S, controlled T, and their inverses. (CZ is its own inverse.) A bug was corrected in phase gates, earlier, that had caused the QFT benchmarks to regress in performance, but CS and CT commutators seem to recover some of this loss. Maybe more importantly, this seems to point to a general approach for optimizing QFT simulation, by handling commutation with H for singly-controlled phase gates up the n-th root of unity for n qubits in the QFT.

PR #239 attempted to take the work from around the time of #220 and isolate just the second order case. #241 attempted to carry to this to something useful by breaking with the earlier experimental approach and essentially "fusing" controlled phase gates at the QUnit level. All such PRs related to "Fourier basis" have been closed without merging. (I'm about to close #239, but in favor of this one.) The last comment in #239 pertaining the commutation of H and CZ finally seems to make some practical headway, though. This has been very roundabout, and I'm sorry to think aloud on the main repo.

For this PR, I'm aiming for 2 primary goals, before review: generalization to arbitrary n-th roots of unity (or 64 ad hoc orders, if I can't help myself,) and unit tests to cover the changes. S and T seem to be straightforward, once I had Z.