### PR TITLE
Option to redirect benchmark output to file

### DIFF
--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -46,7 +46,6 @@ double formatTime(double t, bool logNormal)
 void benchmarkLoopVariable(std::function<void(QInterfacePtr, int)> fn, bitLenInt mxQbts, bool resetRandomPerm = true,
     bool hadamardRandomBits = false, bool logNormal = false)
 {
-
     const int ITERATIONS = 100;
 
     std::cout << std::endl;


### PR DESCRIPTION
Per issue #245, this PR adds the option to output benchmark data to a user-specified file (as `--output=your_file.csv`). A minimum of changes were needed.