### PR TITLE
Experimental uint128_t support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,6 +100,10 @@ message ("Single accuracy is: ${ENABLE_COMPLEX8}")
 message ("Complex_x2/AVX Support is: ${ENABLE_COMPLEX_X2}")
 message ("VM6502Q disassembler support is: ${ENABLE_VM6502Q_DEBUG}")
 
+if (ENABLE_UINT128 AND ENABLE_PURE32)
+    message(FATAL_ERROR "You cannot require both ENABLE_UINT128 and ENABLE_PURE32 at the same time! 128 bit and pure 32 bit modes are mutually exclusive.")
+endif (ENABLE_UINT128 AND ENABLE_PURE32)
+
 if (MSVC)
     set(QRACK_COMPILE_OPTS -std=c++11 -Wall)
     set(TEST_COMPILE_OPTS -std=c++11 -Wall)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,7 +85,9 @@ add_test (NAME qrack_cl_precompile
     )
 
 # Included after the library and other modules have been declared
+option (ENABLE_OPENCL "Use OpenCL optimizations" ON)
 include ("cmake/Examples.cmake")
+include ("cmake/UInt128.cmake")
 include ("cmake/OpenCL.cmake" )
 include ("cmake/Complex8.cmake")
 include ("cmake/Complex_x2.cmake")
@@ -93,6 +95,7 @@ include ("cmake/Pure32.cmake")
 include ("cmake/VM6502Q.cmake")
 
 message ("Pure 32-bit compilation is: ${ENABLE_PURE32}")
+message ("128-bit compilation is: ${ENABLE_UINT128}")
 message ("Single accuracy is: ${ENABLE_COMPLEX8}")
 message ("Complex_x2/AVX Support is: ${ENABLE_COMPLEX_X2}")
 message ("VM6502Q disassembler support is: ${ENABLE_VM6502Q_DEBUG}")

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Turn off the option to attempt using on-chip hardware random number generation, 
 ```
 $ cmake -DENABLE_PURE32=ON ..
 ```
-This option is needed for certain older or simpler hardware. This removes all use of 64 bit types from the OpenCL kernels, as well as completely removing the use of SIMD intrinsics. Note that this build option theoretically supports only up to 32 qubits, whereas `-DENABLE_PURE32=OFF` could support up to 64 qubits, (if the memory requirements were realistically attainable for either 32-bit or 64-bit hardware). `-DENABLE_PURE32=ON` should be necessary but sufficient to support the VC4CL OpenCL compiler for the VideoCore GPU of the Raspberry Pi 3.
+This option is needed for certain older or simpler hardware. This removes all use of 64 bit types from the OpenCL kernels, as well as completely removing the use of SIMD intrinsics. Note that this build option theoretically supports only up to 32 qubits, whereas `-DENABLE_PURE32=OFF` could support up to 64 qubits, (if the memory requirements were realistically attainable for either 32-bit or 64-bit hardware). `-DENABLE_PURE32=ON` is necessary to support the VC4CL OpenCL compiler for the VideoCore GPU of the Raspberry Pi 3. (Additionally, for that platform, the RDRAND instruction is not available, and you should `-DENABLE_RDRAND=OFF`.
 
 ## Precompiled OpenCL kernels
 

--- a/cmake/OpenCL.cmake
+++ b/cmake/OpenCL.cmake
@@ -1,5 +1,3 @@
-option (ENABLE_OPENCL "Use OpenCL optimizations" ON)
-
 set (OPENCL_AMDSDK /opt/AMDAPPSDK-3.0 CACHE PATH "Installation path for the installed AMD OpenCL SDK, if used")
 
 # Options used when building the project

--- a/cmake/UInt128.cmake
+++ b/cmake/UInt128.cmake
@@ -1,8 +1,6 @@
 option (ENABLE_UINT128 "128 bit capacity (not OpenCL compatible)" OFF)
 
 if (ENABLE_UINT128)
-    set(ENABLE_VC4CL OFF)
-    set(ENABLE_PURE32 OFF)
     set(ENABLE_OPENCL OFF)
     target_compile_definitions (qrack PUBLIC ENABLE_UINT128=1)
 endif (ENABLE_UINT128)

--- a/cmake/UInt128.cmake
+++ b/cmake/UInt128.cmake
@@ -1,0 +1,6 @@
+option (ENABLE_UINT128 "128 bit capacity (not OpenCL compatible)" OFF)
+
+if (ENABLE_UINT128)
+    set(ENABLE_OPENCL OFF)
+    target_compile_definitions (qrack PUBLIC ENABLE_UINT128=1)
+endif (ENABLE_UINT128)

--- a/cmake/UInt128.cmake
+++ b/cmake/UInt128.cmake
@@ -1,6 +1,8 @@
 option (ENABLE_UINT128 "128 bit capacity (not OpenCL compatible)" OFF)
 
 if (ENABLE_UINT128)
+    set(ENABLE_VC4CL OFF)
+    set(ENABLE_PURE32 OFF)
     set(ENABLE_OPENCL OFF)
     target_compile_definitions (qrack PUBLIC ENABLE_UINT128=1)
 endif (ENABLE_UINT128)

--- a/examples/quantum_associative_memory.cpp
+++ b/examples/quantum_associative_memory.cpp
@@ -48,7 +48,7 @@ int main()
     bool bit;
     std::cout << "Learning (Two's complement)..." << std::endl;
     for (perm = 0; perm < InputPower; perm++) {
-        std::cout << "Epoch " << (perm + 1U) << " out of " << InputPower << std::endl;
+        std::cout << "Epoch " << (uint64_t)(perm + 1U) << " out of " << (uint64_t)InputPower << std::endl;
         comp = (~perm) + 1U;
         for (bitLenInt i = 0; i < OutputCount; i++) {
             qReg->SetPermutation(perm);

--- a/examples/quantum_associative_memory.cpp
+++ b/examples/quantum_associative_memory.cpp
@@ -48,7 +48,7 @@ int main()
     bool bit;
     std::cout << "Learning (Two's complement)..." << std::endl;
     for (perm = 0; perm < InputPower; perm++) {
-        std::cout << "Epoch " << (uint64_t)(perm + 1U) << " out of " << (uint64_t)InputPower << std::endl;
+        std::cout << "Epoch " << (perm + 1U) << " out of " << InputPower << std::endl;
         comp = (~perm) + 1U;
         for (bitLenInt i = 0; i < OutputCount; i++) {
             qReg->SetPermutation(perm);
@@ -64,6 +64,6 @@ int main()
             outputLayer[i]->Predict();
         }
         comp = qReg->MReg(InputCount, OutputCount);
-        std::cout << "Input: " << (int)perm << ", Output: " << (int)comp << std::endl;
+        std::cout << "Input: " << perm << ", Output: " << comp << std::endl;
     }
 }

--- a/examples/quantum_perceptron.cpp
+++ b/examples/quantum_perceptron.cpp
@@ -42,7 +42,7 @@ int main()
     bitCapInt perm;
     std::cout << "Learning (to recognize powers of 2)..." << std::endl;
     for (perm = 0; perm < ControlPower; perm++) {
-        std::cout << "Epoch " << (uint64_t)(perm + 1U) << " out of " << (uint64_t)ControlPower << std::endl;
+        std::cout << "Epoch " << (perm + 1U) << " out of " << ControlPower << std::endl;
         qReg->SetPermutation(perm);
         isPowerOf2 = ((perm != 0) && ((perm & (perm - 1U)) == 0));
         qPerceptron->LearnPermutation(isPowerOf2, eta);
@@ -51,7 +51,7 @@ int main()
     std::cout << "Should be close to 1 for powers of two, and close to 0 for all else..." << std::endl;
     for (perm = 0; perm < ControlPower; perm++) {
         qReg->SetPermutation(perm);
-        std::cout << "Permutation: " << (int)perm << ", Probability: " << qPerceptron->Predict() << std::endl;
+        std::cout << "Permutation: " << perm << ", Probability: " << qPerceptron->Predict() << std::endl;
     }
 
     // Now, we prepare a superposition of all available powers of 2, to predict.

--- a/examples/quantum_perceptron.cpp
+++ b/examples/quantum_perceptron.cpp
@@ -42,7 +42,7 @@ int main()
     bitCapInt perm;
     std::cout << "Learning (to recognize powers of 2)..." << std::endl;
     for (perm = 0; perm < ControlPower; perm++) {
-        std::cout << "Epoch " << (perm + 1U) << " out of " << ControlPower << std::endl;
+        std::cout << "Epoch " << (uint64_t)(perm + 1U) << " out of " << (uint64_t)ControlPower << std::endl;
         qReg->SetPermutation(perm);
         isPowerOf2 = ((perm != 0) && ((perm & (perm - 1U)) == 0));
         qPerceptron->LearnPermutation(isPowerOf2, eta);

--- a/examples/shors_factoring.cpp
+++ b/examples/shors_factoring.cpp
@@ -58,7 +58,8 @@ real1 calc_continued_fraction(std::vector<bitCapInt> denominators, bitCapInt* nu
 
 int main()
 {
-    bitCapInt toFactor, base;
+    uint64_t toFactor;
+    bitCapInt base;
 
     std::cout << "Number to factor: ";
     std::cin >> toFactor;
@@ -73,7 +74,7 @@ int main()
 
     bitCapInt testFactor = gcd(toFactor, base);
     if (testFactor != 1) {
-        std::cout << "Chose non- relative prime: " << testFactor << " * " << (toFactor / testFactor) << std::endl;
+        std::cout << "Chose non- relative prime: " << (uint64_t)testFactor << " * " << (uint64_t)(toFactor / testFactor) << std::endl;
         return 0;
     }
 
@@ -118,7 +119,7 @@ int main()
     if (r & 1U) {
         r *= 2;
     }
-    bitCapInt apowrhalf = (int)pow(base, r >> 1) % toFactor;
+    bitCapInt apowrhalf = ((bitCapInt)pow((double)base, (double)(r >> 1U))) % toFactor;
     bitCapInt f1 = gcd(apowrhalf + 1, toFactor);
     bitCapInt f2 = gcd(apowrhalf - 1, toFactor);
     bitCapInt res1 = f1;
@@ -129,9 +130,9 @@ int main()
         res2 = toFactor / (f1 * f2);
     }
     if (((res1 * res2) == toFactor) && (res1 > 1) && (res2 > 1)) {
-        std::cout << "Success: Found " << res1 << " * " << res2 << " = " << toFactor << std::endl;
+        std::cout << "Success: Found " << (uint64_t)res1 << " * " << (uint64_t)res2 << " = " << (uint64_t)toFactor << std::endl;
     } else {
-        std::cout << "Failure: Found " << res1 << " and " << res2 << std::endl;
+        std::cout << "Failure: Found " << (uint64_t)res1 << " and " << (uint64_t)res2 << std::endl;
     }
 
     return 0;

--- a/examples/shors_factoring.cpp
+++ b/examples/shors_factoring.cpp
@@ -74,8 +74,7 @@ int main()
 
     bitCapInt testFactor = gcd(toFactor, base);
     if (testFactor != 1) {
-        std::cout << "Chose non- relative prime: " << (uint64_t)testFactor << " * " << (uint64_t)(toFactor / testFactor)
-                  << std::endl;
+        std::cout << "Chose non- relative prime: " << testFactor << " * " << (toFactor / testFactor) << std::endl;
         return 0;
     }
 

--- a/examples/shors_factoring.cpp
+++ b/examples/shors_factoring.cpp
@@ -74,7 +74,8 @@ int main()
 
     bitCapInt testFactor = gcd(toFactor, base);
     if (testFactor != 1) {
-        std::cout << "Chose non- relative prime: " << (uint64_t)testFactor << " * " << (uint64_t)(toFactor / testFactor) << std::endl;
+        std::cout << "Chose non- relative prime: " << (uint64_t)testFactor << " * " << (uint64_t)(toFactor / testFactor)
+                  << std::endl;
         return 0;
     }
 
@@ -130,9 +131,9 @@ int main()
         res2 = toFactor / (f1 * f2);
     }
     if (((res1 * res2) == toFactor) && (res1 > 1) && (res2 > 1)) {
-        std::cout << "Success: Found " << (uint64_t)res1 << " * " << (uint64_t)res2 << " = " << (uint64_t)toFactor << std::endl;
+        std::cout << "Success: Found " << res1 << " * " << res2 << " = " << toFactor << std::endl;
     } else {
-        std::cout << "Failure: Found " << (uint64_t)res1 << " and " << (uint64_t)res2 << std::endl;
+        std::cout << "Failure: Found " << res1 << " and " << res2 << std::endl;
     }
 
     return 0;

--- a/include/common/qrack_types.hpp
+++ b/include/common/qrack_types.hpp
@@ -21,10 +21,10 @@
 #define ONE_BCI 1U
 #elif ENABLE_UINT128
 #define bitCapInt __uint128_t
-#define ONE_BCI 1ULL
+#define ONE_BCI ((__uint128_t)1U)
 #else
 #define bitCapInt uint64_t
-#define ONE_BCI ((uint64_t)1U)
+#define ONE_BCI 1ULL
 #endif
 #define bitsInByte 8
 #define qrack_rand_gen std::mt19937_64

--- a/include/common/qrack_types.hpp
+++ b/include/common/qrack_types.hpp
@@ -24,7 +24,7 @@
 #define ONE_BCI 1ULL
 #else
 #define bitCapInt uint64_t
-#define ONE_BCI 1ULLL
+#define ONE_BCI 1ULL
 #endif
 #define bitsInByte 8
 #define qrack_rand_gen std::mt19937_64

--- a/include/common/qrack_types.hpp
+++ b/include/common/qrack_types.hpp
@@ -24,7 +24,7 @@
 #define ONE_BCI 1ULL
 #else
 #define bitCapInt uint64_t
-#define ONE_BCI 1ULL
+#define ONE_BCI ((uint64_t)1U)
 #endif
 #define bitsInByte 8
 #define qrack_rand_gen std::mt19937_64

--- a/include/common/qrack_types.hpp
+++ b/include/common/qrack_types.hpp
@@ -19,9 +19,12 @@
 #if ENABLE_PURE32
 #define bitCapInt uint32_t
 #define ONE_BCI 1U
+#elif ENABLE_UINT128
+#define bitCapInt __uint128_t
+#define ONE_BCI 1ULL
 #else
 #define bitCapInt uint64_t
-#define ONE_BCI 1ULL
+#define ONE_BCI 1ULLL
 #endif
 #define bitsInByte 8
 #define qrack_rand_gen std::mt19937_64

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -19,6 +19,10 @@
 #include <memory>
 #include <vector>
 
+#if ENABLE_UINT128
+#include <ostream>
+#endif
+
 #include "common/parallel_for.hpp"
 #include "common/qrack_types.hpp"
 #include "common/rdrandwrapper.hpp"
@@ -36,6 +40,7 @@ bool isOverflowAdd(bitCapInt inOutInt, bitCapInt inInt, const bitCapInt& signMas
 bool isOverflowSub(bitCapInt inOutInt, bitCapInt inInt, const bitCapInt& signMask, const bitCapInt& lengthPower);
 bitCapInt pushApartBits(const bitCapInt& perm, const bitCapInt* skipPowers, const bitLenInt skipPowersCount);
 bitCapInt intPow(bitCapInt base, bitCapInt power);
+std::ostream& operator<<(std::ostream& left, const __uint128_t& right);
 inline bitCapInt pow2(const bitLenInt& p) { return 1ULL << p; }
 inline bitCapInt pow2Mask(const bitLenInt& p) { return (1ULL << p) - 1ULL; }
 inline bitCapInt bitSlice(const bitLenInt& bit, const bitCapInt& source) { return (1ULL << bit) & source; }

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -1636,8 +1636,8 @@ void QEngineOCL::IFullAdd(bitLenInt inputBit1, bitLenInt inputBit2, bitLenInt ca
 void QEngineOCL::FullAdx(
     bitLenInt inputBit1, bitLenInt inputBit2, bitLenInt carryInSumOut, bitLenInt carryOut, OCLAPI api_call)
 {
-    bitCapInt bciArgs[BCI_ARG_LEN] = { maxQPower >> (2U * ONE_BCI), pow2(inputBit1), pow2(inputBit2), pow2(carryInSumOut),
-        pow2(carryOut), 0, 0, 0, 0, 0 };
+    bitCapInt bciArgs[BCI_ARG_LEN] = { maxQPower >> (2U * ONE_BCI), pow2(inputBit1), pow2(inputBit2),
+        pow2(carryInSumOut), pow2(carryOut), 0, 0, 0, 0, 0 };
 
     EventVecPtr waitVec = ResetWaitEvents();
     PoolItemPtr poolItem = GetFreePoolItem();

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -1641,7 +1641,7 @@ void QEngineOCL::IFullAdd(bitLenInt inputBit1, bitLenInt inputBit2, bitLenInt ca
 void QEngineOCL::FullAdx(
     bitLenInt inputBit1, bitLenInt inputBit2, bitLenInt carryInSumOut, bitLenInt carryOut, OCLAPI api_call)
 {
-    bitCapInt bciArgs[BCI_ARG_LEN] = { maxQPower >> 2UL, pow2(inputBit1), pow2(inputBit2), pow2(carryInSumOut),
+    bitCapInt bciArgs[BCI_ARG_LEN] = { maxQPower >> (2U * ONE_BCI), pow2(inputBit1), pow2(inputBit2), pow2(carryInSumOut),
         pow2(carryOut), 0, 0, 0, 0, 0 };
 
     EventVecPtr waitVec = ResetWaitEvents();

--- a/src/qinterface/arithmetic.cpp
+++ b/src/qinterface/arithmetic.cpp
@@ -163,14 +163,14 @@ void QInterface::ADC(bitLenInt input1, bitLenInt input2, bitLenInt output, bitLe
 
     FullAdd(input1, input2, carry, output);
 
-    if (length == 1) {
+    if (length == 1U) {
         Swap(carry, output);
         return;
     }
 
     // Otherwise, length > 1.
     bitLenInt end = length - 1U;
-    for (bitLenInt i = 1; i < end; i++) {
+    for (bitLenInt i = 1U; i < end; i++) {
         FullAdd(input1 + i, input2 + i, output + i, output + i + 1);
     }
     FullAdd(input1 + end, input2 + end, output + end, carry);
@@ -185,13 +185,13 @@ void QInterface::IADC(bitLenInt input1, bitLenInt input2, bitLenInt output, bitL
     bitLenInt end = length - 1U;
     IFullAdd(input1 + end, input2 + end, output + end, carry);
 
-    if (length == 1) {
+    if (length == 1U) {
         Swap(carry, output);
         return;
     }
 
     // Otherwise, length > 1.
-    for (bitLenInt i = (end - 1); i > 0; i--) {
+    for (bitLenInt i = (end - 1U); i > 0; i--) {
         IFullAdd(input1 + i, input2 + i, output + i, output + i + 1);
     }
     IFullAdd(input1, input2, carry, output);

--- a/src/qinterface/protected.cpp
+++ b/src/qinterface/protected.cpp
@@ -246,6 +246,7 @@ bool QInterface::IsIdentity(const complex* mtrx)
 #if ENABLE_UINT128
 std::ostream& operator<<(std::ostream& left, const __uint128_t& right)
 {
+    // TODO: As 128-bit simulation with QUnit becomes more practical, change this to print the full 128 bits as decimal.
     left << (const uint64_t&)right;
     return left;
 }

--- a/src/qinterface/protected.cpp
+++ b/src/qinterface/protected.cpp
@@ -243,4 +243,12 @@ bool QInterface::IsIdentity(const complex* mtrx)
     return true;
 }
 
+#if ENABLE_UINT128
+std::ostream& operator<<(std::ostream& left, const __uint128_t& right)
+{
+    left << (const uint64_t&)right;
+    return left;
+}
+#endif
+
 } // namespace Qrack


### PR DESCRIPTION
GCC and clang already offer unsigned 128 bit integral types. These are not compatible with the OpenCL standard, yet. It's possible (or likely) we have an unsafe 64 bit operation to ruin this compatibility, somewhere. However, we handled the 32 bit boundary, and we'll handle the 64 bit boundary, as well, as >64 bit support is demanded. This PR starts us on experimenting with support for more than 64 qubits (when the particular problem is tractable with QUnit).