### PR TITLE
Phase optimization (and cosmology benchmark)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,11 @@ install:
   - sudo pip3 install dormouse pybind11 networkx
   - sudo pip3 install --upgrade numpy
 script:
-  - mkdir _build && cd _build && cmake -DENABLE_OPENCL=OFF -DENABLE_COMPLEX8=OFF .. && make -j 8 all
+  - mkdir _build && cd _build && cmake -DENABLE_OPENCL=OFF -DENABLE_COMPLEX8=ON .. && make -j 8 all
   - sudo make install
   - cd .. && sudo rm -r _build
-  - mkdir _build && cd _build && cmake -DENABLE_OPENCL=OFF -DENABLE_COMPLEX8=ON .. && make -j 8 all
+  - mkdir _build && cd _build && cmake -DENABLE_OPENCL=OFF -DENABLE_COMPLEX8=OFF .. && make -j 8 all
   - ./unittest --proc-cpu
-  - cd .. && git clone https://github.com/vm6502q/ProjectQ.git && cd ProjectQ
+  - cd .. && git clone -b qrack_unit_tests https://github.com/vm6502q/ProjectQ.git && cd ProjectQ
   - sudo python3 setup.py --with-qracksimulator install
   - cd build && export OMP_NUM_THREADS=1 && sudo python3 -m pytest .

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -161,7 +161,7 @@ protected:
         toFree = NULL;
     }
 
-    bool IsIdentity(const complex* mtrx);
+    bool IsIdentity(const complex* mtrx, const bool isControlled = false);
 
 public:
     QInterface(bitLenInt n, qrack_rand_gen_ptr rgp = nullptr, bool doNorm = false, bool useHardwareRNG = true,

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -49,10 +49,7 @@ inline bitCapInt bitRegMask(const bitLenInt& start, const bitLenInt& length)
     return ((ONE_BCI << length) - ONE_BCI) << start;
 }
 // Source: https://www.exploringbinary.com/ten-ways-to-check-if-an-integer-is-a-power-of-two-in-c/
-inline bool isPowerOfTwo (const bitCapInt& x)
-{
-  return ((x != 0U) && !(x & (x - ONE_BCI)));
-}
+inline bool isPowerOfTwo(const bitCapInt& x) { return ((x != 0U) && !(x & (x - ONE_BCI))); }
 
 class QInterface;
 typedef std::shared_ptr<QInterface> QInterfacePtr;

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -528,18 +528,18 @@ protected:
     void TransformInvert(const complex& topRight, const complex& bottomLeft, complex* mtrxOut);
 
     void TransformBasis1Qb(const bool& toPlusMinus, const bitLenInt& i);
+    void TransformBasis1Qb(const bool& toPlusMinus, QEngineShard& shard);
 
-    void RevertBasis2Qb(bitLenInt i);
-
+    void RevertBasis2Qb(const bitLenInt& i);
     void RevertBasis2Qb(const bitLenInt& start, const bitLenInt& length)
     {
         for (bitLenInt i = 0; i < length; i++) {
             RevertBasis2Qb(start + i);
         }
     }
-
     void ToPermBasis(const bitLenInt& i)
     {
+        PopStackedBasis2Qb(i);
         TransformBasis1Qb(false, i);
         RevertBasis2Qb(i);
     }
@@ -550,6 +550,14 @@ protected:
         }
     }
     void ToPermBasisAll() { ToPermBasis(0, qubitCount); }
+    void PopStackedBasis2Qb(const bitLenInt& i)
+    {
+        QEngineShard& shard = shards[i];
+        if (shard.isPlusMinus && ((shard.targetOfShards.size() != 0) || (shard.controlsShards.size() != 0))) {
+            TransformBasis1Qb(false, i);
+        }
+    }
+
     void CheckShardSeparable(const bitLenInt& target);
 
     void DirtyShardRange(bitLenInt start, bitLenInt length)

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -166,7 +166,7 @@ struct QEngineShard {
         // Buffers with "angle0" = 0 are actually symmetric (unchanged) under exchange of control and target.
         // We can reduce our number of buffer instances by taking advantage of this kind of symmetry:
         ShardToPhaseMap::iterator controlShard = controlsShards.find(control);
-        if ((controlShard != controlsShards.end()) && (abs(controlShard->second.angle0) < (2 * M_PI * min_norm))) {
+        if ((controlShard != controlsShards.end()) && (abs(controlShard->second.angle0) < (4 * M_PI * min_norm))) {
             nAngle1 += controlShard->second.angle1;
             RemovePhaseTarget(control);
         }

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -528,7 +528,6 @@ protected:
     void TransformInvert(const complex& topRight, const complex& bottomLeft, complex* mtrxOut);
 
     void TransformBasis1Qb(const bool& toPlusMinus, const bitLenInt& i);
-    void TransformBasis1Qb(const bool& toPlusMinus, QEngineShard& shard);
 
     void RevertBasis2Qb(const bitLenInt& i);
     void RevertBasis2Qb(const bitLenInt& start, const bitLenInt& length)

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -161,14 +161,22 @@ struct QEngineShard {
         MakePhaseControlledBy(control);
 
         real1 nAngle0 = targetOfShards[control].angle0 + angle0Diff;
+        real1 nAngle1 = targetOfShards[control].angle1 + angle1Diff;
+
+        // Buffers with "angle0" = 0 are actually symmetric (unchanged) under exchange of control and target.
+        // We can reduce our number of buffer instances by taking advantage of this kind of symmetry:
+        ShardToPhaseMap::iterator controlShard = controlsShards.find(control);
+        if ((controlShard != controlsShards.end()) && (abs(controlShard->second.angle0) < (2 * M_PI * min_norm))) {
+            nAngle1 += controlShard->second.angle1;
+            RemovePhaseTarget(control);
+        }
+
         while (nAngle0 < (-2 * M_PI)) {
             nAngle0 += 4 * M_PI;
         }
         while (nAngle0 >= (2 * M_PI)) {
             nAngle0 -= 4 * M_PI;
         }
-
-        real1 nAngle1 = targetOfShards[control].angle1 + angle1Diff;
         while (nAngle1 < (-2 * M_PI)) {
             nAngle1 += 4 * M_PI;
         }

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -548,7 +548,7 @@ protected:
         }
     }
     void ToPermBasisAll() { ToPermBasis(0, qubitCount); }
-    void PopStackedBasis2Qb(const bitLenInt& i)
+    void PopHBasis2Qb(const bitLenInt& i)
     {
         QEngineShard& shard = shards[i];
         if (shard.isPlusMinus && ((shard.targetOfShards.size() != 0) || (shard.controlsShards.size() != 0))) {

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -539,7 +539,6 @@ protected:
     }
     void ToPermBasis(const bitLenInt& i)
     {
-        PopStackedBasis2Qb(i);
         TransformBasis1Qb(false, i);
         RevertBasis2Qb(i);
     }

--- a/include/statevector.hpp
+++ b/include/statevector.hpp
@@ -111,7 +111,7 @@ public:
         amplitudes[i2] = c2;
     };
 
-    void clear() { std::fill(amplitudes, amplitudes + capacity, complex(ZERO_R1, ZERO_R1)); }
+    void clear() { std::fill(amplitudes, amplitudes + capacity, ZERO_CMPLX); }
 
     void copy_in(const complex* copyIn) { std::copy(copyIn, copyIn + capacity, amplitudes); }
 
@@ -152,7 +152,7 @@ public:
         std::map<bitCapInt, complex>::const_iterator it = amplitudes.find(i);
         if (it == amplitudes.end()) {
             mtx.unlock();
-            toRet = complex(ZERO_R1, ZERO_R1);
+            toRet = ZERO_CMPLX;
         } else {
             toRet = it->second;
             mtx.unlock();

--- a/src/bitbuffer.cpp
+++ b/src/bitbuffer.cpp
@@ -142,11 +142,11 @@ bool GateBuffer::IsIdentity()
     // If the global phase offset has not been randomized, user code might explicitly depend on the global phase
     // offset (but shouldn't).
     complex toTest = matrix.get()[0];
-    if ((real(toTest) < (ONE_R1 - min_norm)) || (imag(toTest) > min_norm)) {
+    if ((real(toTest) < (ONE_R1 - min_norm)) || (abs(imag(toTest)) > min_norm)) {
         return false;
     }
     toTest = matrix.get()[3];
-    if ((real(toTest) < (ONE_R1 - min_norm)) || (imag(toTest) > min_norm)) {
+    if ((real(toTest) < (ONE_R1 - min_norm)) || (abs(imag(toTest)) > min_norm)) {
         return false;
     }
 

--- a/src/qinterface/protected.cpp
+++ b/src/qinterface/protected.cpp
@@ -207,7 +207,7 @@ bitCapInt pushApartBits(const bitCapInt& perm, const bitCapInt* skipPowers, cons
     return i;
 }
 
-bool QInterface::IsIdentity(const complex* mtrx)
+bool QInterface::IsIdentity(const complex* mtrx, bool isControlled)
 {
     // If the effect of applying the buffer would be (approximately or exactly) that of applying the identity
     // operator, then we can discard this buffer without applying it.
@@ -215,7 +215,7 @@ bool QInterface::IsIdentity(const complex* mtrx)
         return false;
     }
 
-    if (randGlobalPhase) {
+    if (randGlobalPhase && !isControlled) {
         // If the global phase offset has been randomized, we assume that global phase offsets are inconsequential, for
         // the user's purposes.
         real1 toTest = norm(mtrx[0]);
@@ -230,11 +230,11 @@ bool QInterface::IsIdentity(const complex* mtrx)
         // If the global phase offset has not been randomized, user code might explicitly depend on the global phase
         // offset (but shouldn't).
         complex toTest = mtrx[0];
-        if ((real(toTest) < (ONE_R1 - min_norm)) || (imag(toTest) > min_norm)) {
+        if ((real(toTest) < (ONE_R1 - min_norm)) || (abs(imag(toTest)) > min_norm)) {
             return false;
         }
         toTest = mtrx[3];
-        if ((real(toTest) < (ONE_R1 - min_norm)) || (imag(toTest) > min_norm)) {
+        if ((real(toTest) < (ONE_R1 - min_norm)) || (abs(imag(toTest)) > min_norm)) {
             return false;
         }
     }

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1208,8 +1208,6 @@ void QUnit::ApplySinglePhase(const complex topLeft, const complex bottomRight, b
 {
     QEngineShard& shard = shards[target];
 
-    RevertBasis2Qb(target);
-
     if (!PHASE_MATTERS(shard)) {
         return;
     }

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1103,7 +1103,7 @@ bool QUnit::TryCnotOptimize(const bitLenInt* controls, const bitLenInt& controlL
     for (bitLenInt i = 0; i < controlLen; i++) {
         QEngineShard& shard = shards[controls[i]];
         if (CACHED_CLASSICAL(shard)) {
-            if ((!anti && (norm(shard.amp1) < min_norm)) || (anti && (norm(shard.amp0) < min_norm))) {
+            if ((!anti && !SHARD_STATE(shard)) || (anti && SHARD_STATE(shard))) {
                 return true;
             }
         } else {
@@ -1119,7 +1119,7 @@ bool QUnit::TryCnotOptimize(const bitLenInt* controls, const bitLenInt& controlL
         ApplySingleInvert(topRight, bottomLeft, true, target);
         return true;
     } else if (rControlLen == 1U) {
-        complex iTest[4] = { bottomLeft, 0, 0, topRight };
+        complex iTest[4] = { topRight, 0, 0, bottomLeft };
         if (IsIdentity(iTest, true)) {
             if (anti) {
                 AntiCNOT(rControl, target);

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1302,21 +1302,6 @@ void QUnit::ApplyControlledSinglePhase(const bitLenInt* cControls, const bitLenI
         return;
     }
 
-    QEngineShard& tShard = shards[cTarget];
-    QEngineShard& cShard = shards[cControls[0]];
-
-    if (!freezeBasis || (controlLen != 1U)) {
-        PopHBasis2Qb(cTarget);
-        for (bitLenInt i = 0; i < controlLen; i++) {
-            PopHBasis2Qb(cControls[i]);
-        }
-    }
-
-    if (!freezeBasis && (controlLen == 1U)) {
-        tShard.AddPhaseAngles(&cShard, (real1)(2 * arg(topLeft)), (real1)(2 * arg(bottomRight)));
-        return;
-    }
-
     bitLenInt* controls = new bitLenInt[controlLen];
     std::copy(cControls, cControls + controlLen, controls);
     bitLenInt target = cTarget;
@@ -1339,6 +1324,21 @@ void QUnit::ApplyControlledSinglePhase(const bitLenInt* cControls, const bitLenI
 
     if ((imag(bottomRight) < min_norm) && (real(bottomRight) > (ONE_R1 - min_norm)) && CACHED_ONE(shards[target])) {
         delete[] controls;
+        return;
+    }
+
+    QEngineShard& tShard = shards[target];
+    QEngineShard& cShard = shards[controls[0]];
+
+    if (!freezeBasis || (controlLen != 1U)) {
+        PopHBasis2Qb(target);
+        for (bitLenInt i = 0; i < controlLen; i++) {
+            PopHBasis2Qb(controls[i]);
+        }
+    }
+
+    if (!freezeBasis && (controlLen == 1U)) {
+        tShard.AddPhaseAngles(&cShard, (real1)(2 * arg(topLeft)), (real1)(2 * arg(bottomRight)));
         return;
     }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -965,7 +965,7 @@ void QUnit::X(bitLenInt target)
 {
     QEngineShard& shard = shards[target];
 
-    PopStackedBasis2Qb(target);
+    PopHBasis2Qb(target);
 
     shard.FlipPhaseAnti();
 
@@ -981,7 +981,7 @@ void QUnit::Z(bitLenInt target)
     // Commutes with controlled phase optimizations
     QEngineShard& shard = shards[target];
 
-    PopStackedBasis2Qb(target);
+    PopHBasis2Qb(target);
 
     if (!shard.isPlusMinus) {
         if (PHASE_MATTERS(shard)) {
@@ -1249,7 +1249,7 @@ void QUnit::ApplySingleInvert(const complex topRight, const complex bottomLeft, 
 {
     QEngineShard& shard = shards[target];
 
-    PopStackedBasis2Qb(target);
+    PopHBasis2Qb(target);
 
     if (!PHASE_MATTERS(shard)) {
         X(target);
@@ -1305,9 +1305,11 @@ void QUnit::ApplyControlledSinglePhase(const bitLenInt* cControls, const bitLenI
     QEngineShard& tShard = shards[cTarget];
     QEngineShard& cShard = shards[cControls[0]];
 
-    PopStackedBasis2Qb(cTarget);
-    for (bitLenInt i = 0; i < controlLen; i++) {
-        PopStackedBasis2Qb(cControls[i]);
+    if (!freezeBasis || (controlLen != 1U)) {
+        PopHBasis2Qb(cTarget);
+        for (bitLenInt i = 0; i < controlLen; i++) {
+            PopHBasis2Qb(cControls[i]);
+        }
     }
 
     if (!freezeBasis && (controlLen == 1U)) {

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -41,6 +41,7 @@
 #define UNSAFE_CACHED_ZERO(shard) (UNSAFE_CACHED_CLASSICAL(shard) && !SHARD_STATE(shard))
 #define PHASE_MATTERS(shard) (!randGlobalPhase || !CACHED_CLASSICAL(shard))
 #define DIRTY(shard) (shard.isPhaseDirty || shard.isProbDirty)
+#define IS_POSITIVE_REAL(c) (abs(imag(c)) < min_norm) && (real(c) > (ONE_R1 - min_norm))
 
 namespace Qrack {
 
@@ -1302,7 +1303,7 @@ void QUnit::ApplyControlledSinglePhase(const bitLenInt* cControls, const bitLenI
     std::copy(cControls, cControls + controlLen, controls);
     bitLenInt target = cTarget;
 
-    if ((abs(imag(topLeft)) < min_norm) && (real(topLeft) > (ONE_R1 - min_norm))) {
+    if (IS_POSITIVE_REAL(topLeft)) {
         if (CACHED_ZERO(shards[target])) {
             delete[] controls;
             return;
@@ -1318,8 +1319,7 @@ void QUnit::ApplyControlledSinglePhase(const bitLenInt* cControls, const bitLenI
         }
     }
 
-    if ((abs(imag(bottomRight)) < min_norm) && (real(bottomRight) > (ONE_R1 - min_norm)) &&
-        CACHED_ONE(shards[target])) {
+    if (IS_POSITIVE_REAL(bottomRight) && CACHED_ONE(shards[target])) {
         delete[] controls;
         return;
     }
@@ -1369,11 +1369,7 @@ void QUnit::ApplyAntiControlledSinglePhase(const bitLenInt* cControls, const bit
     std::copy(cControls, cControls + controlLen, controls);
     bitLenInt target = cTarget;
 
-    if ((abs(imag(topLeft)) < min_norm) && (real(topLeft) > (ONE_R1 - min_norm)) && CACHED_ZERO(shard)) {
-        delete[] controls;
-        return;
-    }
-    if ((abs(imag(bottomRight)) < min_norm) && (real(bottomRight) > (ONE_R1 - min_norm)) && CACHED_ONE(shard)) {
+    if ((IS_POSITIVE_REAL(topLeft) && CACHED_ZERO(shard)) || (IS_POSITIVE_REAL(bottomRight) && CACHED_ONE(shard))) {
         delete[] controls;
         return;
     }

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1193,9 +1193,6 @@ void QUnit::CZ(bitLenInt control, bitLenInt target)
     QEngineShard& tShard = shards[target];
     QEngineShard& cShard = shards[control];
 
-    PopStackedBasis2Qb(target);
-    PopStackedBasis2Qb(control);
-
     if (CACHED_ZERO(tShard) || CACHED_ZERO(cShard)) {
         return;
     }
@@ -1221,8 +1218,6 @@ void QUnit::CZ(bitLenInt control, bitLenInt target)
 void QUnit::ApplySinglePhase(const complex topLeft, const complex bottomRight, bool doCalcNorm, bitLenInt target)
 {
     QEngineShard& shard = shards[target];
-
-    PopStackedBasis2Qb(target);
 
     if (!PHASE_MATTERS(shard)) {
         return;

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -2774,20 +2774,6 @@ void QUnit::TransformBasis1Qb(const bool& toPlusMinus, const bitLenInt& i)
     freezeBasis = false;
 }
 
-void QUnit::TransformBasis1Qb(const bool& toPlusMinus, QEngineShard& shard)
-{
-    if (freezeBasis || (toPlusMinus == shard.isPlusMinus)) {
-        // Recursive call that should be blocked,
-        // or already in target basis.
-        return;
-    }
-
-    freezeBasis = true;
-    H(FindShardIndex(shard));
-    shard.isPlusMinus = toPlusMinus;
-    freezeBasis = false;
-}
-
 void QUnit::RevertBasis2Qb(const bitLenInt& i)
 {
     QEngineShard& shard = shards[i];

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1133,9 +1133,7 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
     QEngineShard& cShard = shards[control];
     QEngineShard& tShard = shards[target];
 
-    PopStackedBasis2Qb(control);
     RevertBasis2Qb(control);
-    PopStackedBasis2Qb(control);
     RevertBasis2Qb(target);
 
     // We're free to transform gates to any orthonormal basis of the Hilbert space.
@@ -1409,7 +1407,6 @@ void QUnit::ApplySingleBit(const complex* mtrx, bool doCalcNorm, bitLenInt targe
 
     QEngineShard& shard = shards[target];
 
-    PopStackedBasis2Qb(target);
     RevertBasis2Qb(target);
 
     complex trnsMtrx[4];
@@ -1547,7 +1544,6 @@ void QUnit::ApplyEitherControlled(const bitLenInt* controls, const bitLenInt& co
     }
 
     for (i = 0; i < targets.size(); i++) {
-        PopStackedBasis2Qb(targets[i]);
         RevertBasis2Qb(targets[i]);
     }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -102,6 +102,16 @@ void QUnit::SetQuantumState(const complex* inputState)
     for (bitLenInt idx = 0; idx < qubitCount; idx++) {
         shards[idx] = QEngineShard(unit, idx);
     }
+
+    if (qubitCount == 1U) {
+        QEngineShard& shard = shards[0];
+        shard.isEmulated = false;
+        shard.isProbDirty = false;
+        shard.isPhaseDirty = false;
+        shard.amp0 = inputState[0];
+        shard.amp1 = inputState[1];
+        shard.isPlusMinus = false;
+    }
 }
 
 void QUnit::GetQuantumState(complex* outputState)

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -51,9 +51,9 @@ QInterfacePtr MakeRandQubit()
         rng, ONE_CMPLX, enable_normalization, true, false, device_id, !disable_hardware_rng);
 
     real1 prob = qubit->Rand();
-    real1 angle = 2 * M_PI * qubit->Rand();
+    complex phaseFactor = std::polar(ONE_R1, (real1)(2 * M_PI * qubit->Rand()));
 
-    complex state[2] = { sqrt(ONE_R1 - prob), sqrt(prob) * angle };
+    complex state[2] = { sqrt(ONE_R1 - prob), sqrt(prob) * phaseFactor };
     qubit->SetQuantumState(state);
 
     return qubit;

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -53,7 +53,7 @@ QInterfacePtr MakeRandQubit()
     real1 prob = qubit->Rand();
     complex phaseFactor = std::polar(ONE_R1, (real1)(2 * M_PI * qubit->Rand()));
 
-    complex state[2] = { sqrt(ONE_R1 - prob), sqrt(prob) * phaseFactor };
+    complex state[2] = { (real1)sqrt(ONE_R1 - prob), ((real1)sqrt(prob)) * phaseFactor };
     qubit->SetQuantumState(state);
 
     return qubit;

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -617,3 +617,34 @@ TEST_CASE("test_cosmology", "[cosmos]")
         },
         false, false, false, true);
 }
+
+TEST_CASE("test_cosmology_2", "[cosmos]")
+{
+    // Inspired by https://arxiv.org/abs/1702.06959
+    // This is "scratch work." If the (inverse) DFT is truly maximally entangling, it might not be appropriate to
+    // iterate it as a time-step, because this then consumes the entire entropy budget of the Hubble sphere in one step.
+    // Further, deterministic progression toward higher entanglement, and therefore higher effective entropy, assumes a
+    // fixed direction for the "arrow of time." Given the time symmetry of unitary evolution, hopefully, the
+    // thermodynamic arrow of time would be emergent in a very-early-universe model, rather than assumed to be fixed. As
+    // such, suppose that there is locally a 0.5/0.5 of 1.0 probability for either direction of apparent time in step,
+    // represented by randomly choosing QFT or inverse on a local region. Further, initially indepedent regions cannot
+    // be causally influenced by distant regions faster than the speed of light, where the light cone grows at a rate of
+    // one Planck distance per Planck time. However, we assume that causally disconnected regions develop local
+    // entanglement in parallel. (We must acknowledge, it is apparent to us that this is a significantly easier problem
+    // for Qrack::QUnit.)
+
+    benchmarkLoop(
+        [](QInterfacePtr qUniverse, int n) {
+            int t, x;
+            for (t = 1; t < n; t++) {
+                for (x = 0; x < (n / t); x++) {
+                    if (qUniverse->Rand() < (ONE_R1 / 2)) {
+                        qUniverse->QFT(x * t, t);
+                    } else {
+                        qUniverse->IQFT(x * t, t);
+                    }
+                }
+            }
+        },
+        false, false, false, true);
+}

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -611,7 +611,7 @@ TEST_CASE("test_cosmology", "[cosmos]")
     // number of subsystems is due to resource limit for our model, but it might effectively represent an entanglement
     // or "entropy" budget for a closed universe; the time to maximum entanglement for "n" available qubits should be
     // "n" Planck time steps on average. (The von Neumann entropy actually remains 0, in this entire simulation, as the
-    // state is pure and involves in a unitary fashion, but, if unitary evolution holds for the entire real physical
+    // state is pure and evolves in a unitary fashion, but, if unitary evolution holds for the entire real physical
     // cosmological system of our universe, then this entangling action gives rise to the appearance of non-zero von
     // Neumann entropy of a mixed state.)  We limit to the 1 spatial + 1 time dimension case.
     //
@@ -628,7 +628,7 @@ TEST_CASE("test_cosmology", "[cosmos]")
     // entanglement in parallel. However, if we took a longer time step, an integer multiple of the Planck time, then
     // higher order QFTs would be needed to simulate the step. Probably, the most accurate simulation would take the
     // "squarest" possible time step by space step, but then this is simply a single QFT or its inverse for the entire
-    // "entropy budget" of the space. (We must acknowledge, it is apparent to us that this simulation we choose is a
+    // entropy budget of the space. (We must acknowledge, it is apparent to us that this simulation we choose is a
     // problem that can be made relatively easy for Qrack::QUnit.)
 
     // "RandInit" -
@@ -673,7 +673,11 @@ TEST_CASE("test_cosmology", "[cosmos]")
                 // Orbifold the last and first bits.
                 qUniverse->ROL(TStep, 0, n);
                 for (x = 0; x < TStep; x++) {
-                    qUniverse->QFT(x, TStep + 1U);
+                    if (qUniverse->Rand() < (ONE_R1 / 2)) {
+                        qUniverse->QFT(x, TStep + 1U);
+                    } else {
+                        qUniverse->IQFT(x, TStep + 1U);
+                    }
                 }
                 qUniverse->ROR(TStep, 0, n);
             }

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -637,11 +637,12 @@ TEST_CASE("test_cosmology_2", "[cosmos]")
         [](QInterfacePtr qUniverse, int n) {
             int t, x;
             for (t = 1; t < n; t++) {
-                for (x = 0; x < (n / t); x++) {
+                // TODO: We hit an array boundary, so we use (n-t), but orbifold this
+                for (x = 0; x < (n-t); x++) {
                     if (qUniverse->Rand() < (ONE_R1 / 2)) {
-                        qUniverse->QFT(x * t, t);
+                        qUniverse->QFT(x, t);
                     } else {
-                        qUniverse->IQFT(x * t, t);
+                        qUniverse->IQFT(x, t);
                     }
                 }
             }

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -47,8 +47,8 @@ double formatTime(double t, bool logNormal)
 
 QInterfacePtr MakeRandQubit()
 {
-    QInterfacePtr qubit = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, ONE_BCI, 0,
-        rng, ONE_CMPLX, enable_normalization, true, false, device_id, !disable_hardware_rng);
+    QInterfacePtr qubit = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 1U, 0, rng,
+        ONE_CMPLX, enable_normalization, true, false, device_id, !disable_hardware_rng);
 
     real1 prob = qubit->Rand();
     complex phaseFactor = std::polar(ONE_R1, (real1)(2 * M_PI * qubit->Rand()));

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -648,7 +648,7 @@ TEST_CASE("test_cosmology", "[cosmos]")
     const bool UseTDepth = true;
     const int TDepth = 8;
     // Time step of simulation, (in "Planck times")
-    const bitLenInt TStep = 2;
+    const bitLenInt TStep = 1;
     // If true, loop the parallel local evolution back around on the boundaries of the qubit array.
     const bool DoOrbifold = true;
 
@@ -683,4 +683,19 @@ TEST_CASE("test_cosmology", "[cosmos]")
             }
         },
         false, false, false, RandInit);
+}
+
+TEST_CASE("test_qft_cosmology", "[cosmos]")
+{
+    // This is "scratch work" inspired by https://arxiv.org/abs/1702.06959
+    //
+    // Per the notes in the previous test, this is probably our most accurate possible simulation of a cosmos: one QFT
+    // (or inverse) to consume the entire "entropy" budget.
+    //
+    // Note that, when choosing between QFT and inverse QFT, AKA inverse DFT and DFT respectively, the choice of the QFT
+    // over the IQFT is not entirely arbitrary: we are mapping from a single phase in the phase space of potential
+    // universes to a single coordinate. Remember that we initialize as a collection of entirely random, single,
+    // separable qubits.
+
+    benchmarkLoop([&](QInterfacePtr qUniverse, int n) { qUniverse->QFT(0, n); }, false, false, false, true);
 }

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -694,7 +694,7 @@ TEST_CASE("test_qft_cosmology", "[cosmos]")
     //
     // Note that, when choosing between QFT and inverse QFT, AKA inverse DFT and DFT respectively, the choice of the QFT
     // over the IQFT is not entirely arbitrary: we are mapping from a single phase in the phase space of potential
-    // universes to a single coordinate. Remember that we initialize as a collection of entirely random, single,
+    // universes to a single configuration. Remember that we initialize as a collection of entirely random, single,
     // separable qubits.
 
     benchmarkLoop([&](QInterfacePtr qUniverse, int n) { qUniverse->QFT(0, n); }, false, false, false, true);

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -615,5 +615,5 @@ TEST_CASE("test_cosmology", "[cosmos]")
                 qUniverse->QFT(0, n);
             }
         },
-        false, false, testEngineType == QINTERFACE_QUNIT);
+        false, false, false, true);
 }

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -655,7 +655,7 @@ TEST_CASE("test_cosmology", "[cosmos]")
     benchmarkLoop(
         [&](QInterfacePtr qUniverse, int n) {
             int t, x;
-            int tMax = UseTDepth ? n : TDepth;
+            int tMax = UseTDepth ? TDepth : n;
 
             for (t = 1; t < tMax; t += TStep) {
                 for (x = 0; x < (n - TStep); x++) {

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -634,18 +634,18 @@ TEST_CASE("test_cosmology", "[cosmos]")
     // eigenstate, then maybe we can call each initial state the local |0> state, by convention. (This might not
     // actually be self-consistent; the limitation on causality and homogeneity might preempt the validity of this
     // initialization. It might still be an interesting case to consider, and to debug with.)
-    const bool randInit = true;
+    const bool RandInit = true;
 
     // "tDepth"
     // true - for "n" qubits, simulate time to depth "n"
-    // false - simulate to at most "depth" time steps
-    const bool tDepth = true;
-    const int depth = 8;
+    // false - simulate to "depth" time steps
+    const bool TDepth = true;
+    const int Depth = 8;
 
     benchmarkLoop(
         [&](QInterfacePtr qUniverse, int n) {
             int t, x;
-            int tMax = (tDepth || (depth > n)) ? n : depth;
+            int tMax = TDepth ? n : Depth;
             bitLenInt low, high;
 
             for (t = 1; t < tMax; t++) {
@@ -669,5 +669,5 @@ TEST_CASE("test_cosmology", "[cosmos]")
                 qUniverse->H(high);
             }
         },
-        false, false, false, randInit);
+        false, false, false, RandInit);
 }


### PR DESCRIPTION
This tidies up some work that was left partially finished on phase gate optimization in QUnit. Further, last night, I read "Quantum Circuit Cosmology: The Expansion of the Universe Since the First Qubit" (https://arxiv.org/abs/1702.06959) and I was really impressed by it, and I thought it would make a great benchmark (or set thereof).

In the process of tinkering with QUnit for the benchmark, the ProjectQ unit tests broke. The piece of code that primarily precipitated this starts on line 107 of qunit.cpp. The offending code, however, was line 42, where we had been missing a negation on a check for `randGlobalPhase`. Trying to diagnose and fix that, I corrected a number of sloppy floating point value checks. However, the maximum qubit case of the ProjectQ state preparation decomposition checks still failed in CI at the end of this debugging process, but I can't reproduce the failure on my local machine. (I wonder if a package version change sneaked into the CI overnight, while the branch was truly broken and I wasn't paying attention to the repeatedly failing CI.) Seeing as this same test passes on my local development machine, and as it's only the largest case of a test that iterates over parameters, I'm not particularly concerned by this failure, for the moment. For the work of this branch, the phase logic is clearly more correct overall, in edge cases.

The work of the benchmark is my first attempt at turning "Quantum Circuit Cosmology..." into a practical circuit. It will be modified in the future. Explanation of my reasoning is included in comments on the test. However, whether it's right as cosmology, it makes a good benchmark, particularly for my experiments with "Fourier basis" optimizations for QUnit. (Maybe, for our friend looking for fractal emergence in quantum circuits, if you can't find them in a cosmological model of the emergence of the macroscopic world from a cosmological pure quantum state, I don't know where you're going to find them!)