### PR TITLE
Sparse state vector optimization (Gottesman-Knill)

### DIFF
--- a/include/common/parallel_for.hpp
+++ b/include/common/parallel_for.hpp
@@ -12,7 +12,6 @@
 
 #pragma once
 
-#include <functional>
 #include <vector>
 
 /* Needed for bitCapInt typedefs. */
@@ -37,10 +36,6 @@ public:
     /*
      * Parallelization routines for spreading work across multiple cores.
      */
-
-    /** Called once per value between begin and end. */
-    typedef std::function<void(const bitCapInt, const int cpu)> ParallelFunc;
-    typedef std::function<bitCapInt(const bitCapInt, const int cpu)> IncrementFunc;
 
     /**
      * Iterate through the permutations a maximum of end-begin times, allowing

--- a/include/common/parallel_for.hpp
+++ b/include/common/parallel_for.hpp
@@ -64,6 +64,10 @@ public:
     /** Iterate over a sparse state vector. */
     void par_for_set(const std::set<bitCapInt>& sparseSet, ParallelFunc fn);
 
+    /** Iterate over the power set of 2 sparse state vectors. */
+    void par_for_sparse_compose(const std::set<bitCapInt>& lowSet, const std::set<bitCapInt>& highSet,
+        const bitLenInt& highStart, ParallelFunc fn);
+
     /** Calculate the normal for the array. */
     real1 par_norm(const bitCapInt maxQPower, const StateVectorPtr stateArray);
 };

--- a/include/common/qrack_types.hpp
+++ b/include/common/qrack_types.hpp
@@ -12,6 +12,7 @@
 
 #pragma once
 
+#include <functional>
 #include <memory>
 #include <random>
 
@@ -72,6 +73,10 @@ typedef double real1;
 
 namespace Qrack {
 typedef std::shared_ptr<complex> BitOp;
+
+/** Called once per value between begin and end. */
+typedef std::function<void(const bitCapInt, const int cpu)> ParallelFunc;
+typedef std::function<bitCapInt(const bitCapInt, const int cpu)> IncrementFunc;
 
 void mul2x2(complex* left, complex* right, complex* out);
 void exp2x2(complex* matrix2x2, complex* outMatrix2x2);

--- a/include/qengine.hpp
+++ b/include/qengine.hpp
@@ -12,8 +12,9 @@
 
 #pragma once
 
-#include "qinterface.hpp"
 #include <algorithm>
+
+#include "qinterface.hpp"
 
 namespace Qrack {
 

--- a/include/qengine_cpu.hpp
+++ b/include/qengine_cpu.hpp
@@ -15,10 +15,9 @@
 #include <algorithm>
 #include <memory>
 
+#include "common/parallel_for.hpp"
 #include "qengine.hpp"
 #include "statevector.hpp"
-
-#include "common/parallel_for.hpp"
 
 namespace Qrack {
 

--- a/include/qengine_cpu.hpp
+++ b/include/qengine_cpu.hpp
@@ -12,7 +12,6 @@
 
 #pragma once
 
-#include <algorithm>
 #include <memory>
 
 #include "common/parallel_for.hpp"

--- a/include/statevector.hpp
+++ b/include/statevector.hpp
@@ -226,7 +226,6 @@ public:
     {
         bitCapInt unsetMask = ~setMask;
         bitCapInt unfilterMask = ~filterMask;
-        bitCapInt val;
         std::set<bitCapInt> toRet;
 
         mtx.lock();
@@ -234,10 +233,7 @@ public:
         std::map<bitCapInt, complex>::const_iterator it = amplitudes.begin();
         while (it != amplitudes.end()) {
             if ((it->first & filterMask) == filterValues) {
-                val = (it->first & unsetMask & unfilterMask);
-                if (toRet.find(val) == toRet.end()) {
-                    toRet.insert(val);
-                }
+                toRet.insert(it->first & unsetMask & unfilterMask);
             }
             it++;
         }

--- a/src/common/parallel_for.cpp
+++ b/src/common/parallel_for.cpp
@@ -129,6 +129,25 @@ void ParallelFor::par_for_set(const std::set<bitCapInt>& sparseSet, ParallelFunc
         fn);
 }
 
+void ParallelFor::par_for_sparse_compose(
+    const std::set<bitCapInt>& lowSet, const std::set<bitCapInt>& highSet, const bitLenInt& highStart, ParallelFunc fn)
+{
+    bitCapInt lowSize = lowSet.size();
+    par_for_inc(0, lowSize * highSet.size(),
+        [&lowSize, &highStart, &lowSet, &highSet](const bitCapInt i, int cpu) {
+            bitCapInt lowPerm = i % lowSet.size();
+            bitCapInt highPerm = (i - lowPerm) / lowSet.size();
+            auto it = lowSet.begin();
+            std::advance(it, lowPerm);
+            bitCapInt perm = *it;
+            it = highSet.begin();
+            std::advance(it, highPerm);
+            perm |= *it << highStart;
+            return perm;
+        },
+        fn);
+}
+
 void ParallelFor::par_for_skip(
     const bitCapInt begin, const bitCapInt end, const bitCapInt skipMask, const bitLenInt maskWidth, ParallelFunc fn)
 {

--- a/src/qengine/state.cpp
+++ b/src/qengine/state.cpp
@@ -569,17 +569,19 @@ real1 QEngineCPU::Prob(bitLenInt qubit)
     }
 
     bitCapInt qPower = pow2(qubit);
-    bitCapInt qMask = qPower - ONE_BCI;
     real1 oneChance = 0;
 
     int numCores = GetConcurrencyLevel();
     real1* oneChanceBuff = new real1[numCores]();
 
-    par_for(0, maxQPower >> ONE_BCI, [&](const bitCapInt lcv, const int cpu) {
-        bitCapInt i = lcv & qMask;
-        i |= ((lcv ^ i) << ONE_BCI) | qPower;
-        oneChanceBuff[cpu] += norm(stateVec->read(i));
-    });
+    ParallelFunc fn = [&](const bitCapInt lcv, const int cpu) {
+        oneChanceBuff[cpu] += norm(stateVec->read(lcv | qPower));
+    };
+    if (stateVec->is_sparse()) {
+        par_for_set(stateVec->iterable(qPower, qPower, qPower), fn);
+    } else {
+        par_for_skip(0, maxQPower, qPower, 1U, fn);
+    }
 
     for (int i = 0; i < numCores; i++) {
         oneChance += oneChanceBuff[i];
@@ -612,8 +614,12 @@ real1 QEngineCPU::ProbReg(const bitLenInt& start, const bitLenInt& length, const
 
     bitCapInt perm = permutation << start;
 
-    par_for_skip(0, maxQPower, pow2(start), length,
-        [&](const bitCapInt lcv, const int cpu) { probs[cpu] += norm(stateVec->read(lcv | perm)); });
+    ParallelFunc fn = [&](const bitCapInt lcv, const int cpu) { probs[cpu] += norm(stateVec->read(lcv | perm)); };
+    if (stateVec->is_sparse()) {
+        par_for_set(stateVec->iterable(0, bitRegMask(start, length), perm), fn);
+    } else {
+        par_for_skip(0, maxQPower, pow2(start), length, fn);
+    }
 
     real1 prob = ZERO_R1;
     for (int thrd = 0; thrd < num_threads; thrd++) {

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -704,8 +704,18 @@ TEST_CASE("test_n_bell", "[stabilizer]")
 {
     benchmarkLoop([](QInterfacePtr qftReg, int n) {
         qftReg->H(0);
-        for (bitLenInt i = 0; i < n; i++) {
-            qftReg->CNOT(0, i);
+        for (bitLenInt i = 0; i < (n - 1); i++) {
+            qftReg->CNOT(i, i + 1U);
+        }
+    });
+}
+
+TEST_CASE("test_repeat_h_cnot", "[stabilizer]")
+{
+    benchmarkLoop([](QInterfacePtr qftReg, int n) {
+        for (bitLenInt i = 0; i < (n - 1); i++) {
+            qftReg->H(i);
+            qftReg->CNOT(i, i + 1U);
         }
     });
 }

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -103,7 +103,7 @@ void benchmarkLoopVariable(std::function<void(QInterfacePtr, int)> fn, bitLenInt
         QInterfacePtr qftReg = NULL;
         if (!qUniverse) {
             qftReg = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, numBits, 0, rng,
-                ONE_CMPLX, enable_normalization, true, false, device_id, !disable_hardware_rng);
+                ONE_CMPLX, enable_normalization, true, false, device_id, !disable_hardware_rng, sparse);
         }
         avgt = 0.0;
 
@@ -698,4 +698,14 @@ TEST_CASE("test_qft_cosmology", "[cosmos]")
     // separable qubits.
 
     benchmarkLoop([&](QInterfacePtr qUniverse, int n) { qUniverse->QFT(0, n); }, false, false, false, true);
+}
+
+TEST_CASE("test_n_bell", "[stabilizer]")
+{
+    benchmarkLoop([](QInterfacePtr qftReg, int n) {
+        qftReg->H(0);
+        for (bitLenInt i = 0; i < n; i++) {
+            qftReg->CNOT(0, i);
+        }
+    });
 }

--- a/test/benchmarks_main.cpp
+++ b/test/benchmarks_main.cpp
@@ -29,6 +29,7 @@ qrack_rand_gen_ptr rng;
 bool enable_normalization = false;
 bool disable_hardware_rng = false;
 bool async_time = false;
+bool sparse = false;
 int device_id = -1;
 bitLenInt max_qubits = 24;
 bool single_qubit_run = false;
@@ -77,7 +78,9 @@ int main(int argc, char* argv[])
         Opt(isBinaryOutput)["--binary-output"]("If included, specifies that the --measure-output file "
                                                "type should be binary. (By default, it is "
                                                "human-readable.)") |
-        Opt(single_qubit_run)["--single"]("Only run single (maximum) qubit count for tests");
+        Opt(single_qubit_run)["--single"]("Only run single (maximum) qubit count for tests") |
+        Opt(sparse)["--sparse"](
+            "(For QEngineCPU, under QUnit:) Use a state vector optimized for sparse representation and iteration.");
 
     session.cli(cli);
 
@@ -200,7 +203,11 @@ int main(int argc, char* argv[])
     if (num_failed == 0 && qunit) {
         testEngineType = QINTERFACE_QUNIT;
         if (num_failed == 0 && cpu) {
-            session.config().stream() << "############ QUnit -> QEngine -> CPU ############" << std::endl;
+            if (sparse) {
+                session.config().stream() << "############ QUnit -> QEngine -> CPU (Sparse) ############" << std::endl;
+            } else {
+                session.config().stream() << "############ QUnit -> QEngine -> CPU ############" << std::endl;
+            }
             testSubEngineType = QINTERFACE_CPU;
             testSubEngineType = QINTERFACE_CPU;
             num_failed = session.run();
@@ -221,7 +228,11 @@ int main(int argc, char* argv[])
         testEngineType = QINTERFACE_QUNIT;
         testSubEngineType = QINTERFACE_QFUSION;
         if (num_failed == 0 && cpu) {
-            session.config().stream() << "############ QUnit -> QFusion -> CPU ############" << std::endl;
+            if (sparse) {
+                session.config().stream() << "############ QUnit -> QFusion -> CPU (Sparse) ############" << std::endl;
+            } else {
+                session.config().stream() << "############ QUnit -> QFusion -> CPU ############" << std::endl;
+            }
             testSubSubEngineType = QINTERFACE_CPU;
             num_failed = session.run();
         }

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -4339,3 +4339,20 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_qneuron")
         REQUIRE(comp == test);
     }
 }
+
+TEST_CASE_METHOD(QInterfaceTestFixture, "test_n_bell")
+{
+    int i;
+
+    qftReg->SetPermutation(10);
+
+    qftReg->H(0);
+    for (i = 0; i <= 18; i++) {
+        qftReg->CNOT(i, i + 1U);
+    }
+    for (i = 18; i >= 0; i--) {
+        qftReg->CNOT(i, i + 1U);
+    }
+    qftReg->H(0);
+    REQUIRE_THAT(qftReg, HasProbability(0, 20, 10));
+}

--- a/test/tests.hpp
+++ b/test/tests.hpp
@@ -33,6 +33,7 @@ extern qrack_rand_gen_ptr rng;
 extern bool enable_normalization;
 extern bool disable_hardware_rng;
 extern bool async_time;
+extern bool sparse;
 extern int device_id;
 extern bitLenInt max_qubits;
 extern bool single_qubit_run;


### PR DESCRIPTION
QUnit lacks intrinsic support for fundamentally optimized preparation of Bell pairs, and similar states. To my knowledge, this is the only case missing (from CNOT) in order to cover a full stabilizer (Clifford) algebra.

However, it occurred to me, this one case that QUnit can't handle on its own results in states that are amenable to the "sparse state vector" optimization constructor option. Some minor tweaks to `Prob()` and `Compose()` result in an efficient stabilizer simulator super set!

This optimization isn't a 100% general optimization for QUnit, and it can't operate at all with QEngineOCL, but it's an important case! We might now start to quantify exactly how far we have extended "fundamentally efficient" simulation in QUnit to past and including a full Clifford algebra.