### PR TITLE
H / controlled phase optimization commutation; "solved circuit" demonstration

### DIFF
--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -2767,18 +2767,15 @@ void QUnit::RevertBasis2Qb(const bitLenInt& i)
 {
     QEngineShard& shard = shards[i];
 
-    if (!QUEUED_PHASE(shard)) {
-        return;
-    }
-
-    TransformBasis1Qb(false, i);
-
-    if (freezeBasis) {
-        // Recursive calls stop here
+    if (freezeBasis || !QUEUED_PHASE(shard)) {
+        // Recursive call that should be blocked,
+        // or already in target basis.
         return;
     }
 
     bitLenInt controls[1];
+    complex polar0, polar1;
+    complex mtrx[4];
 
     ShardToPhaseMap::iterator phaseShard;
     while (shard.targetOfShards.size() > 0) {
@@ -2786,15 +2783,27 @@ void QUnit::RevertBasis2Qb(const bitLenInt& i)
         QEngineShardPtr partner = phaseShard->first;
         bitLenInt j = FindShardIndex(*partner);
 
-        TransformBasis1Qb(false, j);
         controls[0] = j;
 
-        complex polar0 = std::polar(ONE_R1, phaseShard->second.angle0 / 2);
-        complex polar1 = std::polar(ONE_R1, phaseShard->second.angle1 / 2);
+        polar0 = std::polar(ONE_R1, phaseShard->second.angle0 / 2);
+        polar1 = std::polar(ONE_R1, phaseShard->second.angle1 / 2);
 
-        freezeBasis = true;
-        ApplyControlledSinglePhase(controls, 1U, i, polar0, polar1);
-        freezeBasis = false;
+        if (shards[i].isPlusMinus) {
+            mtrx[0] = (polar0 + polar1) / (ONE_R1 * 2);
+            mtrx[1] = (polar0 - polar1) / (ONE_R1 * 2);
+            mtrx[2] = mtrx[1];
+            mtrx[3] = mtrx[0];
+
+            shards[i].isPlusMinus = false;
+            freezeBasis = true;
+            ApplyControlledSingleBit(controls, 1U, i, mtrx);
+            freezeBasis = false;
+            shards[i].isPlusMinus = true;
+        } else {
+            freezeBasis = true;
+            ApplyControlledSinglePhase(controls, 1U, i, polar0, polar1);
+            freezeBasis = false;
+        }
 
         shard.RemovePhaseControl(partner);
     }
@@ -2805,14 +2814,25 @@ void QUnit::RevertBasis2Qb(const bitLenInt& i)
         QEngineShard* partner = phaseShard->first;
         bitLenInt j = FindShardIndex(*partner);
 
-        TransformBasis1Qb(false, j);
+        polar0 = std::polar(ONE_R1, phaseShard->second.angle0 / 2);
+        polar1 = std::polar(ONE_R1, phaseShard->second.angle1 / 2);
 
-        complex polar0 = std::polar(ONE_R1, phaseShard->second.angle0 / 2);
-        complex polar1 = std::polar(ONE_R1, phaseShard->second.angle1 / 2);
+        if (shards[j].isPlusMinus) {
+            mtrx[0] = (polar0 + polar1) / (ONE_R1 * 2);
+            mtrx[1] = (polar0 - polar1) / (ONE_R1 * 2);
+            mtrx[2] = mtrx[1];
+            mtrx[3] = mtrx[0];
 
-        freezeBasis = true;
-        ApplyControlledSinglePhase(controls, 1U, j, polar0, polar1);
-        freezeBasis = false;
+            shards[j].isPlusMinus = false;
+            freezeBasis = true;
+            ApplyControlledSingleBit(controls, 1U, j, mtrx);
+            freezeBasis = false;
+            shards[j].isPlusMinus = true;
+        } else {
+            freezeBasis = true;
+            ApplyControlledSinglePhase(controls, 1U, j, polar0, polar1);
+            freezeBasis = false;
+        }
 
         shard.RemovePhaseTarget(partner);
     }

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -926,9 +926,7 @@ void QUnit::H(bitLenInt target)
     QEngineShard& shard = shards[target];
 
     if (!freezeBasis) {
-        if (QUEUED_PHASE(shard)) {
-            ToPermBasis(target);
-        }
+        RevertBasis2Qb(target);
         shard.isPlusMinus = !shard.isPlusMinus;
         return;
     }


### PR DESCRIPTION
I wonder whether caching controlled phase gates in QUnit was the most useful optimization, but it at least doesn't have to hurt H gate basis transformation optimizations, we see in this PR. When we need to clear controlled phase gate buffers, I think it's literally not possible to "fuse" them as controlled single bit gates with H gates cached behind them in the queue, but we can transform the controlled phase target to bring the H gate basis transformation to the other side of application of the controlled phase gate. This is actually quite important, for further work basis transformation optimizations.

Additionally, I added a benchmark that randomly selects from a set of gates that can all be executed "efficiently" together, to form random circuits. I believe the set does not fully cover a Clifford gate algebra, but I think it does contain some non-Clifford gates. Basis transformation optimization, starting with the H gates, might get us up to an arbitrary, finite order of "Fourier basis" plus non-Clifford gates, I suspect.