### PR TITLE
Windows debugging

### DIFF
--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -40,7 +40,9 @@ bool isOverflowAdd(bitCapInt inOutInt, bitCapInt inInt, const bitCapInt& signMas
 bool isOverflowSub(bitCapInt inOutInt, bitCapInt inInt, const bitCapInt& signMask, const bitCapInt& lengthPower);
 bitCapInt pushApartBits(const bitCapInt& perm, const bitCapInt* skipPowers, const bitLenInt skipPowersCount);
 bitCapInt intPow(bitCapInt base, bitCapInt power);
+#if ENABLE_UINT128
 std::ostream& operator<<(std::ostream& left, __uint128_t right);
+#endif
 inline bitCapInt pow2(const bitLenInt& p) { return ONE_BCI << p; }
 inline bitCapInt pow2Mask(const bitLenInt& p) { return (ONE_BCI << p) - ONE_BCI; }
 inline bitCapInt bitSlice(const bitLenInt& bit, const bitCapInt& source) { return (ONE_BCI << bit) & source; }

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -547,7 +547,7 @@ TEST_CASE("test_quantum_supremacy", "[supreme]")
 
     const int depth = 20;
 
-    benchmarkLoop([](QInterfacePtr qReg, int n) {
+    benchmarkLoop([&](QInterfacePtr qReg, int n) {
 
         // The test runs 2 bit gates according to a tiling sequence.
         // The 1 bit indicates +/- column offset.

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -479,7 +479,7 @@ TEST_CASE("test_solved_circuit", "[supreme]")
     const int GateCount2Qb = 3;
     const int Depth = 20;
 
-    benchmarkLoop([](QInterfacePtr qReg, int n) {
+    benchmarkLoop([&](QInterfacePtr qReg, int n) {
 
         int d;
         bitLenInt i;


### PR DESCRIPTION
I missed a usage of `__uint128_t` when the flag is off, and it became apparent in the Windows build. (As far as I know, the C++ compiler for Visual Studio does not support native 128 bit integral types at all.)