### PR TITLE
TryHCommute() for QUnit controlled phase buffers

### DIFF
--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -17,6 +17,8 @@
 
 #include "qinterface.hpp"
 
+#define ANGLE_MIN_NORM (4 * M_PI * min_norm)
+
 namespace Qrack {
 
 // "PhaseShard" optimizations are basically just a very specific "gate fusion" type optimization, where multiple gates
@@ -169,7 +171,7 @@ struct QEngineShard {
         // We can reduce our number of buffer instances by taking advantage of this kind of symmetry:
         ShardToPhaseMap::iterator controlShard = controlsShards.find(control);
         if (!targetOfShards[control].isInvert && (controlShard != controlsShards.end()) &&
-            (abs(controlShard->second.angle0) < (4 * M_PI * min_norm))) {
+            (abs(controlShard->second.angle0) < ANGLE_MIN_NORM)) {
             nAngle1 += controlShard->second.angle1;
             RemovePhaseTarget(control);
         }
@@ -187,8 +189,7 @@ struct QEngineShard {
             nAngle1 -= 4 * M_PI;
         }
 
-        if (!targetOfShards[control].isInvert && (abs(nAngle0) < (4 * M_PI * min_norm)) &&
-            (abs(nAngle1) < (4 * M_PI * min_norm))) {
+        if (!targetOfShards[control].isInvert && (abs(nAngle0) < ANGLE_MIN_NORM) && (abs(nAngle1) < ANGLE_MIN_NORM)) {
             // The buffer is equal to the identity operator, and it can be removed.
             RemovePhaseControl(control);
             return;

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -168,7 +168,8 @@ struct QEngineShard {
         // Buffers with "angle0" = 0 are actually symmetric (unchanged) under exchange of control and target.
         // We can reduce our number of buffer instances by taking advantage of this kind of symmetry:
         ShardToPhaseMap::iterator controlShard = controlsShards.find(control);
-        if ((controlShard != controlsShards.end()) && (abs(controlShard->second.angle0) < (4 * M_PI * min_norm))) {
+        if (!targetOfShards[control].isInvert && (controlShard != controlsShards.end()) &&
+            (abs(controlShard->second.angle0) < (4 * M_PI * min_norm))) {
             nAngle1 += controlShard->second.angle1;
             RemovePhaseTarget(control);
         }
@@ -186,7 +187,8 @@ struct QEngineShard {
             nAngle1 -= 4 * M_PI;
         }
 
-        if ((abs(nAngle0) < (4 * M_PI * min_norm)) && (abs(nAngle1) < (4 * M_PI * min_norm))) {
+        if (!targetOfShards[control].isInvert && (abs(nAngle0) < (4 * M_PI * min_norm)) &&
+            (abs(nAngle1) < (4 * M_PI * min_norm))) {
             // The buffer is equal to the identity operator, and it can be removed.
             RemovePhaseControl(control);
             return;
@@ -196,6 +198,13 @@ struct QEngineShard {
             targetOfShards[control].angle1 = nAngle1;
             control->controlsShards[this].angle1 = nAngle1;
         }
+    }
+
+    void AddInversionAngles(QEngineShardPtr control, real1 angle0Diff, real1 angle1Diff)
+    {
+        targetOfShards[control].isInvert = !targetOfShards[control].isInvert;
+        control->controlsShards[this].isInvert = !control->controlsShards[this].isInvert;
+        AddPhaseAngles(control, angle0Diff, angle1Diff);
     }
 
     /// If an "inversion" gate is applied to a qubit with controlled phase buffers, we can transform the buffers to

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -208,6 +208,27 @@ struct QEngineShard {
         }
     }
 
+    bool TryHCommute()
+    {
+        complex polar0, polar1;
+        ShardToPhaseMap::iterator phaseShard;
+        for (phaseShard = targetOfShards.begin(); phaseShard != targetOfShards.end(); phaseShard++) {
+            polar0 = std::polar(ONE_R1, phaseShard->second.angle0 / 2);
+            polar1 = std::polar(ONE_R1, phaseShard->second.angle1 / 2);
+            if (norm(polar0 - polar1) >= min_norm) {
+                return false;
+            }
+        }
+        for (phaseShard = controlsShards.begin(); phaseShard != controlsShards.end(); phaseShard++) {
+            polar0 = std::polar(ONE_R1, phaseShard->second.angle0 / 2);
+            polar1 = std::polar(ONE_R1, phaseShard->second.angle1 / 2);
+            if (norm(polar0 - polar1) >= min_norm) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     bool operator==(const QEngineShard& rhs) { return (mapped == rhs.mapped) && (unit == rhs.unit); }
     bool operator!=(const QEngineShard& rhs) { return (mapped != rhs.mapped) || (unit != rhs.unit); }
 };

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -202,8 +202,16 @@ struct QEngineShard {
 
     void AddInversionAngles(QEngineShardPtr control, real1 angle0Diff, real1 angle1Diff)
     {
-        targetOfShards[control].isInvert = !targetOfShards[control].isInvert;
-        control->controlsShards[this].isInvert = !control->controlsShards[this].isInvert;
+        MakePhaseControlledBy(control);
+
+        PhaseShard& targetOfShard = targetOfShards[control];
+        targetOfShard.isInvert = !targetOfShard.isInvert;
+        std::swap(targetOfShard.angle0, targetOfShard.angle1);
+
+        PhaseShard& controlShard = control->controlsShards[this];
+        controlShard.isInvert = !controlShard.isInvert;
+        std::swap(controlShard.angle0, controlShard.angle1);
+
         AddPhaseAngles(control, angle0Diff, angle1Diff);
     }
 

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -215,6 +215,18 @@ struct QEngineShard {
         AddPhaseAngles(control, angle0Diff, angle1Diff);
     }
 
+    bool isInvertControl()
+    {
+        ShardToPhaseMap::iterator phaseShard;
+        for (phaseShard = controlsShards.begin(); phaseShard != controlsShards.end(); phaseShard++) {
+            if (phaseShard->second.isInvert) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     /// If an "inversion" gate is applied to a qubit with controlled phase buffers, we can transform the buffers to
     /// commute, instead of incurring the cost of applying the buffers.
     void FlipPhaseAnti()

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -231,30 +231,36 @@ struct QEngineShard {
             }
         }
 
+        bool didFlip;
         for (phaseShard = targetOfShards.begin(); phaseShard != targetOfShards.end(); phaseShard++) {
             polar0 = std::polar(ONE_R1, phaseShard->second.angle0 / 2);
             polar1 = std::polar(ONE_R1, phaseShard->second.angle1 / 2);
+            didFlip = false;
             if (norm(polar0 - polar1) < min_norm) {
                 if (phaseShard->second.isInvert) {
-                    // targetsOfToFlip.push_back(phaseShard);
-                    return false;
+                    polar0 = (polar0 + polar1) / (2 * ONE_R1);
+                    polar1 = -polar0;
+                    didFlip = true;
                 }
             } else if (norm(polar0 + polar1) < min_norm) {
                 if (!phaseShard->second.isInvert) {
                     polar0 = (polar0 + polar1) / (2 * ONE_R1);
                     polar1 = polar0;
-
-                    phaseShard->second.isInvert = !phaseShard->second.isInvert;
-                    phaseShard->second.angle0 = ((2 * ONE_R1) * arg(polar0));
-                    phaseShard->second.angle1 = ((2 * ONE_R1) * arg(polar1));
-
-                    PhaseShard& remotePhase = phaseShard->first->controlsShards[this];
-                    remotePhase.isInvert = !remotePhase.isInvert;
-                    remotePhase.angle0 = phaseShard->second.angle0;
-                    remotePhase.angle1 = phaseShard->second.angle1;
+                    didFlip = true;
                 }
             } else {
                 return false;
+            }
+
+            if (didFlip) {
+                phaseShard->second.isInvert = !phaseShard->second.isInvert;
+                phaseShard->second.angle0 = ((2 * ONE_R1) * arg(polar0));
+                phaseShard->second.angle1 = ((2 * ONE_R1) * arg(polar1));
+
+                PhaseShard& remotePhase = phaseShard->first->controlsShards[this];
+                remotePhase.isInvert = !remotePhase.isInvert;
+                remotePhase.angle0 = phaseShard->second.angle0;
+                remotePhase.angle1 = phaseShard->second.angle1;
             }
         }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -926,7 +926,9 @@ void QUnit::H(bitLenInt target)
     QEngineShard& shard = shards[target];
 
     if (!freezeBasis) {
-        RevertBasis2Qb(target);
+        if (!shard.TryHCommute()) {
+            RevertBasis2Qb(target);
+        }
         shard.isPlusMinus = !shard.isPlusMinus;
         return;
     }

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1144,6 +1144,11 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
     QEngineShard& cShard = shards[control];
     QEngineShard& tShard = shards[target];
 
+    // if (!freezeBasis) {
+    //    tShard.AddInversionAngles(&cShard, 0, 0);
+    //    return;
+    //}
+
     RevertBasis2Qb(control);
     RevertBasis2Qb(target);
 
@@ -1350,6 +1355,12 @@ void QUnit::ApplyControlledSingleInvert(const bitLenInt* controls, const bitLenI
     const complex topRight, const complex bottomLeft)
 {
     if (!TryCnotOptimize(controls, controlLen, target, bottomLeft, topRight, false)) {
+
+        // if (!freezeBasis && (controlLen == 1U)) {
+        //    shards[target].AddInversionAngles(&(shards[controls[0]]), (real1)(2 * arg(topRight)), (real1)(2 *
+        //    arg(bottomLeft))); return;
+        //}
+
         CTRLED_INVERT_WRAP(ApplyControlledSingleInvert(CTRL_I_ARGS), ApplyControlledSingleBit(CTRL_GEN_ARGS),
             ApplySingleInvert(topRight, bottomLeft, true, target), false);
     }

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1139,10 +1139,13 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
     QEngineShard& cShard = shards[control];
     QEngineShard& tShard = shards[target];
 
-    // if (!freezeBasis) {
-    //    tShard.AddInversionAngles(&cShard, 0, 0);
-    //    return;
-    //}
+    if (!freezeBasis) {
+        if (tShard.isInvertControl()) {
+            RevertBasis2Qb(target);
+        }
+        tShard.AddInversionAngles(&cShard, 0, 0);
+        return;
+    }
 
     bitLenInt controls[1] = { control };
     bitLenInt controlLen = 1;
@@ -1355,11 +1358,14 @@ void QUnit::ApplyControlledSingleInvert(const bitLenInt* controls, const bitLenI
     const complex topRight, const complex bottomLeft)
 {
     if (!TryCnotOptimize(controls, controlLen, target, bottomLeft, topRight, false)) {
-
-        // if (!freezeBasis && (controlLen == 1U)) {
-        //    shards[target].AddInversionAngles(&(shards[controls[0]]), (real1)(2 * arg(topRight)), (real1)(2 *
-        //    arg(bottomLeft))); return;
-        //}
+        if (!freezeBasis && (controlLen == 1U)) {
+            QEngineShard& tShard = shards[target];
+            if (tShard.isInvertControl()) {
+                RevertBasis2Qb(target);
+            }
+            tShard.AddInversionAngles(&(shards[controls[0]]), (real1)(2 * arg(topRight)), (real1)(2 * arg(bottomLeft)));
+            return;
+        }
 
         CTRLED_INVERT_WRAP(ApplyControlledSingleInvert(CTRL_I_ARGS), ApplyControlledSingleBit(CTRL_GEN_ARGS),
             ApplySingleInvert(topRight, bottomLeft, true, target), false);

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -2796,10 +2796,17 @@ void QUnit::RevertBasis2Qb(const bitLenInt& i)
         polar1 = std::polar(ONE_R1, phaseShard->second.angle1 / 2);
 
         if (shards[i].isPlusMinus) {
-            mtrx[0] = (polar0 + polar1) / (ONE_R1 * 2);
-            mtrx[1] = (polar0 - polar1) / (ONE_R1 * 2);
-            mtrx[2] = mtrx[1];
-            mtrx[3] = mtrx[0];
+            if (phaseShard->second.isInvert) {
+                mtrx[0] = (polar0 + polar1) / (ONE_R1 * 2);
+                mtrx[1] = (-polar0 + polar1) / (ONE_R1 * 2);
+                mtrx[2] = (polar0 - polar1) / (ONE_R1 * 2);
+                mtrx[3] = (-polar0 - polar1) / (ONE_R1 * 2);
+            } else {
+                mtrx[0] = (polar0 + polar1) / (ONE_R1 * 2);
+                mtrx[1] = (polar0 - polar1) / (ONE_R1 * 2);
+                mtrx[2] = mtrx[1];
+                mtrx[3] = mtrx[0];
+            }
 
             shards[i].isPlusMinus = false;
             freezeBasis = true;
@@ -2808,7 +2815,11 @@ void QUnit::RevertBasis2Qb(const bitLenInt& i)
             shards[i].isPlusMinus = true;
         } else {
             freezeBasis = true;
-            ApplyControlledSinglePhase(controls, 1U, i, polar0, polar1);
+            if (phaseShard->second.isInvert) {
+                ApplyControlledSingleInvert(controls, 1U, i, polar0, polar1);
+            } else {
+                ApplyControlledSinglePhase(controls, 1U, i, polar0, polar1);
+            }
             freezeBasis = false;
         }
 
@@ -2825,10 +2836,17 @@ void QUnit::RevertBasis2Qb(const bitLenInt& i)
         polar1 = std::polar(ONE_R1, phaseShard->second.angle1 / 2);
 
         if (shards[j].isPlusMinus) {
-            mtrx[0] = (polar0 + polar1) / (ONE_R1 * 2);
-            mtrx[1] = (polar0 - polar1) / (ONE_R1 * 2);
-            mtrx[2] = mtrx[1];
-            mtrx[3] = mtrx[0];
+            if (phaseShard->second.isInvert) {
+                mtrx[0] = (polar0 + polar1) / (ONE_R1 * 2);
+                mtrx[1] = (-polar0 + polar1) / (ONE_R1 * 2);
+                mtrx[2] = (polar0 - polar1) / (ONE_R1 * 2);
+                mtrx[3] = (-polar0 - polar1) / (ONE_R1 * 2);
+            } else {
+                mtrx[0] = (polar0 + polar1) / (ONE_R1 * 2);
+                mtrx[1] = (polar0 - polar1) / (ONE_R1 * 2);
+                mtrx[2] = mtrx[1];
+                mtrx[3] = mtrx[0];
+            }
 
             shards[j].isPlusMinus = false;
             freezeBasis = true;
@@ -2837,7 +2855,11 @@ void QUnit::RevertBasis2Qb(const bitLenInt& i)
             shards[j].isPlusMinus = true;
         } else {
             freezeBasis = true;
-            ApplyControlledSinglePhase(controls, 1U, j, polar0, polar1);
+            if (phaseShard->second.isInvert) {
+                ApplyControlledSingleInvert(controls, 1U, j, polar0, polar1);
+            } else {
+                ApplyControlledSinglePhase(controls, 1U, j, polar0, polar1);
+            }
             freezeBasis = false;
         }
 

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -473,9 +473,9 @@ TEST_CASE("test_qft_superposition_round_trip", "[qft]")
         true, true, testEngineType == QINTERFACE_QUNIT);
 }
 
-TEST_CASE("test_solved_circuit", "[supreme]")
+TEST_CASE("test_solved_universal_circuit", "[supreme]")
 {
-    const int GateCount1Qb = 3;
+    const int GateCount1Qb = 4;
     const int GateCount2Qb = 3;
     const int Depth = 20;
 
@@ -494,6 +494,8 @@ TEST_CASE("test_solved_circuit", "[supreme]")
                     qReg->X(i);
                 } else if (gateRand < (2 * ONE_R1 / GateCount1Qb)) {
                     qReg->Y(i);
+                } else if (gateRand < (2 * ONE_R1 / GateCount1Qb)) {
+                    qReg->H(i);
                 } else {
                     qReg->PhaseRootN(4U, i);
                 }

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -494,7 +494,7 @@ TEST_CASE("test_solved_universal_circuit", "[supreme]")
                     qReg->X(i);
                 } else if (gateRand < (2 * ONE_R1 / GateCount1Qb)) {
                     qReg->Y(i);
-                } else if (gateRand < (2 * ONE_R1 / GateCount1Qb)) {
+                } else if (gateRand < (3 * ONE_R1 / GateCount1Qb)) {
                     qReg->H(i);
                 } else {
                     qReg->PhaseRootN(4U, i);

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -473,7 +473,7 @@ TEST_CASE("test_qft_superposition_round_trip", "[qft]")
         true, true, testEngineType == QINTERFACE_QUNIT);
 }
 
-TEST_CASE("test_solved_universal_circuit", "[supreme]")
+TEST_CASE("test_universal_circuit", "[supreme]")
 {
     const int GateCount1Qb = 4;
     const int GateCount2Qb = 3;

--- a/test/tests.hpp
+++ b/test/tests.hpp
@@ -20,7 +20,7 @@
 #include "qfactory.hpp"
 
 /* A quick-and-dirty epsilon for clamping floating point values. */
-#define QRACK_TEST_EPSILON 0.5
+#define QRACK_TEST_EPSILON 0.9
 
 /*
  * Default engine type to run the tests with. Global because catch doesn't


### PR DESCRIPTION
If both phase angles of a cached controlled phase gate are the same, the buffer commutes with H. (Note that this gate can still have physically significant effect with identical angles, since the phase change is only imparted to half the permutations.) Maybe surprisingly, this case occurs with some frequency in the QFT, and we gain a significant average speed improvement on `test_qft_superposition_round_trip`.