### PR TITLE
Universal quantum gate set test

### DIFF
--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -618,11 +618,12 @@ protected:
 
     void TransformBasis1Qb(const bool& toPlusMinus, const bitLenInt& i);
 
-    void RevertBasis2Qb(const bitLenInt& i, const bool& onlyInvertControls = false);
-    void RevertBasis2Qb(const bitLenInt& start, const bitLenInt& length, const bool& onlyInvertControls = false)
+    void RevertBasis2Qb(const bitLenInt& i, const bool& onlyInvert = false, const bool& targetInvert = false);
+    void RevertBasis2Qb(const bitLenInt& start, const bitLenInt& length, const bool& onlyInvert = false,
+        const bool& targetInvert = false)
     {
         for (bitLenInt i = 0; i < length; i++) {
-            RevertBasis2Qb(start + i, onlyInvertControls);
+            RevertBasis2Qb(start + i, onlyInvert, targetInvert);
         }
     }
     void ToPermBasis(const bitLenInt& i)

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -618,11 +618,11 @@ protected:
 
     void TransformBasis1Qb(const bool& toPlusMinus, const bitLenInt& i);
 
-    void RevertBasis2Qb(const bitLenInt& i);
-    void RevertBasis2Qb(const bitLenInt& start, const bitLenInt& length)
+    void RevertBasis2Qb(const bitLenInt& i, const bool& onlyInvertControls = false);
+    void RevertBasis2Qb(const bitLenInt& start, const bitLenInt& length, const bool& onlyInvertControls = false)
     {
         for (bitLenInt i = 0; i < length; i++) {
-            RevertBasis2Qb(start + i);
+            RevertBasis2Qb(start + i, onlyInvertControls);
         }
     }
     void ToPermBasis(const bitLenInt& i)

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -228,6 +228,26 @@ struct QEngineShard {
         return false;
     }
 
+    bool isInvertTarget()
+    {
+        ShardToPhaseMap::iterator phaseShard;
+        for (phaseShard = targetOfShards.begin(); phaseShard != targetOfShards.end(); phaseShard++) {
+            if (phaseShard->second.isInvert) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    bool isInvert()
+    {
+        if (isInvertControl()) {
+            return true;
+        }
+        return isInvertTarget();
+    }
+
     /// If an "inversion" gate is applied to a qubit with controlled phase buffers, we can transform the buffers to
     /// commute, instead of incurring the cost of applying the buffers.
     void FlipPhaseAnti()
@@ -637,12 +657,11 @@ protected:
 
     void TransformBasis1Qb(const bool& toPlusMinus, const bitLenInt& i);
 
-    void RevertBasis2Qb(const bitLenInt& i, const bool& onlyInvert = false, const bool& targetInvert = false);
-    void RevertBasis2Qb(const bitLenInt& start, const bitLenInt& length, const bool& onlyInvert = false,
-        const bool& targetInvert = false)
+    void RevertBasis2Qb(const bitLenInt& i, const bool& onlyInvert = false);
+    void RevertBasis2Qb(const bitLenInt& start, const bitLenInt& length, const bool& onlyInvert = false)
     {
         for (bitLenInt i = 0; i < length; i++) {
-            RevertBasis2Qb(start + i, onlyInvert, targetInvert);
+            RevertBasis2Qb(start + i, onlyInvert);
         }
     }
     void ToPermBasis(const bitLenInt& i)

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -240,6 +240,25 @@ struct QEngineShard {
         }
     }
 
+    void CommutePhase(const complex& topLeft, const complex& bottomRight)
+    {
+        ShardToPhaseMap::iterator phaseShard;
+        for (phaseShard = targetOfShards.begin(); phaseShard != targetOfShards.end(); phaseShard++) {
+            if (!phaseShard->second.isInvert) {
+                continue;
+            }
+
+            phaseShard->second.angle0 =
+                2 * std::arg(std::polar(ONE_R1, phaseShard->second.angle0 / 2) * topLeft / bottomRight);
+            phaseShard->second.angle1 =
+                2 * std::arg(std::polar(ONE_R1, phaseShard->second.angle1 / 2) * bottomRight / topLeft);
+
+            PhaseShard& remotePhase = phaseShard->first->controlsShards[this];
+            remotePhase.angle0 = phaseShard->second.angle0;
+            remotePhase.angle1 = phaseShard->second.angle1;
+        }
+    }
+
     bool TryHCommute()
     {
         complex polar0, polar1;

--- a/src/qinterface/gates.cpp
+++ b/src/qinterface/gates.cpp
@@ -203,8 +203,23 @@ void QInterface::CZ(bitLenInt control, bitLenInt target)
 /// Doubly-controlled not
 void QInterface::CCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target)
 {
-    bitLenInt controls[2] = { control1, control2 };
-    ApplyControlledSingleInvert(controls, 2, target, ONE_CMPLX, ONE_CMPLX);
+    H(target);
+    CNOT(control2, target);
+    IT(target);
+    CNOT(control1, target);
+    T(target);
+    CNOT(control2, target);
+    IT(target);
+    CNOT(control1, target);
+    T(target);
+    T(control2);
+    H(target);
+    CNOT(control1, control2);
+    IT(control2);
+    T(control1);
+    CNOT(control1, control2);
+    /*bitLenInt controls[2] = { control1, control2 };
+    ApplyControlledSingleInvert(controls, 2, target, ONE_CMPLX, ONE_CMPLX);*/
 }
 
 /// "Anti-doubly-controlled not" - Apply "not" if control bits are both zero, do not apply if either control bit is one.

--- a/src/qinterface/gates.cpp
+++ b/src/qinterface/gates.cpp
@@ -203,23 +203,8 @@ void QInterface::CZ(bitLenInt control, bitLenInt target)
 /// Doubly-controlled not
 void QInterface::CCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target)
 {
-    H(target);
-    CNOT(control2, target);
-    IT(target);
-    CNOT(control1, target);
-    T(target);
-    CNOT(control2, target);
-    IT(target);
-    CNOT(control1, target);
-    T(target);
-    T(control2);
-    H(target);
-    CNOT(control1, control2);
-    IT(control2);
-    T(control1);
-    CNOT(control1, control2);
-    /*bitLenInt controls[2] = { control1, control2 };
-    ApplyControlledSingleInvert(controls, 2, target, ONE_CMPLX, ONE_CMPLX);*/
+    bitLenInt controls[2] = { control1, control2 };
+    ApplyControlledSingleInvert(controls, 2, target, ONE_CMPLX, ONE_CMPLX);
 }
 
 /// "Anti-doubly-controlled not" - Apply "not" if control bits are both zero, do not apply if either control bit is one.

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -994,9 +994,6 @@ void QUnit::Z(bitLenInt target)
     // Commutes with controlled phase optimizations
     QEngineShard& shard = shards[target];
 
-    if (QUEUED_PHASE(shard)) {
-        TransformBasis1Qb(false, target);
-    }
     shard.CommutePhase(ONE_CMPLX, -ONE_CMPLX);
 
     if (!shard.isPlusMinus) {

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -162,7 +162,7 @@ complex QUnit::GetAmplitude(bitCapInt perm)
     }
 
     if (shards[0].unit->GetQubitCount() > 1) {
-        if (abs(ONE_R1 - norm(result)) < min_norm) {
+        if (norm(result) >= (ONE_R1 - min_norm)) {
             SetPermutation(perm);
         }
     }

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1264,13 +1264,13 @@ void QUnit::CZ(bitLenInt control, bitLenInt target)
 
 void QUnit::ApplySinglePhase(const complex topLeft, const complex bottomRight, bool doCalcNorm, bitLenInt target)
 {
+    RevertBasis2Qb(target, true, true);
+
     QEngineShard& shard = shards[target];
 
     if (!PHASE_MATTERS(target)) {
         return;
     }
-
-    RevertBasis2Qb(target, true, true);
 
     if (!shard.isPlusMinus) {
         // If the target bit is in a |0>/|1> eigenstate, this gate has no effect.
@@ -2908,7 +2908,7 @@ void QUnit::RevertBasis2Qb(const bitLenInt& i, const bool& onlyInvert, const boo
         shard.RemovePhaseTarget(partner);
     }
 
-    if (targetInvert) {
+    if (onlyInvert && !targetInvert) {
         return;
     }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -32,16 +32,20 @@
 #define QUEUED_PHASE(shard) ((shard.targetOfShards.size() != 0) || (shard.controlsShards.size() != 0))
 #define QUEUED_H_PHASE(shard) (shard.isPlusMinus && QUEUED_PHASE(shard))
 /* "UNSAFE" variants here do not check whether the bit is in |0>/|1> rather than |+>/|-> basis. */
-#define UNSAFE_CACHED_CLASSICAL(shard)                                                                                 \
-    (!shard.isProbDirty && ((norm(shard.amp0) < min_norm) || (norm(shard.amp1) < min_norm)))
-#define CACHED_CLASSICAL(shard) (!shard.isPlusMinus && !QUEUED_PHASE(shard) && UNSAFE_CACHED_CLASSICAL(shard))
-#define CACHED_ONE(shard) (CACHED_CLASSICAL(shard) && SHARD_STATE(shard))
-#define CACHED_ZERO(shard) (CACHED_CLASSICAL(shard) && !SHARD_STATE(shard))
-#define UNSAFE_CACHED_ONE(shard) (UNSAFE_CACHED_CLASSICAL(shard) && SHARD_STATE(shard))
-#define UNSAFE_CACHED_ZERO(shard) (UNSAFE_CACHED_CLASSICAL(shard) && !SHARD_STATE(shard))
-#define PHASE_MATTERS(shard) (!randGlobalPhase || !CACHED_CLASSICAL(shard))
+#define UNSAFE_CACHED_CLASSICAL(shardIndex)                                                                            \
+    (!shards[shardIndex].isProbDirty &&                                                                                \
+        ((ProbBase(shardIndex) < min_norm) || ((ONE_R1 - ProbBase(shardIndex)) < min_norm)))
+#define CACHED_1QB(shardIndex) (!shards[shardIndex].isProbDirty && !shards[shardIndex].isPlusMinus)
+#define CACHED_PROB(shardIndex)                                                                                        \
+    (CACHED_1QB(shardIndex) && (shards[shardIndex].targetOfShards.size() == 0) &&                                      \
+        (shards[shardIndex].controlsShards.size() == 0))
+#define CACHED_CLASSICAL(shardIndex)                                                                                   \
+    (CACHED_PROB(shardIndex) && ((Prob(shardIndex) < min_norm) || ((ONE_R1 - Prob(shardIndex)) < min_norm)))
+#define CACHED_ONE(shardIndex) (CACHED_PROB(shardIndex) && ((ONE_R1 - Prob(shardIndex)) < min_norm))
+#define CACHED_ZERO(shardIndex) (CACHED_PROB(shardIndex) && (Prob(shardIndex) < min_norm))
+#define PHASE_MATTERS(shardIndex) (!randGlobalPhase || !CACHED_CLASSICAL(shardIndex))
 #define DIRTY(shard) (shard.isPhaseDirty || shard.isProbDirty)
-#define IS_POSITIVE_REAL(c) ((abs(imag(c)) < min_norm) && (real(c) >= (ONE_R1 - min_norm)))
+#define IS_POSITIVE_REAL(c) ((abs(imag(c)) < min_norm) && (abs(ONE_R1 - real(c)) < min_norm))
 
 namespace Qrack {
 
@@ -189,9 +193,7 @@ void QUnit::Detach(bitLenInt start, bitLenInt length, QUnitPtr dest)
     /* TODO: This method should compose the bits for the destination without cohering the length first */
 
     for (bitLenInt i = 0; i < length; i++) {
-        if (QUEUED_PHASE(shards[start + i])) {
-            ToPermBasis(start + i);
-        }
+        RevertBasis2Qb(start + i);
     }
 
     QInterfacePtr destEngine;
@@ -576,7 +578,7 @@ bool QUnit::CheckBitPermutation(const bitLenInt& qubitIndex, const bool& inCurre
     if (!inCurrentBasis) {
         ToPermBasis(qubitIndex);
     }
-    if (UNSAFE_CACHED_CLASSICAL(shards[qubitIndex])) {
+    if (UNSAFE_CACHED_CLASSICAL(qubitIndex)) {
         return true;
     } else {
         return false;
@@ -714,12 +716,14 @@ void QUnit::SeparateBit(bool value, bitLenInt qubit)
 bool QUnit::ForceM(bitLenInt qubit, bool res, bool doForce)
 {
     ToPermBasis(qubit);
+
     QEngineShard& shard = shards[qubit];
 
     bool result;
-    if (CACHED_CLASSICAL(shard)) {
+    if (CACHED_CLASSICAL(qubit)) {
         result = SHARD_STATE(shard);
     } else {
+        EndEmulation(qubit);
         result = shard.unit->ForceM(shard.mapped, res, doForce);
     }
 
@@ -788,7 +792,7 @@ void QUnit::ISwap(bitLenInt qubit1, bitLenInt qubit2)
     QEngineShard& shard1 = shards[qubit1];
     QEngineShard& shard2 = shards[qubit2];
 
-    if (CACHED_CLASSICAL(shard1) && CACHED_CLASSICAL(shard2)) {
+    if (CACHED_CLASSICAL(qubit1) && CACHED_CLASSICAL(qubit2)) {
         // We can avoid dirtying the cache and entangling, since the bits are classical.
         if (SHARD_STATE(shard1) != SHARD_STATE(shard2)) {
             Swap(qubit1, qubit2);
@@ -820,7 +824,7 @@ void QUnit::SqrtSwap(bitLenInt qubit1, bitLenInt qubit2)
     QEngineShard& shard1 = shards[qubit1];
     QEngineShard& shard2 = shards[qubit2];
 
-    if (CACHED_CLASSICAL(shard1) && CACHED_CLASSICAL(shard2) && (SHARD_STATE(shard1) == SHARD_STATE(shard2))) {
+    if (CACHED_CLASSICAL(qubit1) && CACHED_CLASSICAL(qubit2) && (SHARD_STATE(shard1) == SHARD_STATE(shard2))) {
         // We can avoid dirtying the cache and entangling, since this gate doesn't swap identical classical bits.
         return;
     }
@@ -844,7 +848,7 @@ void QUnit::ISqrtSwap(bitLenInt qubit1, bitLenInt qubit2)
     QEngineShard& shard1 = shards[qubit1];
     QEngineShard& shard2 = shards[qubit2];
 
-    if (CACHED_CLASSICAL(shard1) && CACHED_CLASSICAL(shard2) && (SHARD_STATE(shard1) == SHARD_STATE(shard2))) {
+    if (CACHED_CLASSICAL(qubit1) && CACHED_CLASSICAL(qubit2) && (SHARD_STATE(shard1) == SHARD_STATE(shard2))) {
         // We can avoid dirtying the cache and entangling, since this gate doesn't swap identical classical bits.
         return;
     }
@@ -965,7 +969,7 @@ void QUnit::ZBase(const bitLenInt& target)
 {
     QEngineShard& shard = shards[target];
     // If the target bit is in a |0>/|1> eigenstate, this gate has no effect.
-    if (PHASE_MATTERS(shard)) {
+    if (PHASE_MATTERS(target)) {
         EndEmulation(shard);
         shard.unit->Z(shard.mapped);
         shard.amp1 = -shard.amp1;
@@ -991,7 +995,7 @@ void QUnit::Z(bitLenInt target)
     QEngineShard& shard = shards[target];
 
     if (!shard.isPlusMinus) {
-        if (PHASE_MATTERS(shard)) {
+        if (PHASE_MATTERS(target)) {
             ApplyOrEmulate(shard, [&](QEngineShard& shard) { shard.unit->Z(shard.mapped); });
             shard.amp1 = -shard.amp1;
         }
@@ -1099,7 +1103,7 @@ bool QUnit::TryCnotOptimize(const bitLenInt* controls, const bitLenInt& controlL
     bitLenInt rControlLen = 0;
     for (bitLenInt i = 0; i < controlLen; i++) {
         QEngineShard& shard = shards[controls[i]];
-        if (CACHED_CLASSICAL(shard)) {
+        if (CACHED_CLASSICAL(controls[i])) {
             if ((!anti && !SHARD_STATE(shard)) || (anti && SHARD_STATE(shard))) {
                 return true;
             }
@@ -1137,7 +1141,7 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
 
     if (!freezeBasis) {
         if (tShard.isInvertControl()) {
-            RevertBasis2Qb(target, true);
+            RevertBasis2Qb(target, true, false);
         }
         tShard.AddInversionAngles(&cShard, 0, 0);
         return;
@@ -1183,9 +1187,45 @@ void QUnit::AntiCNOT(bitLenInt control, bitLenInt target)
 
 void QUnit::CCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target)
 {
-    bitLenInt controls[2] = { control1, control2 };
-    bitLenInt controlLen = 2;
-    CTRLED2_CALL_WRAP(CCNOT(CTRL_2_ARGS), CNOT(CTRL_1_ARGS), X(target), false);
+    if ((CACHED_1QB(control1) && (Prob(control1) < min_norm)) ||
+        (CACHED_1QB(control2) && (Prob(control2) < min_norm))) {
+        return;
+    }
+
+    if ((CACHED_1QB(control1) && ((ONE_R1 - Prob(control1)) < min_norm))) {
+        CNOT(control2, target);
+        return;
+    }
+
+    if ((CACHED_1QB(control2) && ((ONE_R1 - Prob(control2)) < min_norm))) {
+        CNOT(control1, target);
+        return;
+    }
+
+    QEngineShard& c1Shard = shards[control1];
+    QEngineShard& c2Shard = shards[control2];
+    QEngineShard& tShard = shards[target];
+
+    if ((c1Shard.unit == c2Shard.unit) && (c1Shard.unit == tShard.unit)) {
+        tShard.unit->CCNOT(c1Shard.mapped, c2Shard.mapped, tShard.mapped);
+        return;
+    }
+
+    H(target);
+    CNOT(control2, target);
+    IT(target);
+    CNOT(control1, target);
+    T(target);
+    CNOT(control2, target);
+    IT(target);
+    CNOT(control1, target);
+    T(target);
+    T(control2);
+    H(target);
+    CNOT(control1, control2);
+    T(control1);
+    IT(control2);
+    CNOT(control1, control2);
 }
 
 void QUnit::AntiCCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target)
@@ -1200,7 +1240,7 @@ void QUnit::CZ(bitLenInt control, bitLenInt target)
     QEngineShard& tShard = shards[target];
     QEngineShard& cShard = shards[control];
 
-    if (CACHED_ZERO(tShard) || CACHED_ZERO(cShard)) {
+    if (CACHED_ZERO(target) || CACHED_ZERO(control)) {
         return;
     }
 
@@ -1226,13 +1266,15 @@ void QUnit::ApplySinglePhase(const complex topLeft, const complex bottomRight, b
 {
     QEngineShard& shard = shards[target];
 
-    if (!PHASE_MATTERS(shard)) {
+    if (!PHASE_MATTERS(target)) {
         return;
     }
 
+    RevertBasis2Qb(target, true, true);
+
     if (!shard.isPlusMinus) {
         // If the target bit is in a |0>/|1> eigenstate, this gate has no effect.
-        if (PHASE_MATTERS(shard)) {
+        if (PHASE_MATTERS(target)) {
             ApplyOrEmulate(shard, [&](QEngineShard& shard) {
                 shard.unit->ApplySinglePhase(topLeft, bottomRight, doCalcNorm, shard.mapped);
             });
@@ -1258,7 +1300,7 @@ void QUnit::ApplySingleInvert(const complex topRight, const complex bottomLeft, 
 {
     QEngineShard& shard = shards[target];
 
-    if (!PHASE_MATTERS(shard) || (randGlobalPhase && (norm(topRight - bottomLeft) < min_norm))) {
+    if (!PHASE_MATTERS(target) || (randGlobalPhase && (norm(topRight - bottomLeft) < min_norm))) {
         X(target);
         return;
     }
@@ -1301,16 +1343,23 @@ void QUnit::ApplyControlledSinglePhase(const bitLenInt* cControls, const bitLenI
     std::copy(cControls, cControls + controlLen, controls);
     bitLenInt target = cTarget;
 
+    if (IS_POSITIVE_REAL(bottomRight) && CACHED_ONE(target)) {
+        delete[] controls;
+        return;
+    }
+
     if (IS_POSITIVE_REAL(topLeft)) {
-        if ((controlLen == 1U) && IS_POSITIVE_REAL(-bottomRight)) {
-            CZ(controls[0], target);
+        if (CACHED_ZERO(target)) {
             delete[] controls;
             return;
         }
 
-        if (CACHED_ZERO(shards[target])) {
-            delete[] controls;
-            return;
+        if (controlLen == 1U) {
+            if (IS_POSITIVE_REAL(-bottomRight)) {
+                CZ(controls[0], target);
+                delete[] controls;
+                return;
+            }
         }
 
         if (!shards[target].isPlusMinus) {
@@ -1321,11 +1370,6 @@ void QUnit::ApplyControlledSinglePhase(const bitLenInt* cControls, const bitLenI
                 }
             }
         }
-    }
-
-    if (IS_POSITIVE_REAL(bottomRight) && CACHED_ONE(shards[target])) {
-        delete[] controls;
-        return;
     }
 
     QEngineShard& tShard = shards[target];
@@ -1356,7 +1400,7 @@ void QUnit::ApplyControlledSingleInvert(const bitLenInt* controls, const bitLenI
         if (!freezeBasis && (controlLen == 1U)) {
             QEngineShard& tShard = shards[target];
             if (tShard.isInvertControl()) {
-                RevertBasis2Qb(target, true);
+                RevertBasis2Qb(target, true, false);
             }
             tShard.AddInversionAngles(&(shards[controls[0]]), (real1)(2 * arg(topRight)), (real1)(2 * arg(bottomLeft)));
             return;
@@ -1376,13 +1420,11 @@ void QUnit::ApplyAntiControlledSinglePhase(const bitLenInt* cControls, const bit
         return;
     }
 
-    QEngineShard& shard = shards[cTarget];
-
     bitLenInt* controls = new bitLenInt[controlLen];
     std::copy(cControls, cControls + controlLen, controls);
     bitLenInt target = cTarget;
 
-    if ((IS_POSITIVE_REAL(topLeft) && CACHED_ZERO(shard)) || (IS_POSITIVE_REAL(bottomRight) && CACHED_ONE(shard))) {
+    if ((IS_POSITIVE_REAL(topLeft) && CACHED_ZERO(cTarget)) || (IS_POSITIVE_REAL(bottomRight) && CACHED_ONE(cTarget))) {
         delete[] controls;
         return;
     }
@@ -2545,7 +2587,7 @@ void QUnit::CPhaseFlipIfLess(bitCapInt greaterPerm, bitLenInt start, bitLenInt l
 void QUnit::PhaseFlip()
 {
     QEngineShard& shard = shards[0];
-    if (PHASE_MATTERS(shard)) {
+    if (PHASE_MATTERS(0)) {
         TransformBasis1Qb(false, 0);
         ApplyOrEmulate(shard, [&](QEngineShard& shard) { shard.unit->PhaseFlip(); });
         shard.amp1 = -shard.amp1;
@@ -2801,7 +2843,7 @@ void QUnit::TransformBasis1Qb(const bool& toPlusMinus, const bitLenInt& i)
     freezeBasis = false;
 }
 
-void QUnit::RevertBasis2Qb(const bitLenInt& i, const bool& onlyInvertControls)
+void QUnit::RevertBasis2Qb(const bitLenInt& i, const bool& onlyInvert, const bool& targetInvert)
 {
     QEngineShard& shard = shards[i];
 
@@ -2817,12 +2859,15 @@ void QUnit::RevertBasis2Qb(const bitLenInt& i, const bool& onlyInvertControls)
 
     ShardToPhaseMap::iterator phaseShard;
     controls[0] = i;
-    ShardToPhaseMap controlsShards = shard.controlsShards;
+    ShardToPhaseMap controlsShards;
+    if (!targetInvert) {
+        controlsShards = shard.controlsShards;
+    }
     while (controlsShards.size() > 0) {
         phaseShard = controlsShards.begin();
         controlsShards.erase(phaseShard);
 
-        if (onlyInvertControls && !phaseShard->second.isInvert) {
+        if (onlyInvert && !phaseShard->second.isInvert) {
             continue;
         }
 
@@ -2863,12 +2908,19 @@ void QUnit::RevertBasis2Qb(const bitLenInt& i, const bool& onlyInvertControls)
         shard.RemovePhaseTarget(partner);
     }
 
-    if (onlyInvertControls) {
+    if (targetInvert) {
         return;
     }
 
-    while (shard.targetOfShards.size() > 0) {
-        phaseShard = shard.targetOfShards.begin();
+    ShardToPhaseMap targetOfShards = shard.targetOfShards;
+    while (targetOfShards.size() > 0) {
+        phaseShard = targetOfShards.begin();
+        targetOfShards.erase(phaseShard);
+
+        if (onlyInvert && !phaseShard->second.isInvert) {
+            continue;
+        }
+
         QEngineShardPtr partner = phaseShard->first;
         bitLenInt j = FindShardIndex(*partner);
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -991,10 +991,10 @@ void QUnit::X(bitLenInt target)
 
 void QUnit::Z(bitLenInt target)
 {
-    RevertBasis2Qb(target, true, true);
-
     // Commutes with controlled phase optimizations
     QEngineShard& shard = shards[target];
+
+    shard.CommutePhase(ONE_CMPLX, -ONE_CMPLX);
 
     if (!shard.isPlusMinus) {
         if (PHASE_MATTERS(target)) {
@@ -1230,13 +1230,13 @@ void QUnit::CZ(bitLenInt control, bitLenInt target)
 
 void QUnit::ApplySinglePhase(const complex topLeft, const complex bottomRight, bool doCalcNorm, bitLenInt target)
 {
-    RevertBasis2Qb(target, true, true);
-
     QEngineShard& shard = shards[target];
 
     if (!PHASE_MATTERS(target)) {
         return;
     }
+
+    shard.CommutePhase(topLeft, bottomRight);
 
     if (!shard.isPlusMinus) {
         // If the target bit is in a |0>/|1> eigenstate, this gate has no effect.

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -991,6 +991,8 @@ void QUnit::X(bitLenInt target)
 
 void QUnit::Z(bitLenInt target)
 {
+    RevertBasis2Qb(target, true, true);
+
     // Commutes with controlled phase optimizations
     QEngineShard& shard = shards[target];
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -994,6 +994,9 @@ void QUnit::Z(bitLenInt target)
     // Commutes with controlled phase optimizations
     QEngineShard& shard = shards[target];
 
+    if (QUEUED_PHASE(shard)) {
+        TransformBasis1Qb(false, target);
+    }
     shard.CommutePhase(ONE_CMPLX, -ONE_CMPLX);
 
     if (!shard.isPlusMinus) {
@@ -1236,6 +1239,9 @@ void QUnit::ApplySinglePhase(const complex topLeft, const complex bottomRight, b
         return;
     }
 
+    if (QUEUED_PHASE(shard)) {
+        TransformBasis1Qb(false, target);
+    }
     shard.CommutePhase(topLeft, bottomRight);
 
     if (!shard.isPlusMinus) {

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1192,8 +1192,25 @@ void QUnit::AntiCNOT(bitLenInt control, bitLenInt target)
 void QUnit::CCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target)
 {
     bitLenInt controls[2] = { control1, control2 };
-    bitLenInt controlLen = 2;
-    CTRLED2_CALL_WRAP(CCNOT(CTRL_2_ARGS), CNOT(CTRL_1_ARGS), X(target), false);
+
+    ApplyEitherControlled(controls, 2, { target }, false,
+        [&](QInterfacePtr unit, std::vector<bitLenInt> mappedControls) {
+            if (shards[target].isPlusMinus) {
+                if (mappedControls.size() == 2) {
+                    unit->ApplyControlledSinglePhase(
+                        &(mappedControls[0]), mappedControls.size(), shards[target].mapped, ONE_CMPLX, -ONE_CMPLX);
+                } else {
+                    unit->CZ(CTRL_1_ARGS);
+                }
+            } else {
+                if (mappedControls.size() == 2) {
+                    unit->CCNOT(CTRL_2_ARGS);
+                } else {
+                    unit->CNOT(CTRL_1_ARGS);
+                }
+            }
+        },
+        [&]() { X(target); });
 }
 
 void QUnit::AntiCCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target)

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1241,9 +1241,6 @@ void QUnit::ApplySinglePhase(const complex topLeft, const complex bottomRight, b
         return;
     }
 
-    if (QUEUED_PHASE(shard)) {
-        TransformBasis1Qb(false, target);
-    }
     shard.CommutePhase(topLeft, bottomRight);
 
     if (!shard.isPlusMinus) {

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1332,6 +1332,20 @@ void QUnit::ApplyControlledSinglePhase(const bitLenInt* cControls, const bitLenI
                 delete[] controls;
                 return;
             }
+
+            // This should be equivalent to ApplyControlledSinglePhase:
+            /*if (!freezeBasis && (shards[controls[0]].unit != shards[target].unit)) {
+                complex phaseSqrt = std::sqrt(bottomRight);
+
+                CNOT(controls[0], target);
+                ApplySinglePhase(ONE_CMPLX, ONE_CMPLX / phaseSqrt, true, target);
+                CNOT(controls[0], target);
+                ApplySinglePhase(ONE_CMPLX, phaseSqrt, true, controls[0]);
+                ApplySinglePhase(ONE_CMPLX, phaseSqrt, true, target);
+
+                delete[] controls;
+                return;
+            }*/
         }
 
         if (!shards[target].isPlusMinus) {

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1144,13 +1144,13 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
     QEngineShard& cShard = shards[control];
     QEngineShard& tShard = shards[target];
 
-    if (!freezeBasis) {
+    /*if (!freezeBasis) {
         if (tShard.isInvertControl()) {
             RevertBasis2Qb(target, true, false);
         }
         tShard.AddInversionAngles(&cShard, 0, 0);
         return;
-    }
+    }*/
 
     bitLenInt controls[1] = { control };
     bitLenInt controlLen = 1;
@@ -1195,6 +1195,24 @@ void QUnit::CCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target)
     bitLenInt controls[2] = { control1, control2 };
     bitLenInt controlLen = 2;
     CTRLED2_CALL_WRAP(CCNOT(CTRL_2_ARGS), CNOT(CTRL_1_ARGS), X(target), false);
+
+    /* TODO: Use this decomposition if and when efficient:
+    H(target);
+    CNOT(control2, target);
+    IT(target);
+    CNOT(control1, target);
+    T(target);
+    CNOT(control2, target);
+    IT(target);
+    CNOT(control1, target);
+    T(target);
+    T(control2);
+    H(target);
+    CNOT(control1, control2);
+    IT(control2);
+    T(control1);
+    CNOT(control1, control2);
+    */
 }
 
 void QUnit::AntiCCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target)
@@ -1383,14 +1401,14 @@ void QUnit::ApplyControlledSingleInvert(const bitLenInt* controls, const bitLenI
     const complex topRight, const complex bottomLeft)
 {
     if (!TryCnotOptimize(controls, controlLen, target, bottomLeft, topRight, false)) {
-        if (!freezeBasis && (controlLen == 1U)) {
+        /*if (!freezeBasis && (controlLen == 1U)) {
             QEngineShard& tShard = shards[target];
             if (tShard.isInvertControl()) {
                 RevertBasis2Qb(target, true, false);
             }
             tShard.AddInversionAngles(&(shards[controls[0]]), (real1)(2 * arg(topRight)), (real1)(2 * arg(bottomLeft)));
             return;
-        }
+        }*/
 
         CTRLED_INVERT_WRAP(ApplyControlledSingleInvert(CTRL_I_ARGS), ApplyControlledSingleBit(CTRL_GEN_ARGS),
             ApplySingleInvert(topRight, bottomLeft, true, target), false);

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -976,8 +976,6 @@ void QUnit::X(bitLenInt target)
 {
     QEngineShard& shard = shards[target];
 
-    PopHBasis2Qb(target);
-
     shard.FlipPhaseAnti();
 
     if (!shard.isPlusMinus) {
@@ -991,8 +989,6 @@ void QUnit::Z(bitLenInt target)
 {
     // Commutes with controlled phase optimizations
     QEngineShard& shard = shards[target];
-
-    PopHBasis2Qb(target);
 
     if (!shard.isPlusMinus) {
         if (PHASE_MATTERS(shard)) {
@@ -1306,13 +1302,13 @@ void QUnit::ApplyControlledSinglePhase(const bitLenInt* cControls, const bitLenI
     bitLenInt target = cTarget;
 
     if (IS_POSITIVE_REAL(topLeft)) {
-        if (CACHED_ZERO(shards[target])) {
+        if ((controlLen == 1U) && IS_POSITIVE_REAL(-bottomRight)) {
+            CZ(controls[0], target);
             delete[] controls;
             return;
         }
 
-        if ((controlLen == 1U) && IS_POSITIVE_REAL(-bottomRight)) {
-            CZ(controls[0], target);
+        if (CACHED_ZERO(shards[target])) {
             delete[] controls;
             return;
         }
@@ -1336,7 +1332,6 @@ void QUnit::ApplyControlledSinglePhase(const bitLenInt* cControls, const bitLenI
     QEngineShard& cShard = shards[controls[0]];
 
     if (!freezeBasis || (controlLen != 1U)) {
-        PopHBasis2Qb(target);
         for (bitLenInt i = 0; i < controlLen; i++) {
             PopHBasis2Qb(controls[i]);
         }

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1189,45 +1189,9 @@ void QUnit::AntiCNOT(bitLenInt control, bitLenInt target)
 
 void QUnit::CCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target)
 {
-    if ((CACHED_1QB(control1) && (Prob(control1) < min_norm)) ||
-        (CACHED_1QB(control2) && (Prob(control2) < min_norm))) {
-        return;
-    }
-
-    if ((CACHED_1QB(control1) && ((ONE_R1 - Prob(control1)) < min_norm))) {
-        CNOT(control2, target);
-        return;
-    }
-
-    if ((CACHED_1QB(control2) && ((ONE_R1 - Prob(control2)) < min_norm))) {
-        CNOT(control1, target);
-        return;
-    }
-
-    QEngineShard& c1Shard = shards[control1];
-    QEngineShard& c2Shard = shards[control2];
-    QEngineShard& tShard = shards[target];
-
-    if ((c1Shard.unit == c2Shard.unit) && (c1Shard.unit == tShard.unit)) {
-        tShard.unit->CCNOT(c1Shard.mapped, c2Shard.mapped, tShard.mapped);
-        return;
-    }
-
-    H(target);
-    CNOT(control2, target);
-    IT(target);
-    CNOT(control1, target);
-    T(target);
-    CNOT(control2, target);
-    IT(target);
-    CNOT(control1, target);
-    T(target);
-    T(control2);
-    H(target);
-    CNOT(control1, control2);
-    T(control1);
-    IT(control2);
-    CNOT(control1, control2);
+    bitLenInt controls[2] = { control1, control2 };
+    bitLenInt controlLen = 2;
+    CTRLED2_CALL_WRAP(CCNOT(CTRL_2_ARGS), CNOT(CTRL_1_ARGS), X(target), false);
 }
 
 void QUnit::AntiCCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target)

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1197,24 +1197,6 @@ void QUnit::CCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target)
     bitLenInt controls[2] = { control1, control2 };
     bitLenInt controlLen = 2;
     CTRLED2_CALL_WRAP(CCNOT(CTRL_2_ARGS), CNOT(CTRL_1_ARGS), X(target), false);
-
-    /* TODO: Use this decomposition if and when efficient:
-    H(target);
-    CNOT(control2, target);
-    IT(target);
-    CNOT(control1, target);
-    T(target);
-    CNOT(control2, target);
-    IT(target);
-    CNOT(control1, target);
-    T(target);
-    T(control2);
-    H(target);
-    CNOT(control1, control2);
-    IT(control2);
-    T(control1);
-    CNOT(control1, control2);
-    */
 }
 
 void QUnit::AntiCCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target)

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -504,8 +504,8 @@ TEST_CASE("test_universal_circuit", "[supreme]")
 
                 std::set<bitLenInt> unusedBits;
                 for (i = 0; i < n; i++) {
-                    // TrySeparate hurts average time, in this case, but it majorly benefits worst case, on these random
-                    // circuits.
+                    // TrySeparate hurts average time, in this case, but it majorly benefits statistically common worse
+                    // cases, on these random circuits.
                     qReg->TrySeparate(i);
                     unusedBits.insert(unusedBits.end(), i);
                 }

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -486,6 +486,8 @@ TEST_CASE("test_universal_circuit", "[supreme]")
             bitLenInt i;
             real1 gateRand;
             bitLenInt bitRand, b1, b2;
+            bitLenInt control[1];
+            complex polar0, polar1;
 
             for (d = 0; d < Depth; d++) {
 
@@ -529,10 +531,15 @@ TEST_CASE("test_universal_circuit", "[supreme]")
                     gateRand = qReg->Rand();
                     if (gateRand < (ONE_R1 / GateCount2Qb)) {
                         qReg->Swap(b1, b2);
-                    } else if (gateRand < (2 * ONE_R1 / GateCount2Qb)) {
-                        qReg->CZ(b1, b2);
                     } else {
-                        qReg->CNOT(b1, b2);
+                        control[0] = b1;
+                        polar0 = std::polar(ONE_R1, (real1)(2 * M_PI * qReg->Rand()));
+                        polar1 = (qReg->Rand() < (ONE_R1 / 2)) ? polar0 : -polar0;
+                        if (gateRand < (2 * ONE_R1 / GateCount2Qb)) {
+                            qReg->ApplyControlledSinglePhase(control, 1U, b2, polar0, polar1);
+                        } else {
+                            qReg->ApplyControlledSingleInvert(control, 1U, b2, polar0, polar1);
+                        }
                     }
                 }
             }

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -487,26 +487,16 @@ TEST_CASE("test_universal_circuit", "[supreme]")
             real1 gateRand;
             bitLenInt bitRand, b1, b2;
 
-            complex polar0, polar1;
-            real1 angleRand;
-
-            bitLenInt controls[1];
-
             for (d = 0; d < Depth; d++) {
 
                 for (i = 0; i < n; i++) {
                     gateRand = qReg->Rand();
                     if (gateRand < (ONE_R1 / GateCount1Qb)) {
                         qReg->H(i);
+                    } else if (gateRand < (2 * ONE_R1 / GateCount1Qb)) {
+                        qReg->ApplySinglePhase(ONE_CMPLX, 2 * M_PI * qReg->Rand(), false, i);
                     } else {
-                        angleRand = 2 * M_PI * qReg->Rand();
-                        polar0 = std::polar(ONE_R1, angleRand);
-
-                        if (gateRand < (2 * ONE_R1 / GateCount1Qb)) {
-                            qReg->ApplySinglePhase(ONE_CMPLX, polar0, false, i);
-                        } else {
-                            qReg->ApplySingleInvert(ONE_CMPLX, polar0, false, i);
-                        }
+                        qReg->ApplySingleInvert(ONE_CMPLX, 2 * M_PI * qReg->Rand(), false, i);
                     }
                 }
 
@@ -539,18 +529,10 @@ TEST_CASE("test_universal_circuit", "[supreme]")
                     gateRand = qReg->Rand();
                     if (gateRand < (ONE_R1 / GateCount2Qb)) {
                         qReg->Swap(b1, b2);
+                    } else if (gateRand < (2 * ONE_R1 / GateCount2Qb)) {
+                        qReg->CZ(b1, b2);
                     } else {
-                        controls[0] = b1;
-                        angleRand = 2 * M_PI * qReg->Rand();
-                        polar0 = std::polar(ONE_R1, angleRand);
-                        angleRand = 2 * M_PI * qReg->Rand();
-                        polar1 = std::polar(ONE_R1, angleRand);
-
-                        if (gateRand < (2 * ONE_R1 / GateCount2Qb)) {
-                            qReg->ApplyControlledSinglePhase(controls, 1U, b2, polar0, polar1);
-                        } else {
-                            qReg->ApplyControlledSingleInvert(controls, 1U, b2, polar0, polar1);
-                        }
+                        qReg->CNOT(b1, b2);
                     }
                 }
             }

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -487,7 +487,7 @@ TEST_CASE("test_universal_circuit", "[supreme]")
             real1 gateRand;
             bitLenInt bitRand, b1, b2;
             bitLenInt control[1];
-            complex polar0, polar1;
+            complex polar0;
 
             for (d = 0; d < Depth; d++) {
 
@@ -534,11 +534,10 @@ TEST_CASE("test_universal_circuit", "[supreme]")
                     } else {
                         control[0] = b1;
                         polar0 = std::polar(ONE_R1, (real1)(2 * M_PI * qReg->Rand()));
-                        polar1 = (qReg->Rand() < (ONE_R1 / 2)) ? polar0 : -polar0;
                         if (gateRand < (2 * ONE_R1 / GateCount2Qb)) {
-                            qReg->ApplyControlledSinglePhase(control, 1U, b2, polar0, polar1);
+                            qReg->ApplyControlledSinglePhase(control, 1U, b2, polar0, -polar0);
                         } else {
-                            qReg->ApplyControlledSingleInvert(control, 1U, b2, polar0, polar1);
+                            qReg->ApplyControlledSingleInvert(control, 1U, b2, polar0, polar0);
                         }
                     }
                 }

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -504,6 +504,9 @@ TEST_CASE("test_universal_circuit", "[supreme]")
 
                 std::set<bitLenInt> unusedBits;
                 for (i = 0; i < n; i++) {
+                    // TrySeparate hurts average time, in this case, but it majorly benefits worst case, on these random
+                    // circuits.
+                    qReg->TrySeparate(i);
                     unusedBits.insert(unusedBits.end(), i);
                 }
 

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -473,9 +473,9 @@ TEST_CASE("test_qft_superposition_round_trip", "[qft]")
         true, true, testEngineType == QINTERFACE_QUNIT);
 }
 
-TEST_CASE("test_universal_circuit", "[supreme]")
+TEST_CASE("test_solved_universal_circuit", "[supreme]")
 {
-    const int GateCount1Qb = 4;
+    const int GateCount1Qb = 3;
     const int GateCount2Qb = 3;
     const int Depth = 20;
 
@@ -486,18 +486,26 @@ TEST_CASE("test_universal_circuit", "[supreme]")
         real1 gateRand;
         bitLenInt bitRand, b1, b2;
 
+        complex polar0, polar1;
+        real1 angleRand;
+
+        bitLenInt controls[1];
+
         for (d = 0; d < Depth; d++) {
 
             for (i = 0; i < n; i++) {
                 gateRand = qReg->Rand();
                 if (gateRand < (ONE_R1 / GateCount1Qb)) {
-                    qReg->X(i);
-                } else if (gateRand < (2 * ONE_R1 / GateCount1Qb)) {
-                    qReg->Y(i);
-                } else if (gateRand < (3 * ONE_R1 / GateCount1Qb)) {
                     qReg->H(i);
                 } else {
-                    qReg->PhaseRootN(4U, i);
+                    angleRand = 2 * M_PI * qReg->Rand();
+                    polar0 = std::polar(ONE_R1, angleRand);
+
+                    if (gateRand < (2 * ONE_R1 / GateCount1Qb)) {
+                        qReg->ApplySinglePhase(ONE_CMPLX, polar0, false, i);
+                    } else {
+                        qReg->ApplySingleInvert(ONE_CMPLX, polar0, false, i);
+                    }
                 }
             }
 
@@ -530,10 +538,18 @@ TEST_CASE("test_universal_circuit", "[supreme]")
                 gateRand = qReg->Rand();
                 if (gateRand < (ONE_R1 / GateCount2Qb)) {
                     qReg->Swap(b1, b2);
-                } else if (gateRand < (2 * ONE_R1 / GateCount2Qb)) {
-                    qReg->CNOT(b1, b2);
                 } else {
-                    qReg->CY(b1, b2);
+                    controls[0] = b1;
+                    angleRand = 2 * M_PI * qReg->Rand();
+                    polar0 = std::polar(ONE_R1, angleRand);
+                    angleRand = 2 * M_PI * qReg->Rand();
+                    polar1 = std::polar(ONE_R1, angleRand);
+
+                    if (gateRand < (2 * ONE_R1 / GateCount2Qb)) {
+                        qReg->ApplyControlledSinglePhase(controls, 1U, b2, polar0, polar1);
+                    } else {
+                        qReg->ApplyControlledSingleInvert(controls, 1U, b2, polar0, polar1);
+                    }
                 }
             }
         }

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -489,7 +489,7 @@ TEST_CASE("test_universal_circuit", "[supreme]")
             bitLenInt control[1];
             complex polar0;
             bool canDo3;
-            real1 gateThreshold;
+            int gateThreshold, gateMax;
 
             for (d = 0; d < Depth; d++) {
 
@@ -534,10 +534,16 @@ TEST_CASE("test_universal_circuit", "[supreme]")
                     unusedBits.erase(bitIterator);
 
                     canDo3 = (unusedBits.size() > 0);
-                    gateThreshold = canDo3 ? (3 * ONE_R1 / GateCountMultiQb) : (2 * ONE_R1 / (GateCountMultiQb - 1));
+                    if (canDo3) {
+                        gateThreshold = 3;
+                        gateMax = GateCountMultiQb;
+                    } else {
+                        gateThreshold = 2;
+                        gateMax = GateCountMultiQb - 1;
+                    }
 
                     gateRand = qReg->Rand();
-                    if (gateRand < (ONE_R1 / GateCountMultiQb)) {
+                    if (gateRand < (ONE_R1 / gateMax)) {
                         qReg->Swap(b1, b2);
                     } else if (canDo3 && (gateRand < (2 * ONE_R1 / GateCountMultiQb))) {
                         bitIterator = unusedBits.begin();
@@ -553,7 +559,7 @@ TEST_CASE("test_universal_circuit", "[supreme]")
                     } else {
                         control[0] = b1;
                         polar0 = std::polar(ONE_R1, (real1)(2 * M_PI * qReg->Rand()));
-                        if (gateRand < gateThreshold) {
+                        if (gateRand < (gateThreshold * ONE_R1 / gateMax)) {
                             qReg->ApplyControlledSinglePhase(control, 1U, b2, polar0, -polar0);
                         } else {
                             qReg->ApplyControlledSingleInvert(control, 1U, b2, polar0, polar0);

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -4377,10 +4377,7 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_repeat_h_cnot")
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_universal_set")
 {
-    // Using any gate in this test, with a control index array of length 0 or 1, with any phase arguments, should
-    // form a universal algebra for QUnit.
-
-    bitLenInt controls[1] = { 1U };
+    // Using any gate in this test, with any phase arguments, should form a universal algebra.
 
     qftReg->SetPermutation(0);
 
@@ -4391,11 +4388,11 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_universal_set")
 
     qftReg->ApplySingleInvert(ONE_CMPLX, ONE_CMPLX, false, 1);
     qftReg->H(0);
-    qftReg->ApplyControlledSinglePhase(controls, 1U, 0, ONE_CMPLX, -ONE_CMPLX);
+    qftReg->CZ(1, 0);
     qftReg->H(0);
     REQUIRE_THAT(qftReg, HasProbability(0, 20, 2));
 
-    qftReg->ApplyControlledSingleInvert(controls, 1U, 0, ONE_CMPLX, ONE_CMPLX);
+    qftReg->CNOT(1, 0);
     qftReg->MReg(0, 20);
     REQUIRE_THAT(qftReg, HasProbability(0, 20, 3));
 }

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -4378,7 +4378,7 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_repeat_h_cnot")
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_universal_set")
 {
     // Using any gate in this test, with a control index array of length 0 or 1, with any phase arguments, should
-    // form a classically "efficient" algebra for QUnit.
+    // form a universal algebra for QUnit.
 
     bitLenInt controls[1] = { 1U };
 

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -362,6 +362,16 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_ccnot")
     REQUIRE_THAT(qftReg, HasProbability(0xCAC00));
     qftReg->CCNOT(16, 12, 8, 4);
     REQUIRE_THAT(qftReg, HasProbability(0xCA400));
+
+    bitLenInt controls[2] = { 0, 1 };
+
+    qftReg->SetPermutation(0x03);
+    qftReg->H(0, 3);
+    qftReg->CCNOT(0, 1, 2);
+    qftReg->H(2);
+    qftReg->ApplyControlledSinglePhase(controls, 2, 2, ONE_CMPLX, -ONE_CMPLX);
+    qftReg->H(0, 2);
+    REQUIRE_THAT(qftReg, HasProbability(0x03));
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_anticcnot")

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -4412,4 +4412,30 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_inversion_buffers")
     qftReg->H(0);
 
     REQUIRE_THAT(qftReg, HasProbability(0, 20, 3));
+
+    qftReg->SetPermutation(0xCAC00);
+    REQUIRE_THAT(qftReg, HasProbability(0xCAC00));
+
+    // This should be equivalent to a register-spanning CCNOT:
+    const bitLenInt control1 = 16;
+    const bitLenInt control2 = 12;
+    const bitLenInt target = 8;
+    for (bitLenInt i = 0; i < 4; i++) {
+        qftReg->H(target + i);
+        qftReg->CNOT(control2 + i, target + i);
+        qftReg->IT(target + i);
+        qftReg->CNOT(control1 + i, target + i);
+        qftReg->T(target + i);
+        qftReg->CNOT(control2 + i, target + i);
+        qftReg->IT(target + i);
+        qftReg->CNOT(control1 + i, target + i);
+        qftReg->T(target + i);
+        qftReg->T(control2 + i);
+        qftReg->H(target + i);
+        qftReg->CNOT(control1 + i, control2 + i);
+        qftReg->IT(control2 + i);
+        qftReg->T(control1 + i);
+        qftReg->CNOT(control1 + i, control2 + i);
+    }
+    REQUIRE_THAT(qftReg, HasProbability(0xCA400));
 }

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -380,6 +380,16 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_anticcnot")
     REQUIRE_THAT(qftReg, HasProbability(0xCAC00));
     qftReg->AntiCCNOT(16, 12, 8, 4);
     REQUIRE_THAT(qftReg, HasProbability(0xCAD00));
+
+    bitLenInt controls[2] = { 0, 1 };
+
+    qftReg->SetPermutation(0x00);
+    qftReg->H(0, 3);
+    qftReg->AntiCCNOT(0, 1, 2);
+    qftReg->H(2);
+    qftReg->ApplyAntiControlledSinglePhase(controls, 2, 2, ONE_CMPLX, -ONE_CMPLX);
+    qftReg->H(0, 2);
+    REQUIRE_THAT(qftReg, HasProbability(0x00));
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_swap")

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -4374,3 +4374,28 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_repeat_h_cnot")
 
     REQUIRE_THAT(qftReg, HasProbability(0, 20, 10));
 }
+
+TEST_CASE_METHOD(QInterfaceTestFixture, "test_universal_set")
+{
+    // Using any gate in this test, with a control index array of length 0 or 1, with any phase arguments, should
+    // form a classically "efficient" algebra for QUnit.
+
+    bitLenInt controls[1] = { 1U };
+
+    qftReg->SetPermutation(0);
+
+    qftReg->H(0);
+    qftReg->ApplySinglePhase(ONE_CMPLX, -ONE_CMPLX, false, 0);
+    qftReg->H(0);
+    REQUIRE_THAT(qftReg, HasProbability(0, 20, 1));
+
+    qftReg->ApplySingleInvert(ONE_CMPLX, ONE_CMPLX, false, 1);
+    qftReg->H(0);
+    qftReg->ApplyControlledSinglePhase(controls, 1U, 0, ONE_CMPLX, -ONE_CMPLX);
+    qftReg->H(0);
+    REQUIRE_THAT(qftReg, HasProbability(0, 20, 2));
+
+    qftReg->ApplyControlledSingleInvert(controls, 1U, 0, ONE_CMPLX, ONE_CMPLX);
+    qftReg->MReg(0, 20);
+    REQUIRE_THAT(qftReg, HasProbability(0, 20, 3));
+}

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -4401,7 +4401,7 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_inversion_buffers")
 {
     qftReg->SetPermutation(2);
     qftReg->H(0);
-    
+
     // This should be equivalent to CZ:
     qftReg->CNOT(1, 0);
     qftReg->IS(0);

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -4396,3 +4396,20 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_universal_set")
     qftReg->MReg(0, 20);
     REQUIRE_THAT(qftReg, HasProbability(0, 20, 3));
 }
+
+TEST_CASE_METHOD(QInterfaceTestFixture, "test_inversion_buffers")
+{
+    qftReg->SetPermutation(2);
+    qftReg->H(0);
+    
+    // This should be equivalent to CZ:
+    qftReg->CNOT(1, 0);
+    qftReg->IS(0);
+    qftReg->CNOT(1, 0);
+    qftReg->S(0);
+    qftReg->S(1);
+
+    qftReg->H(0);
+
+    REQUIRE_THAT(qftReg, HasProbability(0, 20, 3));
+}


### PR DESCRIPTION
If we actually have an efficient alternative implementation of a Gottesman-Knill Clifford algebra, I can't think of any reason we can't throw a gate of arbitrary phase in:

```
$ ./benchmarks --layer-qunit-qfusion --proc-opencl-single --max-qubits=-1 test_solved_universal_circuit
Random Seed: 1575056458 (Overridden by hardware generation!)
Device #0, Loaded binary from: /home/iamu/.qrack/qrack_ocl_dev_0.ir
Device #1, Loaded binary from: /home/iamu/.qrack/qrack_ocl_dev_1.ir
Device #2, Loaded binary from: /home/iamu/.qrack/qrack_ocl_dev_2.ir
Default platform: NVIDIA CUDA
Default device: GeForce GTX 1070
OpenCL device #0: Intel(R) Gen9 HD Graphics NEO
OpenCL device #1: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
OpenCL device #2: GeForce GTX 1070
############ QUnit -> QFusion -> OpenCL ############
Filters: test_solved_universal_circuit

>>> 'test_solved_universal_circuit':
100 iterations
# of Qubits, Average Time (ms), Sample Std. Deviation (ms), Fastest (ms), 1st Quartile (ms), Median (ms), 3rd Quartile (ms), Slowest (ms)
4, 11.1835,1.30903,8.475,10.3305,10.9945,11.948,15.937
5, 15.6855,2.48378,10.717,13.6415,15.5025,17.407,23.549
6, 21.6443,3.37876,14.377,18.5705,21.619,24.262,30.503
7, 24.3647,4.10113,17.398,20.9315,24.074,27.234,36.002
8, 31.0884,4.82533,21.454,26.9865,31.3765,34.291,41.572
9, 33.7088,5.06138,24.259,30.2985,33.392,36.7665,46.705
10, 39.2402,6.62585,26.303,32.99,39.9255,43.6325,54.132
11, 42.3311,6.4603,30.797,36.63,41.7825,47.6095,56.508
12, 49.8788,7.00065,34.414,44.3105,50.5415,54.6305,67.437
13, 52.8477,5.82349,39.084,49.2675,52.8835,56.5005,65.769
14, 59.631,6.52986,44.462,55.942,59.1895,64.6415,74.496
15, 62.8342,7.51829,45.404,57.5305,63.3515,68.374,81.053
16, 71.0161,8.59645,50.192,65.412,71.8115,77.1935,95.889
17, 73.5028,8.5109,49.91,68.9235,73.71,79.9465,98.514
18, 82.1728,9.8354,59.918,76.059,82.3295,87.2325,108.136
19, 86.6909,8.95148,67.399,80.3205,85.957,93.6305,109.922
20, 95.2628,9.05126,70.754,89.615,95.4315,102.456,117.256
21, 89.2714,9.88199,71.603,82.613,88.2055,96.8005,116.849
22, 99.1948,10.1707,76.467,91.7745,97.433,107.02,124.762
23, 110.219,9.7821,87.281,102.459,109.247,117.959,132.989
24, 132.063,16.7104,101.769,120.478,128.19,141.318,203.739
25, 156.385,46.9554,102.348,123.559,133.556,193.514,300.64
26, 194.379,92.4347,107.706,135.214,150.431,212.325,466.073
27, 257.526,184.259,111.602,139.756,155.167,328.015,804.696
===============================================================================
test cases: 1 | 1 passed
assertions: - none -
```

Looks plausible as polynomial scaling, to me. (Remember that the number of gates also increases with each iteration of the test.) If anyone has any commentary or questions on this, please, speak up.

Regardless, even if I'm off my rocker, the benchmark is still worth including, which is the entire code content of this PR.