### PR TITLE
Convert libqrack to shared library (closed to rebase)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ include_directories ("include" "include/common")
 set(PSTRIDE "16" CACHE STRING "Stride of parallel for loops (must be power of 2)")
 
 # Declare the library
-add_library (qrack STATIC
+add_library (qrack SHARED
     src/common/parallel_for.cpp
     src/common/rdrandwrapper.cpp
     src/qinterface/arithmetic.cpp
@@ -30,6 +30,8 @@ add_library (qrack STATIC
     src/qfusion.cpp
     src/qunit.cpp
     )
+
+set_target_properties(qrack PROPERTIES VERSION 3.1 SOVERSION 1 PUBLIC_HEADER include/qfactory.hpp)
 
 if (MSVC)
     set(QRACK_LIBS qrack)
@@ -171,7 +173,7 @@ install (FILES
 
 # Install the archive
 install (TARGETS qrack
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
     )
 

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -112,13 +112,6 @@ struct QEngineShard {
     {
     }
 
-    ~QEngineShard()
-    {
-        if (unit && (mapped == 0)) {
-            unit->Finish();
-        }
-    }
-
     /// Remove another qubit as being a cached control of a phase gate buffer, for "this" as target bit.
     void RemovePhaseControl(QEngineShardPtr p)
     {
@@ -172,7 +165,7 @@ struct QEngineShard {
         // We can reduce our number of buffer instances by taking advantage of this kind of symmetry:
         ShardToPhaseMap::iterator controlShard = controlsShards.find(control);
         if (!targetOfShards[control].isInvert && (controlShard != controlsShards.end()) &&
-            (abs(controlShard->second.angle0) < ANGLE_MIN_NORM)) {
+            !controlShard->second.isInvert && (abs(controlShard->second.angle0) < ANGLE_MIN_NORM)) {
             nAngle1 += controlShard->second.angle1;
             RemovePhaseTarget(control);
         }

--- a/src/qinterface/protected.cpp
+++ b/src/qinterface/protected.cpp
@@ -200,7 +200,7 @@ bitCapInt pushApartBits(const bitCapInt& perm, const bitCapInt* skipPowers, cons
     for (p = 0; p < skipPowersCount; p++) {
         iLow = iHigh & (skipPowers[p] - ONE_BCI);
         i |= iLow;
-        iHigh = (iHigh ^ iLow) << 1U;
+        iHigh = (iHigh ^ iLow) << ONE_BCI;
     }
     i |= iHigh;
 
@@ -225,7 +225,7 @@ bool QInterface::IsIdentity(const complex* mtrx, bool isControlled)
     // the user's purposes. If the global phase offset has not been randomized, user code might explicitly depend on
     // the global phase offset (but shouldn't).
 
-    if ((!randGlobalPhase || isControlled) && (abs(imag(mtrx[0])) > min_norm)) {
+    if ((!randGlobalPhase || isControlled) && (abs(imag(mtrx[0])) >= min_norm)) {
         return false;
     }
 

--- a/src/qinterface/protected.cpp
+++ b/src/qinterface/protected.cpp
@@ -215,7 +215,7 @@ bool QInterface::IsIdentity(const complex* mtrx, bool isControlled)
         return false;
     }
 
-    if (norm(mtrx[0] - mtrx[3]) > min_norm) {
+    if (norm(mtrx[0] - mtrx[3]) > 0) {
         return false;
     }
 

--- a/src/qinterface/protected.cpp
+++ b/src/qinterface/protected.cpp
@@ -211,15 +211,11 @@ bool QInterface::IsIdentity(const complex* mtrx, bool isControlled)
 {
     // If the effect of applying the buffer would be (approximately or exactly) that of applying the identity
     // operator, then we can discard this buffer without applying it.
-    if ((norm(mtrx[1]) != 0) || (norm(mtrx[2]) != 0)) {
+    if ((mtrx[0] != mtrx[3]) || (norm(mtrx[1]) != 0) || (norm(mtrx[2]) != 0)) {
         return false;
     }
 
-    if (mtrx[0] != mtrx[3]) {
-        return false;
-    }
-
-    // Now, we now that mtrx[1] and mtrx[2] are effectively 0 and mtrx[0] and mtrx[3] are effectively equal.
+    // Now, we now that mtrx[1] and mtrx[2] are 0 and mtrx[0]==mtrx[3].
 
     // If the global phase offset has been randomized, we assume that global phase offsets are inconsequential, for
     // the user's purposes. If the global phase offset has not been randomized, user code might explicitly depend on
@@ -229,7 +225,8 @@ bool QInterface::IsIdentity(const complex* mtrx, bool isControlled)
         return false;
     }
 
-    // If we haven't returned false by now, we're buffering (approximately or exactly) an identity operator.
+    // If we haven't returned false by now, we're buffering an identity operator (exactly or up to an arbitrary global
+    // phase factor).
     return true;
 }
 

--- a/src/qinterface/protected.cpp
+++ b/src/qinterface/protected.cpp
@@ -211,11 +211,11 @@ bool QInterface::IsIdentity(const complex* mtrx, bool isControlled)
 {
     // If the effect of applying the buffer would be (approximately or exactly) that of applying the identity
     // operator, then we can discard this buffer without applying it.
-    if ((norm(mtrx[1]) >= min_norm) || (norm(mtrx[2]) >= min_norm)) {
+    if ((norm(mtrx[1]) > 0) || (norm(mtrx[2]) > 0)) {
         return false;
     }
 
-    if (norm(mtrx[0] - mtrx[3]) >= min_norm) {
+    if (norm(mtrx[0] - mtrx[3]) > min_norm) {
         return false;
     }
 
@@ -225,7 +225,7 @@ bool QInterface::IsIdentity(const complex* mtrx, bool isControlled)
     // the user's purposes. If the global phase offset has not been randomized, user code might explicitly depend on
     // the global phase offset (but shouldn't).
 
-    if ((!randGlobalPhase || isControlled) && (abs(imag(mtrx[0])) >= min_norm)) {
+    if ((isControlled || !randGlobalPhase) && (abs(imag(mtrx[0])) > 0)) {
         return false;
     }
 

--- a/src/qinterface/protected.cpp
+++ b/src/qinterface/protected.cpp
@@ -211,32 +211,22 @@ bool QInterface::IsIdentity(const complex* mtrx, bool isControlled)
 {
     // If the effect of applying the buffer would be (approximately or exactly) that of applying the identity
     // operator, then we can discard this buffer without applying it.
-    if ((norm(mtrx[1]) > min_norm) || (norm(mtrx[2]) > min_norm)) {
+    if ((norm(mtrx[1]) >= min_norm) || (norm(mtrx[2]) >= min_norm)) {
         return false;
     }
 
-    if (randGlobalPhase && !isControlled) {
-        // If the global phase offset has been randomized, we assume that global phase offsets are inconsequential, for
-        // the user's purposes.
-        real1 toTest = norm(mtrx[0]);
-        if (toTest < (ONE_R1 - min_norm)) {
-            return false;
-        }
-        toTest = norm(mtrx[0] - mtrx[3]);
-        if (toTest > min_norm) {
-            return false;
-        }
-    } else {
-        // If the global phase offset has not been randomized, user code might explicitly depend on the global phase
-        // offset (but shouldn't).
-        complex toTest = mtrx[0];
-        if ((real(toTest) < (ONE_R1 - min_norm)) || (abs(imag(toTest)) > min_norm)) {
-            return false;
-        }
-        toTest = mtrx[3];
-        if ((real(toTest) < (ONE_R1 - min_norm)) || (abs(imag(toTest)) > min_norm)) {
-            return false;
-        }
+    if (norm(mtrx[0] - mtrx[3]) >= min_norm) {
+        return false;
+    }
+
+    // Now, we now that mtrx[1] and mtrx[2] are effectively 0 and mtrx[0] and mtrx[3] are effectively equal.
+
+    // If the global phase offset has been randomized, we assume that global phase offsets are inconsequential, for
+    // the user's purposes. If the global phase offset has not been randomized, user code might explicitly depend on
+    // the global phase offset (but shouldn't).
+
+    if ((!randGlobalPhase || isControlled) && (abs(imag(mtrx[0])) > min_norm)) {
+        return false;
     }
 
     // If we haven't returned false by now, we're buffering (approximately or exactly) an identity operator.

--- a/src/qinterface/protected.cpp
+++ b/src/qinterface/protected.cpp
@@ -71,9 +71,9 @@ void _expLog2x2(complex* matrix2x2, complex* outMatrix2x2, bool isExp)
 
     // Diagonal matrices are a special case.
     bool isDiag = true;
-    if (norm(matrix2x2[1]) > min_norm) {
+    if (norm(matrix2x2[1]) != 0) {
         isDiag = false;
-    } else if (norm(matrix2x2[2]) > min_norm) {
+    } else if (norm(matrix2x2[2]) != 0) {
         isDiag = false;
     }
 
@@ -211,11 +211,11 @@ bool QInterface::IsIdentity(const complex* mtrx, bool isControlled)
 {
     // If the effect of applying the buffer would be (approximately or exactly) that of applying the identity
     // operator, then we can discard this buffer without applying it.
-    if ((norm(mtrx[1]) > 0) || (norm(mtrx[2]) > 0)) {
+    if ((norm(mtrx[1]) != 0) || (norm(mtrx[2]) != 0)) {
         return false;
     }
 
-    if (norm(mtrx[0] - mtrx[3]) > 0) {
+    if (mtrx[0] != mtrx[3]) {
         return false;
     }
 
@@ -225,7 +225,7 @@ bool QInterface::IsIdentity(const complex* mtrx, bool isControlled)
     // the user's purposes. If the global phase offset has not been randomized, user code might explicitly depend on
     // the global phase offset (but shouldn't).
 
-    if ((isControlled || !randGlobalPhase) && (abs(imag(mtrx[0])) > 0)) {
+    if ((isControlled || !randGlobalPhase) && (imag(mtrx[0]) != 0)) {
         return false;
     }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -45,7 +45,7 @@
 #define CACHED_ZERO(shardIndex) (CACHED_PROB(shardIndex) && (Prob(shardIndex) < min_norm))
 #define PHASE_MATTERS(shardIndex) (!randGlobalPhase || !CACHED_CLASSICAL(shardIndex))
 #define DIRTY(shard) (shard.isPhaseDirty || shard.isProbDirty)
-#define IS_POSITIVE_REAL(c) ((abs(imag(c)) < min_norm) && (abs(ONE_R1 - real(c)) < min_norm))
+#define IS_POSITIVE_REAL(c) ((abs(imag(c)) == 0) && (real(c) == ONE_R1))
 
 namespace Qrack {
 
@@ -162,7 +162,7 @@ complex QUnit::GetAmplitude(bitCapInt perm)
     }
 
     if (shards[0].unit->GetQubitCount() > 1) {
-        if (norm(result) >= (ONE_R1 - min_norm)) {
+        if ((ONE_R1 - norm(result)) < min_norm) {
             SetPermutation(perm);
         }
     }
@@ -678,7 +678,7 @@ real1 QUnit::ProbAll(bitCapInt perm)
         result *= qi.first->ProbAll(qi.second);
     }
 
-    if (result >= (ONE_R1 - min_norm)) {
+    if ((ONE_R1 - result) < min_norm) {
         SetPermutation(perm);
         return ONE_R1;
     }
@@ -1428,11 +1428,15 @@ void QUnit::ApplyAntiControlledSingleInvert(const bitLenInt* controls, const bit
 
 void QUnit::ApplySingleBit(const complex* mtrx, bool doCalcNorm, bitLenInt target)
 {
-    if ((norm(mtrx[1]) < min_norm) && (norm(mtrx[2]) < min_norm)) {
+    if (IsIdentity(mtrx, true)) {
+        return;
+    }
+
+    if ((norm(mtrx[1]) == 0) && (norm(mtrx[2]) == 0)) {
         ApplySinglePhase(mtrx[0], mtrx[3], doCalcNorm, target);
         return;
     }
-    if ((norm(mtrx[0]) < min_norm) && (norm(mtrx[3]) < min_norm)) {
+    if ((norm(mtrx[0]) == 0) && (norm(mtrx[3]) == 0)) {
         ApplySingleInvert(mtrx[1], mtrx[2], doCalcNorm, target);
         return;
     }

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1276,7 +1276,7 @@ void QUnit::ApplySingleInvert(const complex topRight, const complex bottomLeft, 
 {
     QEngineShard& shard = shards[target];
 
-    if (!PHASE_MATTERS(target) || (randGlobalPhase && (norm(topRight - bottomLeft) < min_norm))) {
+    if (!PHASE_MATTERS(target) || (randGlobalPhase && (norm(topRight - bottomLeft) == 0))) {
         X(target);
         return;
     }

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1085,7 +1085,7 @@ bool QUnit::TryCnotOptimize(const bitLenInt* controls, const bitLenInt& controlL
     for (bitLenInt i = 0; i < controlLen; i++) {
         QEngineShard& shard = shards[controls[i]];
         if (CACHED_CLASSICAL(controls[i])) {
-            if ((anti && SHARD_STATE(shard) || (!anti && !SHARD_STATE(shard)))) {
+            if ((anti && SHARD_STATE(shard)) || (!anti && !SHARD_STATE(shard))) {
                 return true;
             }
         } else {

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1335,7 +1335,7 @@ void QUnit::ApplyControlledSinglePhase(const bitLenInt* cControls, const bitLenI
             }
         }
 
-        if (randGlobalPhase && !shards[target].isPlusMinus) {
+        if (!shards[target].isPlusMinus) {
             for (bitLenInt i = 0; i < controlLen; i++) {
                 if (shards[controls[i]].isPlusMinus) {
                     std::swap(controls[i], target);
@@ -1416,9 +1416,11 @@ void QUnit::ApplyAntiControlledSinglePhase(const bitLenInt* cControls, const bit
 void QUnit::ApplyAntiControlledSingleInvert(const bitLenInt* controls, const bitLenInt& controlLen,
     const bitLenInt& target, const complex topRight, const complex bottomLeft)
 {
-    CTRLED_PHASE_INVERT_WRAP(ApplyAntiControlledSingleInvert(CTRL_I_ARGS),
-        ApplyAntiControlledSingleBit(CTRL_GEN_ARGS), ApplySingleInvert(topRight, bottomLeft, true, target), true,
-        true, topRight, bottomLeft);
+    if (!TryCnotOptimize(controls, controlLen, target, bottomLeft, topRight, true)) {
+        CTRLED_PHASE_INVERT_WRAP(ApplyAntiControlledSingleInvert(CTRL_I_ARGS),
+            ApplyAntiControlledSingleBit(CTRL_GEN_ARGS), ApplySingleInvert(topRight, bottomLeft, true, target), true,
+            true, topRight, bottomLeft);
+    }
 }
 
 void QUnit::ApplySingleBit(const complex* mtrx, bool doCalcNorm, bitLenInt target)
@@ -1471,14 +1473,17 @@ void QUnit::ApplyControlledSingleBit(
         return;
     }
 
-    if ((norm(mtrx[1]) == 0) && (norm(mtrx[2]) == 0)) {
-        ApplyControlledSinglePhase(controls, controlLen, target, mtrx[0], mtrx[3]);
-        return;
-    }
+    // Special case probability checks could disturb (arbitrary) phase
+    if (randGlobalPhase) {
+        if ((norm(mtrx[1]) == 0) && (norm(mtrx[2]) == 0)) {
+            ApplyControlledSinglePhase(controls, controlLen, target, mtrx[0], mtrx[3]);
+            return;
+        }
 
-    if ((norm(mtrx[0]) == 0) && (norm(mtrx[3]) == 0)) {
-        ApplyControlledSingleInvert(controls, controlLen, target, mtrx[1], mtrx[2]);
-        return;
+        if ((norm(mtrx[0]) == 0) && (norm(mtrx[3]) == 0)) {
+            ApplyControlledSingleInvert(controls, controlLen, target, mtrx[1], mtrx[2]);
+            return;
+        }
     }
 
     CTRLED_GEN_WRAP(ApplyControlledSingleBit(CTRL_GEN_ARGS), ApplySingleBit(mtrx, true, target), false);
@@ -1491,14 +1496,17 @@ void QUnit::ApplyAntiControlledSingleBit(
         return;
     }
 
-    if ((norm(mtrx[1]) == 0) && (norm(mtrx[2]) == 0)) {
-        ApplyAntiControlledSinglePhase(controls, controlLen, target, mtrx[0], mtrx[3]);
-        return;
-    }
+    // Special case probability checks could disturb (arbitrary) phase
+    if (randGlobalPhase) {
+        if ((norm(mtrx[1]) == 0) && (norm(mtrx[2]) == 0)) {
+            ApplyAntiControlledSinglePhase(controls, controlLen, target, mtrx[0], mtrx[3]);
+            return;
+        }
 
-    if ((norm(mtrx[0]) == 0) && (norm(mtrx[3]) == 0)) {
-        ApplyAntiControlledSingleInvert(controls, controlLen, target, mtrx[1], mtrx[2]);
-        return;
+        if ((norm(mtrx[0]) == 0) && (norm(mtrx[3]) == 0)) {
+            ApplyAntiControlledSingleInvert(controls, controlLen, target, mtrx[1], mtrx[2]);
+            return;
+        }
     }
 
     CTRLED_GEN_WRAP(ApplyAntiControlledSingleBit(CTRL_GEN_ARGS), ApplySingleBit(mtrx, true, target), true);

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1472,6 +1472,16 @@ void QUnit::ApplyControlledSingleBit(
         return;
     }
 
+    if ((norm(mtrx[1]) == 0) && (norm(mtrx[2]) == 0)) {
+        ApplyControlledSinglePhase(controls, controlLen, target, mtrx[0], mtrx[3]);
+        return;
+    }
+
+    if ((norm(mtrx[0]) == 0) && (norm(mtrx[3]) == 0)) {
+        ApplyControlledSingleInvert(controls, controlLen, target, mtrx[1], mtrx[2]);
+        return;
+    }
+
     CTRLED_GEN_WRAP(ApplyControlledSingleBit(CTRL_GEN_ARGS), ApplySingleBit(mtrx, true, target), false);
 }
 
@@ -1479,6 +1489,16 @@ void QUnit::ApplyAntiControlledSingleBit(
     const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& target, const complex* mtrx)
 {
     if (IsIdentity(mtrx, true)) {
+        return;
+    }
+
+    if ((norm(mtrx[1]) == 0) && (norm(mtrx[2]) == 0)) {
+        ApplyAntiControlledSinglePhase(controls, controlLen, target, mtrx[0], mtrx[3]);
+        return;
+    }
+
+    if ((norm(mtrx[0]) == 0) && (norm(mtrx[3]) == 0)) {
+        ApplyAntiControlledSingleInvert(controls, controlLen, target, mtrx[1], mtrx[2]);
         return;
     }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -45,7 +45,7 @@
 #define CACHED_ZERO(shardIndex) (CACHED_PROB(shardIndex) && (Prob(shardIndex) < min_norm))
 #define PHASE_MATTERS(shardIndex) (!randGlobalPhase || !CACHED_CLASSICAL(shardIndex))
 #define DIRTY(shard) (shard.isPhaseDirty || shard.isProbDirty)
-#define IS_POSITIVE_REAL(c) ((abs(imag(c)) == 0) && (real(c) == ONE_R1))
+#define IS_POSITIVE_REAL(c) ((imag(c) == 0) && (real(c) == ONE_R1))
 
 namespace Qrack {
 
@@ -162,7 +162,7 @@ complex QUnit::GetAmplitude(bitCapInt perm)
     }
 
     if (shards[0].unit->GetQubitCount() > 1) {
-        if ((ONE_R1 - norm(result)) < min_norm) {
+        if (norm(result) == ONE_R1) {
             SetPermutation(perm);
         }
     }
@@ -678,9 +678,10 @@ real1 QUnit::ProbAll(bitCapInt perm)
         result *= qi.first->ProbAll(qi.second);
     }
 
-    if ((ONE_R1 - result) < min_norm) {
-        SetPermutation(perm);
-        return ONE_R1;
+    if (shards[0].unit->GetQubitCount() > 1) {
+        if (result == ONE_R1) {
+            SetPermutation(perm);
+        }
     }
 
     return clampProb(result);
@@ -1276,7 +1277,7 @@ void QUnit::ApplySingleInvert(const complex topRight, const complex bottomLeft, 
 {
     QEngineShard& shard = shards[target];
 
-    if (!PHASE_MATTERS(target) || (randGlobalPhase && (norm(topRight - bottomLeft) == 0))) {
+    if (!PHASE_MATTERS(target) || (randGlobalPhase && (topRight == bottomLeft))) {
         X(target);
         return;
     }

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1468,12 +1468,40 @@ void QUnit::ApplySingleBit(const complex* mtrx, bool doCalcNorm, bitLenInt targe
 void QUnit::ApplyControlledSingleBit(
     const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& target, const complex* mtrx)
 {
+    if (IsIdentity(mtrx, true)) {
+        return;
+    }
+
+    if (norm(mtrx[1]) < min_norm && norm(mtrx[2]) < min_norm) {
+        ApplyControlledSinglePhase(controls, controlLen, target, mtrx[0], mtrx[3]);
+        return;
+    }
+
+    if (norm(mtrx[0]) < min_norm && norm(mtrx[3]) < min_norm) {
+        ApplyControlledSingleInvert(controls, controlLen, target, mtrx[1], mtrx[2]);
+        return;
+    }
+
     CTRLED_GEN_WRAP(ApplyControlledSingleBit(CTRL_GEN_ARGS), ApplySingleBit(mtrx, true, target), false);
 }
 
 void QUnit::ApplyAntiControlledSingleBit(
     const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& target, const complex* mtrx)
 {
+    if (IsIdentity(mtrx, true)) {
+        return;
+    }
+
+    if (norm(mtrx[1]) < min_norm && norm(mtrx[2]) < min_norm) {
+        ApplyAntiControlledSinglePhase(controls, controlLen, target, mtrx[0], mtrx[3]);
+        return;
+    }
+
+    if (norm(mtrx[0]) < min_norm && norm(mtrx[3]) < min_norm) {
+        ApplyAntiControlledSingleInvert(controls, controlLen, target, mtrx[1], mtrx[2]);
+        return;
+    }
+
     CTRLED_GEN_WRAP(ApplyAntiControlledSingleBit(CTRL_GEN_ARGS), ApplySingleBit(mtrx, true, target), true);
 }
 
@@ -2869,13 +2897,11 @@ void QUnit::RevertBasis2Qb(const bitLenInt& i, const bool& onlyInvert)
                 mtrx[3] = mtrx[0];
             }
 
-            if (!IsIdentity(mtrx, true)) {
-                shards[j].isPlusMinus = false;
-                freezeBasis = true;
-                ApplyControlledSingleBit(controls, 1U, j, mtrx);
-                freezeBasis = false;
-                shards[j].isPlusMinus = true;
-            }
+            shards[j].isPlusMinus = false;
+            freezeBasis = true;
+            ApplyControlledSingleBit(controls, 1U, j, mtrx);
+            freezeBasis = false;
+            shards[j].isPlusMinus = true;
         } else {
             freezeBasis = true;
             if (phaseShard->second.isInvert) {
@@ -2919,13 +2945,11 @@ void QUnit::RevertBasis2Qb(const bitLenInt& i, const bool& onlyInvert)
                 mtrx[3] = mtrx[0];
             }
 
-            if (!IsIdentity(mtrx, true)) {
-                shards[i].isPlusMinus = false;
-                freezeBasis = true;
-                ApplyControlledSingleBit(controls, 1U, i, mtrx);
-                freezeBasis = false;
-                shards[i].isPlusMinus = true;
-            }
+            shards[i].isPlusMinus = false;
+            freezeBasis = true;
+            ApplyControlledSingleBit(controls, 1U, i, mtrx);
+            freezeBasis = false;
+            shards[i].isPlusMinus = true;
         } else {
             freezeBasis = true;
             if (phaseShard->second.isInvert) {

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1473,14 +1473,17 @@ void QUnit::ApplyControlledSingleBit(
         return;
     }
 
-    if ((norm(mtrx[1]) == 0) && (norm(mtrx[2]) == 0)) {
-        ApplyControlledSinglePhase(controls, controlLen, target, mtrx[0], mtrx[3]);
-        return;
-    }
+    // Special case probability checks could disturb (arbitrary) phase
+    if (randGlobalPhase) {
+        if ((norm(mtrx[1]) == 0) && (norm(mtrx[2]) == 0)) {
+            ApplyControlledSinglePhase(controls, controlLen, target, mtrx[0], mtrx[3]);
+            return;
+        }
 
-    if ((norm(mtrx[0]) == 0) && (norm(mtrx[3]) == 0)) {
-        ApplyControlledSingleInvert(controls, controlLen, target, mtrx[1], mtrx[2]);
-        return;
+        if ((norm(mtrx[0]) == 0) && (norm(mtrx[3]) == 0)) {
+            ApplyControlledSingleInvert(controls, controlLen, target, mtrx[1], mtrx[2]);
+            return;
+        }
     }
 
     CTRLED_GEN_WRAP(ApplyControlledSingleBit(CTRL_GEN_ARGS), ApplySingleBit(mtrx, true, target), false);
@@ -1493,14 +1496,17 @@ void QUnit::ApplyAntiControlledSingleBit(
         return;
     }
 
-    if ((norm(mtrx[1]) == 0) && (norm(mtrx[2]) == 0)) {
-        ApplyAntiControlledSinglePhase(controls, controlLen, target, mtrx[0], mtrx[3]);
-        return;
-    }
+    // Special case probability checks could disturb (arbitrary) phase
+    if (randGlobalPhase) {
+        if ((norm(mtrx[1]) == 0) && (norm(mtrx[2]) == 0)) {
+            ApplyAntiControlledSinglePhase(controls, controlLen, target, mtrx[0], mtrx[3]);
+            return;
+        }
 
-    if ((norm(mtrx[0]) == 0) && (norm(mtrx[3]) == 0)) {
-        ApplyAntiControlledSingleInvert(controls, controlLen, target, mtrx[1], mtrx[2]);
-        return;
+        if ((norm(mtrx[0]) == 0) && (norm(mtrx[3]) == 0)) {
+            ApplyAntiControlledSingleInvert(controls, controlLen, target, mtrx[1], mtrx[2]);
+            return;
+        }
     }
 
     CTRLED_GEN_WRAP(ApplyAntiControlledSingleBit(CTRL_GEN_ARGS), ApplySingleBit(mtrx, true, target), true);

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -2869,11 +2869,13 @@ void QUnit::RevertBasis2Qb(const bitLenInt& i, const bool& onlyInvert)
                 mtrx[3] = mtrx[0];
             }
 
-            shards[j].isPlusMinus = false;
-            freezeBasis = true;
-            ApplyControlledSingleBit(controls, 1U, j, mtrx);
-            freezeBasis = false;
-            shards[j].isPlusMinus = true;
+            if (!IsIdentity(mtrx, true)) {
+                shards[j].isPlusMinus = false;
+                freezeBasis = true;
+                ApplyControlledSingleBit(controls, 1U, j, mtrx);
+                freezeBasis = false;
+                shards[j].isPlusMinus = true;
+            }
         } else {
             freezeBasis = true;
             if (phaseShard->second.isInvert) {
@@ -2917,11 +2919,13 @@ void QUnit::RevertBasis2Qb(const bitLenInt& i, const bool& onlyInvert)
                 mtrx[3] = mtrx[0];
             }
 
-            shards[i].isPlusMinus = false;
-            freezeBasis = true;
-            ApplyControlledSingleBit(controls, 1U, i, mtrx);
-            freezeBasis = false;
-            shards[i].isPlusMinus = true;
+            if (!IsIdentity(mtrx, true)) {
+                shards[i].isPlusMinus = false;
+                freezeBasis = true;
+                ApplyControlledSingleBit(controls, 1U, i, mtrx);
+                freezeBasis = false;
+                shards[i].isPlusMinus = true;
+            }
         } else {
             freezeBasis = true;
             if (phaseShard->second.isInvert) {

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -161,7 +161,7 @@ complex QUnit::GetAmplitude(bitCapInt perm)
         result *= qi.first->GetAmplitude(qi.second);
     }
 
-    if (shards[0].unit->GetQubitCount() > 1) {
+    if (randGlobalPhase && (shards[0].unit->GetQubitCount() > 1)) {
         if (norm(result) == ONE_R1) {
             SetPermutation(perm);
         }
@@ -678,7 +678,7 @@ real1 QUnit::ProbAll(bitCapInt perm)
         result *= qi.first->ProbAll(qi.second);
     }
 
-    if (shards[0].unit->GetQubitCount() > 1) {
+    if (randGlobalPhase && (shards[0].unit->GetQubitCount() > 1)) {
         if (result == ONE_R1) {
             SetPermutation(perm);
         }

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1472,16 +1472,6 @@ void QUnit::ApplyControlledSingleBit(
         return;
     }
 
-    if (norm(mtrx[1]) < min_norm && norm(mtrx[2]) < min_norm) {
-        ApplyControlledSinglePhase(controls, controlLen, target, mtrx[0], mtrx[3]);
-        return;
-    }
-
-    if (norm(mtrx[0]) < min_norm && norm(mtrx[3]) < min_norm) {
-        ApplyControlledSingleInvert(controls, controlLen, target, mtrx[1], mtrx[2]);
-        return;
-    }
-
     CTRLED_GEN_WRAP(ApplyControlledSingleBit(CTRL_GEN_ARGS), ApplySingleBit(mtrx, true, target), false);
 }
 
@@ -1489,16 +1479,6 @@ void QUnit::ApplyAntiControlledSingleBit(
     const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& target, const complex* mtrx)
 {
     if (IsIdentity(mtrx, true)) {
-        return;
-    }
-
-    if (norm(mtrx[1]) < min_norm && norm(mtrx[2]) < min_norm) {
-        ApplyAntiControlledSinglePhase(controls, controlLen, target, mtrx[0], mtrx[3]);
-        return;
-    }
-
-    if (norm(mtrx[0]) < min_norm && norm(mtrx[3]) < min_norm) {
-        ApplyAntiControlledSingleInvert(controls, controlLen, target, mtrx[1], mtrx[2]);
         return;
     }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1473,17 +1473,14 @@ void QUnit::ApplyControlledSingleBit(
         return;
     }
 
-    // Special case probability checks could disturb (arbitrary) phase
-    if (randGlobalPhase) {
-        if ((norm(mtrx[1]) == 0) && (norm(mtrx[2]) == 0)) {
-            ApplyControlledSinglePhase(controls, controlLen, target, mtrx[0], mtrx[3]);
-            return;
-        }
+    if ((norm(mtrx[1]) == 0) && (norm(mtrx[2]) == 0)) {
+        ApplyControlledSinglePhase(controls, controlLen, target, mtrx[0], mtrx[3]);
+        return;
+    }
 
-        if ((norm(mtrx[0]) == 0) && (norm(mtrx[3]) == 0)) {
-            ApplyControlledSingleInvert(controls, controlLen, target, mtrx[1], mtrx[2]);
-            return;
-        }
+    if ((norm(mtrx[0]) == 0) && (norm(mtrx[3]) == 0)) {
+        ApplyControlledSingleInvert(controls, controlLen, target, mtrx[1], mtrx[2]);
+        return;
     }
 
     CTRLED_GEN_WRAP(ApplyControlledSingleBit(CTRL_GEN_ARGS), ApplySingleBit(mtrx, true, target), false);
@@ -1496,17 +1493,14 @@ void QUnit::ApplyAntiControlledSingleBit(
         return;
     }
 
-    // Special case probability checks could disturb (arbitrary) phase
-    if (randGlobalPhase) {
-        if ((norm(mtrx[1]) == 0) && (norm(mtrx[2]) == 0)) {
-            ApplyAntiControlledSinglePhase(controls, controlLen, target, mtrx[0], mtrx[3]);
-            return;
-        }
+    if ((norm(mtrx[1]) == 0) && (norm(mtrx[2]) == 0)) {
+        ApplyAntiControlledSinglePhase(controls, controlLen, target, mtrx[0], mtrx[3]);
+        return;
+    }
 
-        if ((norm(mtrx[0]) == 0) && (norm(mtrx[3]) == 0)) {
-            ApplyAntiControlledSingleInvert(controls, controlLen, target, mtrx[1], mtrx[2]);
-            return;
-        }
+    if ((norm(mtrx[0]) == 0) && (norm(mtrx[3]) == 0)) {
+        ApplyAntiControlledSingleInvert(controls, controlLen, target, mtrx[1], mtrx[2]);
+        return;
     }
 
     CTRLED_GEN_WRAP(ApplyAntiControlledSingleBit(CTRL_GEN_ARGS), ApplySingleBit(mtrx, true, target), true);

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1335,7 +1335,7 @@ void QUnit::ApplyControlledSinglePhase(const bitLenInt* cControls, const bitLenI
             }
         }
 
-        if (!shards[target].isPlusMinus) {
+        if (randGlobalPhase && !shards[target].isPlusMinus) {
             for (bitLenInt i = 0; i < controlLen; i++) {
                 if (shards[controls[i]].isPlusMinus) {
                     std::swap(controls[i], target);
@@ -1416,11 +1416,9 @@ void QUnit::ApplyAntiControlledSinglePhase(const bitLenInt* cControls, const bit
 void QUnit::ApplyAntiControlledSingleInvert(const bitLenInt* controls, const bitLenInt& controlLen,
     const bitLenInt& target, const complex topRight, const complex bottomLeft)
 {
-    if (!TryCnotOptimize(controls, controlLen, target, bottomLeft, topRight, true)) {
-        CTRLED_PHASE_INVERT_WRAP(ApplyAntiControlledSingleInvert(CTRL_I_ARGS),
-            ApplyAntiControlledSingleBit(CTRL_GEN_ARGS), ApplySingleInvert(topRight, bottomLeft, true, target), true,
-            true, topRight, bottomLeft);
-    }
+    CTRLED_PHASE_INVERT_WRAP(ApplyAntiControlledSingleInvert(CTRL_I_ARGS),
+        ApplyAntiControlledSingleBit(CTRL_GEN_ARGS), ApplySingleInvert(topRight, bottomLeft, true, target), true,
+        true, topRight, bottomLeft);
 }
 
 void QUnit::ApplySingleBit(const complex* mtrx, bool doCalcNorm, bitLenInt target)
@@ -1473,17 +1471,14 @@ void QUnit::ApplyControlledSingleBit(
         return;
     }
 
-    // Special case probability checks could disturb (arbitrary) phase
-    if (randGlobalPhase) {
-        if ((norm(mtrx[1]) == 0) && (norm(mtrx[2]) == 0)) {
-            ApplyControlledSinglePhase(controls, controlLen, target, mtrx[0], mtrx[3]);
-            return;
-        }
+    if ((norm(mtrx[1]) == 0) && (norm(mtrx[2]) == 0)) {
+        ApplyControlledSinglePhase(controls, controlLen, target, mtrx[0], mtrx[3]);
+        return;
+    }
 
-        if ((norm(mtrx[0]) == 0) && (norm(mtrx[3]) == 0)) {
-            ApplyControlledSingleInvert(controls, controlLen, target, mtrx[1], mtrx[2]);
-            return;
-        }
+    if ((norm(mtrx[0]) == 0) && (norm(mtrx[3]) == 0)) {
+        ApplyControlledSingleInvert(controls, controlLen, target, mtrx[1], mtrx[2]);
+        return;
     }
 
     CTRLED_GEN_WRAP(ApplyControlledSingleBit(CTRL_GEN_ARGS), ApplySingleBit(mtrx, true, target), false);
@@ -1496,17 +1491,14 @@ void QUnit::ApplyAntiControlledSingleBit(
         return;
     }
 
-    // Special case probability checks could disturb (arbitrary) phase
-    if (randGlobalPhase) {
-        if ((norm(mtrx[1]) == 0) && (norm(mtrx[2]) == 0)) {
-            ApplyAntiControlledSinglePhase(controls, controlLen, target, mtrx[0], mtrx[3]);
-            return;
-        }
+    if ((norm(mtrx[1]) == 0) && (norm(mtrx[2]) == 0)) {
+        ApplyAntiControlledSinglePhase(controls, controlLen, target, mtrx[0], mtrx[3]);
+        return;
+    }
 
-        if ((norm(mtrx[0]) == 0) && (norm(mtrx[3]) == 0)) {
-            ApplyAntiControlledSingleInvert(controls, controlLen, target, mtrx[1], mtrx[2]);
-            return;
-        }
+    if ((norm(mtrx[0]) == 0) && (norm(mtrx[3]) == 0)) {
+        ApplyAntiControlledSingleInvert(controls, controlLen, target, mtrx[1], mtrx[2]);
+        return;
     }
 
     CTRLED_GEN_WRAP(ApplyAntiControlledSingleBit(CTRL_GEN_ARGS), ApplySingleBit(mtrx, true, target), true);

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -45,7 +45,7 @@
 #define CACHED_ZERO(shardIndex) (CACHED_PROB(shardIndex) && (Prob(shardIndex) < min_norm))
 #define PHASE_MATTERS(shardIndex) (!randGlobalPhase || !CACHED_CLASSICAL(shardIndex))
 #define DIRTY(shard) (shard.isPhaseDirty || shard.isProbDirty)
-#define IS_POSITIVE_REAL(c) ((imag(c) == 0) && (real(c) == ONE_R1))
+#define IS_ONE_CMPLX(c) (c == ONE_CMPLX)
 
 namespace Qrack {
 
@@ -161,10 +161,8 @@ complex QUnit::GetAmplitude(bitCapInt perm)
         result *= qi.first->GetAmplitude(qi.second);
     }
 
-    if (randGlobalPhase && (shards[0].unit->GetQubitCount() > 1)) {
-        if (norm(result) == ONE_R1) {
-            SetPermutation(perm);
-        }
+    if (randGlobalPhase && (shards[0].unit->GetQubitCount() > 1) && (norm(result) == ONE_R1)) {
+        SetPermutation(perm);
     }
 
     return result;
@@ -678,10 +676,8 @@ real1 QUnit::ProbAll(bitCapInt perm)
         result *= qi.first->ProbAll(qi.second);
     }
 
-    if (randGlobalPhase && (shards[0].unit->GetQubitCount() > 1)) {
-        if (result == ONE_R1) {
-            SetPermutation(perm);
-        }
+    if (randGlobalPhase && (shards[0].unit->GetQubitCount() > 1) && (result == ONE_R1)) {
+        SetPermutation(perm);
     }
 
     return clampProb(result);
@@ -1089,7 +1085,7 @@ bool QUnit::TryCnotOptimize(const bitLenInt* controls, const bitLenInt& controlL
     for (bitLenInt i = 0; i < controlLen; i++) {
         QEngineShard& shard = shards[controls[i]];
         if (CACHED_CLASSICAL(controls[i])) {
-            if ((!anti && !SHARD_STATE(shard)) || (anti && SHARD_STATE(shard))) {
+            if ((anti && SHARD_STATE(shard) || (!anti && !SHARD_STATE(shard)))) {
                 return true;
             }
         } else {
@@ -1320,19 +1316,19 @@ void QUnit::ApplyControlledSinglePhase(const bitLenInt* cControls, const bitLenI
     std::copy(cControls, cControls + controlLen, controls);
     bitLenInt target = cTarget;
 
-    if (IS_POSITIVE_REAL(bottomRight) && CACHED_ONE(target)) {
+    if (IS_ONE_CMPLX(bottomRight) && CACHED_ONE(target)) {
         delete[] controls;
         return;
     }
 
-    if (IS_POSITIVE_REAL(topLeft)) {
+    if (IS_ONE_CMPLX(topLeft)) {
         if (CACHED_ZERO(target)) {
             delete[] controls;
             return;
         }
 
         if (controlLen == 1U) {
-            if (IS_POSITIVE_REAL(-bottomRight)) {
+            if (IS_ONE_CMPLX(-bottomRight)) {
                 CZ(controls[0], target);
                 delete[] controls;
                 return;
@@ -1406,7 +1402,7 @@ void QUnit::ApplyAntiControlledSinglePhase(const bitLenInt* cControls, const bit
     std::copy(cControls, cControls + controlLen, controls);
     bitLenInt target = cTarget;
 
-    if ((IS_POSITIVE_REAL(topLeft) && CACHED_ZERO(cTarget)) || (IS_POSITIVE_REAL(bottomRight) && CACHED_ONE(cTarget))) {
+    if ((IS_ONE_CMPLX(topLeft) && CACHED_ZERO(cTarget)) || (IS_ONE_CMPLX(bottomRight) && CACHED_ONE(cTarget))) {
         delete[] controls;
         return;
     }

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -528,19 +528,19 @@ TEST_CASE("test_universal_circuit_digital", "[supreme]")
                     b1 = pickRandomBit(qReg, &unusedBits);
                     b2 = pickRandomBit(qReg, &unusedBits);
 
-                    gateRand = qReg->Rand();
-
                     if (unusedBits.size() > 0) {
                         maxGates = GateCountMultiQb;
                     } else {
                         maxGates = GateCountMultiQb - 1U;
                     }
 
-                    if (gateRand < (ONE_R1 / maxGates)) {
+                    gateRand = maxGates * qReg->Rand();
+
+                    if (gateRand < ONE_R1) {
                         qReg->Swap(b1, b2);
-                    } else if (gateRand < (2 * ONE_R1 / maxGates)) {
+                    } else if (gateRand < (2 * ONE_R1)) {
                         qReg->CZ(b1, b2);
-                    } else if (maxGates == GateCountMultiQb || (gateRand < (3 * ONE_R1 / maxGates))) {
+                    } else if ((maxGates != GateCountMultiQb) || gateRand < (3 * ONE_R1)) {
                         qReg->CNOT(b1, b2);
                     } else {
                         b3 = pickRandomBit(qReg, &unusedBits);

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -540,7 +540,7 @@ TEST_CASE("test_universal_circuit_digital", "[supreme]")
                         qReg->Swap(b1, b2);
                     } else if (gateRand < (2 * ONE_R1)) {
                         qReg->CZ(b1, b2);
-                    } else if ((maxGates != GateCountMultiQb) || gateRand < (3 * ONE_R1)) {
+                    } else if ((unusedBits.size() == 0) || (gateRand < (3 * ONE_R1))) {
                         qReg->CNOT(b1, b2);
                     } else {
                         b3 = pickRandomBit(qReg, &unusedBits);
@@ -566,7 +566,7 @@ TEST_CASE("test_universal_circuit_analog", "[supreme]")
             int d;
             bitLenInt i;
             real1 gateRand;
-            bitLenInt bitRand, b1, b2, b3;
+            bitLenInt b1, b2, b3;
             bitLenInt control[1];
             complex polar0;
             bool canDo3;
@@ -593,26 +593,9 @@ TEST_CASE("test_universal_circuit_analog", "[supreme]")
                     unusedBits.insert(unusedBits.end(), i);
                 }
 
-                std::set<bitLenInt>::iterator bitIterator;
                 while (unusedBits.size() > 1) {
-
-                    bitIterator = unusedBits.begin();
-                    bitRand = unusedBits.size() * qReg->Rand();
-                    if (bitRand >= unusedBits.size()) {
-                        bitRand = unusedBits.size() - 1;
-                    }
-                    std::advance(bitIterator, bitRand);
-                    b1 = *bitIterator;
-                    unusedBits.erase(bitIterator);
-
-                    bitIterator = unusedBits.begin();
-                    bitRand = unusedBits.size() * qReg->Rand();
-                    if (bitRand >= unusedBits.size()) {
-                        bitRand = unusedBits.size() - 1;
-                    }
-                    std::advance(bitIterator, bitRand);
-                    b2 = *bitIterator;
-                    unusedBits.erase(bitIterator);
+                    b1 = pickRandomBit(qReg, &unusedBits);
+                    b2 = pickRandomBit(qReg, &unusedBits);
 
                     canDo3 = (unusedBits.size() > 0);
                     if (canDo3) {
@@ -627,15 +610,7 @@ TEST_CASE("test_universal_circuit_analog", "[supreme]")
                     if (gateRand < (ONE_R1 / gateMax)) {
                         qReg->Swap(b1, b2);
                     } else if (canDo3 && (gateRand < (2 * ONE_R1 / GateCountMultiQb))) {
-                        bitIterator = unusedBits.begin();
-                        bitRand = unusedBits.size() * qReg->Rand();
-                        if (bitRand >= unusedBits.size()) {
-                            bitRand = unusedBits.size() - 1;
-                        }
-                        std::advance(bitIterator, bitRand);
-                        b3 = *bitIterator;
-                        unusedBits.erase(bitIterator);
-
+                        b3 = pickRandomBit(qReg, &unusedBits);
                         qReg->CCNOT(b1, b2, b3);
                     } else {
                         control[0] = b1;


### PR DESCRIPTION
We might have done this ages ago, but this is when we do it. The static `libqrack.a` is a total pain to link. As the library's developers, we were somewhat self-shielded from the difficulty of linking the static library by the demand for Python integration, where Python/C++ interface packages made the process "transparent." I actually attempted to link a "Hello world" example outside of the main project repo build system, and it's frustrating enough to give up. With 2 minutes of care to create a shared library, there's no problem.

I realize this is a bigger step forward than I make of it, here, for versioning and downstream dependency. It's time, though.