### PR TITLE
Convert libqrack to shared library

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ install:
 script:
   - mkdir _build && cd _build && cmake -DENABLE_OPENCL=OFF -DENABLE_COMPLEX8=ON .. && make -j 8 all
   - sudo make install
+  - ldconfig
   - cd .. && sudo rm -r _build
   - mkdir _build && cd _build && cmake -DENABLE_OPENCL=OFF -DENABLE_COMPLEX8=OFF .. && make -j 8 all
   - ./unittest --proc-cpu

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
 script:
   - mkdir _build && cd _build && cmake -DENABLE_OPENCL=OFF -DENABLE_COMPLEX8=ON .. && make -j 8 all
   - sudo make install
-  - ldconfig
+  - sudo ldconfig
   - cd .. && sudo rm -r _build
   - mkdir _build && cd _build && cmake -DENABLE_OPENCL=OFF -DENABLE_COMPLEX8=OFF .. && make -j 8 all
   - ./unittest --proc-cpu

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ include_directories ("include" "include/common")
 set(PSTRIDE "16" CACHE STRING "Stride of parallel for loops (must be power of 2)")
 
 # Declare the library
-add_library (qrack STATIC
+add_library (qrack SHARED
     src/common/parallel_for.cpp
     src/common/rdrandwrapper.cpp
     src/qinterface/arithmetic.cpp
@@ -30,6 +30,8 @@ add_library (qrack STATIC
     src/qfusion.cpp
     src/qunit.cpp
     )
+
+set_target_properties(qrack PROPERTIES VERSION 3.1 SOVERSION 1 PUBLIC_HEADER include/qfactory.hpp)
 
 if (MSVC)
     set(QRACK_LIBS qrack)
@@ -171,7 +173,7 @@ install (FILES
 
 # Install the archive
 install (TARGETS qrack
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
     )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,7 +110,7 @@ if (MSVC)
     set(QRACK_COMPILE_OPTS -std=c++11 -Wall)
     set(TEST_COMPILE_OPTS -std=c++11 -Wall)
 else (MSVC)
-    set(QRACK_COMPILE_OPTS -O3 -std=c++11 -Wall -Werror -fPIC)
+    set(QRACK_COMPILE_OPTS -O3 -std=c++11 -Wall -Werror)
     set(TEST_COMPILE_OPTS -O3 -std=c++11 -Wall -Werror)
 endif(MSVC)
 


### PR DESCRIPTION
We might have done this ages ago, but this is when we do it. The static libqrack.a is a total pain to link. As the library's developers, we were somewhat self-shielded from the difficulty of linking the static library by the demand for Python integration, where Python/C++ interface packages made the process "transparent." I actually attempted to link a "Hello world" example outside of the main project repo build system, and it's frustrating enough to give up. With 2 minutes of care to create a shared library, there's no problem.

I realize this is a bigger step forward than I make of it, here, for versioning and downstream dependency. It's time, though.