### PR TITLE
Controlled inversion debugging (for ProjectQ unit tests)

### DIFF
--- a/include/qengine.hpp
+++ b/include/qengine.hpp
@@ -37,7 +37,7 @@ protected:
             real1 angle = Rand() * 2 * M_PI;
             return complex(cos(angle), sin(angle));
         } else {
-            return complex(ONE_R1, ZERO_R1);
+            return ONE_CMPLX;
         }
     }
 

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -297,13 +297,13 @@ struct QEngineShard {
             didFlip = false;
             if (polar0 == polar1) {
                 if (phaseShard->second.isInvert) {
-                    polar0 = (polar0 + polar1) / (2 * ONE_R1);
+                    polar0 = (polar0 + polar1) / (real1)2;
                     polar1 = -polar0;
                     didFlip = true;
                 }
             } else if (polar0 == -polar1) {
                 if (!phaseShard->second.isInvert) {
-                    polar0 = (polar0 + polar1) / (2 * ONE_R1);
+                    polar0 = (polar0 + polar1) / (real1)2;
                     polar1 = polar0;
                     didFlip = true;
                 }

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -739,7 +739,7 @@ void QEngineOCL::UniformlyControlledSingleBit(const bitLenInt* controls, const b
     // Arguments are concatenated into buffers by primitive type, such as integer or complex number.
 
     // Load the integer kernel arguments buffer.
-    bitCapInt maxI = maxQPower >> 1;
+    bitCapInt maxI = maxQPower >> ONE_BCI;
     bitCapInt bciArgs[BCI_ARG_LEN] = { maxI, pow2(qubitIndex), controlLen, mtrxSkipLen, mtrxSkipValueMask, 0, 0, 0, 0,
         0 };
     DISPATCH_WRITE(waitVec, *(poolItem->ulongBuffer), sizeof(bitCapInt) * 5, bciArgs);
@@ -806,7 +806,7 @@ void QEngineOCL::ApplyM(bitCapInt qPower, bool result, complex nrm)
 {
     bitCapInt powerTest = result ? qPower : 0;
 
-    bitCapInt bciArgs[BCI_ARG_LEN] = { maxQPower >> 1, qPower, powerTest, 0, 0, 0, 0, 0, 0, 0 };
+    bitCapInt bciArgs[BCI_ARG_LEN] = { maxQPower >> ONE_BCI, qPower, powerTest, 0, 0, 0, 0, 0, 0, 0 };
 
     ApplyMx(OCL_API_APPLYM, bciArgs, nrm);
 }
@@ -1642,7 +1642,7 @@ void QEngineOCL::IFullAdd(bitLenInt inputBit1, bitLenInt inputBit2, bitLenInt ca
 void QEngineOCL::FullAdx(
     bitLenInt inputBit1, bitLenInt inputBit2, bitLenInt carryInSumOut, bitLenInt carryOut, OCLAPI api_call)
 {
-    bitCapInt bciArgs[BCI_ARG_LEN] = { maxQPower >> (2U * ONE_BCI), pow2(inputBit1), pow2(inputBit2),
+    bitCapInt bciArgs[BCI_ARG_LEN] = { maxQPower >> (bitCapInt)2U, pow2(inputBit1), pow2(inputBit2),
         pow2(carryInSumOut), pow2(carryOut), 0, 0, 0, 0, 0 };
 
     EventVecPtr waitVec = ResetWaitEvents();
@@ -1992,8 +1992,8 @@ void QEngineOCL::CPhaseFlipIfLess(bitCapInt greaterPerm, bitLenInt start, bitLen
 
 void QEngineOCL::PhaseFlipIfLess(bitCapInt greaterPerm, bitLenInt start, bitLenInt length)
 {
-    bitCapInt bciArgs[BCI_ARG_LEN] = { maxQPower >> 1, bitRegMask(start, length), greaterPerm, start, 0, 0, 0, 0, 0,
-        0 };
+    bitCapInt bciArgs[BCI_ARG_LEN] = { maxQPower >> ONE_BCI, bitRegMask(start, length), greaterPerm, start, 0, 0, 0, 0,
+        0, 0 };
 
     PhaseFlipX(OCL_API_PHASEFLIPIFLESS, bciArgs);
 }

--- a/src/qengine/qengine.cpp
+++ b/src/qengine/qengine.cpp
@@ -34,6 +34,10 @@ bool QEngine::ForceM(bitLenInt qubit, bool result, bool doForce)
         nrmlzr = ONE_R1 - oneChance;
     }
 
+    if (nrmlzr <= ZERO_R1) {
+        throw "ERROR: Forced a measurement result with 0 probability";
+    }
+
     bitCapInt qPower = pow2(qubit);
     ApplyM(qPower, result, GetNonunitaryPhase() / (real1)(std::sqrt(nrmlzr)));
 

--- a/src/qinterface/arithmetic.cpp
+++ b/src/qinterface/arithmetic.cpp
@@ -182,16 +182,16 @@ void QInterface::IADC(bitLenInt input1, bitLenInt input2, bitLenInt output, bitL
         return;
     }
 
-    bitLenInt end = length - 1U;
-    IFullAdd(input1 + end, input2 + end, output + end, carry);
-
     if (length == 1U) {
         Swap(carry, output);
+        IFullAdd(input1, input2, carry, output);
         return;
     }
 
     // Otherwise, length > 1.
-    for (bitLenInt i = (end - 1U); i > 0; i--) {
+    bitLenInt end = length - 1U;
+    IFullAdd(input1 + end, input2 + end, output + end, carry);
+    for (bitLenInt i = (end - 1); i > 0; i--) {
         IFullAdd(input1 + i, input2 + i, output + i, output + i + 1);
     }
     IFullAdd(input1, input2, carry, output);
@@ -226,15 +226,15 @@ void QInterface::CIADC(bitLenInt* controls, bitLenInt controlLen, bitLenInt inpu
         return;
     }
 
-    bitLenInt end = length - 1U;
-    CIFullAdd(controls, controlLen, input1 + end, input2 + end, output + end, carry);
-
-    if (length == 1) {
+    if (length == 1U) {
         CSwap(controls, controlLen, carry, output);
+        CIFullAdd(controls, controlLen, input1, input2, carry, output);
         return;
     }
 
     // Otherwise, length > 1.
+    bitLenInt end = length - 1U;
+    CIFullAdd(controls, controlLen, input1 + end, input2 + end, output + end, carry);
     for (bitLenInt i = (end - 1); i > 0; i--) {
         CIFullAdd(controls, controlLen, input1 + i, input2 + i, output + i, output + i + 1);
     }

--- a/src/qinterface/qinterface.cpp
+++ b/src/qinterface/qinterface.cpp
@@ -511,7 +511,7 @@ bitCapInt QInterface::ForceMReg(bitLenInt start, bitLenInt length, bitCapInt res
     bitCapInt power;
     for (bitLenInt bit = 0; bit < length; bit++) {
         power = pow2(bit);
-        res |= ForceM(start + bit, !(!(power & result)), doForce) ? power : 0;
+        res |= ForceM(start + bit, power & result, doForce) ? power : 0;
     }
     return res;
 }

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -703,8 +703,8 @@ bool QUnit::ForceM(bitLenInt qubit, bool res, bool doForce)
         shard.isProbDirty = false;
         shard.isPhaseDirty = false;
         shard.isEmulated = true;
-        shard.amp0 = result ? complex(ZERO_R1, ZERO_R1) : complex(ONE_R1, ZERO_R1);
-        shard.amp1 = result ? complex(ONE_R1, ZERO_R1) : complex(ZERO_R1, ZERO_R1);
+        shard.amp0 = result ? ZERO_CMPLX : ONE_CMPLX;
+        shard.amp1 = result ? ONE_CMPLX : ZERO_CMPLX;
 
         /* If we're keeping the bits, and they're already in their own unit, there's nothing to do. */
         return result;

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -658,6 +658,8 @@ real1 QUnit::ProbAll(bitCapInt perm) { return clampProb(norm(GetAmplitude(perm))
 
 void QUnit::SeparateBit(bool value, bitLenInt qubit)
 {
+    RevertBasis2Qb(qubit);
+
     QInterfacePtr unit = shards[qubit].unit;
     bitLenInt mapped = shards[qubit].mapped;
 
@@ -690,8 +692,8 @@ bool QUnit::ForceM(bitLenInt qubit, bool res, bool doForce)
     QEngineShard& shard = shards[qubit];
 
     bool result;
-    if (!doForce && CACHED_CLASSICAL(qubit)) {
-        result = SHARD_STATE(shard);
+    if (CACHED_CLASSICAL(qubit)) {
+        result = doForce ? res : SHARD_STATE(shard);
     } else {
         EndEmulation(qubit);
         result = shard.unit->ForceM(shard.mapped, res, doForce);

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1329,22 +1329,19 @@ void QUnit::ApplyControlledSinglePhase(const bitLenInt* cControls, const bitLenI
         }
     }
 
-    // TODO: Debug ProjectQ integration, to remove randGlobalPhase check
-    if (randGlobalPhase) {
-        QEngineShard& tShard = shards[target];
-        QEngineShard& cShard = shards[controls[0]];
+    QEngineShard& tShard = shards[target];
+    QEngineShard& cShard = shards[controls[0]];
 
-        if (!freezeBasis || (controlLen != 1U)) {
-            for (bitLenInt i = 0; i < controlLen; i++) {
-                PopHBasis2Qb(controls[i]);
-            }
+    if (!freezeBasis || (controlLen != 1U)) {
+        for (bitLenInt i = 0; i < controlLen; i++) {
+            PopHBasis2Qb(controls[i]);
         }
+    }
 
-        if (!freezeBasis && (controlLen == 1U)) {
-            tShard.AddPhaseAngles(&cShard, (real1)arg(topLeft), (real1)arg(bottomRight));
-            delete[] controls;
-            return;
-        }
+    if (!freezeBasis && (controlLen == 1U)) {
+        tShard.AddPhaseAngles(&cShard, (real1)arg(topLeft), (real1)arg(bottomRight));
+        delete[] controls;
+        return;
     }
 
     CTRLED_PHASE_INVERT_WRAP(ApplyControlledSinglePhase(CTRL_P_ARGS), ApplyControlledSingleBit(CTRL_GEN_ARGS),

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1354,8 +1354,7 @@ void QUnit::ApplyControlledSingleInvert(const bitLenInt* controls, const bitLenI
     const complex topRight, const complex bottomLeft)
 {
     if (!TryCnotOptimize(controls, controlLen, target, bottomLeft, topRight, false)) {
-        // TODO: Debug ProjectQ integration, to remove randGlobalPhase check
-        if (randGlobalPhase && !freezeBasis && (controlLen == 1U)) {
+        if (!freezeBasis && (controlLen == 1U)) {
             QEngineShard& tShard = shards[target];
             QEngineShard& cShard = shards[controls[0]];
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -690,7 +690,7 @@ bool QUnit::ForceM(bitLenInt qubit, bool res, bool doForce)
     QEngineShard& shard = shards[qubit];
 
     bool result;
-    if (CACHED_CLASSICAL(qubit)) {
+    if (!doForce && CACHED_CLASSICAL(qubit)) {
         result = SHARD_STATE(shard);
     } else {
         EndEmulation(qubit);
@@ -700,6 +700,7 @@ bool QUnit::ForceM(bitLenInt qubit, bool res, bool doForce)
     if (shard.unit->GetQubitCount() == 1) {
         shard.isProbDirty = false;
         shard.isPhaseDirty = false;
+        shard.isEmulated = true;
         shard.amp0 = result ? complex(ZERO_R1, ZERO_R1) : complex(ONE_R1, ZERO_R1);
         shard.amp1 = result ? complex(ONE_R1, ZERO_R1) : complex(ZERO_R1, ZERO_R1);
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1090,10 +1090,19 @@ bool QUnit::TryCnotOptimize(const bitLenInt* controls, const bitLenInt& controlL
 
 void QUnit::CNOT(bitLenInt control, bitLenInt target)
 {
+    if (CACHED_PROB(control)) {
+        if (Prob(control) < min_norm) {
+            return;
+        }
+        if ((ONE_R1 - Prob(control)) < min_norm) {
+            X(target);
+            return;
+        }
+    }
+
     QEngineShard& cShard = shards[control];
     QEngineShard& tShard = shards[target];
 
-    // TODO: Debug ProjectQ integration, to remove randGlobalPhase check
     if (randGlobalPhase && !freezeBasis) {
         RevertBasis2Qb(target, true);
 


### PR DESCRIPTION
This fixes a bug in controlled inversion gates that became apparent while trying to extend new optimizations to be available through our ProjectQ integration repo. (There still seems be an arbitrary global phase factor in the decomposition of uniformly controlled gates through "controlled phase" gates, as opposed to "controlled inversion" gates, but the unit tests have not detected a difference in physically measurable quantities.) Performance is not noticeably reduced.