### PR TITLE
ONE_BCI code standards (and QUnit::ZeroPhaseFlip optimization)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Qrack compiles like a library. To include in your project:
 
 1. In your source code:
 ```
-#include "qfactory.hpp"
+#include "qrack/qfactory.hpp"
 ```
 
 2. On the command line, in the project directory

--- a/include/qfusion.hpp
+++ b/include/qfusion.hpp
@@ -21,7 +21,7 @@
 // the identity operator. (That is, we check if [addend] % [maxInt] == 0, such that we are effectively adding or
 // subtracting 0.) If a method call is equivalent to the identity operator, it makes no difference, so we do not flush
 // for it or buffer it.
-#define MODLEN(arg, len) (arg & ((1U << len) - 1U))
+#define MODLEN(arg, len) (arg & (pow2(len) - ONE_BCI))
 
 namespace Qrack {
 

--- a/include/qneuron.hpp
+++ b/include/qneuron.hpp
@@ -42,7 +42,7 @@ public:
      * will train from a default output of 0.5/0.5 probability to either 1.0 or 0.0 on one training input). */
     QNeuron(QInterfacePtr reg, bitLenInt* inputIndcs, bitLenInt inputCnt, bitLenInt outputIndx, real1 tol = 1e-6)
         : inputCount(inputCnt)
-        , inputPower(1U << inputCnt)
+        , inputPower(pow2(inputCnt))
         , outputIndex(outputIndx)
         , tolerance(tol)
     {
@@ -141,7 +141,7 @@ public:
 
         bitCapInt perm = 0;
         for (bitLenInt i = 0; i < inputCount; i++) {
-            perm |= qReg->M(inputIndices[i]) ? (1U << i) : 0;
+            perm |= qReg->M(inputIndices[i]) ? pow2(i) : 0;
         }
 
         LearnInternal(expected, eta, perm, startProb, resetInit);

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -636,7 +636,8 @@ protected:
 
     template <typename CF, typename F>
     void ApplyEitherControlled(const bitLenInt* controls, const bitLenInt& controlLen,
-        const std::vector<bitLenInt> targets, const bool& anti, CF cfn, F f, const bool& inCurrentBasis = false);
+        const std::vector<bitLenInt> targets, const bool& anti, CF cfn, F f, const bool& hasPhaseFactor,
+        const bool& inCurrentBasis = false);
 
     bitCapInt GetIndexedEigenstate(bitLenInt indexStart, bitLenInt indexLength, bitLenInt valueStart,
         bitLenInt valueLength, unsigned char* values);

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -636,8 +636,7 @@ protected:
 
     template <typename CF, typename F>
     void ApplyEitherControlled(const bitLenInt* controls, const bitLenInt& controlLen,
-        const std::vector<bitLenInt> targets, const bool& anti, CF cfn, F f, const bool& hasPhaseFactor,
-        const bool& inCurrentBasis = false);
+        const std::vector<bitLenInt> targets, const bool& anti, CF cfn, F f, const bool& inCurrentBasis = false);
 
     bitCapInt GetIndexedEigenstate(bitLenInt indexStart, bitLenInt indexLength, bitLenInt valueStart,
         bitLenInt valueLength, unsigned char* values);

--- a/src/common/parallel_for.cpp
+++ b/src/common/parallel_for.cpp
@@ -212,7 +212,7 @@ void ParallelFor::par_for_mask(
         incFn = [&masks, maskLen](bitCapInt i, int cpu) {
             /* Push i apart, one mask at a time. */
             for (bitLenInt m = 0; m < maskLen; m++) {
-                i = ((i << 1U) & masks[m][1]) | (i & masks[m][0]);
+                i = ((i << ONE_BCI) & masks[m][1]) | (i & masks[m][0]);
             }
             return i;
         };

--- a/src/qengine/arithmetic.cpp
+++ b/src/qengine/arithmetic.cpp
@@ -616,7 +616,7 @@ void QEngineCPU::INCBCD(bitCapInt toAdd, bitLenInt inOutStart, bitLenInt length)
     }
 
     bitCapInt inOutMask = bitRegMask(inOutStart, length);
-    bitCapInt otherMask = maxQPower - 1U;
+    bitCapInt otherMask = maxQPower - ONE_BCI;
     otherMask ^= inOutMask;
     StateVectorPtr nStateVec = AllocStateVec(maxQPower);
     nStateVec->clear();

--- a/src/qinterface/arithmetic.cpp
+++ b/src/qinterface/arithmetic.cpp
@@ -21,8 +21,8 @@ void QInterface::QFTINC(bitCapInt toAdd, bitLenInt inOutStart, bitLenInt length)
 
     for (bitLenInt i = 0; i < length; i++) {
         for (bitLenInt j = 0; j <= i; j++) {
-            if ((toAdd >> j) & 1U) {
-                RT((-M_PI * 2) / intPow(2, i - j), inOutStart + i);
+            if ((toAdd >> j) & ONE_BCI) {
+                RT((-M_PI * 2) / intPow(2U, i - j), inOutStart + i);
             }
         }
     }

--- a/src/qinterface/gates.cpp
+++ b/src/qinterface/gates.cpp
@@ -109,7 +109,7 @@ void QInterface::PhaseRootN(bitLenInt n, bitLenInt qubit)
         return;
     }
 
-    ApplySinglePhase(ONE_CMPLX, pow(-ONE_CMPLX, ONE_R1 / (ONE_BCI << (n - 1U))), true, qubit);
+    ApplySinglePhase(ONE_CMPLX, pow(-ONE_CMPLX, ONE_R1 / (pow2(n - 1U))), true, qubit);
 }
 
 /// Apply inverse 1/(2^N) phase rotation
@@ -123,7 +123,7 @@ void QInterface::IPhaseRootN(bitLenInt n, bitLenInt qubit)
         return;
     }
 
-    ApplySinglePhase(ONE_CMPLX, pow(-ONE_CMPLX, -ONE_R1 / (ONE_BCI << (n - 1U))), true, qubit);
+    ApplySinglePhase(ONE_CMPLX, pow(-ONE_CMPLX, -ONE_R1 / (pow2(n - 1U))), true, qubit);
 }
 
 /// NOT gate, which is also Pauli x matrix
@@ -225,14 +225,14 @@ void QInterface::AntiCNOT(bitLenInt control, bitLenInt target)
 void QInterface::CPhaseRootN(bitLenInt n, bitLenInt control, bitLenInt target)
 {
     bitLenInt controls[1] = { control };
-    ApplyControlledSinglePhase(controls, 1, target, ONE_CMPLX, pow(-ONE_CMPLX, ONE_R1 / (ONE_BCI << (n - 1U))));
+    ApplyControlledSinglePhase(controls, 1, target, ONE_CMPLX, pow(-ONE_CMPLX, ONE_R1 / (pow2(n - 1U))));
 }
 
 /// Apply controlled "IPhaseRootN" gate to bit
 void QInterface::CIPhaseRootN(bitLenInt n, bitLenInt control, bitLenInt target)
 {
     bitLenInt controls[1] = { control };
-    ApplyControlledSinglePhase(controls, 1, target, ONE_CMPLX, pow(-ONE_CMPLX, -ONE_R1 / (ONE_BCI << (n - 1U))));
+    ApplyControlledSinglePhase(controls, 1, target, ONE_CMPLX, pow(-ONE_CMPLX, -ONE_R1 / (pow2(n - 1U))));
 }
 
 void QInterface::UniformlyControlledSingleBit(const bitLenInt* controls, const bitLenInt& controlLen,

--- a/src/qinterface/operators.cpp
+++ b/src/qinterface/operators.cpp
@@ -18,7 +18,7 @@ namespace Qrack {
 /// Subtract integer (without sign)
 void QInterface::DEC(bitCapInt toSub, bitLenInt inOutStart, bitLenInt length)
 {
-    bitCapInt invToSub = (1U << length) - toSub;
+    bitCapInt invToSub = pow2(length) - toSub;
     INC(invToSub, inOutStart, length);
 }
 
@@ -29,7 +29,7 @@ void QInterface::DEC(bitCapInt toSub, bitLenInt inOutStart, bitLenInt length)
  */
 void QInterface::DECS(bitCapInt toSub, bitLenInt inOutStart, bitLenInt length, bitLenInt overflowIndex)
 {
-    bitCapInt invToSub = (1U << length) - toSub;
+    bitCapInt invToSub = pow2(length) - toSub;
     INCS(invToSub, inOutStart, length, overflowIndex);
 }
 
@@ -37,7 +37,7 @@ void QInterface::DECS(bitCapInt toSub, bitLenInt inOutStart, bitLenInt length, b
 void QInterface::CDEC(
     bitCapInt toSub, bitLenInt inOutStart, bitLenInt length, bitLenInt* controls, bitLenInt controlLen)
 {
-    bitCapInt invToSub = (1U << length) - toSub;
+    bitCapInt invToSub = pow2(length) - toSub;
     CINC(invToSub, inOutStart, length, controls, controlLen);
 }
 
@@ -205,7 +205,7 @@ void QInterface::TimeEvolve(Hamiltonian h, real1 timeDiff)
 
         bitCapInt maxJ = 4;
         if (op->uniform) {
-            maxJ *= 1U << op->controlLen;
+            maxJ *= pow2(op->controlLen);
         }
         mtrx = new complex[maxJ];
 
@@ -223,8 +223,9 @@ void QInterface::TimeEvolve(Hamiltonian h, real1 timeDiff)
 
         if (op->uniform) {
             complex* expMtrx = new complex[maxJ];
-            for (bitCapInt j = 0; j < (1U << op->controlLen); j++) {
-                exp2x2(mtrx + (j * 4), expMtrx + (j * 4));
+            bitCapInt controlCap = pow2(op->controlLen);
+            for (bitCapInt j = 0; j < controlCap; j++) {
+                exp2x2(mtrx + (j * 4U), expMtrx + (j * 4U));
             }
             UniformlyControlledSingleBit(op->controls, op->controlLen, op->targetBit, expMtrx);
             delete[] expMtrx;

--- a/src/qinterface/operators.cpp
+++ b/src/qinterface/operators.cpp
@@ -222,12 +222,7 @@ void QInterface::TimeEvolve(Hamiltonian h, real1 timeDiff)
         }
 
         if (op->uniform) {
-            complex* expMtrx = new complex[maxJ];
-            bitCapInt controlCap = pow2(op->controlLen);
-            for (bitCapInt j = 0; j < controlCap; j++) {
-                exp2x2(mtrx + (j * 4U), expMtrx + (j * 4U));
-            }
-            UniformlyControlledSingleBit(op->controls, op->controlLen, op->targetBit, expMtrx);
+            UniformlyControlledSingleBit(op->controls, op->controlLen, op->targetBit, op->expMtrx);
             delete[] expMtrx;
         } else {
             Exp(op->controls, op->controlLen, op->targetBit, mtrx, op->anti);

--- a/src/qinterface/operators.cpp
+++ b/src/qinterface/operators.cpp
@@ -222,7 +222,11 @@ void QInterface::TimeEvolve(Hamiltonian h, real1 timeDiff)
         }
 
         if (op->uniform) {
-            UniformlyControlledSingleBit(op->controls, op->controlLen, op->targetBit, op->expMtrx);
+            complex* expMtrx = new complex[maxJ];
+            for (bitCapInt j = 0; j < (1U << op->controlLen); j++) {
+                exp2x2(mtrx + (j * 4), expMtrx + (j * 4));
+            }
+            UniformlyControlledSingleBit(op->controls, op->controlLen, op->targetBit, expMtrx);
             delete[] expMtrx;
         } else {
             Exp(op->controls, op->controlLen, op->targetBit, mtrx, op->anti);

--- a/src/qinterface/protected.cpp
+++ b/src/qinterface/protected.cpp
@@ -48,9 +48,9 @@ void cl_free(void* toFree)
 bitCapInt intPow(bitCapInt base, bitCapInt power)
 {
     if (power == 0U) {
-        return 1U;
+        return ONE_BCI;
     }
-    if (power == 1U) {
+    if (power == ONE_BCI) {
         return base;
     }
     return base * intPow(base, power - 1);

--- a/src/qinterface/qinterface.cpp
+++ b/src/qinterface/qinterface.cpp
@@ -537,7 +537,7 @@ real1 QInterface::ProbReg(const bitLenInt& start, const bitLenInt& length, const
 {
     real1 prob = ONE_R1;
     for (bitLenInt i = 0; i < length; i++) {
-        if ((permutation >> i) & 1U) {
+        if ((permutation >> i) & ONE_BCI) {
             prob *= Prob(start + i);
         } else {
             prob *= (ONE_R1 - Prob(start + i));

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1627,12 +1627,19 @@ void QUnit::ApplyEitherControlled(const bitLenInt* controls, const bitLenInt& co
 
     QInterfacePtr unit = EntangleInCurrentBasis(ebits.begin(), ebits.end());
 
+    bool isTargetPlusMinus = false;
+    for (i = 0; i < targets.size(); i++) {
+        if (shards[targets[i]].isPlusMinus) {
+            isTargetPlusMinus = true;
+            break;
+        }
+    }
+
     std::vector<bitLenInt> controlsMapped(controlVec.size());
     for (i = 0; i < controlVec.size(); i++) {
-        QEngineShard& cShard = shards[controlVec[i]];
-        controlsMapped[i] = cShard.mapped;
-        if (hasPhaseFactor || cShard.isPlusMinus) {
-            cShard.isPhaseDirty = true;
+        controlsMapped[i] = shards[controlVec[i]].mapped;
+        if (hasPhaseFactor || isTargetPlusMinus) {
+            shards[controlVec[i]].isPhaseDirty = true;
         }
     }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -2534,10 +2534,18 @@ void QUnit::ZeroPhaseFlip(bitLenInt start, bitLenInt length)
         return;
     }
 
-    // Otherwise, form the potentially entangled representation:
-    EntangleRange(start, length);
-    shards[start].unit->ZeroPhaseFlip(shards[start].mapped, length);
-    DirtyShardRange(start, length);
+    if (qubitCount == 1U) {
+        shards[0].unit->ZeroPhaseFlip(0, 1);
+        return;
+    }
+
+    bitLenInt min1 = qubitCount - 1U;
+    bitLenInt* controls = new bitLenInt[min1];
+    for (bitLenInt i = 0; i < min1; i++) {
+        controls[i] = i + 1U;
+    }
+    ApplyAntiControlledSinglePhase(controls, min1, 0, -ONE_CMPLX, ONE_CMPLX);
+    delete[] controls;
 }
 
 void QUnit::PhaseFlipIfLess(bitCapInt greaterPerm, bitLenInt start, bitLenInt length)

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1629,10 +1629,10 @@ void QUnit::ApplyEitherControlled(const bitLenInt* controls, const bitLenInt& co
 
     std::vector<bitLenInt> controlsMapped(controlVec.size());
     for (i = 0; i < controlVec.size(); i++) {
-        controlsMapped[i] = shards[controlVec[i]].mapped;
-        QEngineShard& shard = shards[controlVec[i]];
-        if (hasPhaseFactor || shard.isPlusMinus) {
-            shard.isPhaseDirty = true;
+        QEngineShard& cShard = shards[controlVec[i]];
+        controlsMapped[i] = cShard.mapped;
+        if (hasPhaseFactor || cShard.isPlusMinus) {
+            cShard.isPhaseDirty = true;
         }
     }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1649,7 +1649,9 @@ void QUnit::ApplyEitherControlled(const bitLenInt* controls, const bitLenInt& co
 
     for (i = 0; i < targets.size(); i++) {
         shards[targets[i]].isProbDirty = true;
-        shards[targets[i]].isPhaseDirty = true;
+        if (hasPhaseFactor || isTargetPlusMinus) {
+            shards[targets[i]].isPhaseDirty = true;
+        }
     }
 }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1628,8 +1628,9 @@ void QUnit::ApplyEitherControlled(const bitLenInt* controls, const bitLenInt& co
 
     std::vector<bitLenInt> controlsMapped(controlVec.size());
     for (i = 0; i < controlVec.size(); i++) {
-        controlsMapped[i] = shards[controlVec[i]].mapped;
-        shards[controlVec[i]].isPhaseDirty = true;
+        QEngineShard& cShard = shards[controlVec[i]];
+        controlsMapped[i] = cShard.mapped;
+        cShard.isPhaseDirty = true;
     }
 
     cfn(unit, controlsMapped);

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1031,7 +1031,7 @@ void QUnit::TransformInvert(const complex& topRight, const complex& bottomLeft, 
                 unit->ctrldgen;                                                                                        \
             }                                                                                                          \
         },                                                                                                             \
-        [&]() { bare; }, top != bottom && (randGlobalPhase || (top != ONE_R1)));
+        [&]() { bare; }, (top != bottom) && (!randGlobalPhase || (top != ONE_R1)));
 
 #define CTRLED_SWAP_WRAP(ctrld, bare, anti)                                                                            \
     if (qubit1 == qubit2) {                                                                                            \

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -2527,17 +2527,12 @@ void QUnit::CPOWModNOut(bitCapInt toMod, bitCapInt modN, bitLenInt inStart, bitL
 
 void QUnit::ZeroPhaseFlip(bitLenInt start, bitLenInt length)
 {
-    if (qubitCount == 1U) {
-        shards[0].unit->ZeroPhaseFlip(0, 1);
-        return;
-    }
-
-    bitLenInt min1 = qubitCount - 1U;
+    bitLenInt min1 = length - 1U;
     bitLenInt* controls = new bitLenInt[min1];
     for (bitLenInt i = 0; i < min1; i++) {
-        controls[i] = i + 1U;
+        controls[i] = start + i + 1U;
     }
-    ApplyAntiControlledSinglePhase(controls, min1, 0, -ONE_CMPLX, ONE_CMPLX);
+    ApplyAntiControlledSinglePhase(controls, min1, start, -ONE_CMPLX, ONE_CMPLX);
     delete[] controls;
 }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1630,8 +1630,9 @@ void QUnit::ApplyEitherControlled(const bitLenInt* controls, const bitLenInt& co
     std::vector<bitLenInt> controlsMapped(controlVec.size());
     for (i = 0; i < controlVec.size(); i++) {
         controlsMapped[i] = shards[controlVec[i]].mapped;
-        if (hasPhaseFactor) {
-            shards[controlVec[i]].isPhaseDirty = true;
+        QEngineShard& shard = shards[controlVec[i]];
+        if (hasPhaseFactor || shard.isPlusMinus) {
+            shard.isPhaseDirty = true;
         }
     }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -2301,7 +2301,7 @@ void QUnit::xMULModNOut(
                 } else {
                     CINC(toModExp, outStart, length, controls, 1U);
                 }
-                toModExp <<= 1U;
+                toModExp <<= ONE_BCI;
             }
             return;
         }
@@ -2480,7 +2480,7 @@ void QUnit::CxMULModNOut(bitCapInt toMod, bitCapInt modN, bitLenInt inStart, bit
                 } else {
                     CINC(toModExp, outStart, length, lControls, controlVec.size() + 1U);
                 }
-                toModExp <<= 1U;
+                toModExp <<= ONE_BCI;
             }
             delete[] lControls;
             return;

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1014,7 +1014,7 @@ void QUnit::TransformInvert(const complex& topRight, const complex& bottomLeft, 
             }                                                                                                          \
             unit->ctrld;                                                                                               \
         },                                                                                                             \
-        [&]() { bare; }, true);
+        [&]() { bare; });
 
 #define CTRLED_PHASE_INVERT_WRAP(ctrld, ctrldgen, bare, anti, isInvert, top, bottom)                                   \
     ApplyEitherControlled(controls, controlLen, { target }, anti,                                                      \
@@ -1031,7 +1031,7 @@ void QUnit::TransformInvert(const complex& topRight, const complex& bottomLeft, 
                 unit->ctrldgen;                                                                                        \
             }                                                                                                          \
         },                                                                                                             \
-        [&]() { bare; }, (top != bottom) && (!randGlobalPhase || (top != ONE_R1)));
+        [&]() { bare; });
 
 #define CTRLED_SWAP_WRAP(ctrld, bare, anti)                                                                            \
     if (qubit1 == qubit2) {                                                                                            \
@@ -1040,7 +1040,7 @@ void QUnit::TransformInvert(const complex& topRight, const complex& bottomLeft, 
     TransformBasis1Qb(false, qubit1);                                                                                  \
     TransformBasis1Qb(false, qubit2);                                                                                  \
     ApplyEitherControlled(controls, controlLen, { qubit1, qubit2 }, anti,                                              \
-        [&](QInterfacePtr unit, std::vector<bitLenInt> mappedControls) { unit->ctrld; }, [&]() { bare; }, true)
+        [&](QInterfacePtr unit, std::vector<bitLenInt> mappedControls) { unit->ctrld; }, [&]() { bare; })
 #define CTRL_GEN_ARGS &(mappedControls[0]), mappedControls.size(), shards[target].mapped, trnsMtrx
 #define CTRL_ARGS &(mappedControls[0]), mappedControls.size(), shards[target].mapped, mtrx
 #define CTRL_1_ARGS mappedControls[0], shards[target].mapped
@@ -1131,7 +1131,7 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
         std::swap(controls[0], target);
         ApplyEitherControlled(controls, controlLen, { target }, false,
             [&](QInterfacePtr unit, std::vector<bitLenInt> mappedControls) { unit->CNOT(CTRL_1_ARGS); },
-            [&]() { XBase(target); }, false, true);
+            [&]() { XBase(target); }, true);
         return;
     }
 
@@ -1173,7 +1173,7 @@ void QUnit::CCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target)
                 }
             }
         },
-        [&]() { X(target); }, false);
+        [&]() { X(target); });
 }
 
 void QUnit::AntiCCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target)
@@ -1197,7 +1197,7 @@ void QUnit::AntiCCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target)
                 }
             }
         },
-        [&]() { X(target); }, false);
+        [&]() { X(target); });
 }
 
 void QUnit::CZ(bitLenInt control, bitLenInt target)
@@ -1559,8 +1559,7 @@ void QUnit::AntiCISqrtSwap(
 
 template <typename CF, typename F>
 void QUnit::ApplyEitherControlled(const bitLenInt* controls, const bitLenInt& controlLen,
-    const std::vector<bitLenInt> targets, const bool& anti, CF cfn, F fn, const bool& hasPhaseFactor,
-    const bool& inCurrentBasis)
+    const std::vector<bitLenInt> targets, const bool& anti, CF cfn, F fn, const bool& inCurrentBasis)
 {
     bitLenInt i, j;
 
@@ -1627,31 +1626,17 @@ void QUnit::ApplyEitherControlled(const bitLenInt* controls, const bitLenInt& co
 
     QInterfacePtr unit = EntangleInCurrentBasis(ebits.begin(), ebits.end());
 
-    bool isTargetPlusMinus = false;
-    if (!inCurrentBasis) {
-        for (i = 0; i < targets.size(); i++) {
-            if (shards[targets[i]].isPlusMinus) {
-                isTargetPlusMinus = true;
-                break;
-            }
-        }
-    }
-
     std::vector<bitLenInt> controlsMapped(controlVec.size());
     for (i = 0; i < controlVec.size(); i++) {
         controlsMapped[i] = shards[controlVec[i]].mapped;
-        if (hasPhaseFactor || isTargetPlusMinus) {
-            shards[controlVec[i]].isPhaseDirty = true;
-        }
+        shards[controlVec[i]].isPhaseDirty = true;
     }
 
     cfn(unit, controlsMapped);
 
     for (i = 0; i < targets.size(); i++) {
         shards[targets[i]].isProbDirty = true;
-        if (hasPhaseFactor || isTargetPlusMinus) {
-            shards[targets[i]].isPhaseDirty = true;
-        }
+        shards[targets[i]].isPhaseDirty = true;
     }
 }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1628,10 +1628,12 @@ void QUnit::ApplyEitherControlled(const bitLenInt* controls, const bitLenInt& co
     QInterfacePtr unit = EntangleInCurrentBasis(ebits.begin(), ebits.end());
 
     bool isTargetPlusMinus = false;
-    for (i = 0; i < targets.size(); i++) {
-        if (shards[targets[i]].isPlusMinus) {
-            isTargetPlusMinus = true;
-            break;
+    if (!inCurrentBasis) {
+        for (i = 0; i < targets.size(); i++) {
+            if (shards[targets[i]].isPlusMinus) {
+                isTargetPlusMinus = true;
+                break;
+            }
         }
     }
 

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -412,7 +412,7 @@ TEST_CASE("test_grover", "[grover]")
         int i;
         // Twelve iterations maximizes the probablity for 256 searched elements, for example.
         // For an arbitrary number of qubits, this gives the number of iterations for optimal probability.
-        int optIter = M_PI / (4.0 * asin(1.0 / sqrt(1U << n)));
+        int optIter = M_PI / (4.0 * asin(1.0 / sqrt(pow2(n))));
 
         // Our input to the subroutine "oracle" is 8 bits.
         qftReg->SetPermutation(0);
@@ -431,7 +431,7 @@ TEST_CASE("test_grover", "[grover]")
             // qftReg->PhaseFlip();
         }
 
-        // REQUIRE_THAT(qftReg, HasProbability(0x3));
+        REQUIRE_THAT(qftReg, HasProbability(0x3));
 
         qftReg->MReg(0, n);
     });

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -412,7 +412,7 @@ TEST_CASE("test_grover", "[grover]")
         int i;
         // Twelve iterations maximizes the probablity for 256 searched elements, for example.
         // For an arbitrary number of qubits, this gives the number of iterations for optimal probability.
-        int optIter = M_PI / (4.0 * asin(1.0 / sqrt(1 << n)));
+        int optIter = M_PI / (4.0 * asin(1.0 / sqrt(1U << n)));
 
         // Our input to the subroutine "oracle" is 8 bits.
         qftReg->SetPermutation(0);
@@ -428,10 +428,10 @@ TEST_CASE("test_grover", "[grover]")
             qftReg->ZeroPhaseFlip(0, n);
             qftReg->H(0, n);
             // Global phase flip has no physically measurable effect:
-            //qftReg->PhaseFlip();
+            // qftReg->PhaseFlip();
         }
 
-        REQUIRE_THAT(qftReg, HasProbability(0x3));
+        // REQUIRE_THAT(qftReg, HasProbability(0x3));
 
         qftReg->MReg(0, n);
     });

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -427,7 +427,8 @@ TEST_CASE("test_grover", "[grover]")
             qftReg->H(0, n);
             qftReg->ZeroPhaseFlip(0, n);
             qftReg->H(0, n);
-            qftReg->PhaseFlip();
+            // Global phase flip has no physically measurable effect:
+            //qftReg->PhaseFlip();
         }
 
         REQUIRE_THAT(qftReg, HasProbability(0x3));


### PR DESCRIPTION
Mostly, this PR brings intended references to `ONE_BCI` and `pow2()` up to code standards. This might fix issues with certain methods used on `QInterface` instances in excess of about 32 qubits in length.

Additionally, I have added an "optimized" case of `QUnit::ZeroPhaseFlip()`. In practice, when this method is called, entanglement across the length of the register for the operation is probably guaranteed, such that no practical improvement is usually achieved. However, there may be use cases we don't anticipate, where some bits start in |0>/|1> eigenstates when this method is called on them, in which case this change is an improvement in execution time and RAM usage. In any case, there is no practically significant _loss_ of performance from this alternative implementation.