### PR TITLE
Fixing RX() convenience method

### DIFF
--- a/src/qinterface/rotational.cpp
+++ b/src/qinterface/rotational.cpp
@@ -27,7 +27,7 @@ void QInterface::RX(real1 radians, bitLenInt qubit)
 {
     real1 cosine = cos(radians / 2.0);
     real1 sine = sin(radians / 2.0);
-    complex pauliRX[4] = { complex(cosine, ZERO_R1), complex(ZERO_R1, sine), complex(ZERO_R1, -sine),
+    complex pauliRX[4] = { complex(cosine, ZERO_R1), complex(ZERO_R1, sine), complex(ZERO_R1, sine),
         complex(cosine, ZERO_R1) };
     ApplySingleBit(pauliRX, true, qubit);
 }
@@ -155,7 +155,7 @@ void QInterface::CRX(real1 radians, bitLenInt control, bitLenInt target)
 {
     real1 cosine = cos(radians / 2.0);
     real1 sine = sin(radians / 2.0);
-    complex pauliRX[4] = { complex(cosine, ZERO_R1), complex(ZERO_R1, sine), complex(ZERO_R1, -sine),
+    complex pauliRX[4] = { complex(cosine, ZERO_R1), complex(ZERO_R1, sine), complex(ZERO_R1, sine),
         complex(cosine, ZERO_R1) };
     bitLenInt controls[1] = { control };
     ApplyControlledSingleBit(controls, 1, target, pauliRX);

--- a/src/qinterface/rotational.cpp
+++ b/src/qinterface/rotational.cpp
@@ -27,7 +27,7 @@ void QInterface::RX(real1 radians, bitLenInt qubit)
 {
     real1 cosine = cos(radians / 2.0);
     real1 sine = sin(radians / 2.0);
-    complex pauliRX[4] = { complex(cosine, ZERO_R1), complex(ZERO_R1, -sine), complex(ZERO_R1, sine),
+    complex pauliRX[4] = { complex(cosine, ZERO_R1), complex(ZERO_R1, sine), complex(ZERO_R1, -sine),
         complex(cosine, ZERO_R1) };
     ApplySingleBit(pauliRX, true, qubit);
 }
@@ -155,7 +155,7 @@ void QInterface::CRX(real1 radians, bitLenInt control, bitLenInt target)
 {
     real1 cosine = cos(radians / 2.0);
     real1 sine = sin(radians / 2.0);
-    complex pauliRX[4] = { complex(cosine, ZERO_R1), complex(ZERO_R1, -sine), complex(ZERO_R1, sine),
+    complex pauliRX[4] = { complex(cosine, ZERO_R1), complex(ZERO_R1, sine), complex(ZERO_R1, -sine),
         complex(cosine, ZERO_R1) };
     bitLenInt controls[1] = { control };
     ApplyControlledSingleBit(controls, 1, target, pauliRX);

--- a/src/qinterface/rotational.cpp
+++ b/src/qinterface/rotational.cpp
@@ -27,7 +27,7 @@ void QInterface::RX(real1 radians, bitLenInt qubit)
 {
     real1 cosine = cos(radians / 2.0);
     real1 sine = sin(radians / 2.0);
-    complex pauliRX[4] = { complex(cosine, ZERO_R1), complex(ZERO_R1, -sine), complex(ZERO_R1, -sine),
+    complex pauliRX[4] = { complex(cosine, ZERO_R1), complex(ZERO_R1, -sine), complex(ZERO_R1, sine),
         complex(cosine, ZERO_R1) };
     ApplySingleBit(pauliRX, true, qubit);
 }
@@ -155,7 +155,7 @@ void QInterface::CRX(real1 radians, bitLenInt control, bitLenInt target)
 {
     real1 cosine = cos(radians / 2.0);
     real1 sine = sin(radians / 2.0);
-    complex pauliRX[4] = { complex(cosine, ZERO_R1), complex(ZERO_R1, -sine), complex(ZERO_R1, -sine),
+    complex pauliRX[4] = { complex(cosine, ZERO_R1), complex(ZERO_R1, -sine), complex(ZERO_R1, sine),
         complex(cosine, ZERO_R1) };
     bitLenInt controls[1] = { control };
     ApplyControlledSingleBit(controls, 1, target, pauliRX);


### PR DESCRIPTION
I swear to you that I always went to the same pedagogical source for the definition of the Pauli X-axis rotation operator, and the source had it wrong this whole time! I finally noticed the problem when my expectation values for Pauli Y tended to have exactly opposite signs from what was expected, in the Qiskit/Pennylane integration I'm working on. I'll update our unit tests, if they fail in CI. This is slightly complicated to target with a unit test, but the Qiskit/Pennylane unit tests will ultimately cover it, when I add those to the master branch CI.