### PR TITLE
Qiskit debug

### DIFF
--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -305,7 +305,7 @@ struct QEngineShard {
         for (phaseShard = targetOfShards.begin(); phaseShard != targetOfShards.end(); phaseShard++) {
             polar0 = std::polar(ONE_R1, phaseShard->second.angle0);
             polar1 = std::polar(ONE_R1, phaseShard->second.angle1);
-            if ((polar0 != polar1) && !(polar0 == -polar1)) {
+            if ((polar0 != polar1) && (polar0 != -polar1)) {
                 return false;
             }
         }

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -242,18 +242,28 @@ struct QEngineShard {
 
     /// If an "inversion" gate is applied to a qubit with controlled phase buffers, we can transform the buffers to
     /// commute, instead of incurring the cost of applying the buffers.
-    void FlipPhaseAnti()
+    bool TryFlipPhaseAnti()
     {
+        if (controlsShards.size() > 0) {
+            return false;
+        }
+
         ShardToPhaseMap::iterator phaseShard;
         for (phaseShard = targetOfShards.begin(); phaseShard != targetOfShards.end(); phaseShard++) {
             std::swap(phaseShard->second.angle0, phaseShard->second.angle1);
             PhaseShard& remotePhase = phaseShard->first->controlsShards[this];
             std::swap(remotePhase.angle0, remotePhase.angle1);
         }
+
+        return true;
     }
 
-    void CommutePhase(const complex& topLeft, const complex& bottomRight)
+    bool TryCommutePhase(const complex& topLeft, const complex& bottomRight)
     {
+        if (controlsShards.size() > 0) {
+            return false;
+        }
+
         ShardToPhaseMap::iterator phaseShard;
         for (phaseShard = targetOfShards.begin(); phaseShard != targetOfShards.end(); phaseShard++) {
             if (!phaseShard->second.isInvert) {
@@ -267,6 +277,8 @@ struct QEngineShard {
             remotePhase.angle0 = phaseShard->second.angle0;
             remotePhase.angle1 = phaseShard->second.angle1;
         }
+
+        return true;
     }
 
     bool TryHCommute()

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -181,7 +181,7 @@ struct QEngineShard {
             nAngle1 -= 2 * M_PI;
         }
 
-        if (!targetOfShards[control].isInvert && (nAngle0 == 0) && (nAngle1 == 0)) {
+        if ((nAngle0 == ZERO_R1) && (nAngle1 == ZERO_R1) && !targetOfShards[control].isInvert) {
             // The buffer is equal to the identity operator, and it can be removed.
             RemovePhaseControl(control);
             return;
@@ -298,6 +298,14 @@ struct QEngineShard {
                     return false;
                 }
             } else {
+                return false;
+            }
+        }
+
+        for (phaseShard = targetOfShards.begin(); phaseShard != targetOfShards.end(); phaseShard++) {
+            polar0 = std::polar(ONE_R1, phaseShard->second.angle0);
+            polar1 = std::polar(ONE_R1, phaseShard->second.angle1);
+            if ((polar0 != polar1) && !(polar0 == -polar1)) {
                 return false;
             }
         }
@@ -661,11 +669,12 @@ protected:
 
     void TransformBasis1Qb(const bool& toPlusMinus, const bitLenInt& i);
 
-    void RevertBasis2Qb(const bitLenInt& i, const bool& onlyInvert = false);
-    void RevertBasis2Qb(const bitLenInt& start, const bitLenInt& length, const bool& onlyInvert = false)
+    void RevertBasis2Qb(const bitLenInt& i, const bool& onlyInvert = false, const bool& onlyControlling = false);
+    void RevertBasis2Qb(const bitLenInt& start, const bitLenInt& length, const bool& onlyInvert = false,
+        const bool& onlyControlling = false)
     {
         for (bitLenInt i = 0; i < length; i++) {
-            RevertBasis2Qb(start + i, onlyInvert);
+            RevertBasis2Qb(start + i, onlyInvert, onlyControlling);
         }
     }
     void ToPermBasis(const bitLenInt& i)

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -161,12 +161,12 @@ struct QEngineShard {
 
         // Buffers with "angle0" = 0 are actually symmetric (unchanged) under exchange of control and target.
         // We can reduce our number of buffer instances by taking advantage of this kind of symmetry:
-        /*ShardToPhaseMap::iterator controlShard = controlsShards.find(control);
+        ShardToPhaseMap::iterator controlShard = controlsShards.find(control);
         if (!targetOfShards[control].isInvert && (controlShard != controlsShards.end()) &&
             !controlShard->second.isInvert && (controlShard->second.angle0 == 0)) {
             nAngle1 += controlShard->second.angle1;
             RemovePhaseTarget(control);
-        }*/
+        }
 
         while (nAngle0 <= -M_PI) {
             nAngle0 += 2 * M_PI;

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -161,12 +161,12 @@ struct QEngineShard {
 
         // Buffers with "angle0" = 0 are actually symmetric (unchanged) under exchange of control and target.
         // We can reduce our number of buffer instances by taking advantage of this kind of symmetry:
-        ShardToPhaseMap::iterator controlShard = controlsShards.find(control);
+        /*ShardToPhaseMap::iterator controlShard = controlsShards.find(control);
         if (!targetOfShards[control].isInvert && (controlShard != controlsShards.end()) &&
             !controlShard->second.isInvert && (controlShard->second.angle0 == 0)) {
             nAngle1 += controlShard->second.angle1;
             RemovePhaseTarget(control);
-        }
+        }*/
 
         while (nAngle0 <= -M_PI) {
             nAngle0 += 2 * M_PI;

--- a/src/qinterface/gates.cpp
+++ b/src/qinterface/gates.cpp
@@ -154,28 +154,28 @@ GATE_1_BIT(SqrtY, ONE_PLUS_I_DIV_2, -ONE_PLUS_I_DIV_2, ONE_PLUS_I_DIV_2, ONE_PLU
 GATE_1_BIT(ISqrtY, ONE_MINUS_I_DIV_2, ONE_MINUS_I_DIV_2, -ONE_MINUS_I_DIV_2, ONE_MINUS_I_DIV_2);
 
 /// Apply 1/4 phase rotation
-void QInterface::S(bitLenInt qubit) { PhaseRootN(2U, qubit); }
+void QInterface::S(bitLenInt qubit) { IPhaseRootN(2U, qubit); }
 
 /// Apply inverse 1/4 phase rotation
-void QInterface::IS(bitLenInt qubit) { IPhaseRootN(2U, qubit); }
+void QInterface::IS(bitLenInt qubit) { PhaseRootN(2U, qubit); }
 
 /// Apply 1/8 phase rotation
-void QInterface::T(bitLenInt qubit) { PhaseRootN(3U, qubit); }
+void QInterface::T(bitLenInt qubit) { IPhaseRootN(3U, qubit); }
 
 /// Apply inverse 1/8 phase rotation
-void QInterface::IT(bitLenInt qubit) { IPhaseRootN(3U, qubit); }
+void QInterface::IT(bitLenInt qubit) { PhaseRootN(3U, qubit); }
 
 /// Apply controlled S gate to bit
-void QInterface::CS(bitLenInt control, bitLenInt target) { CPhaseRootN(2U, control, target); }
+void QInterface::CS(bitLenInt control, bitLenInt target) { CIPhaseRootN(2U, control, target); }
 
 /// Apply controlled IS gate to bit
-void QInterface::CIS(bitLenInt control, bitLenInt target) { CIPhaseRootN(2U, control, target); }
+void QInterface::CIS(bitLenInt control, bitLenInt target) { CPhaseRootN(2U, control, target); }
 
 /// Apply controlled T gate to bit
-void QInterface::CT(bitLenInt control, bitLenInt target) { CPhaseRootN(3U, control, target); }
+void QInterface::CT(bitLenInt control, bitLenInt target) { CIPhaseRootN(3U, control, target); }
 
 /// Apply controlled IT gate to bit
-void QInterface::CIT(bitLenInt control, bitLenInt target) { CIPhaseRootN(3U, control, target); }
+void QInterface::CIT(bitLenInt control, bitLenInt target) { CPhaseRootN(3U, control, target); }
 
 /// Controlled not
 void QInterface::CNOT(bitLenInt control, bitLenInt target)

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1086,8 +1086,9 @@ void QUnit::X(bitLenInt target)
 {
     QEngineShard& shard = shards[target];
 
-    // shard.FlipPhaseAnti();
-    RevertBasis2Qb(target);
+    if (!shard.TryFlipPhaseAnti()) {
+        RevertBasis2Qb(target);
+    }
 
     if (!shard.isPlusMinus) {
         XBase(target);
@@ -1101,8 +1102,9 @@ void QUnit::Z(bitLenInt target)
     // Commutes with controlled phase optimizations
     QEngineShard& shard = shards[target];
 
-    // shard.CommutePhase(ONE_CMPLX, -ONE_CMPLX);
-    RevertBasis2Qb(target);
+    if (!shard.TryCommutePhase(ONE_CMPLX, -ONE_CMPLX)) {
+        RevertBasis2Qb(target);
+    }
 
     if (!shard.isPlusMinus) {
         if (PHASE_MATTERS(target)) {
@@ -1403,8 +1405,9 @@ void QUnit::ApplySingleInvert(const complex topRight, const complex bottomLeft, 
         return;
     }
 
-    // shard.FlipPhaseAnti();
-    RevertBasis2Qb(target);
+    if (!shard.TryFlipPhaseAnti()) {
+        RevertBasis2Qb(target);
+    }
 
     if (!shard.isPlusMinus) {
         ApplyOrEmulate(

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1036,9 +1036,9 @@ void QUnit::H(bitLenInt target)
     QEngineShard& shard = shards[target];
 
     if (!freezeBasis) {
-        // if (!shard.TryHCommute()) {
-        RevertBasis2Qb(target);
-        //}
+        if (!shard.TryHCommute()) {
+            RevertBasis2Qb(target);
+        }
         shard.isPlusMinus = !shard.isPlusMinus;
         return;
     }
@@ -1262,7 +1262,7 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
         return;
     }
 
-    if (!freezeBasis) {
+    /*if (!freezeBasis) {
         TransformBasis1Qb(false, control);
 
         tShard.AddInversionAngles(&cShard, 0, 0);
@@ -1270,7 +1270,7 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
         // TODO: Remove. For testing/debugging purposes. All this ends up achieving is combining with any previous phase gates before flushing the buffer.
         RevertBasis2Qb(target);
         return;
-    }
+    }*/
 
     CTRLED_PHASE_INVERT_WRAP(
         CNOT(CTRL_1_ARGS), ApplyControlledSingleBit(CTRL_GEN_ARGS), X(target), false, true, ONE_R1, ONE_R1);
@@ -1471,15 +1471,19 @@ void QUnit::ApplyControlledSinglePhase(const bitLenInt* cControls, const bitLenI
         }
     }
 
-    /*QEngineShard& tShard = shards[target];
+    QEngineShard& tShard = shards[target];
     QEngineShard& cShard = shards[controls[0]];
 
     if (!freezeBasis && (controlLen == 1U)) {
         TransformBasis1Qb(false, controls[0]);
         tShard.AddPhaseAngles(&cShard, (real1)arg(topLeft), (real1)arg(bottomRight));
+
+        // TODO: Remove. For testing/debugging purposes. All this ends up achieving is combining with any previous phase gates before flushing the buffer.
+        RevertBasis2Qb(target);
+
         delete[] controls;
         return;
-    }*/
+    }
 
     CTRLED_PHASE_INVERT_WRAP(ApplyControlledSinglePhase(CTRL_P_ARGS), ApplyControlledSingleBit(CTRL_GEN_ARGS),
         ApplySinglePhase(topLeft, bottomRight, target), false, false, topLeft, bottomRight);

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1747,6 +1747,8 @@ void QUnit::ApplyEitherControlled(const bitLenInt* controls, const bitLenInt& co
     std::vector<bitLenInt> allBits(controlVec.size() + targets.size());
     std::copy(controlVec.begin(), controlVec.end(), allBits.begin());
     std::copy(targets.begin(), targets.end(), allBits.begin() + controlVec.size());
+    // (Incidentally, we sort for the efficiency of QUnit's limited "mapper," a 1 dimensional array of qubits without
+    // nearest neighbor restriction.)
     std::sort(allBits.begin(), allBits.end());
 
     std::vector<bitLenInt*> ebits(allBits.size());
@@ -1763,6 +1765,8 @@ void QUnit::ApplyEitherControlled(const bitLenInt* controls, const bitLenInt& co
         cShard.isPhaseDirty = true;
     }
 
+    // This is the original method with the maximum number of non-entangled controls excised, (potentially leaving a
+    // target bit in |+>/|-> basis and acting as if |0>/|1> basis by commutation).
     cfn(unit, controlsMapped);
 
     for (i = 0; i < targets.size(); i++) {

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1030,6 +1030,11 @@ void QUnit::H(bitLenInt target)
         if (!shard.TryHCommute()) {
             RevertBasis2Qb(target);
         }
+        // for (bitLenInt i = 0; i < qubitCount; i++) {
+        //    if (shard.unit == shards[i].unit) {
+        //        ToPermBasis(target);
+        //    }
+        //}
         shard.isPlusMinus = !shard.isPlusMinus;
         return;
     }
@@ -1334,6 +1339,7 @@ void QUnit::CZ(bitLenInt control, bitLenInt target)
     }
 
     if (!freezeBasis) {
+        TransformBasis1Qb(false, control);
         tShard.AddPhaseAngles(&cShard, 0, (real1)M_PI);
         return;
     }

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -858,9 +858,6 @@ void QUnit::Swap(bitLenInt qubit1, bitLenInt qubit2)
         return;
     }
 
-    RevertBasis2Qb(qubit1);
-    RevertBasis2Qb(qubit2);
-
     QEngineShard& shard1 = shards[qubit1];
     QEngineShard& shard2 = shards[qubit2];
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1342,14 +1342,14 @@ void QUnit::CZ(bitLenInt control, bitLenInt target)
         return;
     }
 
+    if (cShard.isPlusMinus && !tShard.isPlusMinus) {
+        std::swap(control, target);
+    }
+
     if (!freezeBasis) {
         TransformBasis1Qb(false, control);
         tShard.AddPhaseAngles(&cShard, 0, (real1)M_PI);
         return;
-    }
-
-    if (cShard.isPlusMinus && !tShard.isPlusMinus) {
-        std::swap(control, target);
     }
 
     bitLenInt controls[1] = { control };

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1086,9 +1086,9 @@ void QUnit::X(bitLenInt target)
 {
     QEngineShard& shard = shards[target];
 
-    if (!shard.TryFlipPhaseAnti()) {
-        RevertBasis2Qb(target);
-    }
+    RevertBasis2Qb(target, false, true);
+    // Not necessary to check return after the above revert:
+    shard.TryFlipPhaseAnti();
 
     if (!shard.isPlusMinus) {
         XBase(target);
@@ -1102,9 +1102,9 @@ void QUnit::Z(bitLenInt target)
     // Commutes with controlled phase optimizations
     QEngineShard& shard = shards[target];
 
-    if (!shard.TryCommutePhase(ONE_CMPLX, -ONE_CMPLX)) {
-        RevertBasis2Qb(target);
-    }
+    RevertBasis2Qb(target, false, true);
+    // Not necessary to check return after the above revert:
+    shard.TryCommutePhase(ONE_CMPLX, -ONE_CMPLX);
 
     if (!shard.isPlusMinus) {
         if (PHASE_MATTERS(target)) {
@@ -1370,9 +1370,9 @@ void QUnit::ApplySinglePhase(const complex topLeft, const complex bottomRight, b
         return;
     }
 
-    if (!shard.TryCommutePhase(topLeft, bottomRight)) {
-        RevertBasis2Qb(target);
-    }
+    RevertBasis2Qb(target, false, true);
+    // Not necessary to check return after the above revert:
+    shard.TryCommutePhase(topLeft, bottomRight);
 
     if (!shard.isPlusMinus) {
         // If the target bit is in a |0>/|1> eigenstate, this gate has no effect.
@@ -1406,9 +1406,9 @@ void QUnit::ApplySingleInvert(const complex topRight, const complex bottomLeft, 
         return;
     }
 
-    if (!shard.TryFlipPhaseAnti()) {
-        RevertBasis2Qb(target);
-    }
+    RevertBasis2Qb(target, false, true);
+    // Not necessary to check return after the above revert:
+    shard.TryFlipPhaseAnti();
 
     if (!shard.isPlusMinus) {
         ApplyOrEmulate(
@@ -2982,7 +2982,7 @@ void QUnit::TransformBasis1Qb(const bool& toPlusMinus, const bitLenInt& i)
     freezeBasis = false;
 }
 
-void QUnit::RevertBasis2Qb(const bitLenInt& i, const bool& onlyInvert)
+void QUnit::RevertBasis2Qb(const bitLenInt& i, const bool& onlyInvert, const bool& onlyControlling)
 {
     QEngineShard& shard = shards[i];
 
@@ -3042,6 +3042,10 @@ void QUnit::RevertBasis2Qb(const bitLenInt& i, const bool& onlyInvert)
         }
 
         shard.RemovePhaseTarget(partner);
+    }
+
+    if (onlyControlling) {
+        return;
     }
 
     ShardToPhaseMap targetOfShards = shard.targetOfShards;

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1170,8 +1170,8 @@ void QUnit::TransformInvert(const complex& topRight, const complex& bottomLeft, 
     if (qubit1 == qubit2) {                                                                                            \
         return;                                                                                                        \
     }                                                                                                                  \
-    TransformBasis1Qb(false, qubit1);                                                                                  \
-    TransformBasis1Qb(false, qubit2);                                                                                  \
+    ToPermBasis(qubit1);                                                                                               \
+    ToPermBasis(qubit2);                                                                                               \
     ApplyEitherControlled(controls, controlLen, { qubit1, qubit2 }, anti,                                              \
         [&](QInterfacePtr unit, std::vector<bitLenInt> mappedControls) { unit->ctrld; }, [&]() { bare; })
 #define CTRL_GEN_ARGS &(mappedControls[0]), mappedControls.size(), shards[target].mapped, trnsMtrx
@@ -1342,11 +1342,11 @@ void QUnit::CZ(bitLenInt control, bitLenInt target)
         return;
     }
 
-    /*if (!freezeBasis) {
+    if (!freezeBasis) {
         TransformBasis1Qb(false, control);
         tShard.AddPhaseAngles(&cShard, 0, (real1)M_PI);
         return;
-    }*/
+    }
 
     if (cShard.isPlusMinus && !tShard.isPlusMinus) {
         std::swap(control, target);

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1036,13 +1036,8 @@ void QUnit::H(bitLenInt target)
     QEngineShard& shard = shards[target];
 
     if (!freezeBasis) {
-        if (!shard.TryHCommute()) {
-            RevertBasis2Qb(target);
-        }
-        // for (bitLenInt i = 0; i < qubitCount; i++) {
-        //    if (shard.unit == shards[i].unit) {
-        //        ToPermBasis(target);
-        //    }
+        // if (!shard.TryHCommute()) {
+        RevertBasis2Qb(target);
         //}
         shard.isPlusMinus = !shard.isPlusMinus;
         return;
@@ -1244,14 +1239,14 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
     QEngineShard& cShard = shards[control];
     QEngineShard& tShard = shards[target];
 
-    if (!freezeBasis) {
+    /*if (!freezeBasis) {
         TransformBasis1Qb(false, control);
         RevertBasis2Qb(control, true);
         RevertBasis2Qb(target, true);
 
         tShard.AddInversionAngles(&cShard, 0, 0);
         return;
-    }
+    }*/
 
     bitLenInt controls[1] = { control };
     bitLenInt controlLen = 1;
@@ -1347,11 +1342,11 @@ void QUnit::CZ(bitLenInt control, bitLenInt target)
         return;
     }
 
-    if (!freezeBasis) {
+    /*if (!freezeBasis) {
         TransformBasis1Qb(false, control);
         tShard.AddPhaseAngles(&cShard, 0, (real1)M_PI);
         return;
-    }
+    }*/
 
     if (cShard.isPlusMinus && !tShard.isPlusMinus) {
         std::swap(control, target);
@@ -1472,20 +1467,15 @@ void QUnit::ApplyControlledSinglePhase(const bitLenInt* cControls, const bitLenI
         }
     }
 
-    QEngineShard& tShard = shards[target];
+    /*QEngineShard& tShard = shards[target];
     QEngineShard& cShard = shards[controls[0]];
 
-    if (!freezeBasis || (controlLen != 1U)) {
-        for (bitLenInt i = 0; i < controlLen; i++) {
-            PopHBasis2Qb(controls[i]);
-        }
-    }
-
     if (!freezeBasis && (controlLen == 1U)) {
+        TransformBasis1Qb(false, controls[0]);
         tShard.AddPhaseAngles(&cShard, (real1)arg(topLeft), (real1)arg(bottomRight));
         delete[] controls;
         return;
-    }
+    }*/
 
     CTRLED_PHASE_INVERT_WRAP(ApplyControlledSinglePhase(CTRL_P_ARGS), ApplyControlledSingleBit(CTRL_GEN_ARGS),
         ApplySinglePhase(topLeft, bottomRight, target), false, false, topLeft, bottomRight);
@@ -1500,14 +1490,14 @@ void QUnit::ApplyControlledSingleInvert(const bitLenInt* controls, const bitLenI
         return;
     }
 
-    if (!freezeBasis && (controlLen == 1U)) {
+    /*if (!freezeBasis && (controlLen == 1U)) {
         TransformBasis1Qb(false, controls[0]);
         RevertBasis2Qb(controls[0], true);
         RevertBasis2Qb(target, true);
 
         shards[target].AddInversionAngles(&(shards[controls[0]]), (real1)arg(topRight), (real1)arg(bottomLeft));
         return;
-    }
+    }*/
 
     CTRLED_PHASE_INVERT_WRAP(ApplyControlledSingleInvert(CTRL_I_ARGS), ApplyControlledSingleBit(CTRL_GEN_ARGS),
         ApplySingleInvert(topRight, bottomLeft, target), false, true, topRight, bottomLeft);

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1370,8 +1370,9 @@ void QUnit::ApplySinglePhase(const complex topLeft, const complex bottomRight, b
         return;
     }
 
-    // shard.CommutePhase(topLeft, bottomRight);
-    RevertBasis2Qb(target);
+    if (!shard.TryCommutePhase(topLeft, bottomRight)) {
+        RevertBasis2Qb(target);
+    }
 
     if (!shard.isPlusMinus) {
         // If the target bit is in a |0>/|1> eigenstate, this gate has no effect.

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -858,14 +858,14 @@ void QUnit::Swap(bitLenInt qubit1, bitLenInt qubit2)
         return;
     }
 
+    RevertBasis2Qb(qubit1);
+    RevertBasis2Qb(qubit2);
+
     QEngineShard& shard1 = shards[qubit1];
     QEngineShard& shard2 = shards[qubit2];
 
-    // Swap the bit mapping.
+    // Simply swap the bit mapping, so long as no 2-qubit gates are buffered.
     std::swap(shard1, shard2);
-    // Swap commutes with Hadamards on both bits, (and the identity,) but the commutator for a single H-ed bit is an H
-    // on the other bit.
-    std::swap(shard1.isPlusMinus, shard2.isPlusMinus);
 
     QInterfacePtr unit = shards[qubit1].unit;
     if (unit == shards[qubit2].unit) {
@@ -885,6 +885,9 @@ void QUnit::ISwap(bitLenInt qubit1, bitLenInt qubit2)
     if (qubit1 == qubit2) {
         return;
     }
+
+    RevertBasis2Qb(qubit1);
+    RevertBasis2Qb(qubit2);
 
     QEngineShard& shard1 = shards[qubit1];
     QEngineShard& shard2 = shards[qubit2];
@@ -918,6 +921,9 @@ void QUnit::SqrtSwap(bitLenInt qubit1, bitLenInt qubit2)
         return;
     }
 
+    RevertBasis2Qb(qubit1);
+    RevertBasis2Qb(qubit2);
+
     QEngineShard& shard1 = shards[qubit1];
     QEngineShard& shard2 = shards[qubit2];
 
@@ -941,6 +947,9 @@ void QUnit::ISqrtSwap(bitLenInt qubit1, bitLenInt qubit2)
     if (qubit1 == qubit2) {
         return;
     }
+
+    RevertBasis2Qb(qubit1);
+    RevertBasis2Qb(qubit2);
 
     QEngineShard& shard1 = shards[qubit1];
     QEngineShard& shard2 = shards[qubit2];

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -412,7 +412,7 @@ TEST_CASE("test_grover", "[grover]")
         int i;
         // Twelve iterations maximizes the probablity for 256 searched elements, for example.
         // For an arbitrary number of qubits, this gives the number of iterations for optimal probability.
-        int optIter = M_PI / (4.0 * asin(1.0 / sqrt(pow2(n))));
+        int optIter = M_PI / (4.0 * asin(1.0 / sqrt((real1)pow2(n))));
 
         // Our input to the subroutine "oracle" is 8 bits.
         qftReg->SetPermutation(0);

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -4394,6 +4394,34 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_qneuron")
     }
 }
 
+TEST_CASE_METHOD(QInterfaceTestFixture, "test_bell_m")
+{
+    bitCapInt qPowers[2] = { 1, 2 };
+    const std::set<bitCapInt> possibleResults = { 0, 3 };
+
+    qftReg->SetPermutation(0);
+
+    qftReg->H(0, 2);
+    qftReg->CZ(0, 1);
+    qftReg->H(0);
+    std::map<bitCapInt, int> results = qftReg->MultiShotMeasureMask(qPowers, 2U, 1000);
+    std::map<bitCapInt, int>::iterator it = results.begin();
+    while (it != results.end()) {
+        REQUIRE(possibleResults.find(it->first) != possibleResults.end());
+        it++;
+    }
+
+    qftReg->H(0, 2);
+    qftReg->CZ(0, 1);
+    qftReg->H(1);
+    results = qftReg->MultiShotMeasureMask(qPowers, 2U, 1000);
+    it = results.begin();
+    while (it != results.end()) {
+        REQUIRE(possibleResults.find(it->first) != possibleResults.end());
+        it++;
+    }
+}
+
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_n_bell")
 {
     int i;

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -4400,7 +4400,6 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_bell_m")
     const std::set<bitCapInt> possibleResults = { 0, 3 };
 
     qftReg->SetPermutation(0);
-
     qftReg->H(0, 2);
     qftReg->CZ(0, 1);
     qftReg->H(0);
@@ -4411,6 +4410,7 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_bell_m")
         it++;
     }
 
+    qftReg->SetPermutation(0);
     qftReg->H(0, 2);
     qftReg->CZ(0, 1);
     qftReg->H(1);


### PR DESCRIPTION
This PR is intended to achieve parity between `QEngineOCL` vs. `QUnit` pass/fail on Qiskit unit tests. As of opening this WIP, the stats are:

QEngineOCL: 675/253
QUnit: 659/269

Failures for QEngineOCL are assumed to be due to lack of supported features in the Qrack API, (such as noise, instructions like "bfunc," multi-qubit-target multiplexing, and certain forms of measurement). Head of master was 654/274 for QUnit. The bug already fixed was in QUnit phase gate buffering, and this is also likely where the rest of the bugs reside, based on my current understanding. I am not yet sure if the pass/fail rate is deterministic, but I will also determine this, by the end.