### PR TITLE
Sycamore benchmark updates (and Rx gate phase sign correction)

### DIFF
--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -704,6 +704,20 @@ public:
     virtual void ISqrtX(bitLenInt qubitIndex);
 
     /**
+     * Phased square root of X gate
+     *
+     * Applies T.SqrtX.IT to the qubit at "qubitIndex."
+     */
+    virtual void SqrtXConjT(bitLenInt qubitIndex);
+
+    /**
+     * Inverse phased square root of X gate
+     *
+     * Applies IT.ISqrtX.T to the qubit at "qubitIndex."
+     */
+    virtual void ISqrtXConjT(bitLenInt qubitIndex);
+
+    /**
      * Square root of Y gate
      *
      * Applies the square root of the Pauli "Y" operator to the qubit at "qubitIndex." The Pauli
@@ -1112,6 +1126,12 @@ public:
 
     /** Bitwise inverse square root of Pauli X operator */
     virtual void ISqrtX(bitLenInt start, bitLenInt length);
+
+    /** Bitwise phased square root of Pauli X operator */
+    virtual void SqrtXConjT(bitLenInt start, bitLenInt length);
+
+    /** Bitwise inverse phased square root of Pauli X operator */
+    virtual void ISqrtXConjT(bitLenInt start, bitLenInt length);
 
     /** Bitwise square root of Pauli Y operator */
     virtual void SqrtY(bitLenInt start, bitLenInt length);

--- a/src/qinterface/gates.cpp
+++ b/src/qinterface/gates.cpp
@@ -13,6 +13,7 @@
 #include "qinterface.hpp"
 
 #define C_SQRT1_2 complex(M_SQRT1_2, ZERO_R1)
+#define C_I_SQRT1_2 complex(ZERO_R1, M_SQRT1_2)
 #define ONE_PLUS_I_DIV_2 complex(ONE_R1 / 2, ONE_R1 / 2)
 #define ONE_MINUS_I_DIV_2 complex(ONE_R1 / 2, -ONE_R1 / 2)
 
@@ -146,6 +147,12 @@ GATE_1_BIT(SqrtX, ONE_PLUS_I_DIV_2, ONE_MINUS_I_DIV_2, ONE_MINUS_I_DIV_2, ONE_PL
 
 /// Inverse square root of NOT gate
 GATE_1_BIT(ISqrtX, ONE_MINUS_I_DIV_2, ONE_PLUS_I_DIV_2, ONE_PLUS_I_DIV_2, ONE_MINUS_I_DIV_2);
+
+/// Phased square root of NOT gate
+GATE_1_BIT(SqrtXConjT, ONE_PLUS_I_DIV_2, -C_I_SQRT1_2, C_SQRT1_2, ONE_PLUS_I_DIV_2);
+
+/// Inverse phased square root of NOT gate
+GATE_1_BIT(ISqrtXConjT, ONE_MINUS_I_DIV_2, C_SQRT1_2, C_I_SQRT1_2, ONE_MINUS_I_DIV_2);
 
 /// Apply Pauli Y matrix to bit
 GATE_1_BIT(SqrtY, ONE_PLUS_I_DIV_2, -ONE_PLUS_I_DIV_2, ONE_PLUS_I_DIV_2, ONE_PLUS_I_DIV_2);

--- a/src/qinterface/qinterface.cpp
+++ b/src/qinterface/qinterface.cpp
@@ -140,6 +140,12 @@ REG_GATE_1(SqrtX);
 /// Apply inverse square root of X gate to each bit in "length," starting from bit index "start"
 REG_GATE_1(ISqrtX);
 
+/// Apply phased square root of X gate to each bit in "length," starting from bit index "start"
+REG_GATE_1(SqrtXConjT);
+
+/// Apply inverse phased square root of X gate to each bit in "length," starting from bit index "start"
+REG_GATE_1(ISqrtXConjT);
+
 /// Apply Hadamard gate to each bit in "length," starting from bit index "start"
 REG_GATE_1(H);
 

--- a/src/qinterface/rotational.cpp
+++ b/src/qinterface/rotational.cpp
@@ -27,7 +27,7 @@ void QInterface::RX(real1 radians, bitLenInt qubit)
 {
     real1 cosine = cos(radians / 2.0);
     real1 sine = sin(radians / 2.0);
-    complex pauliRX[4] = { complex(cosine, ZERO_R1), complex(ZERO_R1, sine), complex(ZERO_R1, sine),
+    complex pauliRX[4] = { complex(cosine, ZERO_R1), complex(ZERO_R1, -sine), complex(ZERO_R1, -sine),
         complex(cosine, ZERO_R1) };
     ApplySingleBit(pauliRX, qubit);
 }

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -688,9 +688,9 @@ TEST_CASE("test_quantum_supremacy", "[supreme]")
                 } else if (gateRand < (2 * ONE_R1 / 3)) {
                     qReg->SqrtY(i);
                 } else {
-                    // "Square root of W" is understood to be the square root of the Walsh-Hadamard transform,
-                    // (a.k.a "H" gate).
-                    qReg->SqrtH(i);
+                    // "Square root of W" appears to be equivalent to T.SqrtX.IT, looking at the definition in the
+                    // supplemental materials.
+                    qReg->SqrtXConjT(i);
                 }
 
                 // This is a QUnit specific optimization attempt method that can "compress" (or "Schmidt decompose")

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -1069,6 +1069,12 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_sqrtx_reg")
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_sqrtxconjt")
 {
     qftReg->SetPermutation(0x80001);
+    REQUIRE_THAT(qftReg, HasProbability(0, 20, 0x80001));
+    qftReg->SqrtXConjT(19);
+    qftReg->SqrtXConjT(19);
+    REQUIRE_THAT(qftReg, HasProbability(0, 20, 1));
+
+    qftReg->SetPermutation(0x80001);
     qftReg->SqrtXConjT(19);
     qftReg->ISqrtXConjT(19);
     REQUIRE_THAT(qftReg, HasProbability(0, 20, 0x80001));
@@ -1076,6 +1082,12 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_sqrtxconjt")
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_sqrtxconjt_reg")
 {
+    qftReg->SetPermutation(0x13);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x13));
+    qftReg->SqrtXConjT(1, 4);
+    qftReg->SqrtXConjT(1, 4);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x0d));
+
     qftReg->SetPermutation(0x1d);
     qftReg->SqrtXConjT(0, 4);
     qftReg->ISqrtXConjT(0, 4);

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -1066,6 +1066,22 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_sqrtx_reg")
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x13));
 }
 
+TEST_CASE_METHOD(QInterfaceTestFixture, "test_sqrtxconjt")
+{
+    qftReg->SetPermutation(0x80001);
+    qftReg->SqrtXConjT(19);
+    qftReg->ISqrtXConjT(19);
+    REQUIRE_THAT(qftReg, HasProbability(0, 20, 0x80001));
+}
+
+TEST_CASE_METHOD(QInterfaceTestFixture, "test_sqrtxconjt_reg")
+{
+    qftReg->SetPermutation(0x1d);
+    qftReg->SqrtXConjT(0, 4);
+    qftReg->ISqrtXConjT(0, 4);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x1d));
+}
+
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_y")
 {
     qftReg->SetReg(0, 8, 0x03);


### PR DESCRIPTION
A closer reading of the paper, and an examination of the supplemental materials, point to at least a couple of changes to the "quantum supremacy" benchmark. Firstly, "square root of W" is not "square root of Walsh-Hadamard transform." I think I have the correct definition of this gate and its inverse, now, called `QInterface::SqrtXConjT` in Qrack. Secondly, if I understand a point of the description in one of the figures, which seems compatible with the circuit definitions in the supplemental materials, the same single bit gate is not to be repeated on a qubit in the immediately following iteration.

These changes make no major difference difference in `QUnit` performance. I have also noticed two other differences between our benchmark and that of the original paper, which will probably not be addressed in the standard Qrack benchmark suite, but will likely go in a special-purpose verification program in this repo or the comparative simulator benchmark repo, under the vm6502q organization:

1. Two-qubit gates are only "typically" roughly equivalent to iSWAP with "1/6th of CZ." In reality, I think the Google researchers have actually regressed what amount to variational definitions of the two-qubit gates, which can be different across the width of the circuit.
2. In collecting a set of iterations for fixed width, depth, and other parameters, the "random" circuit is defined randomly, _once_, then repeated exactly for maybe 1/2 a million iterations, whereas Qrack regenerates its random circuit definition at every iteration.

For the general benchmark suite, I think omitting these two points is actually _more_ generally and usefully representative. Omitting 2 should make the circuit _harder_, since `MultiShotMeasureMask()` could instead be used to sample an arbitrary number of times from a single iteration of the circuit. Further, 1 makes for an ostensibly less useful circuit, (even if universal,) since using the idealized approximation instead closes a multiplication ring 12 steps, I think, with a single reliable gate definition for all nearest neighbors, as opposed to not necessarily closing a multiplication ring at all with "learned" parameters.

As the "WIP" in the title indicates, for now, I am still working on this.