### PR TITLE
Updating test_quantum_supremacy tiling sequence

### DIFF
--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -642,6 +642,8 @@ TEST_CASE("test_quantum_supremacy", "[supreme]")
         // The test runs 2 bit gates according to a tiling sequence.
         // The 1 bit indicates +/- column offset.
         // The 2 bit indicates +/- row offset.
+        // This is the "ABCDCDAB" pattern, from the Cirq definition of the circuit in the supplemental materials to the
+        // paper.
         std::list<bitLenInt> gateSequence = { 0, 3, 2, 1, 2, 1, 0, 3 };
 
         // Depending on which element of the sequential tiling we're running, per depth iteration,

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -642,7 +642,7 @@ TEST_CASE("test_quantum_supremacy", "[supreme]")
         // The test runs 2 bit gates according to a tiling sequence.
         // The 1 bit indicates +/- column offset.
         // The 2 bit indicates +/- row offset.
-        std::list<bitLenInt> gateSequence = { 0, 3, 1, 2, 1, 2, 0, 3 };
+        std::list<bitLenInt> gateSequence = { 0, 3, 2, 1, 2, 1, 0, 3 };
 
         // Depending on which element of the sequential tiling we're running, per depth iteration,
         // we need to start either with row "0" or row "1".


### PR DESCRIPTION
Upon further inspection of the Sycamore benchmark paper's supplemental materials, we need to flip "C" and "D" in our "ABCDCDAB" tiling sequence. Again, this makes no significant difference in `QUnit` performance. I might throw other relevant "tweaks" on top of this, in the PR.

At this point, I think the 54 qubit benchmark in our suite is equivalent to the published Sycamore circuit at depth of 20, upon inspection of the [supplemental materials](https://datadryad.org/stash/dataset/doi:10.5061/dryad.k6t1rj8) for that [paper](https://www.nature.com/articles/s41586-019-1666-5), up to two major differences:

1. The 54th qubit in Google's physical processor instance, which they excluded from the benchmark for noise/performance considerations, is effectively reinserted, in this Qrack benchmark.
2. Qrack uses what that paper calls their "typical" 2-qubit gate, rather than their "learned" parameters for these gates. This "typical" gate is iSWAP with "1/6th of CZ."

We have said in other issues and/or PRs on this repository, the "typical" gate probably has more practical use, since its multiplication ring closes in a small (finite) number of steps, and (or therefore) it is comparatively easy and reliable to "uncompute." ("Uncomputing" sequences of unitary gates is a critical component of many practical quantum algorithms, maybe for reasons including the fact that one cannot just "dump" entangled registers without ruining superposition and entanglement.) The "learned" parameters of the physical chip might effectively close in much larger periods, (or never in the ideal,) and parameters that differ coupler-to-coupler make for very ad hoc practical circuit design, as I conceive it as a simulator developer.

I would like to experiment with the "learned" 2-qubit gate parameters given in the supplemental materials, if time and resources permit this in practicality; I doubt they are more useful, as stated above or by any reasonable argument.

Qrack's performance on this benchmark probably does primarily rely on "Schmidt decomposition," in a general sense, but the critical particular optimizations are probably SWAP variant operations and phase gate observable irrelevance optimizations. That is, despite some confusion in the community about the difference between a "quantum SWAP" and a "classical SWAP," Qrack finds it can classically reindex SWAP targets quite readily, to achieve the quantum gate in a fundamentally simple way. iSWAP phase factors complicate this, but performance is often comparable to SWAP. In part, as with "phase gates," the phase factors imparted by these gates often make _no_ "observable" physical difference, (i.e. no difference in the expectation values of any possible Hermitian operators,) and therefore they can simply be optimized away without execution.

For those not as familiar with the Qrack library, once you follow the instructions in the README or docs to build Qrack, you can run the 54 qubit benchmark I'm talking about like so:

```
$ ./benchmarks --layer-qunit-qfusion --proc-opencl-single --max-qubits=54 --single test_quantum_supremacy
```

My Alienware 17 with a GTX 1070 just completed 100 iterations in an average of ~86 milliseconds per, slowest ~93 ms, fastest ~77 ms.

Happy Qracking!