### PR TITLE
TrySeparate() hurts performance on benchmarks

### DIFF
--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -519,9 +519,7 @@ TEST_CASE("test_universal_circuit_digital", "[supreme]")
 
                 std::set<bitLenInt> unusedBits;
                 for (i = 0; i < n; i++) {
-                    // TrySeparate hurts average time, in this case, but it majorly benefits statistically common worse
-                    // cases, on these random circuits.
-                    qReg->TrySeparate(i);
+                    //qReg->TrySeparate(i);
                     unusedBits.insert(unusedBits.end(), i);
                 }
 

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -576,12 +576,13 @@ TEST_CASE("test_universal_circuit_analog", "[supreme]")
 
                 for (i = 0; i < n; i++) {
                     gateRand = qReg->Rand();
+                    polar0 = std::polar(ONE_R1, (real1)(2 * M_PI * qReg->Rand()));
                     if (gateRand < (ONE_R1 / GateCount1Qb)) {
                         qReg->H(i);
                     } else if (gateRand < (2 * ONE_R1 / GateCount1Qb)) {
-                        qReg->ApplySinglePhase(ONE_CMPLX, 2 * M_PI * qReg->Rand(), i);
+                        qReg->ApplySinglePhase(ONE_CMPLX, polar0, i);
                     } else {
-                        qReg->ApplySingleInvert(ONE_CMPLX, 2 * M_PI * qReg->Rand(), i);
+                        qReg->ApplySingleInvert(ONE_CMPLX, polar0, i);
                     }
                 }
 

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -519,7 +519,8 @@ TEST_CASE("test_universal_circuit_digital", "[supreme]")
 
                 std::set<bitLenInt> unusedBits;
                 for (i = 0; i < n; i++) {
-                    //qReg->TrySeparate(i);
+                    // In the past, "qReg->TrySeparate(i)" was also used, here, to attempt optimization. Be aware that
+                    // the method can give performance advantages, under opportune conditions, but it does not, here.
                     unusedBits.insert(unusedBits.end(), i);
                 }
 


### PR DESCRIPTION
At one point, `TrySeparate()` seemed to help performance on benchmarks. Some or all of these benchmarks no longer see a benefit from it.

No library code has been changed, just one line of code in the benchmarks. If the CI fails again, I most likely need to optionally xFail sporadic failures in the Pennylane Qiskit plugin, or increase those tests' tolerance.