### PR TITLE
Explicitly add 'atomic' library for certain compilers (Raspberry Pi 4)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,9 +32,9 @@ add_library (qrack STATIC
     )
 
 if (MSVC)
-    set(QRACK_LIBS qrack)
+    set(QRACK_LIBS qrack atomic)
 else (MSVC)
-    set(QRACK_LIBS qrack pthread)
+    set(QRACK_LIBS qrack pthread atomic)
 endif (MSVC)
 
 # Declare the unittest executable


### PR DESCRIPTION
The `atomic` library is a default inclusion for most C++11 compilers, but not GCC for the Raspberry Pi 4. Explicitly linking it should not hurt anything.