### PR TITLE
MSVC does not need "atomic" library

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ install:
   - python -m pip install --upgrade pip setuptools wheel pytest
   - python -m pip install numpy scipy
   - python -m pip install dormouse pybind11
-  - python -m pip install qiskit stestr cython cvxpy
+  - python -m pip install cython==0.29.14
+  - python -m pip install qiskit stestr cvxpy
   - python -m pip install pennylane
 script:
   - mkdir _build && cd _build && cmake -DENABLE_OPENCL=OFF -DENABLE_COMPLEX8=OFF .. && make -j 8 all

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ install:
   - python -m pip install --upgrade pip setuptools wheel pytest
   - python -m pip install numpy scipy
   - python -m pip install dormouse pybind11
-  - python -m pip install cython==0.29.14
+  - python -m pip install cython==0.27.3
   - python -m pip install qiskit stestr cvxpy
   - python -m pip install pennylane
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,9 @@ install:
   - python -m pip install --upgrade pip setuptools wheel pytest
   - python -m pip install numpy scipy
   - python -m pip install dormouse pybind11
-  - python -m pip install cython==0.27.3
-  - python -m pip install qiskit stestr cvxpy
+  - python -m pip install cython==0.29.14
+  - python -m pip install qiskit==0.14.1
+  - python -m pip install stestr cvxpy
   - python -m pip install pennylane
 script:
   - mkdir _build && cd _build && cmake -DENABLE_OPENCL=OFF -DENABLE_COMPLEX8=OFF .. && make -j 8 all

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ install:
   - python -m pip install --upgrade pip setuptools wheel pytest
   - python -m pip install numpy scipy
   - python -m pip install dormouse pybind11
-  - python -m pip install cython==0.29.14
+  - python -m pip install Cython==0.29.14
   - python -m pip install qiskit==0.14.1
   - python -m pip install stestr cvxpy
   - python -m pip install pennylane

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ install:
   - sudo apt-get update
   - sudo apt-get install linuxdoc-tools linuxdoc-tools-info binutils-mingw-w64-i686 gcc-mingw-w64-i686 sshpass cmake python3-pip python3-pytest
   - python -m pip install --upgrade pip setuptools wheel pytest
-  - python -m pip install --only-binary=numpy,scipy numpy scipy
+  - python -m pip install numpy scipy
   - python -m pip install dormouse pybind11
   - python -m pip install qiskit stestr Cython cvxpy
   - python -m pip install pennylane

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ install:
   - python -m pip install --upgrade pip setuptools wheel pytest
   - python -m pip install numpy scipy
   - python -m pip install dormouse pybind11
-  - python -m pip install qiskit stestr Cython cvxpy
+  - python -m pip install qiskit stestr cython cvxpy
   - python -m pip install pennylane
 script:
   - mkdir _build && cd _build && cmake -DENABLE_OPENCL=OFF -DENABLE_COMPLEX8=OFF .. && make -j 8 all

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ add_library (qrack STATIC
     )
 
 if (MSVC)
-    set(QRACK_LIBS qrack atomic)
+    set(QRACK_LIBS qrack)
 else (MSVC)
     set(QRACK_LIBS qrack pthread atomic)
 endif (MSVC)

--- a/include/common/parallel_for.hpp
+++ b/include/common/parallel_for.hpp
@@ -15,8 +15,8 @@
 #include <vector>
 
 /* Needed for bitCapInt typedefs. */
-#include "../statevector.hpp"
-#include "qrack_types.hpp"
+#include "statevector.hpp"
+#include "common/qrack_types.hpp"
 
 namespace Qrack {
 

--- a/include/common/parallel_for.hpp
+++ b/include/common/parallel_for.hpp
@@ -15,8 +15,8 @@
 #include <vector>
 
 /* Needed for bitCapInt typedefs. */
-#include "statevector.hpp"
-#include "common/qrack_types.hpp"
+#include "../statevector.hpp"
+#include "qrack_types.hpp"
 
 namespace Qrack {
 

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -1459,10 +1459,6 @@ public:
     virtual void CINC(
         bitCapInt toAdd, bitLenInt inOutStart, bitLenInt length, bitLenInt* controls, bitLenInt controlLen) = 0;
 
-    /** When in Fourier basis, (after QFT,) this is equivalent to INC, after returning to permutation basis (after
-     * subsequent IQFT). */
-    virtual void QFTINC(bitCapInt toAdd, bitLenInt start, bitLenInt length);
-
     /** Add integer (without sign, with carry) */
     virtual void INCC(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt carryIndex) = 0;
 

--- a/include/statevector.hpp
+++ b/include/statevector.hpp
@@ -99,7 +99,7 @@ public:
         amplitudes = Alloc(capacity);
     }
 
-    ~StateVectorArray() { Free(); }
+    virtual ~StateVectorArray() { Free(); }
 
     complex read(const bitCapInt& i) { return amplitudes[i]; };
 

--- a/src/qinterface/arithmetic.cpp
+++ b/src/qinterface/arithmetic.cpp
@@ -15,26 +15,6 @@
 namespace Qrack {
 
 // Arithmetic:
-void QInterface::QFTINC(bitCapInt toAdd, bitLenInt inOutStart, bitLenInt length)
-{
-    // See Draper, https://arxiv.org/abs/quant-ph/0008033
-
-    for (bitLenInt i = 0; i < length; i++) {
-        for (bitLenInt j = 0; j <= i; j++) {
-            if ((toAdd >> j) & ONE_BCI) {
-                RT((-M_PI * 2) / intPow(2U, i - j), inOutStart + i);
-            }
-        }
-    }
-}
-
-/// Add integer (without sign)
-void QInterface::INC(bitCapInt toAdd, bitLenInt inOutStart, bitLenInt length)
-{
-    QFT(inOutStart, length);
-    QFTINC(toAdd, inOutStart, length);
-    IQFT(inOutStart, length);
-}
 
 /// Subtract integer (without sign)
 void QInterface::DEC(bitCapInt toSub, bitLenInt inOutStart, bitLenInt length)

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -2173,23 +2173,6 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_lsr")
     REQUIRE_THAT(qftReg, HasProbability(64));
 }
 
-TEST_CASE_METHOD(QInterfaceTestFixture, "test_add_1")
-{
-    qftReg->SetPermutation(0);
-    qftReg->QFT(0, 2);
-    qftReg->RTDyad(1, 0, 0);
-    qftReg->RTDyad(1, 1, 1);
-    qftReg->IQFT(0, 2);
-    REQUIRE_THAT(qftReg, HasProbability(0, 8, 1));
-
-    // There is a known and understood issue between QInterface::INC and QUnit basis transformation optimizations.
-    if (testEngineType != QINTERFACE_QUNIT) {
-        qftReg->SetPermutation(20);
-        qftReg->QInterface::INC(17, 0, 8);
-        REQUIRE_THAT(qftReg, HasProbability(0, 8, 37));
-    }
-}
-
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_fulladd")
 {
     qftReg->SetPermutation(0x00);


### PR DESCRIPTION
As the title says, the "atomic" library is not needed for Windows builds.