### PR TITLE
Debugging SetDevice()

### DIFF
--- a/include/qengine_opencl.hpp
+++ b/include/qengine_opencl.hpp
@@ -113,7 +113,6 @@ protected:
     size_t maxWorkItems;
     size_t maxMem;
     size_t maxAlloc;
-    size_t baseAlign;
     unsigned int procElemCount;
     bool unlockHostMem;
 


### PR DESCRIPTION
QUnitMulti has given me a reason to look at the OpenCL code, again. This should fix edge cases for using a host pointer vs. device RAM.