### PR TITLE
Fixing CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,8 @@ install:
   - sudo apt-get install linuxdoc-tools linuxdoc-tools-info binutils-mingw-w64-i686 gcc-mingw-w64-i686 sshpass cmake
   - python -m pip install --upgrade pip wheel pytest numpy setuptools==45
   - python -m pip install scipy
-  - python -m pip install dormouse pybind11
-  - python -m pip install cvxpy==1.0.25
-  - python -m pip install Cython==0.29.14
-  - python -m pip install stestr
-  - python -m pip install qiskit
+  - python -m pip install dormouse pybind11 cvxpy Cython stestr
+  - python -m pip install qiskit==0.17.0
   - python -m pip install pennylane
 script:
   - mkdir _build && cd _build && cmake -DENABLE_OPENCL=OFF -DENABLE_COMPLEX8=OFF .. && make -j 8 all
@@ -30,7 +27,7 @@ script:
   - python -m pytest .
   - cd .. && git clone https://github.com/vm6502q/pennylane-qiskit.git && cd pennylane-qiskit
   - python -m pip install .
-#  - python -m pytest .
+  - python -m pytest .
 #  - cd .. && git clone https://github.com/SoftwareQuTech/SimulaQron.git && cd SimulaQron
 #  - python -m pip install .
 #  - echo "import simulaqron" > simulaqron_tests.py && echo "simulaqron.tests()" >> simulaqron_tests.py


### PR DESCRIPTION
When the Qiskit update was released, I had to disable the PennyLane tests. Now, I am trying to re-enable them, by backing the Qiskit version up by one release.