### PR TITLE
Measurement optimization

### DIFF
--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -744,6 +744,18 @@ protected:
         }
     }
     void ToPermBasisAll() { ToPermBasis(0, qubitCount); }
+    void ToPermBasisAllMeasure()
+    {
+        bitLenInt i;
+        for (i = 0; i < qubitCount; i++) {
+            TransformBasis1Qb(i, false);
+        }
+        for (i = 0; i < qubitCount; i++) {
+            RevertBasis2Qb(i, true);
+            shards[i].controlsShards.clear();
+            shards[i].targetOfShards.clear();
+        }
+    }
     void PopHBasis2Qb(const bitLenInt& i)
     {
         QEngineShard& shard = shards[i];

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -763,6 +763,7 @@ bitCapInt QUnit::ForceM(const bitLenInt* bits, const bitLenInt& length, const bo
                 contigRegLength++;
                 i++;
             }
+            // If we're measuring the entire length of the sub-unit, we can skip the "collapse" portion of measurement.
             doApply = (qi.first->GetQubitCount() != contigRegLength);
             toDispose[contigRegStart] = contigRegLength;
             if (values) {

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -829,6 +829,10 @@ bitCapInt QUnit::ForceMReg(bitLenInt start, bitLenInt length, bitCapInt result, 
 {
     bitLenInt i;
 
+    if ((start == 0) && (length == qubitCount)) {
+        ToPermBasisAllMeasure();
+    }
+
     bitLenInt* bits = new bitLenInt[length];
     for (i = 0; i < length; i++) {
         bits[i] = start + i;

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -785,7 +785,7 @@ bitCapInt QUnit::ForceM(const bitLenInt* bits, const bitLenInt& length, const bo
                     real1* probs = new real1[subMaxQPower];
                     qi.first->GetProbs(probs);
                     real1 rnd = Rand();
-                    real1 tot = 0;
+                    real1 tot = ZERO_R1;
                     bitCapInt perm;
                     bitCapInt lastPerm = 0;
                     for (perm = 0; perm < subMaxQPower; perm++) {

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -787,11 +787,18 @@ bitCapInt QUnit::ForceM(const bitLenInt* bits, const bitLenInt& length, const bo
                     real1 rnd = Rand();
                     real1 tot = 0;
                     bitCapInt perm;
+                    bitCapInt lastPerm = 0;
                     for (perm = 0; perm < subMaxQPower; perm++) {
                         tot += probs[perm];
+                        if (probs[perm] > ZERO_R1) {
+                            lastPerm = perm;
+                        }
                         if (rnd < tot) {
                             break;
                         }
+                    }
+                    if (perm == subMaxQPower) {
+                        perm = lastPerm;
                     }
                     partResults.push_back(perm);
                     delete[] probs;

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -750,6 +750,7 @@ bitCapInt QUnit::ForceM(const bitLenInt* bits, const bitLenInt& length, const bo
             continue;
         }
 
+        bool doApply = true;
         std::sort(qi.second.begin(), qi.second.end());
         i = 0;
         std::map<bitLenInt, bitLenInt> toDispose;
@@ -762,6 +763,7 @@ bitCapInt QUnit::ForceM(const bitLenInt* bits, const bitLenInt& length, const bo
                 contigRegLength++;
                 i++;
             }
+            doApply = (qi.first->GetQubitCount() != contigRegLength);
             toDispose[contigRegStart] = contigRegLength;
             if (values) {
                 contigRegResult = 0;
@@ -770,17 +772,40 @@ bitCapInt QUnit::ForceM(const bitLenInt* bits, const bitLenInt& length, const bo
                         contigRegResult |= pow2(j);
                     }
                 }
-                partResults.push_back(qi.first->ForceMReg(contigRegStart, contigRegLength, contigRegResult, true));
+                if (doApply) {
+                    partResults.push_back(qi.first->ForceMReg(contigRegStart, contigRegLength, contigRegResult, true));
+                } else {
+                    partResults.push_back(contigRegResult);
+                }
             } else {
-                partResults.push_back(qi.first->MReg(contigRegStart, contigRegLength));
+                if (doApply) {
+                    partResults.push_back(qi.first->MReg(contigRegStart, contigRegLength));
+                } else {
+                    bitCapInt subMaxQPower = qi.first->GetMaxQPower();
+                    real1* probs = new real1[subMaxQPower];
+                    qi.first->GetProbs(probs);
+                    real1 rnd = Rand();
+                    real1 tot = 0;
+                    bitCapInt perm;
+                    for (perm = 0; perm < subMaxQPower; perm++) {
+                        tot += probs[perm];
+                        if (rnd < tot) {
+                            break;
+                        }
+                    }
+                    partResults.push_back(perm);
+                    delete[] probs;
+                }
             }
         }
 
         // This is critical: it's the "nonlocal correlation" of "wave function collapse".
-        for (j = 0; j < qubitCount; j++) {
-            if (shards[j].unit == qi.first) {
-                shards[j].isProbDirty = true;
-                shards[j].isPhaseDirty = true;
+        if (doApply) {
+            for (j = 0; j < qubitCount; j++) {
+                if (shards[j].unit == qi.first) {
+                    shards[j].isProbDirty = true;
+                    shards[j].isPhaseDirty = true;
+                }
             }
         }
 


### PR DESCRIPTION
QUnit can further optimize its controlled gate buffers, if they're cleared in anticipation of an immediately subsequent measurement: controlled phase gates with both ends within the measured qubit set will not change probability amplitude norms, and measurement will destroy phase information, so these buffer cases can safely be "dumped" without application on measurement.

Also, if a QUnit sub-unit is measured across its entire length, we only need a `bitCapInt` result without a "collapse" of the sub-unit, since it will be replaced by re-initialized single qubit separable shards.