### PR TITLE
Various optimization

### DIFF
--- a/include/qengine.hpp
+++ b/include/qengine.hpp
@@ -61,9 +61,10 @@ public:
 
     virtual ~QEngine() { Finish(); }
 
-    virtual bool ForceM(bitLenInt qubitIndex, bool result, bool doForce = true);
-    virtual bitCapInt ForceM(const bitLenInt* bits, const bitLenInt& length, const bool* values);
-    virtual bitCapInt ForceMReg(bitLenInt start, bitLenInt length, bitCapInt result, bool doForce = true);
+    virtual bool ForceM(bitLenInt qubitIndex, bool result, bool doForce = true, bool doApply = true);
+    virtual bitCapInt ForceM(const bitLenInt* bits, const bitLenInt& length, const bool* values, bool doApply = true);
+    virtual bitCapInt ForceMReg(
+        bitLenInt start, bitLenInt length, bitCapInt result, bool doForce = true, bool doApply = true);
 
     virtual void ApplyM(bitCapInt qPower, bool result, complex nrm)
     {

--- a/include/qfusion.hpp
+++ b/include/qfusion.hpp
@@ -107,9 +107,10 @@ public:
         const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& qubit1, const bitLenInt& qubit2);
     virtual void AntiCISqrtSwap(
         const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& qubit1, const bitLenInt& qubit2);
-    virtual bool ForceM(bitLenInt qubit, bool result, bool doForce = true);
-    virtual bitCapInt ForceM(const bitLenInt* bits, const bitLenInt& length, const bool* values);
-    virtual bitCapInt ForceMReg(bitLenInt start, bitLenInt length, bitCapInt result, bool doForce = true);
+    virtual bool ForceM(bitLenInt qubit, bool result, bool doForce = true, bool doApply = true);
+    virtual bitCapInt ForceM(const bitLenInt* bits, const bitLenInt& length, const bool* values, bool doApply = true);
+    virtual bitCapInt ForceMReg(
+        bitLenInt start, bitLenInt length, bitCapInt result, bool doForce = true, bool doApply = true);
 
     virtual void ROL(bitLenInt shift, bitLenInt start, bitLenInt length);
     virtual void INC(bitCapInt toAdd, bitLenInt start, bitLenInt length);

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -635,7 +635,7 @@ public:
      *
      * \warning PSEUDO-QUANTUM
      */
-    virtual bool ForceM(bitLenInt qubit, bool result, bool doForce = true) = 0;
+    virtual bool ForceM(bitLenInt qubit, bool result, bool doForce = true, bool doApply = true) = 0;
 
     /**
      * S gate
@@ -1666,13 +1666,14 @@ public:
      *
      * \warning PSEUDO-QUANTUM
      */
-    virtual bitCapInt ForceMReg(bitLenInt start, bitLenInt length, bitCapInt result, bool doForce = true);
+    virtual bitCapInt ForceMReg(
+        bitLenInt start, bitLenInt length, bitCapInt result, bool doForce = true, bool doApply = true);
 
     /** Measure bits with indices in array, and return a mask of the results */
     virtual bitCapInt M(const bitLenInt* bits, const bitLenInt& length) { return ForceM(bits, length, NULL); }
 
     /** Measure bits with indices in array, and return a mask of the results */
-    virtual bitCapInt ForceM(const bitLenInt* bits, const bitLenInt& length, const bool* values);
+    virtual bitCapInt ForceM(const bitLenInt* bits, const bitLenInt& length, const bool* values, bool doApply = true);
 
     /**
      * Set 8 bit register bits by a superposed index-offset-based read from

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -516,10 +516,11 @@ public:
     virtual void AntiCISqrtSwap(
         const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& qubit1, const bitLenInt& qubit2);
     using QInterface::ForceM;
-    virtual bool ForceM(bitLenInt qubitIndex, bool result, bool doForce = true);
-    virtual bitCapInt ForceM(const bitLenInt* bits, const bitLenInt& length, const bool* values);
+    virtual bool ForceM(bitLenInt qubitIndex, bool result, bool doForce = true, bool doApply = true);
+    virtual bitCapInt ForceM(const bitLenInt* bits, const bitLenInt& length, const bool* values, bool doApply = true);
     using QInterface::ForceMReg;
-    virtual bitCapInt ForceMReg(bitLenInt start, bitLenInt length, bitCapInt result, bool doForce = true);
+    virtual bitCapInt ForceMReg(
+        bitLenInt start, bitLenInt length, bitCapInt result, bool doForce = true, bool doApply = true);
 
     /** @} */
 

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -2099,21 +2099,9 @@ void QEngineOCL::GetProbs(real1* outputProbs)
         NormalizeState();
     }
 
-    if (stateVec) {
-        LockSync(CL_MAP_READ);
-        std::transform(stateVec, stateVec + maxQPower, outputProbs, normHelper);
-        UnlockSync();
-        return;
-    }
-
-    complex* outputState = AllocStateVec(maxQPower, true);
-    BufferPtr oStateBuffer = MakeStateVecBuffer(outputState);
-    WAIT_COPY(*stateBuffer, *oStateBuffer, sizeof(complex) * maxQPower);
-    queue.enqueueMapBuffer(*oStateBuffer, CL_TRUE, CL_MAP_READ, 0, sizeof(complex) * maxQPower);
-
-    std::transform(outputState, outputState + maxQPower, outputProbs, normHelper);
-
-    FreeStateVec(outputState);
+    LockSync(CL_MAP_READ);
+    std::transform(stateVec, stateVec + maxQPower, outputProbs, normHelper);
+    UnlockSync();
 }
 
 bool QEngineOCL::ApproxCompare(QEngineOCLPtr toCompare)

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -1202,7 +1202,17 @@ void QEngineOCL::ProbRegAll(const bitLenInt& start, const bitLenInt& length, rea
     if ((lengthPower * lengthPower) < nrmGroupCount) {
         // With "lengthPower" count of threads, compared to a redundancy of "lengthPower" with full utilization, this is
         // close to the point where it becomes more efficient to rely on iterating through ProbReg calls.
-        QEngine::ProbRegAll(start, length, probsArray);
+        if ((start == 0) && length == qubitCount) {
+            if (doNormalize) {
+                NormalizeState();
+            }
+
+            LockSync(CL_MAP_READ);
+            std::transform(stateVec, stateVec + maxQPower, probsArray, normHelper);
+            UnlockSync();
+        } else {
+            QEngine::ProbRegAll(start, length, probsArray);
+        }
         return;
     }
 

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -2093,16 +2093,7 @@ void QEngineOCL::GetQuantumState(complex* outputState)
 }
 
 /// Get all probabilities, in unsigned int permutation basis
-void QEngineOCL::GetProbs(real1* outputProbs)
-{
-    if (doNormalize) {
-        NormalizeState();
-    }
-
-    LockSync(CL_MAP_READ);
-    std::transform(stateVec, stateVec + maxQPower, outputProbs, normHelper);
-    UnlockSync();
-}
+void QEngineOCL::GetProbs(real1* outputProbs) { ProbRegAll(0, qubitCount, outputProbs); }
 
 bool QEngineOCL::ApproxCompare(QEngineOCLPtr toCompare)
 {

--- a/src/qengine/qengine.cpp
+++ b/src/qengine/qengine.cpp
@@ -15,7 +15,7 @@
 namespace Qrack {
 
 /// PSEUDO-QUANTUM - Acts like a measurement gate, except with a specified forced result.
-bool QEngine::ForceM(bitLenInt qubit, bool result, bool doForce)
+bool QEngine::ForceM(bitLenInt qubit, bool result, bool doForce, bool doApply)
 {
     if (doNormalize) {
         NormalizeState();
@@ -38,14 +38,16 @@ bool QEngine::ForceM(bitLenInt qubit, bool result, bool doForce)
         throw "ERROR: Forced a measurement result with 0 probability";
     }
 
-    bitCapInt qPower = pow2(qubit);
-    ApplyM(qPower, result, GetNonunitaryPhase() / (real1)(std::sqrt(nrmlzr)));
+    if (doApply) {
+        bitCapInt qPower = pow2(qubit);
+        ApplyM(qPower, result, GetNonunitaryPhase() / (real1)(std::sqrt(nrmlzr)));
+    }
 
     return result;
 }
 
 /// Measure permutation state of a register
-bitCapInt QEngine::ForceM(const bitLenInt* bits, const bitLenInt& length, const bool* values)
+bitCapInt QEngine::ForceM(const bitLenInt* bits, const bitLenInt& length, const bool* values, bool doApply)
 {
     // Single bit operations are better optimized for this special case:
     if (length == 1U) {
@@ -144,7 +146,9 @@ bitCapInt QEngine::ForceM(const bitLenInt* bits, const bitLenInt& length, const 
 
     nrm = phase / (real1)(std::sqrt(nrmlzr));
 
-    ApplyM(regMask, result, nrm);
+    if (doApply) {
+        ApplyM(regMask, result, nrm);
+    }
 
     return result;
 }
@@ -435,7 +439,7 @@ void QEngine::ProbRegAll(const bitLenInt& start, const bitLenInt& length, real1*
 }
 
 /// Measure permutation state of a register
-bitCapInt QEngine::ForceMReg(bitLenInt start, bitLenInt length, bitCapInt result, bool doForce)
+bitCapInt QEngine::ForceMReg(bitLenInt start, bitLenInt length, bitCapInt result, bool doForce, bool doApply)
 {
     // Single bit operations are better optimized for this special case:
     if (length == 1U) {
@@ -492,7 +496,9 @@ bitCapInt QEngine::ForceMReg(bitLenInt start, bitLenInt length, bitCapInt result
     bitCapInt resultPtr = result << (bitCapInt)start;
     complex nrm = GetNonunitaryPhase() / (real1)(std::sqrt(nrmlzr));
 
-    ApplyM(regMask, resultPtr, nrm);
+    if (doApply) {
+        ApplyM(regMask, resultPtr, nrm);
+    }
 
     return result;
 }

--- a/src/qfusion.cpp
+++ b/src/qfusion.cpp
@@ -504,22 +504,22 @@ void QFusion::AntiCISqrtSwap(
     qReg->AntiCISqrtSwap(controls, controlLen, qubit1, qubit2);
 }
 
-bool QFusion::ForceM(bitLenInt qubit, bool result, bool doForce)
+bool QFusion::ForceM(bitLenInt qubit, bool result, bool doForce, bool doApply)
 {
     FlushAll();
-    return qReg->ForceM(qubit, result, doForce);
+    return qReg->ForceM(qubit, result, doForce, doApply);
 }
 
-bitCapInt QFusion::ForceM(const bitLenInt* bits, const bitLenInt& length, const bool* values)
+bitCapInt QFusion::ForceM(const bitLenInt* bits, const bitLenInt& length, const bool* values, bool doApply)
 {
     FlushAll();
-    return qReg->ForceM(bits, length, values);
+    return qReg->ForceM(bits, length, values, doApply);
 }
 
-bitCapInt QFusion::ForceMReg(bitLenInt start, bitLenInt length, bitCapInt result, bool doForce)
+bitCapInt QFusion::ForceMReg(bitLenInt start, bitLenInt length, bitCapInt result, bool doForce, bool doApply)
 {
     FlushAll();
-    return qReg->ForceMReg(start, length, result, doForce);
+    return qReg->ForceMReg(start, length, result, doForce, doApply);
 }
 
 void QFusion::BufferArithmetic(

--- a/src/qinterface/qinterface.cpp
+++ b/src/qinterface/qinterface.cpp
@@ -511,19 +511,19 @@ void QInterface::SetReg(bitLenInt start, bitLenInt length, bitCapInt value)
 }
 
 /// Bit-wise apply measurement gate to a register
-bitCapInt QInterface::ForceMReg(bitLenInt start, bitLenInt length, bitCapInt result, bool doForce)
+bitCapInt QInterface::ForceMReg(bitLenInt start, bitLenInt length, bitCapInt result, bool doForce, bool doApply)
 {
     bitCapInt res = 0;
     bitCapInt power;
     for (bitLenInt bit = 0; bit < length; bit++) {
         power = pow2(bit);
-        res |= ForceM(start + bit, (bool)(power & result), doForce) ? power : 0;
+        res |= ForceM(start + bit, (bool)(power & result), doForce, doApply) ? power : 0;
     }
     return res;
 }
 
 /// Bit-wise apply measurement gate to a register
-bitCapInt QInterface::ForceM(const bitLenInt* bits, const bitLenInt& length, const bool* values)
+bitCapInt QInterface::ForceM(const bitLenInt* bits, const bitLenInt& length, const bool* values, bool doApply)
 {
     bitCapInt result = 0;
     if (values == NULL) {
@@ -532,7 +532,7 @@ bitCapInt QInterface::ForceM(const bitLenInt* bits, const bitLenInt& length, con
         }
     } else {
         for (bitLenInt bit = 0; bit < length; bit++) {
-            result |= ForceM(bits[bit], values[bit]) ? pow2(bits[bit]) : 0;
+            result |= ForceM(bits[bit], values[bit], true, doApply) ? pow2(bits[bit]) : 0;
         }
     }
     return result;


### PR DESCRIPTION
The no-application-measurement in QUnit actually caused performance regression, as originally implemented, but the same principle will be an improvement if the original `ForceMReg()` methods are used, simply without applying unitarity breaking within them. This also makes for a useful "pseudo-quantum" operation mode, for the semi-protected `ForceM()`/`ForceMReg()` API in general.