### PR TITLE
Optimizing sparse QUnit measurement

### DIFF
--- a/examples/pearson32.cpp
+++ b/examples/pearson32.cpp
@@ -68,6 +68,7 @@ void QPearson32(size_t len, unsigned char* T, QInterfacePtr qReg)
         }
         h_index -= 8;
     }
+    qReg->DEC(3, 0, 8);
 }
 
 int main()
@@ -100,4 +101,18 @@ int main()
 
     std::cout << "Classical result: " << (int)classicalResult << std::endl;
     std::cout << "Quantum result:   " << (int)quantumResult << std::endl;
+
+    qReg->SetPermutation(0);
+    qReg->H(0, 8);
+    QPearson32(KEY_SIZE, T, qReg);
+
+    try {
+        qReg->ForceM(8U * KEY_SIZE, false);
+    } catch (...) {
+        std::cout << "Even result:      (failed)" << std::endl;
+    }
+
+    bitCapInt quantumKey = qReg->MReg(0, 8U * KEY_SIZE);
+    quantumResult = qReg->MReg(8U * KEY_SIZE, 32);
+    std::cout << "Even result:      (key: " << (int)quantumKey << ", hash: " << (int)quantumResult << ")" << std::endl;
 };

--- a/src/qengine/state.cpp
+++ b/src/qengine/state.cpp
@@ -627,13 +627,14 @@ void QEngineCPU::Dispose(bitLenInt start, bitLenInt length, bitCapInt disposedPe
     bitCapInt remainderPower = pow2(nLength);
     bitCapInt skipMask = pow2(start) - ONE_BCI;
     bitCapInt disposedRes = disposedPerm << (bitCapInt)start;
+    bitCapInt saveMask = ~((pow2(start + length) - ONE_BCI) ^ skipMask);
 
     StateVectorPtr nStateVec = AllocStateVec(remainderPower);
 
     if (stateVec->is_sparse()) {
         par_for_set(stateVec->iterable(), [&](const bitCapInt lcv, const int cpu) {
             bitCapInt i, iLow, iHigh;
-            iHigh = lcv ^ disposedRes;
+            iHigh = lcv & saveMask;
             iLow = iHigh & skipMask;
             i = iLow | ((iHigh ^ iLow) >> (bitCapInt)length);
             nStateVec->write(i, stateVec->read(lcv));

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -819,6 +819,10 @@ bitCapInt QUnit::ForceM(const bitLenInt* bits, const bitLenInt& length, const bo
 
 bitCapInt QUnit::ForceMReg(bitLenInt start, bitLenInt length, bitCapInt result, bool doForce, bool doApply)
 {
+    if (isSparse) {
+        return QInterface::ForceMReg(start, length, result, doForce, doApply);
+    }
+
     bitLenInt i;
 
     ToPermBasisMeasure(start, length);


### PR DESCRIPTION
For sparse-QEngine-based QUnit instances, the default implementation of `QInterface::ForceMReg()` is much faster than the standard optimized QUnit variant. This makes a proof-of-concept of hashing techniques practically viable.