### PR TITLE
Asynchronous OpenCL cleanup

### DIFF
--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -410,7 +410,7 @@ public:
 class QUnit;
 typedef std::shared_ptr<QUnit> QUnitPtr;
 
-class QUnit : public QInterface {
+class QUnit : public QInterface, public ParallelFor {
 protected:
     QInterfaceEngine engine;
     QInterfaceEngine subengine;

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////////////////
 //
-// (C) Daniel Strano and the Qrack contributors 2017-2019. All rights reserved.
+// (C) Daniel Strano and the Qrack contributors 2017-2020. All rights reserved.
 //
 // QUnit maintains explicit separability of qubits as an optimization on a QEngine.
 // See https://arxiv.org/abs/1710.05867
@@ -410,7 +410,7 @@ public:
 class QUnit;
 typedef std::shared_ptr<QUnit> QUnitPtr;
 
-class QUnit : public QInterface, public ParallelFor {
+class QUnit : public QInterface {
 protected:
     QInterfaceEngine engine;
     QInterfaceEngine subengine;

--- a/include/qunitmulti.hpp
+++ b/include/qunitmulti.hpp
@@ -61,7 +61,7 @@ struct DeviceInfo {
 class QUnitMulti;
 typedef std::shared_ptr<QUnitMulti> QUnitMultiPtr;
 
-class QUnitMulti : public QUnit, public ParallelFor {
+class QUnitMulti : public QUnit {
 
 protected:
     int defaultDeviceID;

--- a/include/qunitmulti.hpp
+++ b/include/qunitmulti.hpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////////////////
 //
-// (C) Daniel Strano and the Qrack contributors 2017, 2018. All rights reserved.
+// (C) Daniel Strano and the Qrack contributors 2017-2020. All rights reserved.
 //
 // QUnit maintains explicit separability of qubits as an optimization on a QEngine.
 // See https://arxiv.org/abs/1710.05867
@@ -61,7 +61,7 @@ struct DeviceInfo {
 class QUnitMulti;
 typedef std::shared_ptr<QUnitMulti> QUnitMultiPtr;
 
-class QUnitMulti : public QUnit {
+class QUnitMulti : public QUnit, public ParallelFor {
 
 protected:
     int defaultDeviceID;

--- a/src/common/oclengine.cpp
+++ b/src/common/oclengine.cpp
@@ -315,6 +315,7 @@ void OCLEngine::InitOCL(bool buildFromSource, bool saveBinaries, std::string hom
         for (unsigned int j = 0; j < kernelHandles.size(); j++) {
             all_dev_contexts[i]->calls[kernelHandles[j].oclapi] =
                 cl::Kernel(program, kernelHandles[j].kernelname.c_str());
+            all_dev_contexts[i]->mutexes.emplace(kernelHandles[j].oclapi, new std::mutex);
         }
 
         if (saveBinaries) {

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -915,8 +915,6 @@ void QEngineOCL::Compose(OCLAPI apiCall, bitCapIntOcl* bciArgs, QEngineOCLPtr to
     complex* nStateVec = AllocStateVec(maxQPowerOcl, forceAlloc);
     BufferPtr nStateBuffer = MakeStateVecBuffer(nStateVec);
 
-    OCLDeviceCall ocl = device_context->Reserve(apiCall);
-
     BufferPtr otherStateBuffer;
     complex* otherStateVec;
     if (toCopy->context != context) {
@@ -2205,8 +2203,6 @@ bool QEngineOCL::ApproxCompare(QEngineOCLPtr toCompare)
 
     toCompare->Finish();
 
-    OCLDeviceCall ocl = device_context->Reserve(OCL_API_APPROXCOMPARE);
-
     bitCapIntOcl bciArgs[BCI_ARG_LEN] = { maxQPowerOcl, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
 
     EventVecPtr waitVec = ResetWaitEvents();
@@ -2312,8 +2308,6 @@ void QEngineOCL::UpdateRunningNorm(real1 norm_thresh)
     if (norm_thresh < ZERO_R1) {
         norm_thresh = amplitudeFloor;
     }
-
-    OCLDeviceCall ocl = device_context->Reserve(OCL_API_UPDATENORM);
 
     PoolItemPtr poolItem = GetFreePoolItem();
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////////////////
 //
-// (C) Daniel Strano and the Qrack contributors 2017-2019. All rights reserved.
+// (C) Daniel Strano and the Qrack contributors 2017-2020. All rights reserved.
 //
 // QUnit maintains explicit separability of qubits as an optimization on a QEngine.
 // See https://arxiv.org/abs/1710.05867
@@ -199,7 +199,7 @@ bitLenInt QUnit::Compose(QUnitPtr toCopy, bitLenInt start, bool isConsumed)
 
 void QUnit::Detach(bitLenInt start, bitLenInt length, QUnitPtr dest)
 {
-    /* TODO: This method should decompose the bits for the destination without composing the length first */
+    /* TODO: This method should compose the bits for the destination without cohering the length first */
 
     for (bitLenInt i = 0; i < length; i++) {
         RevertBasis2Qb(start + i);
@@ -294,23 +294,17 @@ QInterfacePtr QUnit::EntangleInCurrentBasis(
             }
         }
 
-        size_t maxLcv = units.size() / 2U;
-        std::vector<QInterfacePtr> nUnits(maxLcv);
+        std::vector<QInterfacePtr> nUnits;
         std::map<QInterfacePtr, bitLenInt> offsets;
         std::map<QInterfacePtr, QInterfacePtr> offsetPartners;
 
-        for (size_t i = 0; i < maxLcv; i++) {
-            offsets[units[2U * i + 1U]] = 0;
-            offsetPartners[units[2U * i + 1U]] = NULL;
+        for (size_t i = 0; i < units.size(); i += 2) {
+            QInterfacePtr retained = units[i];
+            QInterfacePtr consumed = units[i + 1U];
+            nUnits.push_back(retained);
+            offsets[consumed] = retained->Compose(consumed, true);
+            offsetPartners[consumed] = retained;
         }
-
-        par_for(0, maxLcv, [&](const bitCapInt i, const int cpu) {
-            QInterfacePtr retained = units[2U * i];
-            QInterfacePtr consumed = units[2U * i + 1U];
-            nUnits[i] = retained;
-            offsets.find(consumed)->second = retained->Compose(consumed, true);
-            offsetPartners.find(consumed)->second = retained;
-        });
 
         /* Since each unit will be collapsed in-order, one set of bits at a time. */
         for (auto&& shard : shards) {
@@ -758,50 +752,48 @@ bitCapInt QUnit::ForceM(const bitLenInt* bits, const bitLenInt& length, const bo
         invMap[shard.unit][shard.mapped] = i;
     }
 
-    par_for(0, perms.size(), [&](const bitCapInt permLcv, const int cpu) {
-        std::map<QInterfacePtr, std::vector<bitLenInt>>::iterator qi = perms.begin();
-        std::advance(qi, permLcv);
-        if (qi->second.size() == 1) {
-            return;
+    for (auto&& qi : perms) {
+        if (qi.second.size() == 1) {
+            continue;
         }
 
         bool doApplySub = doApply;
-        std::sort(qi->second.begin(), qi->second.end());
+        std::sort(qi.second.begin(), qi.second.end());
         i = 0;
         std::map<bitLenInt, bitLenInt> toDispose;
         std::vector<bitCapInt> partResults;
-        while (i < qi->second.size()) {
-            contigRegStart = qi->second[i];
+        while (i < qi.second.size()) {
+            contigRegStart = qi.second[i];
             contigRegLength = 1U;
             i++;
-            while (qi->second[i] == (contigRegStart + contigRegLength)) {
+            while (qi.second[i] == (contigRegStart + contigRegLength)) {
                 contigRegLength++;
                 i++;
             }
             // If we're measuring the entire length of the sub-unit, we can skip the "collapse" portion of measurement.
-            doApplySub = doApply && (qi->first->GetQubitCount() != contigRegLength);
+            doApplySub = doApply && (qi.first->GetQubitCount() != contigRegLength);
             toDispose[contigRegStart] = contigRegLength;
             if (values) {
                 contigRegResult = 0;
                 for (j = 0; j < contigRegLength; j++) {
-                    if (values[invMap[qi->first][contigRegStart + j]]) {
+                    if (values[invMap[qi.first][contigRegStart + j]]) {
                         contigRegResult |= pow2(j);
                     }
                 }
                 if (doApplySub) {
-                    partResults.push_back(qi->first->ForceMReg(contigRegStart, contigRegLength, contigRegResult, true));
+                    partResults.push_back(qi.first->ForceMReg(contigRegStart, contigRegLength, contigRegResult, true));
                 } else {
                     partResults.push_back(contigRegResult);
                 }
             } else {
-                partResults.push_back(qi->first->ForceMReg(contigRegStart, contigRegLength, 0, false, doApplySub));
+                partResults.push_back(qi.first->ForceMReg(contigRegStart, contigRegLength, 0, false, doApplySub));
             }
         }
 
         // This is critical: it's the "nonlocal correlation" of "wave function collapse".
         if (doApplySub) {
             for (j = 0; j < qubitCount; j++) {
-                if (shards[j].unit == qi->first) {
+                if (shards[j].unit == qi.first) {
                     shards[j].isProbDirty = true;
                     shards[j].isPhaseDirty = true;
                 }
@@ -811,16 +803,16 @@ bitCapInt QUnit::ForceM(const bitLenInt* bits, const bitLenInt& length, const bo
         for (auto iter = toDispose.rbegin(); iter != toDispose.rend(); ++iter) {
             contigRegResult = partResults.back();
             for (i = iter->first; i < (iter->first + iter->second); i++) {
-                SeparateBit((contigRegResult & ONE_BCI) != 0, bits[invMap[qi->first][i]], false);
+                SeparateBit((contigRegResult & ONE_BCI) != 0, bits[invMap[qi.first][i]], false);
                 contigRegResult >>= ONE_BCI;
             }
             contigRegResult = partResults.back();
             partResults.pop_back();
-            if (qi->first->GetQubitCount() > iter->second) {
-                qi->first->Dispose(iter->first, iter->second, contigRegResult);
+            if (qi.first->GetQubitCount() > iter->second) {
+                qi.first->Dispose(iter->first, iter->second, contigRegResult);
             }
         }
-    });
+    }
 
     return QInterface::ForceM(bits, length, values, doApply);
 }

--- a/src/qunitmulti.cpp
+++ b/src/qunitmulti.cpp
@@ -61,9 +61,11 @@ QUnitMulti::QUnitMulti(bitLenInt qBitCount, bitCapInt initState, qrack_rand_gen_
     RedistributeSingleQubits();
 }
 
-void QUnitMulti::RedistributeSingleQubits() {
+void QUnitMulti::RedistributeSingleQubits()
+{
     for (bitLenInt i = 0; i < qubitCount; i++) {
-        std::dynamic_pointer_cast<QEngineOCL>(shards[i].unit)->SetDevice(deviceList[(int)((real1)(i * deviceList.size()) / qubitCount)].id);
+        std::dynamic_pointer_cast<QEngineOCL>(shards[i].unit)
+            ->SetDevice(deviceList[(int)((real1)(i * deviceList.size()) / qubitCount)].id);
     }
 }
 


### PR DESCRIPTION
`OCLEngine` previously kept a single `std::mutex` for locking a device between setting kernel arguments and enqueuing a kernel: the mutex only needs to lock per kernel, not per device, and this was always the original intent for the `OCLEngine` system, which we missed the target on. This has been fixed. Some extraneous lock guards could also be removed, in the process.

With the locking corrected, and with attention paid to the threading limitations of STL containers, `QUnit` can now carry out parallel piece-wise `Compose()` and `ForceMReg()` calls, within its own internals. This might also benefit `QUnitMulti` performance.