### PR TITLE
Fixing intermittent unit failures

### DIFF
--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -653,7 +653,6 @@ protected:
         bitLenInt* controls, bitLenInt controlLen);
     typedef void (QInterface::*CMULModFn)(bitCapInt toMod, bitCapInt modN, bitLenInt start, bitLenInt carryStart,
         bitLenInt length, bitLenInt* controls, bitLenInt controlLen);
-    void CollapseCarry(bitLenInt flagIndex, bitLenInt start, bitLenInt length);
     void INT(bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt carryIndex, bool hasCarry,
         bitLenInt* controls = NULL, bitLenInt controlLen = 0);
     void INTS(bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt overflowIndex, bitLenInt carryIndex,

--- a/src/qengine/qengine.cpp
+++ b/src/qengine/qengine.cpp
@@ -626,7 +626,9 @@ void QEngine::DECBCDC(bitCapInt toSub, bitLenInt inOutStart, bitLenInt length, b
         toSub++;
     }
 
-    bitCapInt invToSub = intPow(10U, length / 4U) - toSub;
+    bitCapInt maxVal = intPow(10U, length / 4U);
+    toSub %= maxVal;
+    bitCapInt invToSub = maxVal - toSub;
     INCDECBCDC(invToSub, inOutStart, length, carryIndex);
 }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1911,36 +1911,8 @@ void QUnit::CINC(bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt* 
     delete[] lControls;
 }
 
-/// Collapse the carry bit in an optimal way, before carry arithmetic.
-void QUnit::CollapseCarry(bitLenInt flagIndex, bitLenInt start, bitLenInt length)
-{
-    ToPermBasis(flagIndex);
-
-    // Measure the carry flag.
-    // Don't separate the flag just to entangle it again, if it's in the same unit.
-    QInterfacePtr flagUnit = shards[flagIndex].unit;
-    bool isFlagEntangled = false;
-    if (flagUnit->GetQubitCount() > 1) {
-        for (bitLenInt i = 0; i < length; i++) {
-            if (flagUnit == shards[start + i].unit) {
-                isFlagEntangled = true;
-                break;
-            }
-        }
-    }
-    if (isFlagEntangled) {
-        EndEmulation(shards[flagIndex]);
-        flagUnit->M(shards[flagIndex].mapped);
-    } else {
-        M(flagIndex);
-    }
-}
-
 void QUnit::INCx(INCxFn fn, bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt flagIndex)
 {
-    CollapseCarry(flagIndex, start, length);
-
-    /* Make sure the flag bit is entangled in the same QU. */
     EntangleRange(start, length);
 
     std::vector<bitLenInt> bits = { start, flagIndex };
@@ -1960,12 +1932,6 @@ void QUnit::INCx(INCxFn fn, bitCapInt toMod, bitLenInt start, bitLenInt length, 
 void QUnit::INCxx(
     INCxxFn fn, bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt flag1Index, bitLenInt flag2Index)
 {
-    /*
-     * Overflow flag should not be measured, however the carry flag still needs
-     * to be measured.
-     */
-    CollapseCarry(flag2Index, start, length);
-
     /* Make sure the flag bits are entangled in the same QU. */
     EntangleRange(start, length);
     std::vector<bitLenInt> bits = { start, flag1Index, flag2Index };

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -2227,49 +2227,49 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_fulladd_noncoding")
     qftReg->FullAdd(0, 1, 2, 3);
     qftReg2->SetPermutation(0x00 | 8);
     qftReg2->QInterface::FullAdd(0, 1, 2, 3);
-    REQUIRE(qftReg->ApproxCompare(qftReg2));
+    REQUIRE(qftReg->MReg(0, 4) == qftReg2->MReg(0, 4));
 
     qftReg->SetPermutation(0x01 | 8);
     qftReg->FullAdd(0, 1, 2, 3);
     qftReg2->SetPermutation(0x01 | 8);
     qftReg2->QInterface::FullAdd(0, 1, 2, 3);
-    REQUIRE(qftReg->ApproxCompare(qftReg2));
+    REQUIRE(qftReg->MReg(0, 4) == qftReg2->MReg(0, 4));
 
     qftReg->SetPermutation(0x02 | 8);
     qftReg->FullAdd(0, 1, 2, 3);
     qftReg2->SetPermutation(0x02 | 8);
     qftReg2->QInterface::FullAdd(0, 1, 2, 3);
-    REQUIRE(qftReg->ApproxCompare(qftReg2));
+    REQUIRE(qftReg->MReg(0, 4) == qftReg2->MReg(0, 4));
 
     qftReg->SetPermutation(0x03 | 8);
     qftReg->FullAdd(0, 1, 2, 3);
     qftReg2->SetPermutation(0x03 | 8);
     qftReg2->QInterface::FullAdd(0, 1, 2, 3);
-    REQUIRE(qftReg->ApproxCompare(qftReg2));
+    REQUIRE(qftReg->MReg(0, 4) == qftReg2->MReg(0, 4));
 
     qftReg->SetPermutation(0x04 | 8);
     qftReg->FullAdd(0, 1, 2, 3);
     qftReg2->SetPermutation(0x04 | 8);
     qftReg2->QInterface::FullAdd(0, 1, 2, 3);
-    REQUIRE(qftReg->ApproxCompare(qftReg2));
+    REQUIRE(qftReg->MReg(0, 4) == qftReg2->MReg(0, 4));
 
     qftReg->SetPermutation(0x05 | 8);
     qftReg->FullAdd(0, 1, 2, 3);
     qftReg2->SetPermutation(0x05 | 8);
     qftReg2->QInterface::FullAdd(0, 1, 2, 3);
-    REQUIRE(qftReg->ApproxCompare(qftReg2));
+    REQUIRE(qftReg->MReg(0, 4) == qftReg2->MReg(0, 4));
 
     qftReg->SetPermutation(0x06 | 8);
     qftReg->FullAdd(0, 1, 2, 3);
     qftReg2->SetPermutation(0x06 | 8);
     qftReg2->QInterface::FullAdd(0, 1, 2, 3);
-    REQUIRE(qftReg->ApproxCompare(qftReg2));
+    REQUIRE(qftReg->MReg(0, 4) == qftReg2->MReg(0, 4));
 
     qftReg->SetPermutation(0x07 | 8);
     qftReg->FullAdd(0, 1, 2, 3);
     qftReg2->SetPermutation(0x07 | 8);
     qftReg2->QInterface::FullAdd(0, 1, 2, 3);
-    REQUIRE(qftReg->ApproxCompare(qftReg2));
+    REQUIRE(qftReg->MReg(0, 4) == qftReg2->MReg(0, 4));
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_ifulladd")


### PR DESCRIPTION
`test_fulladd_noncoding` was failing intermittently due to reliance on `ApproxCompare`, which was overkill and designer to err on the side of false negatives.

`QUnit::DECBCDC` no longer intermittently fails once `CollapseCarry()` is removed from QUnit. This method is obsolete, probably never gave a significant performance increase, and was apparently bugged.