### PR TITLE
Debugging QUnitMulti GetQuantumState and GetProbs

### DIFF
--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -689,6 +689,8 @@ protected:
         bitLenInt start, bitLenInt length, bitLenInt start2, bitLenInt length2, bitLenInt start3, bitLenInt length3);
     virtual QInterfacePtr EntangleAll() { return EntangleRange(0, qubitCount); }
 
+    virtual QInterfacePtr CloneBody(QUnitPtr copyPtr);
+
     virtual bool CheckBitPermutation(const bitLenInt& qubitIndex, const bool& inCurrentBasis = false);
     virtual bool CheckBitsPermutation(
         const bitLenInt& start, const bitLenInt& length, const bool& inCurrentBasis = false);

--- a/include/qunitmulti.hpp
+++ b/include/qunitmulti.hpp
@@ -91,6 +91,10 @@ public:
     virtual void SetPermutation(bitCapInt perm, complex phaseFac = complex(-999.0, -999.0));
     virtual bool TrySeparate(bitLenInt start, bitLenInt length = 1);
 
+    virtual QInterfacePtr Clone();
+    virtual void GetQuantumState(complex* outputState);
+    virtual void GetProbs(real1* outputProbs);
+
 protected:
     virtual std::vector<QEngineInfo> GetQInfos();
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -2947,16 +2947,19 @@ QInterfacePtr QUnit::Clone()
     ToPermBasisAll();
     EndAllEmulation();
 
-    bitLenInt i;
-
     QUnitPtr copyPtr = std::make_shared<QUnit>(engine, subengine, qubitCount, 0, rand_generator,
         complex(ONE_R1, ZERO_R1), doNormalize, randGlobalPhase, useHostRam);
 
+    return CloneBody(copyPtr);
+}
+
+QInterfacePtr QUnit::CloneBody(QUnitPtr copyPtr)
+{
     std::vector<QInterfacePtr> shardEngines;
     std::vector<QInterfacePtr> dupeEngines;
     std::vector<QInterfacePtr>::iterator origEngine;
     bitLenInt engineIndex;
-    for (i = 0; i < qubitCount; i++) {
+    for (bitLenInt i = 0; i < qubitCount; i++) {
         if (find(shardEngines.begin(), shardEngines.end(), shards[i].unit) == shardEngines.end()) {
             shardEngines.push_back(shards[i].unit);
             dupeEngines.push_back(shards[i].unit->Clone());

--- a/src/qunitmulti.cpp
+++ b/src/qunitmulti.cpp
@@ -220,4 +220,34 @@ void QUnitMulti::SeparateBit(bool value, bitLenInt qubit)
     RedistributeQEngines();
 }
 
+QInterfacePtr QUnitMulti::Clone()
+{
+    // TODO: Copy buffers instead of flushing?
+    ToPermBasisAll();
+    EndAllEmulation();
+
+    QUnitMultiPtr copyPtr = std::make_shared<QUnitMulti>(
+        qubitCount, 0, rand_generator, complex(ONE_R1, ZERO_R1), doNormalize, randGlobalPhase, useHostRam);
+
+    return CloneBody(copyPtr);
+}
+
+void QUnitMulti::GetQuantumState(complex* outputState)
+{
+    ToPermBasisAll();
+    EndAllEmulation();
+
+    OrderContiguous(EntangleAll());
+    shards[0].unit->GetQuantumState(outputState);
+}
+
+void QUnitMulti::GetProbs(real1* outputProbs)
+{
+    ToPermBasisAll();
+    EndAllEmulation();
+
+    OrderContiguous(EntangleAll());
+    shards[0].unit->GetProbs(outputProbs);
+}
+
 } // namespace Qrack


### PR DESCRIPTION
The previous PR seems to have exposed a bug in QUnitMulit's GetQuantumState()/GetProbs(). This drew my attention to a typing problem in QUnit's Clone(). The current fix might not be perfectly optimal, but it works, and we have always discouraged users from relying on GetQuantumState() and GetProbs() in favor of methods more realistic to a hardware quantum computer.