### PR TITLE
Sparse state vector optimization

### DIFF
--- a/examples/pearson32.cpp
+++ b/examples/pearson32.cpp
@@ -24,8 +24,8 @@
 using namespace Qrack;
 
 const size_t TABLE_SIZE = 256;
-const size_t KEY_SIZE = 6;
-const size_t HASH_SIZE = 6;
+const size_t KEY_SIZE = 4;
+const size_t HASH_SIZE = 4;
 
 bitCapInt Pearson(const unsigned char* x, size_t len, const unsigned char* T)
 {

--- a/examples/pearson32.cpp
+++ b/examples/pearson32.cpp
@@ -116,7 +116,7 @@ int main()
         qReg->ForceM(8U * KEY_SIZE, false);
     } catch (...) {
         std::cout << "Even result:      (failed)" << std::endl;
-        return;
+        return 0;
     }
 
     bitCapInt quantumKey = qReg->MReg(0, 8U * KEY_SIZE);

--- a/examples/pearson32.cpp
+++ b/examples/pearson32.cpp
@@ -24,8 +24,8 @@
 using namespace Qrack;
 
 const size_t TABLE_SIZE = 256;
-const size_t KEY_SIZE = 4;
-const size_t HASH_SIZE = 4;
+const size_t KEY_SIZE = 7;
+const size_t HASH_SIZE = 7;
 
 bitCapInt Pearson(const unsigned char* x, size_t len, const unsigned char* T)
 {

--- a/examples/pearson32.cpp
+++ b/examples/pearson32.cpp
@@ -32,7 +32,7 @@ bitCapInt Pearson(const unsigned char* x, size_t len, const unsigned char* T)
     size_t i;
     size_t j;
     unsigned char h;
-    unsigned char hh[8];
+    unsigned char hh[HASH_SIZE];
 
     for (j = 0; j < HASH_SIZE; ++j) {
         // Change the first byte
@@ -56,7 +56,7 @@ void QPearson(size_t len, unsigned char* T, QInterfacePtr qReg)
     size_t i;
     size_t j;
     bitLenInt x_index;
-    bitLenInt h_index = (len + 3) * 8;
+    bitLenInt h_index = (len + HASH_SIZE - 1U) * 8;
 
     for (j = 0; j < HASH_SIZE; ++j) {
         // Change the first byte

--- a/examples/pearson32.cpp
+++ b/examples/pearson32.cpp
@@ -24,8 +24,8 @@
 using namespace Qrack;
 
 const size_t TABLE_SIZE = 256;
-const size_t KEY_SIZE = 4;
-const size_t HASH_SIZE = 4;
+const size_t KEY_SIZE = 6;
+const size_t HASH_SIZE = 6;
 
 bitCapInt Pearson(const unsigned char* x, size_t len, const unsigned char* T)
 {
@@ -74,7 +74,7 @@ void QPearson(size_t len, unsigned char* T, QInterfacePtr qReg)
         }
         h_index -= 8;
     }
-    qReg->DEC(3, 0, 8);
+    qReg->DEC((HASH_SIZE - 2U), 0, 8);
 }
 
 int main()
@@ -116,6 +116,7 @@ int main()
         qReg->ForceM(8U * KEY_SIZE, false);
     } catch (...) {
         std::cout << "Even result:      (failed)" << std::endl;
+        return;
     }
 
     bitCapInt quantumKey = qReg->MReg(0, 8U * KEY_SIZE);

--- a/examples/pearson32.cpp
+++ b/examples/pearson32.cpp
@@ -24,8 +24,8 @@
 using namespace Qrack;
 
 const size_t TABLE_SIZE = 256;
-const size_t KEY_SIZE = 7;
-const size_t HASH_SIZE = 7;
+const size_t KEY_SIZE = 4;
+const size_t HASH_SIZE = 4;
 
 bitCapInt Pearson(const unsigned char* x, size_t len, const unsigned char* T)
 {

--- a/include/common/parallel_for.hpp
+++ b/include/common/parallel_for.hpp
@@ -69,7 +69,7 @@ public:
     void par_for_set(const std::vector<bitCapInt>& sparseSet, ParallelFunc fn);
 
     /** Iterate over the power set of 2 sparse state vectors. */
-    void par_for_sparse_compose(const std::set<bitCapInt>& lowSet, const std::set<bitCapInt>& highSet,
+    void par_for_sparse_compose(const std::vector<bitCapInt>& lowSet, const std::vector<bitCapInt>& highSet,
         const bitLenInt& highStart, ParallelFunc fn);
 
     /** Calculate the normal for the array. */

--- a/include/common/qrack_types.hpp
+++ b/include/common/qrack_types.hpp
@@ -122,8 +122,11 @@ protected:
     bitCapInt capacity;
 
 public:
+    bool isReadLocked;
+
     StateVector(bitCapInt cap)
         : capacity(cap)
+        , isReadLocked(true)
     {
     }
     virtual complex read(const bitCapInt& i) = 0;
@@ -137,9 +140,6 @@ public:
     virtual void copy(StateVectorPtr toCopy) = 0;
     virtual void get_probs(real1* outArray) = 0;
     virtual bool is_sparse() = 0;
-    virtual std::vector<bitCapInt> iterable() = 0;
-    virtual std::set<bitCapInt> iterable(
-        const bitCapInt& setMask, const bitCapInt& filterMask = 0, const bitCapInt& filterValues = 0) = 0;
 };
 
 void mul2x2(complex* left, complex* right, complex* out);

--- a/include/qengine_cpu.hpp
+++ b/include/qengine_cpu.hpp
@@ -36,6 +36,8 @@ protected:
     StateVectorPtr stateVec;
     bool isSparse;
 
+    StateVectorSparsePtr CastStateVecSparse() { return std::dynamic_pointer_cast<StateVectorSparse>(stateVec); }
+
 public:
     QEngineCPU(bitLenInt qBitCount, bitCapInt initState, qrack_rand_gen_ptr rgp = nullptr,
         complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = false, bool randomGlobalPhase = true, bool ignored = false,

--- a/include/statevector.hpp
+++ b/include/statevector.hpp
@@ -129,8 +129,7 @@ protected:
     complex readUnlocked(const bitCapInt& i)
     {
         auto it = amplitudes.find(i);
-        bool isFound = (it != amplitudes.end());
-        return isFound ? it->second : ZERO_CMPLX;
+        return (it == amplitudes.end()) ? ZERO_CMPLX : it->second;
     }
 
     complex readLocked(const bitCapInt& i)

--- a/include/statevector.hpp
+++ b/include/statevector.hpp
@@ -157,18 +157,18 @@ public:
         mtx.lock();
         auto it = amplitudes.find(i);
         bool isFound = (it != amplitudes.end());
-        mtx.unlock();
+        if ((c == ZERO_CMPLX) != isFound) {
+            mtx.unlock();
+        }
 
         if (c != ZERO_CMPLX) {
             if (isFound) {
                 it->second = c;
             } else {
-                mtx.lock();
                 amplitudes[i] = c;
                 mtx.unlock();
             }
         } else if (isFound) {
-            mtx.lock();
             amplitudes.erase(it);
             mtx.unlock();
         }

--- a/include/statevector.hpp
+++ b/include/statevector.hpp
@@ -155,21 +155,20 @@ public:
         bool isCSet = (c != ZERO_CMPLX);
 
         mtx.lock();
+
         auto it = amplitudes.find(i);
         bool isFound = (it != amplitudes.end());
         if (isCSet == isFound) {
             mtx.unlock();
-        }
-
-        if (isCSet) {
-            if (isFound) {
+            if (isCSet) {
                 it->second = c;
-            } else {
-                amplitudes[i] = c;
-                mtx.unlock();
             }
-        } else if (isFound) {
-            amplitudes.erase(it);
+        } else {
+            if (isCSet) {
+                amplitudes[i] = c;
+            } else {
+                amplitudes.erase(it);
+            }
             mtx.unlock();
         }
     }

--- a/include/statevector.hpp
+++ b/include/statevector.hpp
@@ -154,14 +154,16 @@ public:
 
     void write(const bitCapInt& i, const complex& c)
     {
+        bool isCSet = (c != ZERO_CMPLX);
+
         mtx.lock();
         auto it = amplitudes.find(i);
         bool isFound = (it != amplitudes.end());
-        if ((c == ZERO_CMPLX) != isFound) {
+        if (isCSet == isFound) {
             mtx.unlock();
         }
 
-        if (c != ZERO_CMPLX) {
+        if (isCSet) {
             if (isFound) {
                 it->second = c;
             } else {

--- a/include/statevector.hpp
+++ b/include/statevector.hpp
@@ -147,20 +147,29 @@ public:
     {
         mtx.lock();
         auto it = amplitudes.find(i);
-        bool isNotFound = (it == amplitudes.end());
+        bool isFound = (it != amplitudes.end());
         mtx.unlock();
-        return isNotFound ? ZERO_CMPLX : it->second;
+        return isFound ? it->second : ZERO_CMPLX;
     }
 
     void write(const bitCapInt& i, const complex& c)
     {
-        if (c == ZERO_CMPLX) {
+        mtx.lock();
+        auto it = amplitudes.find(i);
+        bool isFound = (it != amplitudes.end());
+        mtx.unlock();
+
+        if (c != ZERO_CMPLX) {
+            if (isFound) {
+                it->second = c;
+            } else {
+                mtx.lock();
+                amplitudes[i] = c;
+                mtx.unlock();
+            }
+        } else if (isFound) {
             mtx.lock();
-            amplitudes.erase(i);
-            mtx.unlock();
-        } else {
-            mtx.lock();
-            amplitudes[i] = c;
+            amplitudes.erase(it);
             mtx.unlock();
         }
     }

--- a/src/common/parallel_for.cpp
+++ b/src/common/parallel_for.cpp
@@ -140,8 +140,8 @@ void ParallelFor::par_for_set(const std::vector<bitCapInt>& sparseSet, ParallelF
         fn);
 }
 
-void ParallelFor::par_for_sparse_compose(
-    const std::set<bitCapInt>& lowSet, const std::set<bitCapInt>& highSet, const bitLenInt& highStart, ParallelFunc fn)
+void ParallelFor::par_for_sparse_compose(const std::vector<bitCapInt>& lowSet, const std::vector<bitCapInt>& highSet,
+    const bitLenInt& highStart, ParallelFunc fn)
 {
     bitCapInt lowSize = lowSet.size();
     par_for_inc(0, lowSize * highSet.size(),

--- a/src/qengine/arithmetic.cpp
+++ b/src/qengine/arithmetic.cpp
@@ -32,6 +32,7 @@ void QEngineCPU::ROL(bitLenInt shift, bitLenInt start, bitLenInt length)
     bitCapInt otherMask = (maxQPower - ONE_BCI) ^ regMask;
 
     StateVectorPtr nStateVec = AllocStateVec(maxQPower);
+    stateVec->isReadLocked = false;
 
     ParallelFunc fn = [&](const bitCapInt lcv, const int cpu) {
         bitCapInt otherRes = lcv & otherMask;
@@ -41,7 +42,7 @@ void QEngineCPU::ROL(bitLenInt shift, bitLenInt start, bitLenInt length)
     };
 
     if (stateVec->is_sparse()) {
-        par_for_set(stateVec->iterable(), fn);
+        par_for_set(CastStateVecSparse()->iterable(), fn);
     } else {
         par_for(0, maxQPower, fn);
     }
@@ -66,6 +67,7 @@ void QEngineCPU::INC(bitCapInt toAdd, bitLenInt inOutStart, bitLenInt length)
     bitCapInt otherMask = (maxQPower - ONE_BCI) ^ inOutMask;
 
     StateVectorPtr nStateVec = AllocStateVec(maxQPower);
+    stateVec->isReadLocked = false;
 
     ParallelFunc fn = [&](const bitCapInt lcv, const int cpu) {
         bitCapInt otherRes = lcv & otherMask;
@@ -75,7 +77,7 @@ void QEngineCPU::INC(bitCapInt toAdd, bitLenInt inOutStart, bitLenInt length)
     };
 
     if (stateVec->is_sparse()) {
-        par_for_set(stateVec->iterable(), fn);
+        par_for_set(CastStateVecSparse()->iterable(), fn);
     } else {
         par_for(0, maxQPower, fn);
     }
@@ -116,6 +118,7 @@ void QEngineCPU::CINC(
 
     StateVectorPtr nStateVec = AllocStateVec(maxQPower);
     nStateVec->copy(stateVec);
+    stateVec->isReadLocked = false;
 
     par_for_mask(0, maxQPower, controlPowers, controlLen, [&](const bitCapInt lcv, const int cpu) {
         bitCapInt otherRes = lcv & otherMask;
@@ -152,6 +155,7 @@ void QEngineCPU::INCDECC(
 
     StateVectorPtr nStateVec = AllocStateVec(maxQPower);
     nStateVec->clear();
+    stateVec->isReadLocked = false;
 
     par_for_skip(0, maxQPower, pow2(carryIndex), ONE_BCI, [&](const bitCapInt lcv, const int cpu) {
         bitCapInt otherRes = lcv & otherMask;
@@ -195,6 +199,7 @@ void QEngineCPU::INCS(bitCapInt toAdd, bitLenInt inOutStart, bitLenInt length, b
 
     StateVectorPtr nStateVec = AllocStateVec(maxQPower);
     nStateVec->clear();
+    stateVec->isReadLocked = false;
 
     ParallelFunc fn = [&](const bitCapInt lcv, const int cpu) {
         bitCapInt otherRes = lcv & otherMask;
@@ -215,7 +220,7 @@ void QEngineCPU::INCS(bitCapInt toAdd, bitLenInt inOutStart, bitLenInt length, b
     };
 
     if (stateVec->is_sparse()) {
-        par_for_set(stateVec->iterable(), fn);
+        par_for_set(CastStateVecSparse()->iterable(), fn);
     } else {
         par_for(0, maxQPower, fn);
     }
@@ -246,6 +251,7 @@ void QEngineCPU::INCDECSC(
 
     StateVectorPtr nStateVec = AllocStateVec(maxQPower);
     nStateVec->clear();
+    stateVec->isReadLocked = false;
 
     par_for_skip(0, maxQPower, carryMask, ONE_BCI, [&](const bitCapInt lcv, const int cpu) {
         bitCapInt otherRes = lcv & otherMask;
@@ -290,6 +296,7 @@ void QEngineCPU::INCDECSC(bitCapInt toMod, const bitLenInt& inOutStart, const bi
 
     StateVectorPtr nStateVec = AllocStateVec(maxQPower);
     nStateVec->clear();
+    stateVec->isReadLocked = false;
 
     par_for_skip(0, maxQPower, carryMask, ONE_BCI, [&](const bitCapInt lcv, const int cpu) {
         bitCapInt otherRes = lcv & otherMask;
@@ -323,6 +330,7 @@ void QEngineCPU::MULDIV(const IOFn& inFn, const IOFn& outFn, const bitCapInt& to
 
     StateVectorPtr nStateVec = AllocStateVec(maxQPower);
     nStateVec->clear();
+    stateVec->isReadLocked = false;
 
     par_for_skip(0, maxQPower, pow2(carryStart), length, [&](const bitCapInt lcv, const int cpu) {
         bitCapInt otherRes = lcv & otherMask;
@@ -389,6 +397,7 @@ void QEngineCPU::CMULDIV(const IOFn& inFn, const IOFn& outFn, const bitCapInt& t
 
     StateVectorPtr nStateVec = AllocStateVec(maxQPower);
     nStateVec->clear();
+    stateVec->isReadLocked = false;
 
     par_for_mask(0, maxQPower, skipPowers, controlLen + length, [&](const bitCapInt lcv, const int cpu) {
         bitCapInt otherRes = lcv & otherMask;
@@ -470,6 +479,7 @@ void QEngineCPU::ModNOut(const MFn& kernelFn, const bitCapInt& modN, const bitLe
 
     StateVectorPtr nStateVec = AllocStateVec(maxQPower);
     nStateVec->clear();
+    stateVec->isReadLocked = false;
 
     par_for_skip(0, maxQPower, pow2(outStart), length, [&](const bitCapInt lcv, const int cpu) {
         bitCapInt otherRes = lcv & otherMask;
@@ -541,6 +551,7 @@ void QEngineCPU::CModNOut(const MFn& kernelFn, const bitCapInt& modN, const bitL
 
     StateVectorPtr nStateVec = AllocStateVec(maxQPower);
     nStateVec->clear();
+    stateVec->isReadLocked = false;
 
     par_for_mask(0, maxQPower, skipPowers, controlLen + length, [&](const bitCapInt lcv, const int cpu) {
         bitCapInt otherRes = lcv & otherMask;
@@ -633,6 +644,7 @@ void QEngineCPU::INCBCD(bitCapInt toAdd, bitLenInt inOutStart, bitLenInt length)
     otherMask ^= inOutMask;
     StateVectorPtr nStateVec = AllocStateVec(maxQPower);
     nStateVec->clear();
+    stateVec->isReadLocked = false;
 
     ParallelFunc fn = [&](const bitCapInt lcv, const int cpu) {
         bitCapInt otherRes = lcv & otherMask;
@@ -671,7 +683,7 @@ void QEngineCPU::INCBCD(bitCapInt toAdd, bitLenInt inOutStart, bitLenInt length)
     };
 
     if (stateVec->is_sparse()) {
-        par_for_set(stateVec->iterable(), fn);
+        par_for_set(CastStateVecSparse()->iterable(), fn);
     } else {
         par_for(0, maxQPower, fn);
     }
@@ -706,6 +718,7 @@ void QEngineCPU::INCDECBCDC(
 
     StateVectorPtr nStateVec = AllocStateVec(maxQPower);
     nStateVec->clear();
+    stateVec->isReadLocked = false;
 
     par_for_skip(0, maxQPower, pow2(carryIndex), ONE_BCI, [&](const bitCapInt lcv, const int cpu) {
         bitCapInt otherRes = lcv & otherMask;
@@ -777,6 +790,7 @@ bitCapInt QEngineCPU::IndexedLDA(bitLenInt indexStart, bitLenInt indexLength, bi
 
     StateVectorPtr nStateVec = AllocStateVec(maxQPower);
     nStateVec->clear();
+    stateVec->isReadLocked = false;
 
     ParallelFunc fn;
     if (valueBytes == 1) {
@@ -797,7 +811,7 @@ bitCapInt QEngineCPU::IndexedLDA(bitLenInt indexStart, bitLenInt indexLength, bi
     }
 
     if (stateVec->is_sparse()) {
-        par_for_set(stateVec->iterable(), fn);
+        par_for_set(CastStateVecSparse()->iterable(), fn);
     } else {
         par_for_skip(0, maxQPower, skipPower, valueLength, fn);
     }
@@ -837,6 +851,7 @@ bitCapInt QEngineCPU::IndexedADC(bitLenInt indexStart, bitLenInt indexLength, bi
     // We calloc a new stateVector for output.
     StateVectorPtr nStateVec = AllocStateVec(maxQPower);
     nStateVec->clear();
+    stateVec->isReadLocked = false;
 
     // We're going to loop over every eigenstate in the vector, (except, we
     // already know the carry is zero).  This bit masks let us quickly
@@ -892,7 +907,7 @@ bitCapInt QEngineCPU::IndexedADC(bitLenInt indexStart, bitLenInt indexLength, bi
     };
 
     if (stateVec->is_sparse()) {
-        par_for_set(stateVec->iterable(0, skipPower, 0), fn);
+        par_for_set(CastStateVecSparse()->iterable(0, skipPower, 0), fn);
     } else {
         par_for_skip(0, maxQPower, skipPower, 1, fn);
     }
@@ -935,6 +950,7 @@ bitCapInt QEngineCPU::IndexedSBC(bitLenInt indexStart, bitLenInt indexLength, bi
     // We calloc a new stateVector for output.
     StateVectorPtr nStateVec = AllocStateVec(maxQPower);
     nStateVec->clear();
+    stateVec->isReadLocked = false;
 
     // We're going to loop over every eigenstate in the vector, (except, we already know the carry is zero).
     // This bit masks let us quickly distinguish the different values of the input register, output register, carry, and
@@ -993,7 +1009,7 @@ bitCapInt QEngineCPU::IndexedSBC(bitLenInt indexStart, bitLenInt indexLength, bi
     };
 
     if (stateVec->is_sparse()) {
-        par_for_set(stateVec->iterable(0, skipPower, 0), fn);
+        par_for_set(CastStateVecSparse()->iterable(0, skipPower, 0), fn);
     } else {
         par_for_skip(0, maxQPower, skipPower, valueLength, fn);
     }
@@ -1019,6 +1035,7 @@ void QEngineCPU::Hash(bitLenInt start, bitLenInt length, unsigned char* values)
 
     StateVectorPtr nStateVec = AllocStateVec(maxQPower);
     nStateVec->clear();
+    stateVec->isReadLocked = false;
 
     ParallelFunc fn = [&](const bitCapInt lcv, const int cpu) {
         bitCapInt inputRes = lcv & inputMask;
@@ -1032,7 +1049,7 @@ void QEngineCPU::Hash(bitLenInt start, bitLenInt length, unsigned char* values)
     };
 
     if (stateVec->is_sparse()) {
-        par_for_set(stateVec->iterable(), fn);
+        par_for_set(CastStateVecSparse()->iterable(), fn);
     } else {
         par_for(0, maxQPower, fn);
     }

--- a/src/qengine/gates.cpp
+++ b/src/qengine/gates.cpp
@@ -25,7 +25,7 @@ void QEngineCPU::ApplyM(bitCapInt regMask, bitCapInt result, complex nrm)
     };
 
     if (stateVec->is_sparse()) {
-        par_for_set(stateVec->iterable(), fn);
+        par_for_set(CastStateVecSparse()->iterable(), fn);
     } else {
         par_for(0, maxQPower, fn);
     }
@@ -45,7 +45,7 @@ void QEngineCPU::PhaseFlip()
     ParallelFunc fn = [&](const bitCapInt lcv, const int cpu) { stateVec->write(lcv, -stateVec->read(lcv)); };
 
     if (stateVec->is_sparse()) {
-        par_for_set(stateVec->iterable(), fn);
+        par_for_set(CastStateVecSparse()->iterable(), fn);
     } else {
         par_for(0, maxQPower, fn);
     }

--- a/src/qengine/state.cpp
+++ b/src/qengine/state.cpp
@@ -207,7 +207,7 @@ void QEngineCPU::Apply2x2(bitCapInt offset1, bitCapInt offset2, const complex* m
             filterMask |= (qPowersSorted[i] & ~setMask);
         }
         bitCapInt filterValues = filterMask & offset1 & offset2;
-        par_for_set(stateVec->iterable(setMask, filterMask, filterValues), fn);
+        par_for_set(CastStateVecSparse()->iterable(setMask, filterMask, filterValues), fn);
     } else {
         par_for_mask(0, maxQPower, qPowersSorted, bitCount, fn);
     }
@@ -284,7 +284,7 @@ void QEngineCPU::Apply2x2(bitCapInt offset1, bitCapInt offset2, const complex* m
             filterMask |= (qPowersSorted[i] & ~setMask);
         }
         bitCapInt filterValues = filterMask & offset1 & offset2;
-        par_for_set(stateVec->iterable(setMask, filterMask, filterValues), fn);
+        par_for_set(CastStateVecSparse()->iterable(setMask, filterMask, filterValues), fn);
     } else {
         par_for_mask(0, maxQPower, qPowersSorted, bitCount, fn);
     }
@@ -393,12 +393,14 @@ bitLenInt QEngineCPU::Compose(QEngineCPUPtr toCopy, bool isConsumed)
     bitCapInt endMask = (toCopy->maxQPower - ONE_BCI) << qubitCount;
 
     StateVectorPtr nStateVec = AllocStateVec(nMaxQPower);
+    stateVec->isReadLocked = false;
 
     ParallelFunc fn = [&](const bitCapInt lcv, const int cpu) {
         nStateVec->write(lcv, stateVec->read(lcv & startMask) * toCopy->stateVec->read((lcv & endMask) >> qubitCount));
     };
     if (stateVec->is_sparse() || toCopy->stateVec->is_sparse()) {
-        par_for_sparse_compose(stateVec->iterable(), toCopy->stateVec->iterable(), qubitCount, fn);
+        par_for_sparse_compose(
+            CastStateVecSparse()->iterable(), toCopy->CastStateVecSparse()->iterable(), qubitCount, fn);
     } else {
         par_for(0, nMaxQPower, fn);
     }
@@ -432,6 +434,7 @@ bitLenInt QEngineCPU::Compose(QEngineCPUPtr toCopy, bitLenInt start, bool isCons
     bitCapInt endMask = pow2Mask(qubitCount + oQubitCount) & ~(startMask | midMask);
 
     StateVectorPtr nStateVec = AllocStateVec(nMaxQPower);
+    stateVec->isReadLocked = false;
 
     par_for(0, nMaxQPower, [&](const bitCapInt lcv, const int cpu) {
         nStateVec->write(lcv,
@@ -485,6 +488,7 @@ std::map<QInterfacePtr, bitLenInt> QEngineCPU::Compose(std::vector<QInterfacePtr
     nMaxQPower = pow2(nQubitCount);
 
     StateVectorPtr nStateVec = AllocStateVec(nMaxQPower);
+    stateVec->isReadLocked = false;
 
     par_for(0, nMaxQPower, [&](const bitCapInt lcv, const int cpu) {
         nStateVec->write(lcv, stateVec->read(lcv & startMask));
@@ -634,9 +638,10 @@ void QEngineCPU::Dispose(bitLenInt start, bitLenInt length, bitCapInt disposedPe
     bitCapInt saveMask = ~((pow2(start + length) - ONE_BCI) ^ skipMask);
 
     StateVectorPtr nStateVec = AllocStateVec(remainderPower);
+    stateVec->isReadLocked = false;
 
     if (stateVec->is_sparse()) {
-        par_for_set(stateVec->iterable(), [&](const bitCapInt lcv, const int cpu) {
+        par_for_set(CastStateVecSparse()->iterable(), [&](const bitCapInt lcv, const int cpu) {
             bitCapInt i, iLow, iHigh;
             iHigh = lcv & saveMask;
             iLow = iHigh & skipMask;
@@ -679,7 +684,7 @@ real1 QEngineCPU::Prob(bitLenInt qubit)
         oneChanceBuff[cpu] += norm(stateVec->read(lcv | qPower));
     };
     if (stateVec->is_sparse()) {
-        par_for_set(stateVec->iterable(qPower, qPower, qPower), fn);
+        par_for_set(CastStateVecSparse()->iterable(qPower, qPower, qPower), fn);
     } else {
         par_for_skip(0, maxQPower, qPower, 1U, fn);
     }
@@ -717,7 +722,7 @@ real1 QEngineCPU::ProbReg(const bitLenInt& start, const bitLenInt& length, const
 
     ParallelFunc fn = [&](const bitCapInt lcv, const int cpu) { probs[cpu] += norm(stateVec->read(lcv | perm)); };
     if (stateVec->is_sparse()) {
-        par_for_set(stateVec->iterable(0, bitRegMask(start, length), perm), fn);
+        par_for_set(CastStateVecSparse()->iterable(0, bitRegMask(start, length), perm), fn);
     } else {
         par_for_skip(0, maxQPower, pow2(start), length, fn);
     }

--- a/src/qengine/state.cpp
+++ b/src/qengine/state.cpp
@@ -398,7 +398,7 @@ bitLenInt QEngineCPU::Compose(QEngineCPUPtr toCopy, bool isConsumed)
         nStateVec->write(lcv, stateVec->read(lcv & startMask) * toCopy->stateVec->read((lcv & endMask) >> qubitCount));
     };
     if (stateVec->is_sparse() || toCopy->stateVec->is_sparse()) {
-        par_for_sparse_compose(stateVec->iterable(0, 0, 0), toCopy->stateVec->iterable(0, 0, 0), qubitCount, fn);
+        par_for_sparse_compose(stateVec->iterable(), toCopy->stateVec->iterable(), qubitCount, fn);
     } else {
         par_for(0, nMaxQPower, fn);
     }


### PR DESCRIPTION
The sparse state vector option for `QEngineCPU` (when used with the `QUnit` layer) could be become an important workhorse for particular applications that cannot be handled by `QUnit` optimizations alone.

If a method acts "out-of-place," reading from the old state vector while writing into a new one, the mutex locks can be removed for reading from the old state vector. Also, as `read()` and `write()` should be basically "micro" inline methods carried out many times in a gate, every bit of performance we can squeeze out of their general implementations helps.