### PR TITLE
Measurement and CNOT optimization

### DIFF
--- a/src/qengine/qengine.cpp
+++ b/src/qengine/qengine.cpp
@@ -23,8 +23,14 @@ bool QEngine::ForceM(bitLenInt qubit, bool result, bool doForce, bool doApply)
 
     real1 oneChance = Prob(qubit);
     if (!doForce) {
-        real1 prob = Rand();
-        result = (prob <= oneChance);
+        if (oneChance >= ONE_R1) {
+            result = true;
+        } else if (oneChance <= ZERO_R1) {
+            result = false;
+        } else {
+            real1 prob = Rand();
+            result = (prob <= oneChance);
+        }
     }
 
     real1 nrmlzr;

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -836,13 +836,13 @@ bitCapInt QUnit::ForceM(const bitLenInt* bits, const bitLenInt& length, const bo
 
 bitCapInt QUnit::ForceMReg(bitLenInt start, bitLenInt length, bitCapInt result, bool doForce, bool doApply)
 {
+    ToPermBasisMeasure(start, length);
+
     if (isSparse) {
         return QInterface::ForceMReg(start, length, result, doForce, doApply);
     }
 
     bitLenInt i;
-
-    ToPermBasisMeasure(start, length);
 
     bitLenInt* bits = new bitLenInt[length];
     for (i = 0; i < length; i++) {

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -711,6 +711,8 @@ bool QUnit::ForceM(bitLenInt qubit, bool res, bool doForce, bool doApply)
     bool result;
     if (CACHED_CLASSICAL(qubit)) {
         result = doForce ? res : SHARD_STATE(shard);
+    } else if (!shard.isProbDirty && (shard.unit->GetQubitCount() == 1U)) {
+        result = doForce ? res : (Rand() <= oneChance);
     } else {
         EndEmulation(qubit);
         result = shard.unit->ForceM(shard.mapped, res, doForce, doApply);
@@ -720,7 +722,7 @@ bool QUnit::ForceM(bitLenInt qubit, bool res, bool doForce, bool doApply)
         return result;
     }
 
-    if (shard.unit->GetQubitCount() == 1) {
+    if (shard.unit->GetQubitCount() == 1U) {
         shard.isProbDirty = false;
         shard.isPhaseDirty = false;
         shard.isEmulated = true;

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -712,7 +712,7 @@ bool QUnit::ForceM(bitLenInt qubit, bool res, bool doForce, bool doApply)
     if (CACHED_CLASSICAL(qubit)) {
         result = doForce ? res : SHARD_STATE(shard);
     } else if (!shard.isProbDirty && (shard.unit->GetQubitCount() == 1U)) {
-        result = doForce ? res : (Rand() <= oneChance);
+        result = doForce ? res : (Rand() <= norm(shard.amp1));
     } else {
         EndEmulation(qubit);
         result = shard.unit->ForceM(shard.mapped, res, doForce, doApply);

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1264,6 +1264,10 @@ bool QUnit::TryCnotOptimize(const bitLenInt* controls, const bitLenInt& controlL
 
 void QUnit::CNOT(bitLenInt control, bitLenInt target)
 {
+    if (CACHED_1QB_H(target)) {
+        return;
+    }
+
     if (CACHED_PROB(control)) {
         if (Prob(control) < min_norm) {
             return;
@@ -1312,6 +1316,10 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
 
 void QUnit::AntiCNOT(bitLenInt control, bitLenInt target)
 {
+    if (CACHED_1QB_H(target)) {
+        return;
+    }
+
     bitLenInt controls[1] = { control };
     bitLenInt controlLen = 1;
 
@@ -1321,6 +1329,10 @@ void QUnit::AntiCNOT(bitLenInt control, bitLenInt target)
 
 void QUnit::CCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target)
 {
+    if (CACHED_1QB_H(target)) {
+        return;
+    }
+
     bitLenInt controls[2] = { control1, control2 };
 
     if (TryCnotOptimize(controls, 2, target, ONE_CMPLX, ONE_CMPLX, false)) {
@@ -1349,6 +1361,10 @@ void QUnit::CCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target)
 
 void QUnit::AntiCCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target)
 {
+    if (CACHED_1QB_H(target)) {
+        return;
+    }
+
     bitLenInt controls[2] = { control1, control2 };
 
     if (TryCnotOptimize(controls, 2, target, ONE_CMPLX, ONE_CMPLX, true)) {

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -38,6 +38,9 @@
 #define CACHED_1QB(shardIndex) (!shards[shardIndex].isProbDirty && !shards[shardIndex].isPlusMinus)
 #define CACHED_1QB_H(shardIndex)                                                                                       \
     (shards[shardIndex].isPlusMinus && !QUEUED_PHASE(shards[shardIndex]) && UNSAFE_CACHED_CLASSICAL(shardIndex))
+#define CACHED_1QB_PLUS(shardIndex)                                                                                    \
+    (shards[shardIndex].isPlusMinus && !QUEUED_PHASE(shards[shardIndex]) &&                                            \
+        (!shards[shardIndex].isProbDirty && ((ONE_R1 - ProbBase(shardIndex)) < min_norm)))
 #define CACHED_PROB(shardIndex)                                                                                        \
     (CACHED_1QB(shardIndex) && (shards[shardIndex].targetOfShards.size() == 0) &&                                      \
         (shards[shardIndex].controlsShards.size() == 0))
@@ -626,7 +629,7 @@ bool QUnit::CheckBitsPlus(const bitLenInt& qubitIndex, const bitLenInt& length)
 {
     bool isHBasis = true;
     for (bitLenInt i = 0; i < length; i++) {
-        if (!(CACHED_1QB_H(qubitIndex + i) && (ProbBase(qubitIndex + i) < min_norm))) {
+        if (!CACHED_1QB_PLUS(qubitIndex + i)) {
             isHBasis = false;
             break;
         }
@@ -1264,7 +1267,7 @@ bool QUnit::TryCnotOptimize(const bitLenInt* controls, const bitLenInt& controlL
 
 void QUnit::CNOT(bitLenInt control, bitLenInt target)
 {
-    if (CACHED_1QB_H(target)) {
+    if (CACHED_1QB_PLUS(target)) {
         return;
     }
 
@@ -1316,7 +1319,7 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
 
 void QUnit::AntiCNOT(bitLenInt control, bitLenInt target)
 {
-    if (CACHED_1QB_H(target)) {
+    if (CACHED_1QB_PLUS(target)) {
         return;
     }
 
@@ -1329,7 +1332,7 @@ void QUnit::AntiCNOT(bitLenInt control, bitLenInt target)
 
 void QUnit::CCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target)
 {
-    if (CACHED_1QB_H(target)) {
+    if (CACHED_1QB_PLUS(target)) {
         return;
     }
 
@@ -1361,7 +1364,7 @@ void QUnit::CCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target)
 
 void QUnit::AntiCCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target)
 {
-    if (CACHED_1QB_H(target)) {
+    if (CACHED_1QB_PLUS(target)) {
         return;
     }
 


### PR DESCRIPTION
If a system is using `RDRAND` for Qrack's random number generator, (which is the default option and ostensibly ubiquitous,) use of the opcode comes with a relatively high premium entropy rate of the random number generator. If we measure a |0>/|1> eigenstate, we don't need random data at all.

I'm also hacking away at the performance on the universal circuit benchmarks. I've added a couple of new benchmarks representative of different universal gate sets, (from [https://inst.eecs.berkeley.edu/~cs191/fa07/lectures/lecture9_fa07.pdf](https://inst.eecs.berkeley.edu/~cs191/fa07/lectures/lecture9_fa07.pdf)). In looking for potential improvements in these sets, I realized that CNOT and CCNOT with targets that are exactly |+> can be entirely skipped. This is a situation that likely comes up commonly, and it's inexpensive to check.