### PR TITLE
Cross entropy benchmark for test_universal_circuit_digital

### DIFF
--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -1039,16 +1039,20 @@ struct MultiQubitGate {
 
 TEST_CASE("test_universal_circuit_digital_cross_entropy", "[supreme]")
 {
-    std::cout << "Starting cross entropy benchmark..." << std::endl;
+    std::cout << ">>> 'test_universal_circuit_digital_cross_entropy':" << std::endl;
 
     const int GateCount1Qb = 4;
     const int GateCountMultiQb = 4;
-    const int Depth = 1;
+    const int Depth = 3;
 
-    const int ITERATIONS = 100000;
-    const int n = 6;
+    const int ITERATIONS = 20000;
+    const int n = 8;
     bitCapInt permCount = pow2(n);
     bitCapInt perm;
+
+    std::cout << "Width: " << n << " qubits" << std::endl;
+    std::cout << "Depth: " << Depth << " layers of 1 qubit then multi-qubit gates" << std::endl;
+    std::cout << "samples collected: " << ITERATIONS << std::endl;
 
     int d;
     bitLenInt i;
@@ -1131,7 +1135,6 @@ TEST_CASE("test_universal_circuit_digital_cross_entropy", "[supreme]")
     }
 
     std::map<bitCapInt, int> goldStandardResult = goldStandard->MultiShotMeasureMask(qPowers, n, ITERATIONS);
-    std::cout << "Calculated gold standard distribution." << std::endl;
 
     std::map<bitCapInt, int>::iterator measurementBin;
 


### PR DESCRIPTION
This PR adds a cross entropy benchmark that can establish the accordance of results of `QEngine` types with `QUnit` types. (For the moment, parameters need to be adjusted by hand in code, to experiment.) I argue the default parameters give a reasonable experiment, and typical output looks like this:

```
$ ./benchmarks --proc-opencl-single --layer-qunit-qfusion --enable-normalization test_universal_circuit_digital_cross_entropy
Random Seed: 1587426549 (Overridden by hardware generation!)
############ QUnit -> QFusion -> OpenCL ############
Device #0, Loaded binary from: /home/iamu/.qrack/qrack_ocl_dev_0.ir
Device #1, Loaded binary from: /home/iamu/.qrack/qrack_ocl_dev_1.ir
Device #2, Loaded binary from: /home/iamu/.qrack/qrack_ocl_dev_2.ir
Default platform: NVIDIA CUDA
Default device: GeForce GTX 1070
OpenCL device #0: Intel(R) Gen9 HD Graphics NEO
OpenCL device #1: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
OpenCL device #2: GeForce GTX 1070
Filters: test_universal_circuit_digital_cross_entropy
>>> 'test_universal_circuit_digital_cross_entropy':
Width: 8 qubits
Depth: 3 layers of 1 qubit then multi-qubit gates
samples collected: 20000
Calculated gold standard distribution.
Gold standard vs. uniform random cross entropy (out of 1.0): 0.651946
Gold standard vs. gold standard cross entropy (out of 1.0): 0.990022
Gold standard vs. test case cross entropy (out of 1.0): 0.994449
===============================================================================
test cases: 1 | 1 passed
assertions: - none -
```

Our definition of cross entropy, here, is 1 minus the Euclidean norm of the residual difference between distributions, normalized between 0 and 1 based on the number of samples collected.