### PR TITLE
WIP: QUnit Cleanup

### DIFF
--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -121,13 +121,13 @@ public:
     {
         if (norm(amp0) < min_norm) {
             amp0 = ZERO_R1;
-            amp1 = ONE_CMPLX;
+            amp1 /= abs(amp1);
             if (!isProbDirty) {
                 isPhaseDirty = false;
             }
         } else if (norm(amp1) < min_norm) {
             amp1 = ZERO_R1;
-            amp0 = ONE_CMPLX;
+            amp0 /= abs(amp0);
             if (!isProbDirty) {
                 isPhaseDirty = false;
             }

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -111,7 +111,8 @@ public:
     {
     }
 
-    void MakeDirty() {
+    void MakeDirty()
+    {
         isProbDirty = true;
         isPhaseDirty = true;
     }

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -116,13 +116,15 @@ public:
         if (norm(amp0) < min_norm) {
             amp0 = ZERO_R1;
             amp1 = ONE_CMPLX;
-            isProbDirty = false;
-            isPhaseDirty = false;
+            if (!isProbDirty) {
+                isPhaseDirty = false;
+            }
         } else if (norm(amp1) < min_norm) {
             amp1 = ZERO_R1;
             amp0 = ONE_CMPLX;
-            isProbDirty = false;
-            isPhaseDirty = false;
+            if (!isProbDirty) {
+                isPhaseDirty = false;
+            }
         }
     }
 

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -115,10 +115,14 @@ public:
     {
         if (norm(amp0) < min_norm) {
             amp0 = ZERO_R1;
-            amp1 /= abs(amp1);
+            amp1 = ONE_CMPLX;
+            isProbDirty = false;
+            isPhaseDirty = false;
         } else if (norm(amp1) < min_norm) {
             amp1 = ZERO_R1;
-            amp0 /= abs(amp0);
+            amp0 = ONE_CMPLX;
+            isProbDirty = false;
+            isPhaseDirty = false;
         }
     }
 

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -117,15 +117,15 @@ public:
         isPhaseDirty = true;
     }
 
-    void ClampAmps()
+    void ClampAmps(real1 norm_thresh)
     {
-        if (norm(amp0) < min_norm) {
+        if (norm(amp0) < norm_thresh) {
             amp0 = ZERO_R1;
             amp1 /= abs(amp1);
             if (!isProbDirty) {
                 isPhaseDirty = false;
             }
-        } else if (norm(amp1) < min_norm) {
+        } else if (norm(amp1) < norm_thresh) {
             amp1 = ZERO_R1;
             amp0 /= abs(amp0);
             if (!isProbDirty) {

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -111,6 +111,11 @@ public:
     {
     }
 
+    void MakeDirty() {
+        isProbDirty = true;
+        isPhaseDirty = true;
+    }
+
     void ClampAmps()
     {
         if (norm(amp0) < min_norm) {

--- a/src/common/qheader_float.cl
+++ b/src/common/qheader_float.cl
@@ -19,7 +19,7 @@
 #define ONE_BCI 1UL
 #define SineShift M_PI_2_F
 #define PI_R1 M_PI_F
-#define min_norm 1e-13f
+#define min_norm 1e-14f
 #define bitCapInt ulong
 #define bitCapInt2 ulong2
 #define bitCapInt4 ulong4

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1401,6 +1401,11 @@ void QUnit::CZ(bitLenInt control, bitLenInt target)
         return;
     }
 
+    if (CACHED_ONE(cShard)) {
+        Z(target);
+        return;
+    }
+
     if (!freezeBasis) {
         TransformBasis1Qb(false, control);
         tShard.AddPhaseAngles(&cShard, 0, (real1)M_PI);

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -652,11 +652,7 @@ real1 QUnit::ProbBase(const bitLenInt& qubit)
         }
         shard.isProbDirty = false;
 
-        if (shard.amp0 == ZERO_CMPLX) {
-            SeparateBit(true, qubit);
-        } else if (shard.amp1 == ZERO_CMPLX) {
-            SeparateBit(false, qubit);
-        }
+        CheckShardSeparable(qubit);
     }
 
     return norm(shard.amp1);

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -669,7 +669,7 @@ real1 QUnit::Prob(bitLenInt qubit)
     return ProbBase(qubit);
 }
 
-real1 QUnit::ProbAll(bitCapInt perm) { return norm(GetAmplitude(perm)); }
+real1 QUnit::ProbAll(bitCapInt perm) { return clampProb(norm(GetAmplitude(perm))); }
 
 void QUnit::SeparateBit(bool value, bitLenInt qubit, bool doDispose)
 {

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -889,15 +889,8 @@ void QUnit::Swap(bitLenInt qubit1, bitLenInt qubit2)
         return;
     }
 
-    // TODO: Can we avoid flushing some or all of the 2 qubit gate buffers?
-    RevertBasis2Qb(qubit1);
-    RevertBasis2Qb(qubit2);
-
-    QEngineShard& shard1 = shards[qubit1];
-    QEngineShard& shard2 = shards[qubit2];
-
-    // Simply swap the bit mapping, so long as no 2-qubit gates are buffered.
-    std::swap(shard1, shard2);
+    // Simply swap the bit mapping.
+    std::swap(shards[qubit1], shards[qubit2]);
 
     QInterfacePtr unit = shards[qubit1].unit;
     if (unit == shards[qubit2].unit) {

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -3189,7 +3189,7 @@ void QUnit::CheckShardSeparable(const bitLenInt& target)
 {
     QEngineShard& shard = shards[target];
 
-    if (shard.isProbDirty || (shard.unit->GetQubitCount() == 1U)) {
+    if (shard.isProbDirty || (shard.unit->GetQubitCount() == 1U) || QUEUED_PHASE(shard)) {
         return;
     }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -889,6 +889,10 @@ void QUnit::Swap(bitLenInt qubit1, bitLenInt qubit2)
         return;
     }
 
+    // TODO: Can we avoid flushing some or all of the 2 qubit gate buffers?
+    RevertBasis2Qb(qubit1);
+    RevertBasis2Qb(qubit2);
+
     QEngineShard& shard1 = shards[qubit1];
     QEngineShard& shard2 = shards[qubit2];
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -676,8 +676,6 @@ real1 QUnit::ProbAll(bitCapInt perm) { return clampProb(norm(GetAmplitude(perm))
 
 void QUnit::SeparateBit(bool value, bitLenInt qubit, bool doDispose)
 {
-    RevertBasis2Qb(qubit);
-
     QInterfacePtr unit = shards[qubit].unit;
     bitLenInt mapped = shards[qubit].mapped;
 
@@ -1092,13 +1090,7 @@ void QUnit::H(bitLenInt target)
         shard.ClampAmps();
     }
 
-    if (shard.unit->GetQubitCount() > 1U) {
-        if (shard.amp0 == ZERO_CMPLX) {
-            SeparateBit(true, target);
-        } else if (shard.amp1 == ZERO_CMPLX) {
-            SeparateBit(false, target);
-        }
-    }
+    CheckShardSeparable(target);
 }
 
 void QUnit::XBase(const bitLenInt& target)

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1407,6 +1407,10 @@ void QUnit::CZ(bitLenInt control, bitLenInt target)
         return;
     }
 
+    // TODO: Seems like this basis revert should happen in ApplyEitherControlled
+    RevertBasis2Qb(control);
+    RevertBasis2Qb(target);
+
     bitLenInt controls[1] = { control };
     bitLenInt controlLen = 1;
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1390,15 +1390,15 @@ void QUnit::AntiCCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target)
 
 void QUnit::CZ(bitLenInt control, bitLenInt target)
 {
+    if (shards[control].isPlusMinus && !shards[target].isPlusMinus) {
+        std::swap(control, target);
+    }
+
     QEngineShard& tShard = shards[target];
     QEngineShard& cShard = shards[control];
 
     if (CACHED_ZERO(tShard) || CACHED_ZERO(cShard)) {
         return;
-    }
-
-    if (cShard.isPlusMinus && !tShard.isPlusMinus) {
-        std::swap(control, target);
     }
 
     if (!freezeBasis) {

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -1150,6 +1150,9 @@ TEST_CASE("test_universal_circuit_digital_cross_entropy", "[supreme]")
         }
         crossEntropy += (uniformRandomCount - goldBinResult) * (uniformRandomCount - goldBinResult);
     }
+    if (crossEntropy < ZERO_R1) {
+        crossEntropy = ZERO_R1;
+    }
     crossEntropy = ONE_R1 - sqrt(crossEntropy) / ITERATIONS;
     std::cout << "Gold standard vs. uniform random cross entropy (out of 1.0): " << crossEntropy << std::endl;
 
@@ -1172,6 +1175,9 @@ TEST_CASE("test_universal_circuit_digital_cross_entropy", "[supreme]")
             testBinResult = measurementBin->second;
         }
         crossEntropy += (testBinResult - goldBinResult) * (testBinResult - goldBinResult);
+    }
+    if (crossEntropy < ZERO_R1) {
+        crossEntropy = ZERO_R1;
     }
     crossEntropy = ONE_R1 - sqrt(crossEntropy) / ITERATIONS;
     std::cout << "Gold standard vs. gold standard cross entropy (out of 1.0): " << crossEntropy << std::endl;
@@ -1239,7 +1245,9 @@ TEST_CASE("test_universal_circuit_digital_cross_entropy", "[supreme]")
         }
         crossEntropy += (testBinResult - goldBinResult) * (testBinResult - goldBinResult);
     }
-    if (crossEntropy < ZERO_R1) crossEntropy = ZERO_R1;
+    if (crossEntropy < ZERO_R1) {
+        crossEntropy = ZERO_R1;
+    }
     crossEntropy = ONE_R1 - sqrt(crossEntropy) / ITERATIONS;
     std::cout << "Gold standard vs. test case cross entropy (out of 1.0): " << crossEntropy << std::endl;
 }

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -1220,7 +1220,7 @@ TEST_CASE("test_universal_circuit_digital_cross_entropy", "[supreme]")
             testCaseResult[perm] += 1;
         }
     }
-    // std::map<bitCapInt, int> testCaseResult = testCase->MultiShotMeasureMask(qPowers, n, ITERATIONS);
+    // testCaseResult = testCase->MultiShotMeasureMask(qPowers, n, ITERATIONS);
 
     crossEntropy = ZERO_R1;
     for (perm = 0; perm < permCount; perm++) {
@@ -1239,6 +1239,7 @@ TEST_CASE("test_universal_circuit_digital_cross_entropy", "[supreme]")
         }
         crossEntropy += (testBinResult - goldBinResult) * (testBinResult - goldBinResult);
     }
+    if (crossEntropy < ZERO_R1) crossEntropy = ZERO_R1;
     crossEntropy = ONE_R1 - sqrt(crossEntropy) / ITERATIONS;
     std::cout << "Gold standard vs. test case cross entropy (out of 1.0): " << crossEntropy << std::endl;
 }


### PR DESCRIPTION
The cross entropy benchmarks on random universal circuits revealed some very well-hidden bugs in QUnit. CZ and Swap caused cross entropy test failures, but a sample of about 100 runs or more no longer shows any unexpected differences from QEngine types.