### PR TITLE
Cross entropy debugging (CNOT edge case and TryCnotOptimize refactor)

### DIFF
--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -889,7 +889,7 @@ protected:
     }
 
     bool TryCnotOptimize(const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& target,
-        const complex& bottomLeft, const complex& topRight, const bool& anti);
+        const complex& topRight, const complex& bottomLeft, const bool& anti);
 
     /* Debugging and diagnostic routines. */
     void DumpShards();

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -1228,7 +1228,7 @@ TEST_CASE("test_universal_circuit_digital_cross_entropy", "[supreme]")
     }
     // Comment out the ITERATIONS loop and testCaseResult[perm] update above, and uncomment this line below, for a
     // faster benchmark. This will not test the effect of the MReg() method.
-    testCaseResult = testCase->MultiShotMeasureMask(qPowers, n, ITERATIONS);
+    // testCaseResult = testCase->MultiShotMeasureMask(qPowers, n, ITERATIONS);
 
     crossEntropy = ZERO_R1;
     for (perm = 0; perm < permCount; perm++) {

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -1226,7 +1226,9 @@ TEST_CASE("test_universal_circuit_digital_cross_entropy", "[supreme]")
             testCaseResult[perm] += 1;
         }
     }
-    // testCaseResult = testCase->MultiShotMeasureMask(qPowers, n, ITERATIONS);
+    // Comment out the ITERATIONS loop and testCaseResult[perm] update above, and uncomment this line below, for a
+    // faster benchmark. This will not test the effect of the MReg() method.
+    testCaseResult = testCase->MultiShotMeasureMask(qPowers, n, ITERATIONS);
 
     crossEntropy = ZERO_R1;
     for (perm = 0; perm < permCount; perm++) {


### PR DESCRIPTION
It seems that an edge case in CNOT was responsible for the very infrequent cross entropy benchmark failures.