### PR TITLE
Dirty bits after CCNOT

### DIFF
--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -714,8 +714,6 @@ protected:
         std::vector<bitLenInt*>::iterator first, std::vector<bitLenInt*>::iterator last);
 
     template <typename F, typename... B> void EntangleAndCallMember(F fn, B... bits);
-    template <typename F, typename... B> void EntangleAndCall(F fn, B... bits);
-    template <typename F, typename... B> void EntangleAndCallMemberRot(F fn, real1 radians, B... bits);
 
     typedef bool (*ParallelUnitFn)(QInterfacePtr unit, real1 param1, real1 param2);
     bool ParallelUnitApply(ParallelUnitFn fn, real1 param1 = ZERO_R1, real1 param2 = ZERO_R1);

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -694,6 +694,7 @@ protected:
     void CBoolReg(const bitLenInt& qInputStart, const bitCapInt& classicalInput, const bitLenInt& outputStart,
         const bitLenInt& length, F fn);
 
+    virtual QInterfacePtr Entangle(std::vector<bitLenInt> bits);
     virtual QInterfacePtr Entangle(std::vector<bitLenInt*> bits);
     virtual QInterfacePtr EntangleRange(bitLenInt start, bitLenInt length);
     virtual QInterfacePtr EntangleRange(bitLenInt start, bitLenInt length, bitLenInt start2, bitLenInt length2);
@@ -712,8 +713,6 @@ protected:
 
     virtual QInterfacePtr EntangleInCurrentBasis(
         std::vector<bitLenInt*>::iterator first, std::vector<bitLenInt*>::iterator last);
-
-    template <typename F, typename... B> void EntangleAndCallMember(F fn, B... bits);
 
     typedef bool (*ParallelUnitFn)(QInterfacePtr unit, real1 param1, real1 param2);
     bool ParallelUnitApply(ParallelUnitFn fn, real1 param1 = ZERO_R1, real1 param2 = ZERO_R1);

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1339,8 +1339,8 @@ void QUnit::CCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target)
 
     shards[control1].isPhaseDirty = true;
     shards[control2].isPhaseDirty = true;
-    tShard.isProbDirty = true;
-    tShard.isPhaseDirty = true;
+    shards[target].isProbDirty = true;
+    shards[target].isPhaseDirty = true;
 }
 
 void QUnit::AntiCCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target)
@@ -1363,8 +1363,8 @@ void QUnit::AntiCCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target)
 
     shards[control1].isPhaseDirty = true;
     shards[control2].isPhaseDirty = true;
-    tShard.isProbDirty = true;
-    tShard.isPhaseDirty = true;
+    shards[target].isProbDirty = true;
+    shards[target].isPhaseDirty = true;
 }
 
 void QUnit::CZ(bitLenInt control, bitLenInt target)

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1341,9 +1341,7 @@ void QUnit::CCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target)
 
     QInterfacePtr unit = Entangle(ebits);
 
-    std::vector<bitLenInt> controlsMapped = { shards[control1].mapped, shards[control2].mapped };
-
-    unit->CCNOT(controlsMapped[0], controlsMapped[1], shards[target].mapped);
+    unit->CCNOT(shards[control1].mapped, shards[control2].mapped, shards[target].mapped);
 
     shards[control1].isPhaseDirty = true;
     shards[control2].isPhaseDirty = true;
@@ -1376,9 +1374,7 @@ void QUnit::AntiCCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target)
 
     QInterfacePtr unit = Entangle(ebits);
 
-    std::vector<bitLenInt> controlsMapped = { shards[control1].mapped, shards[control2].mapped };
-
-    unit->AntiCCNOT(controlsMapped[0], controlsMapped[1], shards[target].mapped);
+    unit->AntiCCNOT(shards[control1].mapped, shards[control2].mapped, shards[target].mapped);
 
     shards[control1].isPhaseDirty = true;
     shards[control2].isPhaseDirty = true;

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -913,10 +913,10 @@ void QUnit::ISwap(bitLenInt qubit1, bitLenInt qubit2)
 
     // TODO: If we multiply out cached amplitudes, we can optimize this.
 
-    shards[qubit1].mapped.isProbDirty = true;
-    shards[qubit1].mapped.isPhaseDirty = true;
-    shards[qubit2].mapped.isProbDirty = true;
-    shards[qubit2].mapped.isPhaseDirty = true;
+    shards[qubit1].isProbDirty = true;
+    shards[qubit1].isPhaseDirty = true;
+    shards[qubit2].isProbDirty = true;
+    shards[qubit2].isPhaseDirty = true;
 }
 
 void QUnit::SqrtSwap(bitLenInt qubit1, bitLenInt qubit2)
@@ -941,10 +941,10 @@ void QUnit::SqrtSwap(bitLenInt qubit1, bitLenInt qubit2)
 
     // TODO: If we multiply out cached amplitudes, we can optimize this.
 
-    shards[qubit1].mapped.isProbDirty = true;
-    shards[qubit1].mapped.isPhaseDirty = true;
-    shards[qubit2].mapped.isProbDirty = true;
-    shards[qubit2].mapped.isPhaseDirty = true;
+    shards[qubit1].isProbDirty = true;
+    shards[qubit1].isPhaseDirty = true;
+    shards[qubit2].isProbDirty = true;
+    shards[qubit2].isPhaseDirty = true;
 }
 
 void QUnit::ISqrtSwap(bitLenInt qubit1, bitLenInt qubit2)
@@ -969,10 +969,10 @@ void QUnit::ISqrtSwap(bitLenInt qubit1, bitLenInt qubit2)
 
     // TODO: If we multiply out cached amplitudes, we can optimize this.
 
-    shards[qubit1].mapped.isProbDirty = true;
-    shards[qubit1].mapped.isPhaseDirty = true;
-    shards[qubit2].mapped.isProbDirty = true;
-    shards[qubit2].mapped.isPhaseDirty = true;
+    shards[qubit1].isProbDirty = true;
+    shards[qubit1].isPhaseDirty = true;
+    shards[qubit2].isProbDirty = true;
+    shards[qubit2].isPhaseDirty = true;
 }
 
 void QUnit::UniformlyControlledSingleBit(const bitLenInt* controls, const bitLenInt& controlLen, bitLenInt qubitIndex,

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1343,9 +1343,7 @@ void QUnit::CCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target)
     // TryCnotOptimize() already tried everything ApplyEitherControlled() would do.
     EntangleAndCallMember(PTR3(CCNOT), control1, control2, target);
 
-    shards[control1].isProbDirty = true;
     shards[control1].isPhaseDirty = true;
-    shards[control2].isProbDirty = true;
     shards[control2].isPhaseDirty = true;
     tShard.isProbDirty = true;
     tShard.isPhaseDirty = true;

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1264,8 +1264,14 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
 {
     QEngineShard& tShard = shards[target];
 
-    if (CACHED_PLUS(tShard)) {
-        return;
+    if (CACHED_PLUS_MINUS(tShard)) {
+        if (tShard.amp1 == ZERO_CMPLX) {
+            return;
+        }
+        if (tShard.amp0 == ZERO_CMPLX) {
+            Z(control);
+            return;
+        }
     }
 
     QEngineShard& cShard = shards[control];

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1277,11 +1277,11 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
     QEngineShard& cShard = shards[control];
 
     if (CACHED_PROB(cShard)) {
-        if (norm(cShard.amp0) == ZERO_R1) {
+        if (cShard.amp0 == ZERO_CMPLX) {
             X(target);
             return;
         }
-        if (norm(cShard.amp1) == ZERO_R1) {
+        if (cShard.amp1 == ZERO_CMPLX) {
             return;
         }
     }

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -913,10 +913,10 @@ void QUnit::ISwap(bitLenInt qubit1, bitLenInt qubit2)
 
     // TODO: If we multiply out cached amplitudes, we can optimize this.
 
-    shard1.isProbDirty = true;
-    shard1.isPhaseDirty = true;
-    shard2.isProbDirty = true;
-    shard2.isPhaseDirty = true;
+    shards[qubit1].mapped.isProbDirty = true;
+    shards[qubit1].mapped.isPhaseDirty = true;
+    shards[qubit2].mapped.isProbDirty = true;
+    shards[qubit2].mapped.isPhaseDirty = true;
 }
 
 void QUnit::SqrtSwap(bitLenInt qubit1, bitLenInt qubit2)
@@ -941,10 +941,10 @@ void QUnit::SqrtSwap(bitLenInt qubit1, bitLenInt qubit2)
 
     // TODO: If we multiply out cached amplitudes, we can optimize this.
 
-    shard1.isProbDirty = true;
-    shard1.isPhaseDirty = true;
-    shard2.isProbDirty = true;
-    shard2.isPhaseDirty = true;
+    shards[qubit1].mapped.isProbDirty = true;
+    shards[qubit1].mapped.isPhaseDirty = true;
+    shards[qubit2].mapped.isProbDirty = true;
+    shards[qubit2].mapped.isPhaseDirty = true;
 }
 
 void QUnit::ISqrtSwap(bitLenInt qubit1, bitLenInt qubit2)
@@ -969,10 +969,10 @@ void QUnit::ISqrtSwap(bitLenInt qubit1, bitLenInt qubit2)
 
     // TODO: If we multiply out cached amplitudes, we can optimize this.
 
-    shard1.isProbDirty = true;
-    shard1.isPhaseDirty = true;
-    shard2.isProbDirty = true;
-    shard2.isPhaseDirty = true;
+    shards[qubit1].mapped.isProbDirty = true;
+    shards[qubit1].mapped.isPhaseDirty = true;
+    shards[qubit2].mapped.isProbDirty = true;
+    shards[qubit2].mapped.isPhaseDirty = true;
 }
 
 void QUnit::UniformlyControlledSingleBit(const bitLenInt* controls, const bitLenInt& controlLen, bitLenInt qubitIndex,

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -881,12 +881,7 @@ void QUnit::Swap(bitLenInt qubit1, bitLenInt qubit2)
     }
 }
 
-/* Unfortunately, many methods are overloaded, which prevents using just the address-to-member. */
-#define PTR3(OP) (void (QInterface::*)(bitLenInt, bitLenInt, bitLenInt))(&QInterface::OP)
 #define PTR2(OP) (void (QInterface::*)(bitLenInt, bitLenInt))(&QInterface::OP)
-#define PTR1(OP) (void (QInterface::*)(bitLenInt))(&QInterface::OP)
-#define PTR2A(OP) (void (QInterface::*)(real1, bitLenInt, bitLenInt))(&QInterface::OP)
-#define PTRA(OP) (void (QInterface::*)(real1, bitLenInt))(&QInterface::OP)
 
 void QUnit::ISwap(bitLenInt qubit1, bitLenInt qubit2)
 {

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1365,9 +1365,7 @@ void QUnit::AntiCCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target)
     // TryCnotOptimize() already tried everything ApplyEitherControlled() would do.
     EntangleAndCallMember(PTR3(AntiCCNOT), control1, control2, target);
 
-    shards[control1].isProbDirty = true;
     shards[control1].isPhaseDirty = true;
-    shards[control2].isProbDirty = true;
     shards[control2].isPhaseDirty = true;
     tShard.isProbDirty = true;
     tShard.isPhaseDirty = true;

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1342,6 +1342,13 @@ void QUnit::CCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target)
 
     // TryCnotOptimize() already tried everything ApplyEitherControlled() would do.
     EntangleAndCallMember(PTR3(CCNOT), control1, control2, target);
+
+    shards[control1].isProbDirty = true;
+    shards[control1].isPhaseDirty = true;
+    shards[control2].isProbDirty = true;
+    shards[control2].isPhaseDirty = true;
+    tShard.isProbDirty = true;
+    tShard.isPhaseDirty = true;
 }
 
 void QUnit::AntiCCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target)
@@ -1359,6 +1366,13 @@ void QUnit::AntiCCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target)
 
     // TryCnotOptimize() already tried everything ApplyEitherControlled() would do.
     EntangleAndCallMember(PTR3(AntiCCNOT), control1, control2, target);
+
+    shards[control1].isProbDirty = true;
+    shards[control1].isPhaseDirty = true;
+    shards[control2].isProbDirty = true;
+    shards[control2].isPhaseDirty = true;
+    tShard.isProbDirty = true;
+    tShard.isPhaseDirty = true;
 }
 
 void QUnit::CZ(bitLenInt control, bitLenInt target)

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -1091,7 +1091,7 @@ TEST_CASE("test_universal_circuit_digital_cross_entropy", "[supreme]")
 
             multiGate.gate = maxGates * goldStandard->Rand();
 
-            if (multiGate.gate == 3) {
+            if (multiGate.gate > 2) {
                 multiGate.b3 = pickRandomBit(goldStandard, &unusedBits);
             }
 


### PR DESCRIPTION
In refactoring CCNOT, I accidentally removed the section where "shards" are marked "dirty" afterward.