### PR TITLE
QUnit refactor; benchmark garbage collection

### DIFF
--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -117,21 +117,25 @@ public:
         isPhaseDirty = true;
     }
 
-    void ClampAmps(real1 norm_thresh)
+    bool ClampAmps(real1 norm_thresh)
     {
+        bool didClamp = false;
         if (norm(amp0) < norm_thresh) {
+            didClamp = true;
             amp0 = ZERO_R1;
             amp1 /= abs(amp1);
             if (!isProbDirty) {
                 isPhaseDirty = false;
             }
         } else if (norm(amp1) < norm_thresh) {
+            didClamp = true;
             amp1 = ZERO_R1;
             amp0 /= abs(amp0);
             if (!isProbDirty) {
                 isPhaseDirty = false;
             }
         }
+        return didClamp;
     }
 
     /// Remove another qubit as being a cached control of a phase gate buffer, for "this" as target bit.

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -30,7 +30,7 @@
 
 #define DIRTY(shard) (shard.isPhaseDirty || shard.isProbDirty)
 #define IS_ONE_CMPLX(c) (c == ONE_CMPLX)
-#define IS_NORM_ZERO(c) (c == ZERO_CMPLX)
+#define IS_NORM_ZERO(c) (norm(c) < amplitudeFloor)
 #define SHARD_STATE(shard) (norm(shard.amp0) < (ONE_R1 / 2))
 #define QUEUED_PHASE(shard) ((shard.targetOfShards.size() != 0) || (shard.controlsShards.size() != 0))
 /* "UNSAFE" variants here do not check whether the bit is in |0>/|1> rather than |+>/|-> basis. */

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -30,7 +30,7 @@
 
 #define DIRTY(shard) (shard.isPhaseDirty || shard.isProbDirty)
 #define IS_ONE_CMPLX(c) (c == ONE_CMPLX)
-#define IS_NORM_ZERO(c) (norm(c) < amplitudeFloor)
+#define IS_NORM_ZERO(c) (c == ZERO_CMPLX)
 #define SHARD_STATE(shard) (norm(shard.amp0) < (ONE_R1 / 2))
 #define QUEUED_PHASE(shard) ((shard.targetOfShards.size() != 0) || (shard.controlsShards.size() != 0))
 /* "UNSAFE" variants here do not check whether the bit is in |0>/|1> rather than |+>/|-> basis. */

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1220,7 +1220,7 @@ bool QUnit::TryCnotOptimize(const bitLenInt* controls, const bitLenInt& controlL
             return true;
         }
 
-        if (IS_NORM_ZERO(shard.amp0) || IS_NORM_ZERO(shard.amp1)) {
+        if (!((!anti && IS_NORM_ZERO(shard.amp0)) || (anti && IS_NORM_ZERO(shard.amp1)))) {
             rControl = controls[i];
             rControlLen++;
             if (rControlLen > 1U) {

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1207,7 +1207,7 @@ bool QUnit::TryCnotOptimize(const bitLenInt* controls, const bitLenInt& controlL
     for (bitLenInt i = 0; i < controlLen; i++) {
         QEngineShard& shard = shards[controls[i]];
 
-        if (!CACHED_PROB(shard) || (!((anti && IS_NORM_ZERO(shard.amp1)) || (!anti && IS_NORM_ZERO(shard.amp0))))) {
+        if (!CACHED_PROB(shard)) {
             rControl = controls[i];
             rControlLen++;
             if (rControlLen > 1U) {
@@ -1218,6 +1218,14 @@ bool QUnit::TryCnotOptimize(const bitLenInt* controls, const bitLenInt& controlL
 
         if ((anti && IS_NORM_ZERO(shard.amp0)) || (!anti && IS_NORM_ZERO(shard.amp1))) {
             return true;
+        }
+
+        if (IS_NORM_ZERO(shard.amp0) || IS_NORM_ZERO(shard.amp1)) {
+            rControl = controls[i];
+            rControlLen++;
+            if (rControlLen > 1U) {
+                break;
+            }
         }
     }
 

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -91,6 +91,8 @@ void benchmarkLoopVariable(std::function<void(QInterfacePtr, bitLenInt)> fn, bit
         mnQbts = 4;
     }
 
+    QInterfacePtr qftReg = NULL;
+
     for (numBits = mnQbts; numBits <= mxQbts; numBits++) {
 
         if (isBinaryOutput) {
@@ -100,8 +102,10 @@ void benchmarkLoopVariable(std::function<void(QInterfacePtr, bitLenInt)> fn, bit
             mOutputFile << sizeof(bitCapInt) << " bytes in bitCapInt" << std::endl;
         }
 
-        QInterfacePtr qftReg = NULL;
         if (!qUniverse) {
+            if (qftReg != NULL) {
+                qftReg.reset();
+            }
             qftReg = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, numBits, 0, rng,
                 ONE_CMPLX, enable_normalization, true, false, device_id, !disable_hardware_rng, sparse);
         }
@@ -122,6 +126,9 @@ void benchmarkLoopVariable(std::function<void(QInterfacePtr, bitLenInt)> fn, bit
                     }
                 }
             } else {
+                if (qftReg != NULL) {
+                    qftReg.reset();
+                }
                 qftReg = MakeRandQubit();
                 for (bitLenInt i = 1; i < numBits; i++) {
                     qftReg->Compose(MakeRandQubit());


### PR DESCRIPTION
Now that we have some form of cross entropy testing between the simulator types, optimization and bug fixes will follow, as we try to bring cross entropy results fully into line, on top of unit tests.

For QUnit, it makes sense to pull cached shard amplitude checks for exact 0/1 equality into a macro, so a float rounding neighborhood can be inserted or removed as necessary and convenient.

C++ `shared_ptr` instances holding `QInterface` instances don't always seem to know when to release their garbage, during benchmarks, so we can call `reset()` when we know we're done with them.