### PR TITLE
WIP: Optimization and debugging

### DIFF
--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -33,13 +33,13 @@ namespace Qrack {
 /** Caches controlled gate phase between shards, (as a case of "gate fusion" optimization particularly useful to QUnit)
  */
 struct PhaseShard {
-    real1 angle0;
-    real1 angle1;
+    real1 angle0DivPi;
+    real1 angle1DivPi;
     bool isInvert;
 
     PhaseShard()
-        : angle0(ZERO_R1)
-        , angle1(ZERO_R1)
+        : angle0DivPi(ZERO_R1)
+        , angle1DivPi(ZERO_R1)
         , isInvert(false)
     {
     }
@@ -180,45 +180,45 @@ public:
 
     /// "Fuse" phase gate buffer angles, (and initialize the buffer, if necessary,) for the buffer with "this" as target
     /// bit and a another qubit as control
-    void AddPhaseAngles(QEngineShardPtr control, real1 angle0Diff, real1 angle1Diff)
+    void AddPhaseAngles(QEngineShardPtr control, real1 angle0DiffDivPi, real1 angle1DiffDivPi)
     {
         MakePhaseControlledBy(control);
 
-        real1 nAngle0 = targetOfShards[control]->angle0 + angle0Diff;
-        real1 nAngle1 = targetOfShards[control]->angle1 + angle1Diff;
+        real1 nAngle0DivPi = targetOfShards[control]->angle0DivPi + angle0DiffDivPi;
+        real1 nAngle1DivPi = targetOfShards[control]->angle1DivPi + angle1DiffDivPi;
 
-        while (nAngle0 <= -M_PI) {
-            nAngle0 += 2 * M_PI;
+        while (nAngle0DivPi <= -1) {
+            nAngle0DivPi += 2;
         }
-        while (nAngle0 > M_PI) {
-            nAngle0 -= 2 * M_PI;
+        while (nAngle0DivPi > 1) {
+            nAngle0DivPi -= 2;
         }
-        while (nAngle1 <= -M_PI) {
-            nAngle1 += 2 * M_PI;
+        while (nAngle1DivPi <= -1) {
+            nAngle1DivPi += 2;
         }
-        while (nAngle1 > M_PI) {
-            nAngle1 -= 2 * M_PI;
+        while (nAngle1DivPi > 1) {
+            nAngle1DivPi -= 2;
         }
 
-        if ((nAngle0 == ZERO_R1) && (nAngle1 == ZERO_R1) && !targetOfShards[control]->isInvert) {
+        if ((nAngle0DivPi == ZERO_R1) && (nAngle1DivPi == ZERO_R1) && !targetOfShards[control]->isInvert) {
             // The buffer is equal to the identity operator, and it can be removed.
             RemovePhaseControl(control);
             return;
         }
 
-        targetOfShards[control]->angle0 = nAngle0;
-        targetOfShards[control]->angle1 = nAngle1;
+        targetOfShards[control]->angle0DivPi = nAngle0DivPi;
+        targetOfShards[control]->angle1DivPi = nAngle1DivPi;
     }
 
-    void AddInversionAngles(QEngineShardPtr control, real1 angle0Diff, real1 angle1Diff)
+    void AddInversionAngles(QEngineShardPtr control, real1 angle0DiffDivPi, real1 angle1DiffDivPi)
     {
         MakePhaseControlledBy(control);
 
         PhaseShardPtr targetOfShard = targetOfShards[control];
         targetOfShard->isInvert = !targetOfShard->isInvert;
-        std::swap(targetOfShard->angle0, targetOfShard->angle1);
+        std::swap(targetOfShard->angle0DivPi, targetOfShard->angle1DivPi);
 
-        AddPhaseAngles(control, angle0Diff, angle1Diff);
+        AddPhaseAngles(control, angle0DiffDivPi, angle1DiffDivPi);
     }
 
     bool isInvertControl()
@@ -258,12 +258,12 @@ public:
             ShardToPhaseMap::iterator phaseShard = tempControls.begin();
             std::advance(phaseShard, lcv);
             if ((isPlusMinus != phaseShard->first->isPlusMinus) || phaseShard->second->isInvert ||
-                (phaseShard->second->angle0 != ZERO_R1)) {
+                (phaseShard->second->angle0DivPi != ZERO_R1)) {
                 return;
             }
 
             partner = phaseShard->first;
-            partnerAngle = phaseShard->second->angle1;
+            partnerAngle = phaseShard->second->angle1DivPi;
 
             phaseShard->first->targetOfShards.erase(this);
             controlsShards.erase(partner);
@@ -296,15 +296,15 @@ public:
                 return;
             }
 
-            if (!phaseShard->second->isInvert && (phaseShard->second->angle0 == ZERO_R1)) {
-                partnerAngle = phaseShard->second->angle1;
+            if (!phaseShard->second->isInvert && (phaseShard->second->angle0DivPi == ZERO_R1)) {
+                partnerAngle = phaseShard->second->angle1DivPi;
 
                 phaseShard->first->targetOfShards.erase(this);
                 controlsShards.erase(partner);
 
                 AddPhaseAngles(partner, ZERO_R1, partnerAngle);
-            } else if (!partnerShard->second->isInvert && (partnerShard->second->angle0 == ZERO_R1)) {
-                partnerAngle = partnerShard->second->angle1;
+            } else if (!partnerShard->second->isInvert && (partnerShard->second->angle0DivPi == ZERO_R1)) {
+                partnerAngle = partnerShard->second->angle1DivPi;
 
                 phaseShard->first->controlsShards.erase(this);
                 targetOfShards.erase(partner);
@@ -326,7 +326,7 @@ public:
         par_for(0, targetOfShards.size(), [&](const bitCapInt lcv, const int cpu) {
             ShardToPhaseMap::iterator phaseShard = targetOfShards.begin();
             std::advance(phaseShard, lcv);
-            std::swap(phaseShard->second->angle0, phaseShard->second->angle1);
+            std::swap(phaseShard->second->angle0DivPi, phaseShard->second->angle1DivPi);
         });
     }
 
@@ -348,10 +348,10 @@ public:
                 return;
             }
 
-            phaseShard->second->angle0 =
-                std::arg(std::polar(ONE_R1, phaseShard->second->angle0) * topLeft / bottomRight);
-            phaseShard->second->angle1 =
-                std::arg(std::polar(ONE_R1, phaseShard->second->angle1) * bottomRight / topLeft);
+            phaseShard->second->angle0DivPi =
+                std::arg(std::polar(ONE_R1, (real1)(phaseShard->second->angle0DivPi * M_PI)) * topLeft / bottomRight);
+            phaseShard->second->angle1DivPi =
+                std::arg(std::polar(ONE_R1, (real1)(phaseShard->second->angle1DivPi * M_PI)) * bottomRight / topLeft);
         });
     }
 
@@ -389,8 +389,8 @@ public:
 
         bool didFlip;
         for (phaseShard = targetOfShards.begin(); phaseShard != targetOfShards.end(); phaseShard++) {
-            polar0 = std::polar(ONE_R1, phaseShard->second->angle0);
-            polar1 = std::polar(ONE_R1, phaseShard->second->angle1);
+            polar0 = std::polar(ONE_R1, (real1)(phaseShard->second->angle0DivPi * M_PI));
+            polar1 = std::polar(ONE_R1, (real1)(phaseShard->second->angle1DivPi * M_PI));
             didFlip = false;
             if (polar0 == polar1) {
                 if (phaseShard->second->isInvert) {
@@ -408,8 +408,8 @@ public:
 
             if (didFlip) {
                 phaseShard->second->isInvert = !phaseShard->second->isInvert;
-                phaseShard->second->angle0 = (real1)arg(polar0);
-                phaseShard->second->angle1 = (real1)arg(polar1);
+                phaseShard->second->angle0DivPi = (real1)(arg(polar0) / M_PI);
+                phaseShard->second->angle1DivPi = (real1)(arg(polar1) / M_PI);
             }
         }
     }

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -221,32 +221,6 @@ public:
         AddPhaseAngles(control, angle0DiffDivPi, angle1DiffDivPi);
     }
 
-    bool isInvertControl()
-    {
-        ShardToPhaseMap::iterator phaseShard;
-        for (phaseShard = controlsShards.begin(); phaseShard != controlsShards.end(); phaseShard++) {
-            if (phaseShard->second->isInvert) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    bool isInvertTarget()
-    {
-        ShardToPhaseMap::iterator phaseShard;
-        for (phaseShard = targetOfShards.begin(); phaseShard != targetOfShards.end(); phaseShard++) {
-            if (phaseShard->second->isInvert) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    bool isInvert() { return isInvertControl() || isInvertTarget(); }
-
     /// Take ambiguous control/target operations, and reintrepret them as targeting this bit
     void OptimizeControls()
     {

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -334,7 +334,7 @@ public:
     {
         ShardToPhaseMap::iterator phaseShard;
 
-        // These casess cannot be handled:
+        // These cases cannot be handled:
         // for (phaseShard = controlsShards.begin(); phaseShard != controlsShards.end(); phaseShard++) {
         //    if (phaseShard->second->isInvert) {
         //        return false;
@@ -355,38 +355,37 @@ public:
         });
     }
 
-    // TODO: Just turn this into a QUnit method that flushes all the appropriate failed commutations, then remove them
-    // from here.
-    bool TryHCommute()
+    void CommuteH()
     {
         CombineGates();
 
         complex polar0, polar1;
         ShardToPhaseMap::iterator phaseShard;
 
-        for (phaseShard = controlsShards.begin(); phaseShard != controlsShards.end(); phaseShard++) {
-            polar0 = std::polar(ONE_R1, phaseShard->second->angle0);
-            polar1 = std::polar(ONE_R1, phaseShard->second->angle1);
-            if (polar0 == polar1) {
-                if (phaseShard->second->isInvert) {
-                    return false;
-                }
-            } else if (polar0 == -polar1) {
-                if (!phaseShard->second->isInvert) {
-                    return false;
-                }
-            } else {
-                return false;
-            }
-        }
+        // These cases cannot be handled:
+        // for (phaseShard = controlsShards.begin(); phaseShard != controlsShards.end(); phaseShard++) {
+        //    polar0 = std::polar(ONE_R1, phaseShard->second->angle0);
+        //    polar1 = std::polar(ONE_R1, phaseShard->second->angle1);
+        //    if (polar0 == polar1) {
+        //        if (phaseShard->second->isInvert) {
+        //            return false;
+        //        }
+        //    } else if (polar0 == -polar1) {
+        //        if (!phaseShard->second->isInvert) {
+        //            return false;
+        //        }
+        //    } else {
+        //        return false;
+        //    }
+        //}
 
-        for (phaseShard = targetOfShards.begin(); phaseShard != targetOfShards.end(); phaseShard++) {
-            polar0 = std::polar(ONE_R1, phaseShard->second->angle0);
-            polar1 = std::polar(ONE_R1, phaseShard->second->angle1);
-            if ((polar0 != polar1) && (polar0 != -polar1)) {
-                return false;
-            }
-        }
+        // for (phaseShard = targetOfShards.begin(); phaseShard != targetOfShards.end(); phaseShard++) {
+        //    polar0 = std::polar(ONE_R1, phaseShard->second->angle0);
+        //    polar1 = std::polar(ONE_R1, phaseShard->second->angle1);
+        //    if ((polar0 != polar1) && (polar0 != -polar1)) {
+        //        return false;
+        //    }
+        //}
 
         bool didFlip;
         for (phaseShard = targetOfShards.begin(); phaseShard != targetOfShards.end(); phaseShard++) {
@@ -405,8 +404,6 @@ public:
                     polar1 = polar0;
                     didFlip = true;
                 }
-            } else {
-                return false;
             }
 
             if (didFlip) {
@@ -415,8 +412,6 @@ public:
                 phaseShard->second->angle1 = (real1)arg(polar1);
             }
         }
-
-        return true;
     }
 
     bool operator==(const QEngineShard& rhs) { return (mapped == rhs.mapped) && (unit == rhs.unit); }
@@ -749,6 +744,8 @@ protected:
 
     void TransformBasis1Qb(const bool& toPlusMinus, const bitLenInt& i);
 
+    void ApplyBuffer(ShardToPhaseMap::iterator phaseShard, const bitLenInt& control, const bitLenInt& target);
+
     void RevertBasis2Qb(const bitLenInt& i, const bool& onlyInvert = false, const bool& onlyControlling = false,
         std::set<bitLenInt> exceptControlling = {}, std::set<bitLenInt> exceptTargetedBy = {},
         const bool& dumpSkipped = false);
@@ -903,6 +900,8 @@ protected:
         RevertBasis2Qb(target, true, true);
         shards[target].CommutePhase(topLeft, bottomRight);
     }
+
+    void CommuteH(const bitLenInt& bitIndex);
 
     /* Debugging and diagnostic routines. */
     void DumpShards();

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1246,6 +1246,13 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
         return;
     }
 
+    if (!freezeBasis) {
+        H(target);
+        CZ(control, target);
+        H(target);
+        return;
+    }
+
     bitLenInt controls[1] = { control };
     bitLenInt controlLen = 1;
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1246,13 +1246,6 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
         return;
     }
 
-    if (!freezeBasis) {
-        H(target);
-        CZ(control, target);
-        H(target);
-        return;
-    }
-
     bitLenInt controls[1] = { control };
     bitLenInt controlLen = 1;
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -195,7 +195,7 @@ bitLenInt QUnit::Compose(QUnitPtr toCopy, bitLenInt start, bool isConsumed)
 
 void QUnit::Detach(bitLenInt start, bitLenInt length, QUnitPtr dest)
 {
-    /* TODO: This method should compose the bits for the destination without cohering the length first */
+    /* TODO: This method should decompose the bits for the destination without composing the length first */
 
     for (bitLenInt i = 0; i < length; i++) {
         RevertBasis2Qb(start + i);
@@ -250,7 +250,7 @@ void QUnit::Decompose(bitLenInt start, bitLenInt length, QUnitPtr dest) { Detach
 
 void QUnit::Dispose(bitLenInt start, bitLenInt length) { Detach(start, length, nullptr); }
 
-// The optimization of this method is redudandant with other optimizations in QUnit.
+// The optimization of this method is redundant with other optimizations in QUnit.
 void QUnit::Dispose(bitLenInt start, bitLenInt length, bitCapInt disposedPerm) { Detach(start, length, nullptr); }
 
 QInterfacePtr QUnit::EntangleInCurrentBasis(
@@ -1109,7 +1109,7 @@ void QUnit::Z(bitLenInt target)
     // Commutes with controlled phase optimizations
     QEngineShard& shard = shards[target];
 
-    RevertBasis2Qb(target, true);
+    RevertBasis2Qb(target, true, true);
 
     // Not necessary to check return after the above revert:
     shard.TryCommutePhase(ONE_CMPLX, -ONE_CMPLX);
@@ -1421,7 +1421,7 @@ void QUnit::ApplySinglePhase(const complex topLeft, const complex bottomRight, b
         return;
     }
 
-    RevertBasis2Qb(target, true);
+    RevertBasis2Qb(target, true, true);
 
     // Not necessary to check return after the above revert:
     shard.TryCommutePhase(topLeft, bottomRight);


### PR DESCRIPTION
It makes no sense to "TryCommute" on a shard that can't do anything about blocking gates, while other gates could commute. These protected methods on `QEngineShard()` have been turned into protected methods on `QUnit` instead, so that _only_ gates without optimized commutation rules can be flushed. Further, to help avoid float rounding error, `angle0` and `angle1` in `PhaseShard` instances have been modified to store their radian values _divided_ _by_ _pi_. The result is a `CZ()` gate, for example, stores a whole number, and `S()` `T()` gates differ in 1 or 2 bits of accuracy or precision, which should help make the `PhaseShard` instances more robust for exact equality checks.

Before this PR is done, the entire controlled gate buffering system will be refactored. For the time being, `CNOT()` does not buffer, this way.