### PR TITLE
Removing redundant optimization case checks; QEngineOCL::clDump()

### DIFF
--- a/include/qengine_opencl.hpp
+++ b/include/qengine_opencl.hpp
@@ -151,7 +151,7 @@ public:
 
     virtual ~QEngineOCL()
     {
-        Finish();
+        clDump();
         FreeAligned(nrmArray);
         FreeStateVec();
     }
@@ -311,6 +311,11 @@ protected:
      * device queue is finished, (which might be shared by other QEngineOCL instances).
      */
     virtual void clFinish(bool doHard = false);
+
+    /**
+     * Dumps the remaining asynchronous wait event list or queue of OpenCL events, for the current queue.
+     */
+    virtual void clDump();
 
     size_t FixWorkItemCount(size_t maxI, size_t wic);
     size_t FixGroupSize(size_t wic, size_t gs);

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -146,6 +146,16 @@ void QEngineOCL::clFinish(bool doHard)
     wait_refs.clear();
 }
 
+void QEngineOCL::clDump()
+{
+    if (device_context == NULL) {
+        return;
+    }
+
+    device_context->WaitOnAllEvents();
+    wait_refs.clear();
+}
+
 size_t QEngineOCL::FixWorkItemCount(size_t maxI, size_t wic)
 {
     if (wic > maxI) {

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -613,7 +613,7 @@ bool QUnit::CheckBitsPlus(const bitLenInt& qubitIndex, const bitLenInt& length)
     bool isHBasis = true;
     for (bitLenInt i = 0; i < length; i++) {
         QEngineShard& shard = shards[qubitIndex + i];
-        if (CACHED_PLUS(shard)) {
+        if (!CACHED_PLUS(shard)) {
             isHBasis = false;
             break;
         }

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -2713,7 +2713,7 @@ void QUnit::CPhaseFlipIfLess(bitCapInt greaterPerm, bitLenInt start, bitLenInt l
 void QUnit::PhaseFlip()
 {
     QEngineShard& shard = shards[0];
-    if (!randGlobalPhase && !CACHED_CLASSICAL(shard)) {
+    if (!randGlobalPhase) {
         TransformBasis1Qb(false, 0);
         ApplyOrEmulate(shard, [&](QEngineShard& shard) { shard.unit->PhaseFlip(); });
         shard.amp1 = -shard.amp1;


### PR DESCRIPTION
It doesn't make any sense to try optimize by checking single bit gates for eigenstates, (they would already be cached as shard amplitudes, redundantly,) or if `ApplyEitherControlled()` would find the same eigenstates anyway in the directly subsequent course of program flow.

If the QEngineOCL destructor is called, there's no point in finishing the asynchronous queue beyond the current item on the queue.