### PR TITLE
H/phase commutation

### DIFF
--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -332,51 +332,16 @@ public:
     {
         ShardToPhaseMap::iterator phaseShard;
 
-        // These cases cannot be handled:
-        // for (phaseShard = controlsShards.begin(); phaseShard != controlsShards.end(); phaseShard++) {
-        //    polar0 = std::polar(ONE_R1, phaseShard->second->angle0);
-        //    polar1 = std::polar(ONE_R1, phaseShard->second->angle1);
-        //    if (polar0 == polar1) {
-        //        if (phaseShard->second->isInvert) {
-        //            return false;
-        //        }
-        //    } else if (polar0 == -polar1) {
-        //        if (!phaseShard->second->isInvert) {
-        //            return false;
-        //        }
-        //    } else {
-        //        return false;
-        //    }
-        //}
-
-        // for (phaseShard = targetOfShards.begin(); phaseShard != targetOfShards.end(); phaseShard++) {
-        //    polar0 = std::polar(ONE_R1, phaseShard->second->angle0);
-        //    polar1 = std::polar(ONE_R1, phaseShard->second->angle1);
-        //    if ((polar0 != polar1) && (polar0 != -polar1)) {
-        //        return false;
-        //    }
-        //}
-
-        real1 angleMinus;
-        PhaseShardPtr angleShard;
         for (phaseShard = targetOfShards.begin(); phaseShard != targetOfShards.end(); phaseShard++) {
-            angleShard = phaseShard->second;
-            angleMinus = abs(ClampAngleDivPi(angleShard->angle0DivPi - angleShard->angle1DivPi));
-            if (angleMinus <= FLT_EPSILON) {
-                if (angleShard->isInvert) {
-                    if (angleShard->angle0DivPi >= ZERO_R1) {
-                        angleShard->angle1DivPi -= angleShard->angle0DivPi - ONE_R1;
-                    } else {
-                        angleShard->angle1DivPi -= angleShard->angle0DivPi + ONE_R1;
-                    }
-                    phaseShard->second->isInvert = false;
-                }
-            } else if (abs(ONE_R1 - angleMinus) <= FLT_EPSILON) {
-                if (!angleShard->isInvert) {
-                    angleShard->angle0DivPi = ZERO_R1;
-                    angleShard->angle1DivPi = ZERO_R1;
-                    angleShard->isInvert = true;
-                }
+            if (phaseShard->second->isInvert && (abs(phaseShard->second->angle1DivPi) <= FLT_EPSILON)) {
+                phaseShard->second->angle0DivPi = ZERO_R1;
+                phaseShard->second->angle1DivPi = ONE_R1;
+                phaseShard->second->isInvert = false;
+            } else if (!phaseShard->second->isInvert &&
+                (abs(ONE_R1 - phaseShard->second->angle1DivPi) <= FLT_EPSILON)) {
+                phaseShard->second->angle1DivPi = ZERO_R1;
+                phaseShard->second->angle1DivPi = ZERO_R1;
+                phaseShard->second->isInvert = true;
             }
         }
     }

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -231,7 +231,7 @@ public:
             ShardToPhaseMap::iterator phaseShard = tempControls.begin();
             std::advance(phaseShard, lcv);
             if ((isPlusMinus != phaseShard->first->isPlusMinus) || phaseShard->second->isInvert ||
-                (abs(phaseShard->second->angle0DivPi) > FLT_EPSILON)) {
+                (phaseShard->second->angle0DivPi != ZERO_R1)) {
                 return;
             }
 
@@ -269,14 +269,14 @@ public:
                 return;
             }
 
-            if (!phaseShard->second->isInvert && (abs(phaseShard->second->angle0DivPi) <= FLT_EPSILON)) {
+            if (!phaseShard->second->isInvert && (phaseShard->second->angle0DivPi == ZERO_R1)) {
                 partnerAngle = phaseShard->second->angle1DivPi;
 
                 phaseShard->first->targetOfShards.erase(this);
                 controlsShards.erase(partner);
 
                 AddPhaseAngles(partner, ZERO_R1, partnerAngle);
-            } else if (!partnerShard->second->isInvert && (abs(partnerShard->second->angle0DivPi) <= FLT_EPSILON)) {
+            } else if (!partnerShard->second->isInvert && (partnerShard->second->angle0DivPi == ZERO_R1)) {
                 partnerAngle = partnerShard->second->angle1DivPi;
 
                 phaseShard->first->controlsShards.erase(this);
@@ -335,15 +335,8 @@ public:
 
         for (phaseShard = targetOfShards.begin(); phaseShard != targetOfShards.end(); phaseShard++) {
             buffer = phaseShard->second;
-            if (buffer->isInvert) {
-                buffer->angle0DivPi = ZERO_R1;
-                buffer->angle1DivPi = ONE_R1;
-                buffer->isInvert = false;
-            } else if (!buffer->isInvert) {
-                buffer->angle0DivPi = ZERO_R1;
-                buffer->angle1DivPi = ZERO_R1;
-                buffer->isInvert = true;
-            }
+            buffer->angle1DivPi *= -1;
+            buffer->isInvert = !buffer->isInvert;
         }
     }
 

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -187,17 +187,17 @@ public:
         real1 nAngle0DivPi = targetOfShards[control]->angle0DivPi + angle0DiffDivPi;
         real1 nAngle1DivPi = targetOfShards[control]->angle1DivPi + angle1DiffDivPi;
 
-        while (nAngle0DivPi <= -1) {
-            nAngle0DivPi += 2;
+        while (nAngle0DivPi <= -ONE_R1) {
+            nAngle0DivPi += (real1)2;
         }
-        while (nAngle0DivPi > 1) {
-            nAngle0DivPi -= 2;
+        while (nAngle0DivPi > ONE_R1) {
+            nAngle0DivPi -= (real1)2;
         }
-        while (nAngle1DivPi <= -1) {
-            nAngle1DivPi += 2;
+        while (nAngle1DivPi <= -ONE_R1) {
+            nAngle1DivPi += (real1)2;
         }
-        while (nAngle1DivPi > 1) {
-            nAngle1DivPi -= 2;
+        while (nAngle1DivPi > ONE_R1) {
+            nAngle1DivPi -= (real1)2;
         }
 
         if ((nAngle0DivPi == ZERO_R1) && (nAngle1DivPi == ZERO_R1) && !targetOfShards[control]->isInvert) {
@@ -331,8 +331,6 @@ public:
 
     void CommuteH()
     {
-        CombineGates();
-
         complex polar0, polar1;
         ShardToPhaseMap::iterator phaseShard;
 
@@ -361,29 +359,24 @@ public:
         //    }
         //}
 
-        bool didFlip;
         for (phaseShard = targetOfShards.begin(); phaseShard != targetOfShards.end(); phaseShard++) {
             polar0 = std::polar(ONE_R1, (real1)(phaseShard->second->angle0DivPi * M_PI));
             polar1 = std::polar(ONE_R1, (real1)(phaseShard->second->angle1DivPi * M_PI));
-            didFlip = false;
             if (polar0 == polar1) {
                 if (phaseShard->second->isInvert) {
-                    polar0 = (polar0 + polar1) / (real1)2;
-                    polar1 = -polar0;
-                    didFlip = true;
+                    if (phaseShard->second->angle0DivPi >= ZERO_R1) {
+                        phaseShard->second->angle1DivPi -= phaseShard->second->angle0DivPi - ONE_R1;
+                    } else {
+                        phaseShard->second->angle1DivPi -= phaseShard->second->angle0DivPi + ONE_R1;
+                    }
+                    phaseShard->second->isInvert = false;
                 }
             } else if (polar0 == -polar1) {
                 if (!phaseShard->second->isInvert) {
-                    polar0 = (polar0 + polar1) / (real1)2;
-                    polar1 = polar0;
-                    didFlip = true;
+                    phaseShard->second->angle0DivPi = ZERO_R1;
+                    phaseShard->second->angle1DivPi = ZERO_R1;
+                    phaseShard->second->isInvert = true;
                 }
-            }
-
-            if (didFlip) {
-                phaseShard->second->isInvert = !phaseShard->second->isInvert;
-                phaseShard->second->angle0DivPi = (real1)(arg(polar0) / M_PI);
-                phaseShard->second->angle1DivPi = (real1)(arg(polar1) / M_PI);
             }
         }
     }

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -357,13 +357,12 @@ public:
         //    }
         //}
 
-        real1 angleMinus, anglePlus;
+        real1 angleMinus;
         PhaseShardPtr angleShard;
         for (phaseShard = targetOfShards.begin(); phaseShard != targetOfShards.end(); phaseShard++) {
             angleShard = phaseShard->second;
-            angleMinus = ClampAngleDivPi(angleShard->angle0DivPi - angleShard->angle1DivPi);
-            anglePlus = ClampAngleDivPi(angleShard->angle0DivPi + angleShard->angle1DivPi);
-            if (abs(angleMinus) <= FLT_EPSILON) {
+            angleMinus = abs(ClampAngleDivPi(angleShard->angle0DivPi - angleShard->angle1DivPi));
+            if (angleMinus <= FLT_EPSILON) {
                 if (angleShard->isInvert) {
                     if (angleShard->angle0DivPi >= ZERO_R1) {
                         angleShard->angle1DivPi -= angleShard->angle0DivPi - ONE_R1;
@@ -372,7 +371,7 @@ public:
                     }
                     phaseShard->second->isInvert = false;
                 }
-            } else if (abs(anglePlus) <= FLT_EPSILON) {
+            } else if (abs(ONE_R1 - angleMinus) <= FLT_EPSILON) {
                 if (!angleShard->isInvert) {
                     angleShard->angle0DivPi = ZERO_R1;
                     angleShard->angle1DivPi = ZERO_R1;

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -178,27 +178,25 @@ public:
         }
     }
 
+    static const real1 ClampAngleDivPi(real1 angleDivPi)
+    {
+        while (angleDivPi <= -ONE_R1) {
+            angleDivPi += (real1)2;
+        }
+        while (angleDivPi > ONE_R1) {
+            angleDivPi -= (real1)2;
+        }
+        return angleDivPi;
+    }
+
     /// "Fuse" phase gate buffer angles, (and initialize the buffer, if necessary,) for the buffer with "this" as target
     /// bit and a another qubit as control
     void AddPhaseAngles(QEngineShardPtr control, real1 angle0DiffDivPi, real1 angle1DiffDivPi)
     {
         MakePhaseControlledBy(control);
 
-        real1 nAngle0DivPi = targetOfShards[control]->angle0DivPi + angle0DiffDivPi;
-        real1 nAngle1DivPi = targetOfShards[control]->angle1DivPi + angle1DiffDivPi;
-
-        while (nAngle0DivPi <= -ONE_R1) {
-            nAngle0DivPi += (real1)2;
-        }
-        while (nAngle0DivPi > ONE_R1) {
-            nAngle0DivPi -= (real1)2;
-        }
-        while (nAngle1DivPi <= -ONE_R1) {
-            nAngle1DivPi += (real1)2;
-        }
-        while (nAngle1DivPi > ONE_R1) {
-            nAngle1DivPi -= (real1)2;
-        }
+        real1 nAngle0DivPi = ClampAngleDivPi(targetOfShards[control]->angle0DivPi + angle0DiffDivPi);
+        real1 nAngle1DivPi = ClampAngleDivPi(targetOfShards[control]->angle1DivPi + angle1DiffDivPi);
 
         if ((nAngle0DivPi == ZERO_R1) && (nAngle1DivPi == ZERO_R1) && !targetOfShards[control]->isInvert) {
             // The buffer is equal to the identity operator, and it can be removed.
@@ -331,7 +329,6 @@ public:
 
     void CommuteH()
     {
-        complex polar0, polar1;
         ShardToPhaseMap::iterator phaseShard;
 
         // These cases cannot be handled:
@@ -359,23 +356,25 @@ public:
         //    }
         //}
 
+        real1 negAngle1DivPi;
+        PhaseShardPtr angleShard;
         for (phaseShard = targetOfShards.begin(); phaseShard != targetOfShards.end(); phaseShard++) {
-            polar0 = std::polar(ONE_R1, (real1)(phaseShard->second->angle0DivPi * M_PI));
-            polar1 = std::polar(ONE_R1, (real1)(phaseShard->second->angle1DivPi * M_PI));
-            if (polar0 == polar1) {
-                if (phaseShard->second->isInvert) {
-                    if (phaseShard->second->angle0DivPi >= ZERO_R1) {
-                        phaseShard->second->angle1DivPi -= phaseShard->second->angle0DivPi - ONE_R1;
+            angleShard = phaseShard->second;
+            negAngle1DivPi = ClampAngleDivPi(-angleShard->angle1DivPi);
+            if (angleShard->angle0DivPi == angleShard->angle1DivPi) {
+                if (angleShard->isInvert) {
+                    if (angleShard->angle0DivPi >= ZERO_R1) {
+                        angleShard->angle1DivPi -= angleShard->angle0DivPi - ONE_R1;
                     } else {
-                        phaseShard->second->angle1DivPi -= phaseShard->second->angle0DivPi + ONE_R1;
+                        angleShard->angle1DivPi -= angleShard->angle0DivPi + ONE_R1;
                     }
                     phaseShard->second->isInvert = false;
                 }
-            } else if (polar0 == -polar1) {
-                if (!phaseShard->second->isInvert) {
-                    phaseShard->second->angle0DivPi = ZERO_R1;
-                    phaseShard->second->angle1DivPi = ZERO_R1;
-                    phaseShard->second->isInvert = true;
+            } else if (angleShard->angle0DivPi == negAngle1DivPi) {
+                if (!angleShard->isInvert) {
+                    angleShard->angle0DivPi = ZERO_R1;
+                    angleShard->angle1DivPi = ZERO_R1;
+                    angleShard->isInvert = true;
                 }
             }
         }

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -360,7 +360,7 @@ public:
         PhaseShardPtr angleShard;
         for (phaseShard = targetOfShards.begin(); phaseShard != targetOfShards.end(); phaseShard++) {
             angleShard = phaseShard->second;
-            negAngle1DivPi = ClampAngleDivPi(-angleShard->angle1DivPi);
+            negAngle1DivPi = ClampAngleDivPi(angleShard->angle1DivPi + ONE_R1);
             if (angleShard->angle0DivPi == angleShard->angle1DivPi) {
                 if (angleShard->isInvert) {
                     if (angleShard->angle0DivPi >= ZERO_R1) {

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -330,18 +330,19 @@ public:
 
     void CommuteH()
     {
+        PhaseShardPtr buffer;
         ShardToPhaseMap::iterator phaseShard;
 
         for (phaseShard = targetOfShards.begin(); phaseShard != targetOfShards.end(); phaseShard++) {
-            if (phaseShard->second->isInvert && (abs(phaseShard->second->angle1DivPi) <= FLT_EPSILON)) {
-                phaseShard->second->angle0DivPi = ZERO_R1;
-                phaseShard->second->angle1DivPi = ONE_R1;
-                phaseShard->second->isInvert = false;
-            } else if (!phaseShard->second->isInvert &&
-                (abs(ONE_R1 - phaseShard->second->angle1DivPi) <= FLT_EPSILON)) {
-                phaseShard->second->angle1DivPi = ZERO_R1;
-                phaseShard->second->angle1DivPi = ZERO_R1;
-                phaseShard->second->isInvert = true;
+            buffer = phaseShard->second;
+            if (buffer->isInvert) {
+                buffer->angle0DivPi = ZERO_R1;
+                buffer->angle1DivPi = ONE_R1;
+                buffer->isInvert = false;
+            } else if (!buffer->isInvert) {
+                buffer->angle0DivPi = ZERO_R1;
+                buffer->angle1DivPi = ZERO_R1;
+                buffer->isInvert = true;
             }
         }
     }

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -3033,7 +3033,7 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
     QEngineShard& shard = shards[bitIndex];
     shard.CombineGates();
 
-    real1 angleMinus, anglePlus;
+    real1 angleMinus;
     PhaseShardPtr angleShard;
     QEngineShardPtr partner;
     ShardToPhaseMap::iterator phaseShard;
@@ -3046,15 +3046,14 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
         partner = phaseShard->first;
         bitLenInt target = FindShardIndex(*partner);
 
-        angleMinus = QEngineShard::ClampAngleDivPi(angleShard->angle0DivPi - angleShard->angle1DivPi);
-        anglePlus = QEngineShard::ClampAngleDivPi(angleShard->angle0DivPi + angleShard->angle1DivPi);
+        angleMinus = abs(QEngineShard::ClampAngleDivPi(angleShard->angle0DivPi - angleShard->angle1DivPi));
 
-        if (abs(angleMinus) <= FLT_EPSILON) {
+        if (angleMinus <= FLT_EPSILON) {
             if (angleShard->isInvert) {
                 ApplyBuffer(phaseShard, bitIndex, target);
                 shard.RemovePhaseTarget(partner);
             }
-        } else if (abs(anglePlus) <= FLT_EPSILON) {
+        } else if (abs(ONE_R1 - angleMinus) <= FLT_EPSILON) {
             if (!angleShard->isInvert) {
                 ApplyBuffer(phaseShard, bitIndex, target);
                 shard.RemovePhaseTarget(partner);
@@ -3070,10 +3069,9 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
         partner = phaseShard->first;
         bitLenInt control = FindShardIndex(*partner);
 
-        angleMinus = QEngineShard::ClampAngleDivPi(angleShard->angle0DivPi - angleShard->angle1DivPi);
-        anglePlus = QEngineShard::ClampAngleDivPi(angleShard->angle0DivPi + angleShard->angle1DivPi);
+        angleMinus = abs(QEngineShard::ClampAngleDivPi(angleShard->angle0DivPi - angleShard->angle1DivPi));
 
-        if ((abs(angleMinus) > FLT_EPSILON) && (abs(anglePlus) > FLT_EPSILON)) {
+        if ((angleMinus > FLT_EPSILON) && (abs(ONE_R1 - angleMinus) > FLT_EPSILON)) {
             ApplyBuffer(phaseShard, control, bitIndex);
             shard.RemovePhaseControl(partner);
         }

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -3056,7 +3056,7 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
             continue;
         }
 
-        if (!buffer->isInvert && (abs(ONE_R1 - buffer->angle1DivPi) <= FLT_EPSILON)) {
+        if (!buffer->isInvert && (abs(QEngineShard::ClampAngleDivPi(buffer->angle1DivPi + ONE_R1)) <= FLT_EPSILON)) {
             continue;
         }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -3046,17 +3046,19 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
         partner = phaseShard->first;
         control = FindShardIndex(*partner);
 
-        if (abs(buffer->angle0DivPi) > FLT_EPSILON) {
+        if (buffer->angle0DivPi != ZERO_R1) {
             ApplyBuffer(phaseShard, control, bitIndex);
             shard.RemovePhaseControl(partner);
             continue;
         }
 
-        if (buffer->isInvert && (abs(buffer->angle1DivPi) <= FLT_EPSILON)) {
+        if (buffer->isInvert &&
+            (abs(QEngineShard::ClampAngleDivPi(buffer->angle0DivPi - buffer->angle1DivPi)) <= FLT_EPSILON)) {
             continue;
         }
 
-        if (!buffer->isInvert && ((ONE_R1 - abs(buffer->angle1DivPi)) <= FLT_EPSILON)) {
+        if (!buffer->isInvert &&
+            (abs(QEngineShard::ClampAngleDivPi(buffer->angle0DivPi + buffer->angle1DivPi)) <= FLT_EPSILON)) {
             continue;
         }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -3033,28 +3033,30 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
     QEngineShard& shard = shards[bitIndex];
     shard.CombineGates();
 
-    complex polar0, polar1;
+    real1 negAngle1DivPi;
+    PhaseShardPtr angleShard;
+    QEngineShardPtr partner;
     ShardToPhaseMap::iterator phaseShard;
 
     ShardToPhaseMap controlsShards = shard.controlsShards;
     ShardToPhaseMap targetOfShards = shard.targetOfShards;
 
     for (phaseShard = controlsShards.begin(); phaseShard != controlsShards.end(); phaseShard++) {
-        QEngineShardPtr partner = phaseShard->first;
+        angleShard = phaseShard->second;
+        partner = phaseShard->first;
         bitLenInt target = FindShardIndex(*partner);
 
-        polar0 = std::polar(ONE_R1, (real1)(phaseShard->second->angle0DivPi * M_PI));
-        polar1 = std::polar(ONE_R1, (real1)(phaseShard->second->angle1DivPi * M_PI));
+        negAngle1DivPi = QEngineShard::ClampAngleDivPi(-angleShard->angle1DivPi);
 
-        if (polar0 == polar1) {
-            if (phaseShard->second->isInvert) {
+        if (angleShard->angle0DivPi == angleShard->angle1DivPi) {
+            if (angleShard->isInvert) {
                 ApplyBuffer(phaseShard, bitIndex, target);
-                shard.RemovePhaseTarget(phaseShard->first);
+                shard.RemovePhaseTarget(partner);
             }
-        } else if (polar0 == -polar1) {
-            if (!phaseShard->second->isInvert) {
+        } else if (angleShard->angle0DivPi == negAngle1DivPi) {
+            if (!angleShard->isInvert) {
                 ApplyBuffer(phaseShard, bitIndex, target);
-                shard.RemovePhaseTarget(phaseShard->first);
+                shard.RemovePhaseTarget(partner);
             }
         } else {
             ApplyBuffer(phaseShard, bitIndex, target);
@@ -3063,13 +3065,13 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
     }
 
     for (phaseShard = targetOfShards.begin(); phaseShard != targetOfShards.end(); phaseShard++) {
-        QEngineShardPtr partner = phaseShard->first;
+        angleShard = phaseShard->second;
+        partner = phaseShard->first;
         bitLenInt control = FindShardIndex(*partner);
 
-        polar0 = std::polar(ONE_R1, (real1)(phaseShard->second->angle0DivPi * M_PI));
-        polar1 = std::polar(ONE_R1, (real1)(phaseShard->second->angle1DivPi * M_PI));
+        negAngle1DivPi = QEngineShard::ClampAngleDivPi(-angleShard->angle1DivPi);
 
-        if ((polar0 != polar1) && (polar0 != -polar1)) {
+        if ((angleShard->angle0DivPi != angleShard->angle1DivPi) && (angleShard->angle0DivPi != negAngle1DivPi)) {
             ApplyBuffer(phaseShard, control, bitIndex);
             shard.RemovePhaseControl(partner);
         }

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -3033,7 +3033,7 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
     QEngineShard& shard = shards[bitIndex];
     shard.CombineGates();
 
-    real1 negAngle1DivPi;
+    real1 angleMinus, anglePlus;
     PhaseShardPtr angleShard;
     QEngineShardPtr partner;
     ShardToPhaseMap::iterator phaseShard;
@@ -3046,14 +3046,15 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
         partner = phaseShard->first;
         bitLenInt target = FindShardIndex(*partner);
 
-        negAngle1DivPi = QEngineShard::ClampAngleDivPi(angleShard->angle1DivPi + ONE_R1);
+        angleMinus = QEngineShard::ClampAngleDivPi(angleShard->angle0DivPi - angleShard->angle1DivPi);
+        anglePlus = QEngineShard::ClampAngleDivPi(angleShard->angle0DivPi + angleShard->angle1DivPi);
 
-        if (angleShard->angle0DivPi == angleShard->angle1DivPi) {
+        if (abs(angleMinus) <= FLT_EPSILON) {
             if (angleShard->isInvert) {
                 ApplyBuffer(phaseShard, bitIndex, target);
                 shard.RemovePhaseTarget(partner);
             }
-        } else if (angleShard->angle0DivPi == negAngle1DivPi) {
+        } else if (abs(anglePlus) <= FLT_EPSILON) {
             if (!angleShard->isInvert) {
                 ApplyBuffer(phaseShard, bitIndex, target);
                 shard.RemovePhaseTarget(partner);
@@ -3069,9 +3070,10 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
         partner = phaseShard->first;
         bitLenInt control = FindShardIndex(*partner);
 
-        negAngle1DivPi = QEngineShard::ClampAngleDivPi(angleShard->angle1DivPi + ONE_R1);
+        angleMinus = QEngineShard::ClampAngleDivPi(angleShard->angle0DivPi - angleShard->angle1DivPi);
+        anglePlus = QEngineShard::ClampAngleDivPi(angleShard->angle0DivPi + angleShard->angle1DivPi);
 
-        if ((angleShard->angle0DivPi != angleShard->angle1DivPi) && (angleShard->angle0DivPi != negAngle1DivPi)) {
+        if ((abs(angleMinus) > FLT_EPSILON) && (abs(anglePlus) > FLT_EPSILON)) {
             ApplyBuffer(phaseShard, control, bitIndex);
             shard.RemovePhaseControl(partner);
         }

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -3056,7 +3056,7 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
             continue;
         }
 
-        if (!buffer->isInvert && (abs(QEngineShard::ClampAngleDivPi(buffer->angle1DivPi + ONE_R1)) <= FLT_EPSILON)) {
+        if (!buffer->isInvert && ((ONE_R1 - abs(buffer->angle1DivPi)) <= FLT_EPSILON)) {
             continue;
         }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -3046,7 +3046,7 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
         partner = phaseShard->first;
         bitLenInt target = FindShardIndex(*partner);
 
-        negAngle1DivPi = QEngineShard::ClampAngleDivPi(-angleShard->angle1DivPi);
+        negAngle1DivPi = QEngineShard::ClampAngleDivPi(angleShard->angle1DivPi + ONE_R1);
 
         if (angleShard->angle0DivPi == angleShard->angle1DivPi) {
             if (angleShard->isInvert) {
@@ -3069,7 +3069,7 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
         partner = phaseShard->first;
         bitLenInt control = FindShardIndex(*partner);
 
-        negAngle1DivPi = QEngineShard::ClampAngleDivPi(-angleShard->angle1DivPi);
+        negAngle1DivPi = QEngineShard::ClampAngleDivPi(angleShard->angle1DivPi + ONE_R1);
 
         if ((angleShard->angle0DivPi != angleShard->angle1DivPi) && (angleShard->angle0DivPi != negAngle1DivPi)) {
             ApplyBuffer(phaseShard, control, bitIndex);

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -3031,20 +3031,20 @@ void QUnit::ApplyBuffer(ShardToPhaseMap::iterator phaseShard, const bitLenInt& c
 void QUnit::CommuteH(const bitLenInt& bitIndex)
 {
     QEngineShard& shard = shards[bitIndex];
-    shard.CombineGates();
-    shard.OptimizeControls();
     RevertBasis2Qb(bitIndex, false, true);
 
     ShardToPhaseMap::iterator phaseShard;
     PhaseShardPtr buffer;
     QEngineShardPtr partner;
 
+    bitLenInt control;
+
     ShardToPhaseMap targetOfShards = shard.targetOfShards;
 
     for (phaseShard = targetOfShards.begin(); phaseShard != targetOfShards.end(); phaseShard++) {
         buffer = phaseShard->second;
         partner = phaseShard->first;
-        bitLenInt control = FindShardIndex(*partner);
+        control = FindShardIndex(*partner);
 
         if (abs(buffer->angle0DivPi) > FLT_EPSILON) {
             ApplyBuffer(phaseShard, control, bitIndex);

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -1194,48 +1194,48 @@ TEST_CASE("test_universal_circuit_digital_cross_entropy", "[supreme]")
 
     std::map<bitCapInt, int> testCaseResult;
 
-    for (int iter = 0; iter < ITERATIONS; iter++) {
-        testCase->SetPermutation(0);
-        for (d = 0; d < Depth; d++) {
-            std::vector<int>& layer1QbRands = gate1QbRands[d];
-            for (i = 0; i < layer1QbRands.size(); i++) {
-                int gate1Qb = layer1QbRands[i];
-                if (gate1Qb == 0) {
-                    testCase->H(i);
-                } else if (gate1Qb == 1) {
-                    testCase->X(i);
-                } else if (gate1Qb == 2) {
-                    testCase->Y(i);
-                } else {
-                    testCase->T(i);
-                }
-            }
-
-            std::vector<MultiQubitGate>& layerMultiQbRands = gateMultiQbRands[d];
-            for (i = 0; i < layerMultiQbRands.size(); i++) {
-                MultiQubitGate multiGate = layerMultiQbRands[i];
-                if (multiGate.gate == 0) {
-                    testCase->Swap(multiGate.b1, multiGate.b2);
-                } else if (multiGate.gate == 1) {
-                    testCase->CZ(multiGate.b1, multiGate.b2);
-                } else if (multiGate.gate == 2) {
-                    testCase->CNOT(multiGate.b1, multiGate.b2);
-                } else {
-                    testCase->CCNOT(multiGate.b1, multiGate.b2, multiGate.b3);
-                }
+    // for (int iter = 0; iter < ITERATIONS; iter++) {
+    testCase->SetPermutation(0);
+    for (d = 0; d < Depth; d++) {
+        std::vector<int>& layer1QbRands = gate1QbRands[d];
+        for (i = 0; i < layer1QbRands.size(); i++) {
+            int gate1Qb = layer1QbRands[i];
+            if (gate1Qb == 0) {
+                testCase->H(i);
+            } else if (gate1Qb == 1) {
+                testCase->X(i);
+            } else if (gate1Qb == 2) {
+                testCase->Y(i);
+            } else {
+                testCase->T(i);
             }
         }
 
-        perm = testCase->MReg(0, n);
-        if (testCaseResult.find(perm) == testCaseResult.end()) {
-            testCaseResult[perm] = 1;
-        } else {
-            testCaseResult[perm] += 1;
+        std::vector<MultiQubitGate>& layerMultiQbRands = gateMultiQbRands[d];
+        for (i = 0; i < layerMultiQbRands.size(); i++) {
+            MultiQubitGate multiGate = layerMultiQbRands[i];
+            if (multiGate.gate == 0) {
+                testCase->Swap(multiGate.b1, multiGate.b2);
+            } else if (multiGate.gate == 1) {
+                testCase->CZ(multiGate.b1, multiGate.b2);
+            } else if (multiGate.gate == 2) {
+                testCase->CNOT(multiGate.b1, multiGate.b2);
+            } else {
+                testCase->CCNOT(multiGate.b1, multiGate.b2, multiGate.b3);
+            }
         }
     }
+
+    //    perm = testCase->MReg(0, n);
+    //    if (testCaseResult.find(perm) == testCaseResult.end()) {
+    //        testCaseResult[perm] = 1;
+    //    } else {
+    //        testCaseResult[perm] += 1;
+    //    }
+    //}
     // Comment out the ITERATIONS loop and testCaseResult[perm] update above, and uncomment this line below, for a
     // faster benchmark. This will not test the effect of the MReg() method.
-    // testCaseResult = testCase->MultiShotMeasureMask(qPowers, n, ITERATIONS);
+    testCaseResult = testCase->MultiShotMeasureMask(qPowers, n, ITERATIONS);
 
     crossEntropy = ZERO_R1;
     for (perm = 0; perm < permCount; perm++) {

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -1194,7 +1194,7 @@ TEST_CASE("test_universal_circuit_digital_cross_entropy", "[supreme]")
 
     std::map<bitCapInt, int> testCaseResult;
 
-    //for (int iter = 0; iter < ITERATIONS; iter++) {
+    for (int iter = 0; iter < ITERATIONS; iter++) {
         testCase->SetPermutation(0);
         for (d = 0; d < Depth; d++) {
             std::vector<int>& layer1QbRands = gate1QbRands[d];
@@ -1226,16 +1226,16 @@ TEST_CASE("test_universal_circuit_digital_cross_entropy", "[supreme]")
             }
         }
 
-    //    perm = testCase->MReg(0, n);
-    //    if (testCaseResult.find(perm) == testCaseResult.end()) {
-    //        testCaseResult[perm] = 1;
-    //    } else {
-    //        testCaseResult[perm] += 1;
-    //    }
-    //}
+        perm = testCase->MReg(0, n);
+        if (testCaseResult.find(perm) == testCaseResult.end()) {
+            testCaseResult[perm] = 1;
+        } else {
+            testCaseResult[perm] += 1;
+        }
+    }
     // Comment out the ITERATIONS loop and testCaseResult[perm] update above, and uncomment this line below, for a
     // faster benchmark. This will not test the effect of the MReg() method.
-    testCaseResult = testCase->MultiShotMeasureMask(qPowers, n, ITERATIONS);
+    // testCaseResult = testCase->MultiShotMeasureMask(qPowers, n, ITERATIONS);
 
     crossEntropy = ZERO_R1;
     for (perm = 0; perm < permCount; perm++) {

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -1194,48 +1194,48 @@ TEST_CASE("test_universal_circuit_digital_cross_entropy", "[supreme]")
 
     std::map<bitCapInt, int> testCaseResult;
 
-    // for (int iter = 0; iter < ITERATIONS; iter++) {
-    testCase->SetPermutation(0);
-    for (d = 0; d < Depth; d++) {
-        std::vector<int>& layer1QbRands = gate1QbRands[d];
-        for (i = 0; i < layer1QbRands.size(); i++) {
-            int gate1Qb = layer1QbRands[i];
-            if (gate1Qb == 0) {
-                testCase->H(i);
-            } else if (gate1Qb == 1) {
-                testCase->X(i);
-            } else if (gate1Qb == 2) {
-                testCase->Y(i);
-            } else {
-                testCase->T(i);
+    for (int iter = 0; iter < ITERATIONS; iter++) {
+        testCase->SetPermutation(0);
+        for (d = 0; d < Depth; d++) {
+            std::vector<int>& layer1QbRands = gate1QbRands[d];
+            for (i = 0; i < layer1QbRands.size(); i++) {
+                int gate1Qb = layer1QbRands[i];
+                if (gate1Qb == 0) {
+                    testCase->H(i);
+                } else if (gate1Qb == 1) {
+                    testCase->X(i);
+                } else if (gate1Qb == 2) {
+                    testCase->Y(i);
+                } else {
+                    testCase->T(i);
+                }
+            }
+
+            std::vector<MultiQubitGate>& layerMultiQbRands = gateMultiQbRands[d];
+            for (i = 0; i < layerMultiQbRands.size(); i++) {
+                MultiQubitGate multiGate = layerMultiQbRands[i];
+                if (multiGate.gate == 0) {
+                    testCase->Swap(multiGate.b1, multiGate.b2);
+                } else if (multiGate.gate == 1) {
+                    testCase->CZ(multiGate.b1, multiGate.b2);
+                } else if (multiGate.gate == 2) {
+                    testCase->CNOT(multiGate.b1, multiGate.b2);
+                } else {
+                    testCase->CCNOT(multiGate.b1, multiGate.b2, multiGate.b3);
+                }
             }
         }
 
-        std::vector<MultiQubitGate>& layerMultiQbRands = gateMultiQbRands[d];
-        for (i = 0; i < layerMultiQbRands.size(); i++) {
-            MultiQubitGate multiGate = layerMultiQbRands[i];
-            if (multiGate.gate == 0) {
-                testCase->Swap(multiGate.b1, multiGate.b2);
-            } else if (multiGate.gate == 1) {
-                testCase->CZ(multiGate.b1, multiGate.b2);
-            } else if (multiGate.gate == 2) {
-                testCase->CNOT(multiGate.b1, multiGate.b2);
-            } else {
-                testCase->CCNOT(multiGate.b1, multiGate.b2, multiGate.b3);
-            }
+        perm = testCase->MReg(0, n);
+        if (testCaseResult.find(perm) == testCaseResult.end()) {
+            testCaseResult[perm] = 1;
+        } else {
+            testCaseResult[perm] += 1;
         }
     }
-
-    //    perm = testCase->MReg(0, n);
-    //    if (testCaseResult.find(perm) == testCaseResult.end()) {
-    //        testCaseResult[perm] = 1;
-    //    } else {
-    //        testCaseResult[perm] += 1;
-    //    }
-    //}
     // Comment out the ITERATIONS loop and testCaseResult[perm] update above, and uncomment this line below, for a
     // faster benchmark. This will not test the effect of the MReg() method.
-    testCaseResult = testCase->MultiShotMeasureMask(qPowers, n, ITERATIONS);
+    // testCaseResult = testCase->MultiShotMeasureMask(qPowers, n, ITERATIONS);
 
     crossEntropy = ZERO_R1;
     for (perm = 0; perm < permCount; perm++) {

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -1194,7 +1194,7 @@ TEST_CASE("test_universal_circuit_digital_cross_entropy", "[supreme]")
 
     std::map<bitCapInt, int> testCaseResult;
 
-    for (int iter = 0; iter < ITERATIONS; iter++) {
+    //for (int iter = 0; iter < ITERATIONS; iter++) {
         testCase->SetPermutation(0);
         for (d = 0; d < Depth; d++) {
             std::vector<int>& layer1QbRands = gate1QbRands[d];
@@ -1226,16 +1226,16 @@ TEST_CASE("test_universal_circuit_digital_cross_entropy", "[supreme]")
             }
         }
 
-        perm = testCase->MReg(0, n);
-        if (testCaseResult.find(perm) == testCaseResult.end()) {
-            testCaseResult[perm] = 1;
-        } else {
-            testCaseResult[perm] += 1;
-        }
-    }
+    //    perm = testCase->MReg(0, n);
+    //    if (testCaseResult.find(perm) == testCaseResult.end()) {
+    //        testCaseResult[perm] = 1;
+    //    } else {
+    //        testCaseResult[perm] += 1;
+    //    }
+    //}
     // Comment out the ITERATIONS loop and testCaseResult[perm] update above, and uncomment this line below, for a
     // faster benchmark. This will not test the effect of the MReg() method.
-    // testCaseResult = testCase->MultiShotMeasureMask(qPowers, n, ITERATIONS);
+    testCaseResult = testCase->MultiShotMeasureMask(qPowers, n, ITERATIONS);
 
     crossEntropy = ZERO_R1;
     for (perm = 0; perm < permCount; perm++) {


### PR DESCRIPTION
When I wrote the H/controlled-phase commutation codes, I think I mistook a general set of gates for introducing arbitrary global phase factors, whereas the phase factors are actually non-arbitrary. This works for H/CZ/CNOT, though. I think the absence of a float rounding neighborhood "epsilon" masked the error by effectively only triggering the optimization for H/CZ/CNOT, in the first place.