### PR TITLE
Optimization

### DIFF
--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -405,6 +405,8 @@ public:
         bool useHostMem = false, int deviceId = -1, bool useHardwareRNG = true, bool useSparseStateVec = false,
         real1 norm_thresh = REAL1_DEFAULT_ARG, std::vector<bitLenInt> ignored = {});
 
+    virtual ~QUnit() { Dump(); }
+
     virtual void SetQuantumState(const complex* inputState);
     virtual void GetQuantumState(complex* outputState);
     virtual void GetProbs(real1* outputProbs);

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -591,6 +591,7 @@ public:
     virtual void NormalizeState(real1 nrm = REAL1_DEFAULT_ARG, real1 norm_threshold = REAL1_DEFAULT_ARG);
     virtual void Finish();
     virtual bool isFinished();
+    virtual void Dump();
 
     virtual bool TrySeparate(bitLenInt start, bitLenInt length = 1);
 

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -45,8 +45,8 @@ struct PhaseShard {
     }
 };
 
-#define IS_ARG_0(c) (norm(c - ONE_CMPLX) <= min_norm)
-#define IS_ARG_PI(c) (norm(c + ONE_CMPLX) <= min_norm)
+#define IS_ARG_0(c) (norm(c - ONE_CMPLX) <= amplitudeFloor)
+#define IS_ARG_PI(c) (norm(c + ONE_CMPLX) <= amplitudeFloor)
 
 struct QEngineShard;
 typedef QEngineShard* QEngineShardPtr;
@@ -58,6 +58,7 @@ class QEngineShard : public ParallelFor {
 public:
     QInterfacePtr unit;
     bitLenInt mapped;
+    real1 amplitudeFloor;
     bool isEmulated;
     bool isProbDirty;
     bool isPhaseDirty;
@@ -69,9 +70,10 @@ public:
     // Shards of which this shard is a target
     ShardToPhaseMap targetOfShards;
 
-    QEngineShard()
+    QEngineShard(const real1 amp_thresh = min_norm)
         : unit(NULL)
         , mapped(0)
+        , amplitudeFloor(amp_thresh)
         , isEmulated(false)
         , isProbDirty(false)
         , isPhaseDirty(false)
@@ -83,9 +85,10 @@ public:
     {
     }
 
-    QEngineShard(QInterfacePtr u, const bool& set)
+    QEngineShard(QInterfacePtr u, const bool& set, const real1 amp_thresh = min_norm)
         : unit(u)
         , mapped(0)
+        , amplitudeFloor(amp_thresh)
         , isEmulated(false)
         , isProbDirty(false)
         , isPhaseDirty(false)
@@ -100,9 +103,10 @@ public:
     }
 
     // Dirty state constructor:
-    QEngineShard(QInterfacePtr u, const bitLenInt& mapping)
+    QEngineShard(QInterfacePtr u, const bitLenInt& mapping, const real1 amp_thresh = min_norm)
         : unit(u)
         , mapped(mapping)
+        , amplitudeFloor(amp_thresh)
         , isEmulated(false)
         , isProbDirty(true)
         , isPhaseDirty(true)

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1234,8 +1234,14 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
 {
     QEngineShard& tShard = shards[target];
 
-    if (CACHED_PLUS(tShard)) {
-        return;
+    if (CACHED_PLUS_MINUS(tShard)) {
+        if (IS_NORM_ZERO(tShard.amp1)) {
+            return;
+        }
+        if (IS_NORM_ZERO(tShard.amp0)) {
+            Z(control);
+            return;
+        }
     }
 
     QEngineShard& cShard = shards[control];

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -89,7 +89,7 @@ void QUnit::SetPermutation(bitCapInt perm, complex phaseFac)
 {
     bool bitState;
 
-    Finish();
+    Dump();
 
     for (bitLenInt i = 0; i < qubitCount; i++) {
         bitState = ((perm >> (bitCapIntOcl)i) & ONE_BCI) != 0;
@@ -99,6 +99,8 @@ void QUnit::SetPermutation(bitCapInt perm, complex phaseFac)
 
 void QUnit::SetQuantumState(const complex* inputState)
 {
+    Dump();
+
     QInterfacePtr unit = MakeEngine(qubitCount, 0);
     unit->SetQuantumState(inputState);
 
@@ -2915,6 +2917,14 @@ void QUnit::Finish()
 {
     ParallelUnitApply([](QInterfacePtr unit, real1 unused1, real1 unused2) {
         unit->Finish();
+        return true;
+    });
+}
+
+void QUnit::Dump()
+{
+    ParallelUnitApply([](QInterfacePtr unit, real1 unused1, real1 unused2) {
+        unit.reset();
         return true;
     });
 }

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -1194,48 +1194,48 @@ TEST_CASE("test_universal_circuit_digital_cross_entropy", "[supreme]")
 
     std::map<bitCapInt, int> testCaseResult;
 
-    for (int iter = 0; iter < ITERATIONS; iter++) {
-        testCase->SetPermutation(0);
-        for (d = 0; d < Depth; d++) {
-            std::vector<int>& layer1QbRands = gate1QbRands[d];
-            for (i = 0; i < layer1QbRands.size(); i++) {
-                int gate1Qb = layer1QbRands[i];
-                if (gate1Qb == 0) {
-                    testCase->H(i);
-                } else if (gate1Qb == 1) {
-                    testCase->X(i);
-                } else if (gate1Qb == 2) {
-                    testCase->Y(i);
-                } else {
-                    testCase->T(i);
-                }
-            }
-
-            std::vector<MultiQubitGate>& layerMultiQbRands = gateMultiQbRands[d];
-            for (i = 0; i < layerMultiQbRands.size(); i++) {
-                MultiQubitGate multiGate = layerMultiQbRands[i];
-                if (multiGate.gate == 0) {
-                    testCase->Swap(multiGate.b1, multiGate.b2);
-                } else if (multiGate.gate == 1) {
-                    testCase->CZ(multiGate.b1, multiGate.b2);
-                } else if (multiGate.gate == 2) {
-                    testCase->CNOT(multiGate.b1, multiGate.b2);
-                } else {
-                    testCase->CCNOT(multiGate.b1, multiGate.b2, multiGate.b3);
-                }
+    // for (int iter = 0; iter < ITERATIONS; iter++) {
+    testCase->SetPermutation(0);
+    for (d = 0; d < Depth; d++) {
+        std::vector<int>& layer1QbRands = gate1QbRands[d];
+        for (i = 0; i < layer1QbRands.size(); i++) {
+            int gate1Qb = layer1QbRands[i];
+            if (gate1Qb == 0) {
+                testCase->H(i);
+            } else if (gate1Qb == 1) {
+                testCase->X(i);
+            } else if (gate1Qb == 2) {
+                testCase->Y(i);
+            } else {
+                testCase->T(i);
             }
         }
 
-        perm = testCase->MReg(0, n);
-        if (testCaseResult.find(perm) == testCaseResult.end()) {
-            testCaseResult[perm] = 1;
-        } else {
-            testCaseResult[perm] += 1;
+        std::vector<MultiQubitGate>& layerMultiQbRands = gateMultiQbRands[d];
+        for (i = 0; i < layerMultiQbRands.size(); i++) {
+            MultiQubitGate multiGate = layerMultiQbRands[i];
+            if (multiGate.gate == 0) {
+                testCase->Swap(multiGate.b1, multiGate.b2);
+            } else if (multiGate.gate == 1) {
+                testCase->CZ(multiGate.b1, multiGate.b2);
+            } else if (multiGate.gate == 2) {
+                testCase->CNOT(multiGate.b1, multiGate.b2);
+            } else {
+                testCase->CCNOT(multiGate.b1, multiGate.b2, multiGate.b3);
+            }
         }
     }
+
+    //    perm = testCase->MReg(0, n);
+    //    if (testCaseResult.find(perm) == testCaseResult.end()) {
+    //        testCaseResult[perm] = 1;
+    //    } else {
+    //        testCaseResult[perm] += 1;
+    //    }
+    //}
     // Comment out the ITERATIONS loop and testCaseResult[perm] update above, and uncomment this line below, for a
     // faster benchmark. This will not test the effect of the MReg() method.
-    // testCaseResult = testCase->MultiShotMeasureMask(qPowers, n, ITERATIONS);
+    testCaseResult = testCase->MultiShotMeasureMask(qPowers, n, ITERATIONS);
 
     crossEntropy = ZERO_R1;
     for (perm = 0; perm < permCount; perm++) {

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -1190,52 +1190,52 @@ TEST_CASE("test_universal_circuit_digital_cross_entropy", "[supreme]")
     std::cout << "Gold standard vs. gold standard cross entropy (out of 1.0): " << crossEntropy << std::endl;
 
     QInterfacePtr testCase = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, n, 0, rng,
-        ONE_CMPLX, enable_normalization, true, false, device_id, !disable_hardware_rng, sparse);
+        ONE_CMPLX, false, true, false, device_id, !disable_hardware_rng, sparse);
 
     std::map<bitCapInt, int> testCaseResult;
 
-    // for (int iter = 0; iter < ITERATIONS; iter++) {
-    testCase->SetPermutation(0);
-    for (d = 0; d < Depth; d++) {
-        std::vector<int>& layer1QbRands = gate1QbRands[d];
-        for (i = 0; i < layer1QbRands.size(); i++) {
-            int gate1Qb = layer1QbRands[i];
-            if (gate1Qb == 0) {
-                testCase->H(i);
-            } else if (gate1Qb == 1) {
-                testCase->X(i);
-            } else if (gate1Qb == 2) {
-                testCase->Y(i);
-            } else {
-                testCase->T(i);
+    for (int iter = 0; iter < ITERATIONS; iter++) {
+        testCase->SetPermutation(0);
+        for (d = 0; d < Depth; d++) {
+            std::vector<int>& layer1QbRands = gate1QbRands[d];
+            for (i = 0; i < layer1QbRands.size(); i++) {
+                int gate1Qb = layer1QbRands[i];
+                if (gate1Qb == 0) {
+                    testCase->H(i);
+                } else if (gate1Qb == 1) {
+                    testCase->X(i);
+                } else if (gate1Qb == 2) {
+                    testCase->Y(i);
+                } else {
+                    testCase->T(i);
+                }
+            }
+
+            std::vector<MultiQubitGate>& layerMultiQbRands = gateMultiQbRands[d];
+            for (i = 0; i < layerMultiQbRands.size(); i++) {
+                MultiQubitGate multiGate = layerMultiQbRands[i];
+                if (multiGate.gate == 0) {
+                    testCase->Swap(multiGate.b1, multiGate.b2);
+                } else if (multiGate.gate == 1) {
+                    testCase->CZ(multiGate.b1, multiGate.b2);
+                } else if (multiGate.gate == 2) {
+                    testCase->CNOT(multiGate.b1, multiGate.b2);
+                } else {
+                    testCase->CCNOT(multiGate.b1, multiGate.b2, multiGate.b3);
+                }
             }
         }
 
-        std::vector<MultiQubitGate>& layerMultiQbRands = gateMultiQbRands[d];
-        for (i = 0; i < layerMultiQbRands.size(); i++) {
-            MultiQubitGate multiGate = layerMultiQbRands[i];
-            if (multiGate.gate == 0) {
-                testCase->Swap(multiGate.b1, multiGate.b2);
-            } else if (multiGate.gate == 1) {
-                testCase->CZ(multiGate.b1, multiGate.b2);
-            } else if (multiGate.gate == 2) {
-                testCase->CNOT(multiGate.b1, multiGate.b2);
-            } else {
-                testCase->CCNOT(multiGate.b1, multiGate.b2, multiGate.b3);
-            }
+        perm = testCase->MReg(0, n);
+        if (testCaseResult.find(perm) == testCaseResult.end()) {
+            testCaseResult[perm] = 1;
+        } else {
+            testCaseResult[perm] += 1;
         }
     }
-
-    //    perm = testCase->MReg(0, n);
-    //    if (testCaseResult.find(perm) == testCaseResult.end()) {
-    //        testCaseResult[perm] = 1;
-    //    } else {
-    //        testCaseResult[perm] += 1;
-    //    }
-    //}
     // Comment out the ITERATIONS loop and testCaseResult[perm] update above, and uncomment this line below, for a
     // faster benchmark. This will not test the effect of the MReg() method.
-    testCaseResult = testCase->MultiShotMeasureMask(qPowers, n, ITERATIONS);
+    // testCaseResult = testCase->MultiShotMeasureMask(qPowers, n, ITERATIONS);
 
     crossEntropy = ZERO_R1;
     for (perm = 0; perm < permCount; perm++) {


### PR DESCRIPTION
These are small maintenance tweaks. Consistent with the general convention of QUnit, controlled gate buffer optimizations should switch between relying on exact equality or rounding based on whether the "normalization" options is on. In CNOT, if the target bit is in the |-> state, then the gate can be optimized as equivalent to a Z() on the control. When QUnit implicitly dumps its shared_ptr instances for "shards," it's better to explicitly `Dump()` them.