### PR TITLE
Remove QUnit::CommutePhase

### DIFF
--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -307,6 +307,23 @@ public:
         });
     }
 
+    void RemoveTargetIdentityBuffers()
+    {
+        PhaseShardPtr buffer;
+        ShardToPhaseMap::iterator phaseShard = targetOfShards.begin();
+
+        while (phaseShard != targetOfShards.end()) {
+            buffer = phaseShard->second;
+            if (!buffer->isInvert && IS_ARG_0(buffer->cmplx0) && IS_ARG_0(buffer->cmplx1)) {
+                // The buffer is equal to the identity operator, and it can be removed.
+                phaseShard->first->controlsShards.erase(this);
+                targetOfShards.erase(phaseShard);
+            } else {
+                phaseShard++;
+            }
+        }
+    }
+
     void CommutePhase(const complex& topLeft, const complex& bottomRight)
     {
         ShardToPhaseMap::iterator phaseShard;
@@ -328,6 +345,8 @@ public:
             phaseShard->second->cmplx0 *= topLeft / bottomRight;
             phaseShard->second->cmplx1 *= bottomRight / topLeft;
         });
+
+        RemoveTargetIdentityBuffers();
     }
 
     void CommuteH()
@@ -352,19 +371,7 @@ public:
             }
         });
 
-        PhaseShardPtr buffer;
-        ShardToPhaseMap::iterator phaseShard = targetOfShards.begin();
-
-        while (phaseShard != targetOfShards.end()) {
-            buffer = phaseShard->second;
-            if (!buffer->isInvert && IS_ARG_0(buffer->cmplx0) && IS_ARG_0(buffer->cmplx1)) {
-                // The buffer is equal to the identity operator, and it can be removed.
-                phaseShard->first->controlsShards.erase(this);
-                targetOfShards.erase(phaseShard);
-            } else {
-                phaseShard++;
-            }
-        }
+        RemoveTargetIdentityBuffers();
     }
 
     bool operator==(const QEngineShard& rhs) { return (mapped == rhs.mapped) && (unit == rhs.unit); }

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -324,31 +324,6 @@ public:
         }
     }
 
-    void CommutePhase(const complex& topLeft, const complex& bottomRight)
-    {
-        ShardToPhaseMap::iterator phaseShard;
-
-        // These cases cannot be handled:
-        // for (phaseShard = controlsShards.begin(); phaseShard != controlsShards.end(); phaseShard++) {
-        //    if (phaseShard->second->isInvert) {
-        //        return false;
-        //    }
-        //}
-
-        par_for(0, targetOfShards.size(), [&](const bitCapInt lcv, const int cpu) {
-            ShardToPhaseMap::iterator phaseShard = targetOfShards.begin();
-            std::advance(phaseShard, lcv);
-            if (!phaseShard->second->isInvert) {
-                return;
-            }
-
-            phaseShard->second->cmplx0 *= topLeft / bottomRight;
-            phaseShard->second->cmplx1 *= bottomRight / topLeft;
-        });
-
-        RemoveTargetIdentityBuffers();
-    }
-
     void CommuteH()
     {
         // See QUnit::CommuteH() for which cases cannot be commuted and are flushed.
@@ -760,13 +735,6 @@ protected:
             RevertBasis2Qb(i, true, false, {}, {}, true);
         }
     }
-    void PopHBasis2Qb(const bitLenInt& i)
-    {
-        QEngineShard& shard = shards[i];
-        if (shard.isPlusMinus && ((shard.targetOfShards.size() != 0) || (shard.controlsShards.size() != 0))) {
-            TransformBasis1Qb(false, i);
-        }
-    }
 
     void CheckShardSeparable(const bitLenInt& target);
 
@@ -856,12 +824,6 @@ protected:
     {
         RevertBasis2Qb(target, false, true);
         shards[target].FlipPhaseAnti();
-    }
-
-    void CommutePhase(const bitLenInt& target, const complex& topLeft, const complex& bottomRight)
-    {
-        RevertBasis2Qb(target, true, true);
-        shards[target].CommutePhase(topLeft, bottomRight);
     }
 
     void CommuteH(const bitLenInt& bitIndex);

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1098,7 +1098,8 @@ void QUnit::X(bitLenInt target)
 
 void QUnit::Z(bitLenInt target)
 {
-    CommutePhase(target, ONE_CMPLX, -ONE_CMPLX);
+    // TODO: Find commutation rules:
+    RevertBasis2Qb(target);
 
     if (!shards[target].isPlusMinus) {
         ZBase(target);
@@ -1379,7 +1380,8 @@ void QUnit::ApplySinglePhase(const complex topLeft, const complex bottomRight, b
 {
     QEngineShard& shard = shards[target];
 
-    CommutePhase(target, topLeft, bottomRight);
+    // TODO: Find commutation rules:
+    RevertBasis2Qb(target);
 
     if (!shard.isPlusMinus) {
         // If the target bit is in a |0>/|1> eigenstate, this gate has no effect.

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -3040,6 +3040,12 @@ void QUnit::ApplyBuffer(ShardToPhaseMap::iterator phaseShard, const bitLenInt& c
         freezeBasis = false;
         shards[target].isPlusMinus = true;
     } else {
+        real1 ampThreshold = doNormalize ? amplitudeFloor : ZERO_R1;
+        if (!phaseShard->second->isInvert && (norm(polar0 - ONE_CMPLX) <= ampThreshold) &&
+            (norm(polar1 - ONE_CMPLX) <= ampThreshold)) {
+            return;
+        }
+
         freezeBasis = true;
         if (phaseShard->second->isInvert) {
             ApplyControlledSingleInvert(controls, 1U, target, polar0, polar1);

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -1190,7 +1190,7 @@ TEST_CASE("test_universal_circuit_digital_cross_entropy", "[supreme]")
     std::cout << "Gold standard vs. gold standard cross entropy (out of 1.0): " << crossEntropy << std::endl;
 
     QInterfacePtr testCase = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, n, 0, rng,
-        ONE_CMPLX, false, true, false, device_id, !disable_hardware_rng, sparse);
+        ONE_CMPLX, enable_normalization, true, false, device_id, !disable_hardware_rng, sparse);
 
     std::map<bitCapInt, int> testCaseResult;
 


### PR DESCRIPTION
For a reason that isn't clear to me, QUnit::CommutePhase() seems to have incorrect edge cases. It will be replaced, but, pending refactor, I'm removing it, as speed doesn't matter if logic is wrong.