### PR TITLE
Fix Apple build support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,11 @@ add_library (qrack_pinvoke SHARED
 if (MSVC)
     set(QRACK_LIBS qrack)
 else (MSVC)
-    set(QRACK_LIBS qrack pthread atomic)
+    if (APPLE)
+        set(QRACK_LIBS qrack pthread)
+    else (APPLE)
+        set(QRACK_LIBS qrack pthread atomic)
+    endif (APPLE)
 endif (MSVC)
 
 target_link_libraries (qrack_pinvoke ${QRACK_LIBS})

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -48,7 +48,7 @@ struct PhaseShard {
 #define IS_ARG_0(c) (norm(c - ONE_CMPLX) <= amplitudeFloor)
 #define IS_ARG_PI(c) (norm(c + ONE_CMPLX) <= amplitudeFloor)
 
-struct QEngineShard;
+class QEngineShard;
 typedef QEngineShard* QEngineShardPtr;
 typedef std::shared_ptr<PhaseShard> PhaseShardPtr;
 typedef std::map<QEngineShardPtr, PhaseShardPtr> ShardToPhaseMap;

--- a/include/qunitmulti.hpp
+++ b/include/qunitmulti.hpp
@@ -98,7 +98,7 @@ public:
 protected:
     virtual std::vector<QEngineInfo> GetQInfos();
 
-    virtual void SeparateBit(bool value, bitLenInt qubit);
+    virtual void SeparateBit(bool value, bitLenInt qubit, bool doDispose = true);
 
     virtual void Detach(bitLenInt start, bitLenInt length, QUnitPtr dest)
     {

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -324,7 +324,7 @@ void QEngineOCL::SetDevice(const int& dID, const bool& forceReInit)
 
     complex* nStateVec = NULL;
 
-#if defined(_WIN32) && !defined(__CYGWIN__)
+#if (defined(_WIN32) && !defined(__CYGWIN__)) || defined(__APPLE__)
         bool isSameContext = (dID == deviceID);
 #else
         bool isSameContext = (context == OCLEngine::Instance()->GetDeviceContextPtr(dID)->context);
@@ -934,7 +934,7 @@ void QEngineOCL::Compose(OCLAPI apiCall, bitCapIntOcl* bciArgs, QEngineOCLPtr to
     BufferPtr otherStateBuffer;
     complex* otherStateVec;
 
-#if defined(_WIN32) && !defined(__CYGWIN__)
+#if (defined(_WIN32) && !defined(__CYGWIN__)) || defined(__APPLE__)
     bool isSameContext = (toCopy->GetDeviceID() == GetDeviceID());
 #else
     bool isSameContext = (toCopy->context == context);
@@ -1017,7 +1017,7 @@ void QEngineOCL::DecomposeDispose(bitLenInt start, bitLenInt length, QEngineOCLP
         NormalizeState();
     }
 
-#if defined(_WIN32) && !defined(__CYGWIN__)
+#if (defined(_WIN32) && !defined(__CYGWIN__)) || defined(__APPLE__)
     bool isSameContext = !destination || (destination->GetDeviceID() == GetDeviceID());
 #else
     bool isSameContext = !destination || (destination->context == context);
@@ -2239,7 +2239,7 @@ bool QEngineOCL::ApproxCompare(QEngineOCLPtr toCompare)
 
     DISPATCH_WRITE(waitVec, *(poolItem->ulongBuffer), sizeof(bitCapIntOcl), bciArgs);
 
-#if defined(_WIN32) && !defined(__CYGWIN__)
+#if (defined(_WIN32) && !defined(__CYGWIN__)) || defined(__APPLE__)
     bool isSameContext = (toCompare->GetDeviceID() == GetDeviceID());
 #else
     bool isSameContext = (toCompare->context == context);

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -324,11 +324,8 @@ void QEngineOCL::SetDevice(const int& dID, const bool& forceReInit)
 
     complex* nStateVec = NULL;
 
-#if (defined(_WIN32) && !defined(__CYGWIN__)) || defined(__APPLE__)
-        bool isSameContext = (dID == deviceID);
-#else
-        bool isSameContext = (context == OCLEngine::Instance()->GetDeviceContextPtr(dID)->context);
-#endif
+    bool isSameContext = (device_context == NULL) ||
+        (device_context->context_id == OCLEngine::Instance()->GetDeviceContextPtr(dID)->context_id);
 
     if (didInit) {
         // If we're "switching" to the device we already have, don't reinitialize.
@@ -934,11 +931,7 @@ void QEngineOCL::Compose(OCLAPI apiCall, bitCapIntOcl* bciArgs, QEngineOCLPtr to
     BufferPtr otherStateBuffer;
     complex* otherStateVec;
 
-#if (defined(_WIN32) && !defined(__CYGWIN__)) || defined(__APPLE__)
-    bool isSameContext = (toCopy->GetDeviceID() == GetDeviceID());
-#else
-    bool isSameContext = (toCopy->context == context);
-#endif
+    bool isSameContext = (toCopy->device_context->context_id == device_context->context_id);
 
     if (!isSameContext) {
         toCopy->LockSync(CL_MAP_READ);
@@ -1017,11 +1010,7 @@ void QEngineOCL::DecomposeDispose(bitLenInt start, bitLenInt length, QEngineOCLP
         NormalizeState();
     }
 
-#if (defined(_WIN32) && !defined(__CYGWIN__)) || defined(__APPLE__)
-    bool isSameContext = !destination || (destination->GetDeviceID() == GetDeviceID());
-#else
-    bool isSameContext = !destination || (destination->context == context);
-#endif
+    bool isSameContext = !destination || (destination->device_context->context_id == device_context->context_id);
 
     if (length == qubitCount) {
         if (destination != NULL) {
@@ -2239,11 +2228,7 @@ bool QEngineOCL::ApproxCompare(QEngineOCLPtr toCompare)
 
     DISPATCH_WRITE(waitVec, *(poolItem->ulongBuffer), sizeof(bitCapIntOcl), bciArgs);
 
-#if (defined(_WIN32) && !defined(__CYGWIN__)) || defined(__APPLE__)
-    bool isSameContext = (toCompare->GetDeviceID() == GetDeviceID());
-#else
-    bool isSameContext = (toCompare->context == context);
-#endif
+    bool isSameContext = (toCompare->device_context->context_id == device_context->context_id);
 
     BufferPtr otherStateBuffer;
     complex* otherStateVec;

--- a/src/qunitmulti.cpp
+++ b/src/qunitmulti.cpp
@@ -214,9 +214,9 @@ bool QUnitMulti::TrySeparate(bitLenInt start, bitLenInt length)
     return toRet;
 }
 
-void QUnitMulti::SeparateBit(bool value, bitLenInt qubit)
+void QUnitMulti::SeparateBit(bool value, bitLenInt qubit, bool doDispose)
 {
-    QUnit::SeparateBit(value, qubit);
+    QUnit::SeparateBit(value, qubit, doDispose);
     RedistributeQEngines();
 }
 

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -505,7 +505,6 @@ TEST_CASE("test_universal_circuit_continuous", "[supreme]")
             bitLenInt i;
             real1 theta, phi, lambda;
             bitLenInt b1, b2;
-            complex polar0;
 
             for (d = 0; d < Depth; d++) {
 
@@ -554,7 +553,6 @@ TEST_CASE("test_universal_circuit_discrete", "[supreme]")
             bitLenInt i;
             real1 gateRand;
             bitLenInt b1, b2, b3;
-            complex polar0;
             int maxGates;
 
             for (d = 0; d < Depth; d++) {
@@ -613,7 +611,6 @@ TEST_CASE("test_universal_circuit_digital", "[supreme]")
             bitLenInt i;
             real1 gateRand;
             bitLenInt b1, b2, b3;
-            complex polar0;
             int maxGates;
 
             for (d = 0; d < Depth; d++) {
@@ -1065,7 +1062,6 @@ TEST_CASE("test_universal_circuit_digital_cross_entropy", "[supreme]")
     bitLenInt i;
     std::vector<std::vector<int>> gate1QbRands(Depth);
     std::vector<std::vector<MultiQubitGate>> gateMultiQbRands(Depth);
-    complex polar0;
     int maxGates;
 
     QInterfacePtr goldStandard = CreateQuantumInterface(testSubSubEngineType, n, 0, rng, ONE_CMPLX,


### PR DESCRIPTION
Recent updates broke Windows and Apple build support. We seem to have fixed Windows builds last night, but this fixes Apple builds. Also, it's better to check the context ID we set up in `OCLEngine` for whether buffers can be reused or shared, rather than the Windows kludge we put in last night.