### PR TITLE
Fix Qiskit version in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ install:
   - sudo apt-get update
   - sudo apt-get install linuxdoc-tools linuxdoc-tools-info binutils-mingw-w64-i686 gcc-mingw-w64-i686 sshpass cmake
   - python -m pip install --upgrade pip numpy setuptools==45 wheel
-  - python -m pip install cvxpy cython stestr qiskit pennylane
+  - python -m pip install cvxpy cython stestr qiskit=0.18.3 pennylane
 script:
   - mkdir _build && cd _build && cmake -DENABLE_OPENCL=OFF -DENABLE_COMPLEX8=OFF .. && make -j 8 all
   - sudo make install

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ install:
   - sudo apt-get update
   - sudo apt-get install linuxdoc-tools linuxdoc-tools-info binutils-mingw-w64-i686 gcc-mingw-w64-i686 sshpass cmake
   - python -m pip install --upgrade pip numpy setuptools==45 wheel
-  - python -m pip install cvxpy cython stestr qiskit=0.18.3 pennylane
+  - python -m pip install cvxpy cython stestr qiskit==0.18.3 pennylane
 script:
   - mkdir _build && cd _build && cmake -DENABLE_OPENCL=OFF -DENABLE_COMPLEX8=OFF .. && make -j 8 all
   - sudo make install


### PR DESCRIPTION
Qiskit released a tag at pretty much the same moment as us, and their CI build is broken. (Of course!) I believe the just-previous release should be fine, for now.