### PR TITLE
Swap variant optimizations; "quantum supremacy" cross entropy unit test

### DIFF
--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -208,17 +208,6 @@ public:
         targetOfShard->cmplx1 = nCmplx1;
     }
 
-    void AddInversionAngles(QEngineShardPtr control, const complex& cmplx0, const complex& cmplx1)
-    {
-        MakePhaseControlledBy(control);
-
-        PhaseShardPtr targetOfShard = targetOfShards[control];
-        targetOfShard->isInvert = !targetOfShard->isInvert;
-        std::swap(targetOfShard->cmplx0, targetOfShard->cmplx1);
-
-        AddPhaseAngles(control, cmplx0, cmplx1);
-    }
-
     /// Take ambiguous control/target operations, and reintrepret them as targeting this bit
     void OptimizeControls()
     {
@@ -273,14 +262,14 @@ public:
             if (!buffer1->isInvert && IS_ARG_0(buffer1->cmplx0)) {
                 partnerAngle = buffer1->cmplx1;
 
-                phaseShard->first->targetOfShards.erase(this);
+                partner->targetOfShards.erase(this);
                 controlsShards.erase(partner);
 
                 AddPhaseAngles(partner, ONE_CMPLX, partnerAngle);
             } else if (!buffer2->isInvert && IS_ARG_0(buffer2->cmplx0)) {
                 partnerAngle = buffer2->cmplx1;
 
-                phaseShard->first->controlsShards.erase(this);
+                partner->controlsShards.erase(this);
                 targetOfShards.erase(partner);
 
                 partner->AddPhaseAngles(this, ONE_CMPLX, partnerAngle);

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -788,7 +788,7 @@ void QUnit::SqrtSwap(bitLenInt qubit1, bitLenInt qubit2)
     QEngineShard& shard1 = shards[qubit1];
     QEngineShard& shard2 = shards[qubit2];
 
-    if (USAFE_CACHED_CLASSICAL(shard1) && UNSAFE_CACHED_CLASSICAL(shard2) &&
+    if (UNSAFE_CACHED_CLASSICAL(shard1) && UNSAFE_CACHED_CLASSICAL(shard2) &&
         (SHARD_STATE(shard1) == SHARD_STATE(shard2))) {
         // We can avoid dirtying the cache and entangling, since this gate doesn't swap identical classical bits.
         return;

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -746,13 +746,13 @@ void QUnit::ISwap(bitLenInt qubit1, bitLenInt qubit2)
         return;
     }
 
-    RevertBasis2Qb(qubit1);
-    RevertBasis2Qb(qubit2);
+    RevertBasis2Qb(qubit1, true);
+    RevertBasis2Qb(qubit2, true);
 
     QEngineShard& shard1 = shards[qubit1];
     QEngineShard& shard2 = shards[qubit2];
 
-    if (CACHED_CLASSICAL(shard1) && CACHED_CLASSICAL(shard2)) {
+    if (UNSAFE_CACHED_CLASSICAL(shard1) && UNSAFE_CACHED_CLASSICAL(shard2)) {
         // We can avoid dirtying the cache and entangling, since the bits are classical.
         if (SHARD_STATE(shard1) != SHARD_STATE(shard2)) {
             Swap(qubit1, qubit2);
@@ -782,13 +782,14 @@ void QUnit::SqrtSwap(bitLenInt qubit1, bitLenInt qubit2)
         return;
     }
 
-    RevertBasis2Qb(qubit1);
-    RevertBasis2Qb(qubit2);
+    RevertBasis2Qb(qubit1, true);
+    RevertBasis2Qb(qubit2, true);
 
     QEngineShard& shard1 = shards[qubit1];
     QEngineShard& shard2 = shards[qubit2];
 
-    if (CACHED_CLASSICAL(shard1) && CACHED_CLASSICAL(shard2) && (SHARD_STATE(shard1) == SHARD_STATE(shard2))) {
+    if (USAFE_CACHED_CLASSICAL(shard1) && UNSAFE_CACHED_CLASSICAL(shard2) &&
+        (SHARD_STATE(shard1) == SHARD_STATE(shard2))) {
         // We can avoid dirtying the cache and entangling, since this gate doesn't swap identical classical bits.
         return;
     }
@@ -810,13 +811,14 @@ void QUnit::ISqrtSwap(bitLenInt qubit1, bitLenInt qubit2)
         return;
     }
 
-    RevertBasis2Qb(qubit1);
-    RevertBasis2Qb(qubit2);
+    RevertBasis2Qb(qubit1, true);
+    RevertBasis2Qb(qubit2, true);
 
     QEngineShard& shard1 = shards[qubit1];
     QEngineShard& shard2 = shards[qubit2];
 
-    if (CACHED_CLASSICAL(shard1) && CACHED_CLASSICAL(shard2) && (SHARD_STATE(shard1) == SHARD_STATE(shard2))) {
+    if (UNSAFE_CACHED_CLASSICAL(shard1) && UNSAFE_CACHED_CLASSICAL(shard2) &&
+        (SHARD_STATE(shard1) == SHARD_STATE(shard2))) {
         // We can avoid dirtying the cache and entangling, since this gate doesn't swap identical classical bits.
         return;
     }
@@ -961,7 +963,6 @@ void QUnit::X(bitLenInt target)
 
 void QUnit::Z(bitLenInt target)
 {
-    // TODO: Find commutation rules:
     RevertBasis2Qb(target, true);
 
     QEngineShard& shard = shards[target];
@@ -1256,7 +1257,6 @@ void QUnit::ApplySinglePhase(const complex topLeft, const complex bottomRight, b
 
     QEngineShard& shard = shards[target];
 
-    // TODO: Find commutation rules:
     RevertBasis2Qb(target, true);
 
     if (IS_ONE_CMPLX(topLeft) && UNSAFE_CACHED_ZERO(shard)) {

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -12,6 +12,7 @@
 
 #include <atomic>
 #include <iostream>
+#include <list>
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -4747,7 +4747,7 @@ TEST_CASE("test_quantum_supremacy_cross_entropy", "[supreme]")
 
     const int TRIALS = 200;
     const int ITERATIONS = 60000;
-    const int n = 8;
+    const int n = 9;
     bitCapInt permCount = pow2(n);
     bitCapInt perm;
 


### PR DESCRIPTION
It seemed like the optimizations of #333 could easily be extended to `SWAP` variants, but I hesitated to try this for worry over invalidating the "quantum supremacy" benchmark, without sufficient tests. Herein, we add a cross entropy unit test of the "quantum supremacy" test, so we can keep tabs on whether optimizations change those measurement distribution outcomes, (which they should never do). (Additionally, one can switch `SWAP` variants into the more general `test_universal_circuit_digital_cross_entropy`, which I have also tried.)

It looks like we're all good. This is also a modular test of the cross entropy of `QUnit` against `QEngine` for the "quantum supremacy" circuits in general. It's not necessarily granted that width and depth will scale for a hardware test, but I think it's easier to grant that for a simulator. Assuming we've correctly translated the description of the test in the original paper into Qrack circuits, I can't see any other reason we have not proven Google's claims wrong.