### PR TITLE
Flush H buffers before swap variant optimization checks

### DIFF
--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -746,6 +746,8 @@ void QUnit::ISwap(bitLenInt qubit1, bitLenInt qubit2)
         return;
     }
 
+    TransformBasis1Qb(false, qubit1);
+    TransformBasis1Qb(false, qubit2);
     RevertBasis2Qb(qubit1, true);
     RevertBasis2Qb(qubit2, true);
 
@@ -782,6 +784,8 @@ void QUnit::SqrtSwap(bitLenInt qubit1, bitLenInt qubit2)
         return;
     }
 
+    TransformBasis1Qb(false, qubit1);
+    TransformBasis1Qb(false, qubit2);
     RevertBasis2Qb(qubit1, true);
     RevertBasis2Qb(qubit2, true);
 
@@ -811,6 +815,8 @@ void QUnit::ISqrtSwap(bitLenInt qubit1, bitLenInt qubit2)
         return;
     }
 
+    TransformBasis1Qb(false, qubit1);
+    TransformBasis1Qb(false, qubit2);
     RevertBasis2Qb(qubit1, true);
     RevertBasis2Qb(qubit2, true);
 


### PR DESCRIPTION
H gate buffers will ultimately be flushed anyway, if swap variant optimization checks fail, so it makes sense to flush them 1) before the "shards" become more entangled due to flushed controlled phase gate buffers and 2) when they have some chance of triggering an optimized case check.