### PR TITLE
Add CCZ API

### DIFF
--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -769,6 +769,14 @@ public:
     virtual void CZ(bitLenInt control, bitLenInt target);
 
     /**
+     * Doubly-Controlled Z gate
+     *
+     * If both "control" bits are set to 1, then the Pauli "Z" operator is applied
+     * to "target."
+     */
+    virtual void CCZ(bitLenInt control1, bitLenInt control2, bitLenInt target);
+
+    /**
      * Controlled S gate
      *
      * If the "control" bit is set to 1, then the S gate is applied
@@ -1394,6 +1402,14 @@ public:
      * to "target."
      */
     virtual void CZ(bitLenInt control, bitLenInt target, bitLenInt length);
+
+    /**
+     * Bitwise doubly-controlled Z gate
+     *
+     * If both "control" bits are set to 1, then the Pauli "Z" operator is applied
+     * to "target."
+     */
+    virtual void CCZ(bitLenInt control1, bitLenInt control2, bitLenInt target, bitLenInt length);
 
     /**
      * Bitwise controlled S gate

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -446,6 +446,8 @@ public:
     virtual void AntiCCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target);
     using QInterface::CZ;
     virtual void CZ(bitLenInt control, bitLenInt target);
+    using QInterface::CCZ;
+    virtual void CCZ(bitLenInt control1, bitLenInt control2, bitLenInt target);
 
     virtual void ApplySinglePhase(const complex topLeft, const complex bottomRight, bitLenInt qubitIndex);
     virtual void ApplySingleInvert(const complex topRight, const complex bottomLeft, bitLenInt qubitIndex);

--- a/src/qinterface/gates.cpp
+++ b/src/qinterface/gates.cpp
@@ -205,6 +205,13 @@ void QInterface::CZ(bitLenInt control, bitLenInt target)
     ApplyControlledSinglePhase(controls, 1, target, ONE_CMPLX, -ONE_CMPLX);
 }
 
+/// Apply doubly-controlled Pauli Z matrix to bit
+void QInterface::CCZ(bitLenInt control1, bitLenInt control2, bitLenInt target)
+{
+    bitLenInt controls[2] = { control1, control2 };
+    ApplyControlledSinglePhase(controls, 2, target, ONE_CMPLX, -ONE_CMPLX);
+}
+
 /// Doubly-controlled not
 void QInterface::CCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target)
 {

--- a/src/qinterface/qinterface.cpp
+++ b/src/qinterface/qinterface.cpp
@@ -107,6 +107,9 @@ REG_GATE_2(SqrtSwap);
 /// Bit-wise apply inverse square root of swap to two registers
 REG_GATE_2(ISqrtSwap);
 
+/// Bit-wise apply doubly-controlled-z to two control registers and one target register
+REG_GATE_C2_1(CCZ);
+
 /// Bit-wise apply "anti-"controlled-not to two control registers and one target register
 REG_GATE_C2_1(AntiCCNOT);
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -977,11 +977,6 @@ void QUnit::Z(bitLenInt target)
         return;
     }
 
-    if (UNSAFE_CACHED_ONE(shard)) {
-        PhaseFlip();
-        return;
-    }
-
     RevertBasis2Qb(target);
 
     if (!shard.isPlusMinus) {

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -789,7 +789,7 @@ TEST_CASE("test_ccz_h", "[supreme]")
 
                     if (gateRand < ONE_R1) {
                         qReg->Swap(b1, b2);
-                    } else if (gateRand < (2 * ONE_R1)) {
+                    } else if ((gateRand < (2 * ONE_R1)) || (maxGates < 3)) {
                         qReg->CZ(b1, b2);
                     } else {
                         b3 = pickRandomBit(qReg, &unusedBits);


### PR DESCRIPTION
It's become cumbersome not to have `CCZ` as a primitive. Also, a benchmark has been added based on the { H, Z, CZ, CCZ } set, (which I believe is universal).