### PR TITLE
Debugging buffered "inversion" gates

### DIFF
--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -876,14 +876,19 @@ protected:
 
     void FlipPhaseAnti(const bitLenInt& target)
     {
-        RevertBasis2Qb(target);
-        // shards[target].FlipPhaseAnti();
+        if (shards[target].IsInvert()) {
+            RevertBasis2Qb(target);
+            return;
+        }
+
+        RevertBasis2Qb(target, NONEXCLUSIVE, true);
+        shards[target].FlipPhaseAnti();
     }
 
     void CommutePhase(const bitLenInt& target, const complex& topLeft, const complex& bottomRight)
     {
-        RevertBasis2Qb(target);
-        // shards[target].CommutePhase(topLeft, bottomRight);
+        RevertBasis2Qb(target, ONLY_INVERT, true);
+        shards[target].CommutePhase(topLeft, bottomRight);
     }
 
     void CommuteH(const bitLenInt& bitIndex);

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -720,10 +720,11 @@ protected:
 
     void ApplyBuffer(ShardToPhaseMap::iterator phaseShard, const bitLenInt& control, const bitLenInt& target);
 
-    enum RevertExclusivity { NONEXCLUSIVE = 0, ONLY_INVERT = 1, ONLY_PHASE = 2 };
+    enum RevertExclusivity { INVERT_AND_PHASE = 0, ONLY_INVERT = 1, ONLY_PHASE = 2 };
+    enum RevertControl { CONTROLS_AND_TARGETS = 0, ONLY_CONTROLS = 1, ONLY_TARGETS = 2 };
 
-    void RevertBasis2Qb(const bitLenInt& i, const RevertExclusivity& exclusivity = NONEXCLUSIVE,
-        const bool& onlyControlling = false, std::set<bitLenInt> exceptControlling = {},
+    void RevertBasis2Qb(const bitLenInt& i, const RevertExclusivity& exclusivity = INVERT_AND_PHASE,
+        const RevertControl& controlExclusivity = CONTROLS_AND_TARGETS, std::set<bitLenInt> exceptControlling = {},
         std::set<bitLenInt> exceptTargetedBy = {}, const bool& dumpSkipped = false);
     void ToPermBasis(const bitLenInt& i)
     {
@@ -760,7 +761,7 @@ protected:
         }
         for (i = 0; i < length; i++) {
             RevertBasis2Qb(start + i, ONLY_INVERT);
-            RevertBasis2Qb(start + i, NONEXCLUSIVE, false, exceptBits, exceptBits, true);
+            RevertBasis2Qb(start + i, INVERT_AND_PHASE, CONTROLS_AND_TARGETS, exceptBits, exceptBits, true);
         }
     }
     void ToPermBasisAllMeasure()
@@ -770,7 +771,7 @@ protected:
             TransformBasis1Qb(i, false);
         }
         for (i = 0; i < qubitCount; i++) {
-            RevertBasis2Qb(i, ONLY_INVERT, false, {}, {}, true);
+            RevertBasis2Qb(i, ONLY_INVERT, CONTROLS_AND_TARGETS, {}, {}, true);
         }
     }
 
@@ -861,7 +862,7 @@ protected:
     void FlipPhaseAnti(const bitLenInt& target)
     {
         RevertBasis2Qb(target, ONLY_INVERT);
-        RevertBasis2Qb(target, NONEXCLUSIVE, true);
+        RevertBasis2Qb(target, INVERT_AND_PHASE, ONLY_CONTROLS);
         shards[target].FlipPhaseAnti();
     }
 

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -165,6 +165,21 @@ public:
         }
     }
 
+    void DumpBuffers()
+    {
+        ShardToPhaseMap::iterator phaseShard = targetOfShards.begin();
+        while (phaseShard != targetOfShards.end()) {
+            RemovePhaseControl(phaseShard->first);
+            phaseShard = targetOfShards.begin();
+        }
+
+        phaseShard = controlsShards.begin();
+        while (phaseShard != controlsShards.end()) {
+            RemovePhaseTarget(phaseShard->first);
+            phaseShard = controlsShards.begin();
+        }
+    }
+
     /// Initialize a phase gate buffer, with "this" as target bit and a another qubit "p" as control
     void MakePhaseControlledBy(QEngineShardPtr p)
     {

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -214,7 +214,7 @@ public:
 
         PhaseShardPtr targetOfShard = targetOfShards[control];
         targetOfShard->isInvert = !targetOfShard->isInvert;
-        std::swap(targetOfShard->cmplx0, targetOfShard->cmplx0);
+        std::swap(targetOfShard->cmplx0, targetOfShard->cmplx1);
 
         AddPhaseAngles(control, cmplx0, cmplx1);
     }

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -346,6 +346,26 @@ public:
         RemoveTargetIdentityBuffers();
     }
 
+    bool IsInvertControlOf(QEngineShardPtr target)
+    {
+        ShardToPhaseMap::iterator phaseShard = controlsShards.find(target);
+        if (phaseShard != controlsShards.end()) {
+            return phaseShard->second->isInvert;
+        }
+
+        return false;
+    }
+
+    bool IsInvertTargetOf(QEngineShardPtr control)
+    {
+        ShardToPhaseMap::iterator phaseShard = targetOfShards.find(control);
+        if (phaseShard != targetOfShards.end()) {
+            return phaseShard->second->isInvert;
+        }
+
+        return false;
+    }
+
     bool IsInvertControl()
     {
         ShardToPhaseMap::iterator phaseShard;

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -293,9 +293,8 @@ public:
     void FlipPhaseAnti()
     {
         // These cases cannot be handled:
-        // if (controlsShards.size() > 0) {
-        //    return false;
-        // }
+        // - any controlsShards
+        // - any IsInvert buffers
 
         par_for(0, targetOfShards.size(), [&](const bitCapInt lcv, const int cpu) {
             ShardToPhaseMap::iterator phaseShard = targetOfShards.begin();

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -297,22 +297,6 @@ public:
         });
     }
 
-    void CommutePhase(const complex& topLeft, const complex& bottomRight)
-    {
-        ShardToPhaseMap::iterator phaseShard;
-
-        par_for(0, targetOfShards.size(), [&](const bitCapInt lcv, const int cpu) {
-            ShardToPhaseMap::iterator phaseShard = targetOfShards.begin();
-            std::advance(phaseShard, lcv);
-            if (!phaseShard->second->isInvert) {
-                return;
-            }
-
-            phaseShard->second->cmplx0 *= topLeft / bottomRight;
-            phaseShard->second->cmplx1 *= bottomRight / topLeft;
-        });
-    }
-
     void RemoveTargetIdentityBuffers()
     {
         PhaseShardPtr buffer;
@@ -876,19 +860,9 @@ protected:
 
     void FlipPhaseAnti(const bitLenInt& target)
     {
-        if (shards[target].IsInvert()) {
-            RevertBasis2Qb(target);
-            return;
-        }
-
+        RevertBasis2Qb(target, ONLY_INVERT);
         RevertBasis2Qb(target, NONEXCLUSIVE, true);
         shards[target].FlipPhaseAnti();
-    }
-
-    void CommutePhase(const bitLenInt& target, const complex& topLeft, const complex& bottomRight)
-    {
-        RevertBasis2Qb(target, ONLY_INVERT, true);
-        shards[target].CommutePhase(topLeft, bottomRight);
     }
 
     void CommuteH(const bitLenInt& bitIndex);

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -165,19 +165,30 @@ public:
         }
     }
 
-    void DumpBuffers()
+    void DumpControlOf()
     {
+        ShardToPhaseMap::iterator phaseShard = controlsShards.begin();
+        while (phaseShard != controlsShards.end()) {
+            RemovePhaseTarget(phaseShard->first);
+            phaseShard = controlsShards.begin();
+        }
+    }
+
+    void DumpTargetOf()
+    {
+        OptimizeControls();
+
         ShardToPhaseMap::iterator phaseShard = targetOfShards.begin();
         while (phaseShard != targetOfShards.end()) {
             RemovePhaseControl(phaseShard->first);
             phaseShard = targetOfShards.begin();
         }
+    }
 
-        phaseShard = controlsShards.begin();
-        while (phaseShard != controlsShards.end()) {
-            RemovePhaseTarget(phaseShard->first);
-            phaseShard = controlsShards.begin();
-        }
+    void DumpBuffers()
+    {
+        DumpControlOf();
+        DumpTargetOf();
     }
 
     /// Initialize a phase gate buffer, with "this" as target bit and a another qubit "p" as control

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1160,13 +1160,6 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
         return;
     }
 
-    if (!freezeBasis) {
-        H(target);
-        CZ(control, target);
-        H(target);
-        return;
-    }
-
     CTRLED_PHASE_INVERT_WRAP(
         CNOT(CTRL_1_ARGS), ApplyControlledSingleBit(CTRL_GEN_ARGS), X(target), false, true, ONE_R1, ONE_R1);
 }

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -975,7 +975,7 @@ void QUnit::Z(bitLenInt target)
 
     if (UNSAFE_CACHED_ZERO(shard)) {
         if (!shard.IsInvertControl()) {
-            shard.DumpBuffers();
+            shard.DumpTargetOf();
         }
         return;
     }
@@ -1241,14 +1241,14 @@ void QUnit::CZ(bitLenInt control, bitLenInt target)
 
     if (!tShard.IsInvertTarget() && UNSAFE_CACHED_ZERO(tShard)) {
         if (!tShard.IsInvertControl()) {
-            tShard.DumpBuffers();
+            tShard.DumpTargetOf();
         }
         return;
     }
 
     if (!cShard.IsInvertTarget() && UNSAFE_CACHED_ZERO(cShard)) {
         if (!cShard.IsInvertControl()) {
-            cShard.DumpBuffers();
+            cShard.DumpTargetOf();
         }
         return;
     }
@@ -1288,7 +1288,7 @@ void QUnit::CCZ(bitLenInt control1, bitLenInt control2, bitLenInt target)
     if (!c1Shard.IsInvertTarget()) {
         if (UNSAFE_CACHED_CLASSICAL(c1Shard)) {
             if (!c1Shard.IsInvertControl()) {
-                c1Shard.DumpBuffers();
+                c1Shard.DumpTargetOf();
             }
             if (IS_NORM_ZERO(c1Shard.amp1)) {
                 return;
@@ -1303,7 +1303,7 @@ void QUnit::CCZ(bitLenInt control1, bitLenInt control2, bitLenInt target)
     if (!c2Shard.IsInvertTarget()) {
         if (UNSAFE_CACHED_CLASSICAL(c2Shard)) {
             if (!c2Shard.IsInvertControl()) {
-                c2Shard.DumpBuffers();
+                c2Shard.DumpTargetOf();
             }
             if (IS_NORM_ZERO(c2Shard.amp1)) {
                 return;
@@ -1318,7 +1318,7 @@ void QUnit::CCZ(bitLenInt control1, bitLenInt control2, bitLenInt target)
     if (!tShard.IsInvertTarget()) {
         if (UNSAFE_CACHED_CLASSICAL(tShard)) {
             if (!tShard.IsInvertControl()) {
-                tShard.DumpBuffers();
+                tShard.DumpTargetOf();
             }
             if (IS_NORM_ZERO(tShard.amp1)) {
                 return;
@@ -1475,7 +1475,7 @@ void QUnit::ApplyControlledSinglePhase(const bitLenInt* cControls, const bitLenI
 
     if (IS_ONE_CMPLX(bottomRight) && (!tShard.IsInvertTarget() && UNSAFE_CACHED_ONE(tShard))) {
         if (!tShard.IsInvertControl()) {
-            tShard.DumpBuffers();
+            tShard.DumpTargetOf();
         }
         delete[] controls;
         return;
@@ -1484,7 +1484,7 @@ void QUnit::ApplyControlledSinglePhase(const bitLenInt* cControls, const bitLenI
     if (IS_ONE_CMPLX(topLeft)) {
         if (!tShard.IsInvertTarget() && UNSAFE_CACHED_ZERO(tShard)) {
             if (!tShard.IsInvertControl()) {
-                tShard.DumpBuffers();
+                tShard.DumpTargetOf();
             }
             delete[] controls;
             return;
@@ -1724,7 +1724,7 @@ void QUnit::AntiCISqrtSwap(
     shard = shards[controls[i]];                                                                                       \
     if (IS_NORM_ZERO(shard.amp1)) {                                                                                    \
         if (!inCurrentBasis) {                                                                                         \
-            shard.DumpBuffers();                                                                                       \
+            shard.DumpTargetOf();                                                                                      \
         }                                                                                                              \
         if (!anti) {                                                                                                   \
             /* This gate does nothing, so return without applying anything. */                                         \
@@ -1733,7 +1733,7 @@ void QUnit::AntiCISqrtSwap(
         /* This control has 100% chance to "fire," so don't entangle it. */                                            \
     } else if (IS_NORM_ZERO(shard.amp0)) {                                                                             \
         if (!inCurrentBasis) {                                                                                         \
-            shard.DumpBuffers();                                                                                       \
+            shard.DumpTargetOf();                                                                                      \
         }                                                                                                              \
         if (anti) {                                                                                                    \
             /* This gate does nothing, so return without applying anything. */                                         \

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -975,7 +975,7 @@ void QUnit::Z(bitLenInt target)
 
     if (UNSAFE_CACHED_ZERO(shard)) {
         if (!shard.IsInvertControl()) {
-            shard.DumpTargetOf();
+            shard.DumpControlOf();
         }
         return;
     }
@@ -1241,14 +1241,14 @@ void QUnit::CZ(bitLenInt control, bitLenInt target)
 
     if (!tShard.IsInvertTarget() && UNSAFE_CACHED_ZERO(tShard)) {
         if (!tShard.IsInvertControl()) {
-            tShard.DumpTargetOf();
+            tShard.DumpControlOf();
         }
         return;
     }
 
     if (!cShard.IsInvertTarget() && UNSAFE_CACHED_ZERO(cShard)) {
         if (!cShard.IsInvertControl()) {
-            cShard.DumpTargetOf();
+            cShard.DumpControlOf();
         }
         return;
     }
@@ -1287,10 +1287,10 @@ void QUnit::CCZ(bitLenInt control1, bitLenInt control2, bitLenInt target)
 
     if (!c1Shard.IsInvertTarget()) {
         if (UNSAFE_CACHED_CLASSICAL(c1Shard)) {
-            if (!c1Shard.IsInvertControl()) {
-                c1Shard.DumpTargetOf();
-            }
             if (IS_NORM_ZERO(c1Shard.amp1)) {
+                if (!c1Shard.IsInvertControl()) {
+                    c1Shard.DumpControlOf();
+                }
                 return;
             }
             if (IS_NORM_ZERO(c1Shard.amp0)) {
@@ -1302,10 +1302,10 @@ void QUnit::CCZ(bitLenInt control1, bitLenInt control2, bitLenInt target)
 
     if (!c2Shard.IsInvertTarget()) {
         if (UNSAFE_CACHED_CLASSICAL(c2Shard)) {
-            if (!c2Shard.IsInvertControl()) {
-                c2Shard.DumpTargetOf();
-            }
             if (IS_NORM_ZERO(c2Shard.amp1)) {
+                if (!c2Shard.IsInvertControl()) {
+                    c2Shard.DumpControlOf();
+                }
                 return;
             }
             if (IS_NORM_ZERO(c2Shard.amp0)) {
@@ -1317,10 +1317,10 @@ void QUnit::CCZ(bitLenInt control1, bitLenInt control2, bitLenInt target)
 
     if (!tShard.IsInvertTarget()) {
         if (UNSAFE_CACHED_CLASSICAL(tShard)) {
-            if (!tShard.IsInvertControl()) {
-                tShard.DumpTargetOf();
-            }
             if (IS_NORM_ZERO(tShard.amp1)) {
+                if (!tShard.IsInvertControl()) {
+                    tShard.DumpControlOf();
+                }
                 return;
             }
             if (IS_NORM_ZERO(tShard.amp0)) {
@@ -1474,9 +1474,6 @@ void QUnit::ApplyControlledSinglePhase(const bitLenInt* cControls, const bitLenI
     QEngineShard& tShard = shards[target];
 
     if (IS_ONE_CMPLX(bottomRight) && (!tShard.IsInvertTarget() && UNSAFE_CACHED_ONE(tShard))) {
-        if (!tShard.IsInvertControl()) {
-            tShard.DumpTargetOf();
-        }
         delete[] controls;
         return;
     }
@@ -1484,7 +1481,7 @@ void QUnit::ApplyControlledSinglePhase(const bitLenInt* cControls, const bitLenI
     if (IS_ONE_CMPLX(topLeft)) {
         if (!tShard.IsInvertTarget() && UNSAFE_CACHED_ZERO(tShard)) {
             if (!tShard.IsInvertControl()) {
-                tShard.DumpTargetOf();
+                tShard.DumpControlOf();
             }
             delete[] controls;
             return;
@@ -1724,7 +1721,7 @@ void QUnit::AntiCISqrtSwap(
     shard = shards[controls[i]];                                                                                       \
     if (IS_NORM_ZERO(shard.amp1)) {                                                                                    \
         if (!inCurrentBasis) {                                                                                         \
-            shard.DumpTargetOf();                                                                                      \
+            shard.DumpControlOf();                                                                                     \
         }                                                                                                              \
         if (!anti) {                                                                                                   \
             /* This gate does nothing, so return without applying anything. */                                         \
@@ -1732,9 +1729,6 @@ void QUnit::AntiCISqrtSwap(
         }                                                                                                              \
         /* This control has 100% chance to "fire," so don't entangle it. */                                            \
     } else if (IS_NORM_ZERO(shard.amp0)) {                                                                             \
-        if (!inCurrentBasis) {                                                                                         \
-            shard.DumpTargetOf();                                                                                      \
-        }                                                                                                              \
         if (anti) {                                                                                                    \
             /* This gate does nothing, so return without applying anything. */                                         \
             return;                                                                                                    \
@@ -3129,6 +3123,8 @@ void QUnit::RevertBasis2Qb(const bitLenInt& i, const RevertExclusivity& exclusiv
 
     if ((controlExclusivity == ONLY_CONTROLS) && (exclusivity != ONLY_INVERT)) {
         shard.OptimizeControls();
+    } else if ((controlExclusivity == ONLY_TARGETS) && (exclusivity != ONLY_INVERT)) {
+        shard.OptimizeTargets();
     }
 
     ShardToPhaseMap::iterator phaseShard;

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1123,17 +1123,7 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
         }
     }
 
-    QEngineShard& cShard = shards[control];
 
-    if (!cShard.IsInvert() && UNSAFE_CACHED_CLASSICAL(cShard)) {
-        if (IS_NORM_ZERO(cShard.amp1)) {
-            return;
-        }
-        if (IS_NORM_ZERO(cShard.amp0)) {
-            X(target);
-            return;
-        }
-    }
 
     bitLenInt controls[1] = { control };
     bitLenInt controlLen = 1;

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -731,6 +731,13 @@ void QUnit::Swap(bitLenInt qubit1, bitLenInt qubit2)
         return;
     }
 
+    if (shards[qubit1].IsInvert() || shards[qubit2].IsInvert()) {
+        TransformBasis1Qb(false, qubit1);
+        TransformBasis1Qb(false, qubit2);
+    }
+    RevertBasis2Qb(qubit1, ONLY_INVERT);
+    RevertBasis2Qb(qubit2, ONLY_INVERT);
+
     // Simply swap the bit mapping.
     std::swap(shards[qubit1], shards[qubit2]);
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1160,7 +1160,7 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
         return;
     }
 
-    if (!freezeBasis && (isCachedInvert || (!QUEUED_PHASE(cShard) && !QUEUED_PHASE(tShard)))) {
+    if (!freezeBasis && (isCachedInvert || !QUEUED_PHASE(cShard))) {
         TransformBasis1Qb(false, control);
         TransformBasis1Qb(false, target);
         RevertBasis2Qb(control, NONEXCLUSIVE, true, { target }, {});

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1125,7 +1125,7 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
 
     QEngineShard& cShard = shards[control];
 
-    if (CACHED_CLASSICAL(cShard)) {
+    if (!cShard.IsInvert() && UNSAFE_CACHED_CLASSICAL(cShard)) {
         if (IS_NORM_ZERO(cShard.amp1)) {
             return;
         }
@@ -1138,6 +1138,8 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
     bitLenInt controls[1] = { control };
     bitLenInt controlLen = 1;
 
+    bool isCachedInvert = cShard.IsInvertControlOf(&tShard);
+
     // We're free to transform gates to any orthonormal basis of the Hilbert space.
     // For a 2 qubit system, if the control is the lefthand bit, it's easy to verify the following truth table for CNOT:
     // |++> -> |++>
@@ -1147,7 +1149,7 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
     // Under the Jacobian transformation between these two bases for defining the truth table, the matrix representation
     // is equivalent to the gate with bits flipped. We just let ApplyEitherControlled() know to leave the current basis
     // alone, by way of the last optional "true" argument in the call.
-    if (cShard.isPlusMinus && tShard.isPlusMinus) {
+    if (!isCachedInvert && cShard.isPlusMinus && tShard.isPlusMinus) {
         RevertBasis2Qb(control);
         RevertBasis2Qb(target);
 
@@ -1158,7 +1160,7 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
         return;
     }
 
-    if (!freezeBasis && (cShard.IsInvertControlOf(&tShard) || !QUEUED_PHASE(cShard))) {
+    if (!freezeBasis && (isCachedInvert || (!QUEUED_PHASE(cShard) && !QUEUED_PHASE(tShard)))) {
         TransformBasis1Qb(false, control);
         TransformBasis1Qb(false, target);
         RevertBasis2Qb(control, NONEXCLUSIVE, false, { target }, {});

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -3041,6 +3041,11 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
         isSame |= norm(polar0 - polar1) <= ampThreshold;
         isOpposite |= norm(polar0 + polar1) <= ampThreshold;
 
+        // "isSame" always results in a phase gate.
+        // "isOpposite" always results in an "inversion" gate.
+        // We can buffer multiple phase gates on a bit, but we can only buffer one inversion.
+        // Phase gates commute more generally than inversions, so the phase gate is preferable to the inversion in the
+        // case that we could produce one of either.
         if (isSame) {
             isOpposite = false;
             break;

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1123,7 +1123,7 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
         }
     }
 
-
+    QEngineShard& cShard = shards[control];
 
     bitLenInt controls[1] = { control };
     bitLenInt controlLen = 1;
@@ -1249,8 +1249,8 @@ void QUnit::CZ(bitLenInt control, bitLenInt target)
             std::swap(control, target);
         }
         TransformBasis1Qb(false, control);
-        RevertBasis2Qb(control, ONLY_INVERT, ONLY_TARGETS, { target }, {});
-        RevertBasis2Qb(target, ONLY_INVERT, ONLY_TARGETS, {}, { control });
+        RevertBasis2Qb(control, ONLY_INVERT, CONTROLS_AND_TARGETS, { target }, {});
+        RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, {}, { control });
         shards[target].AddPhaseAngles(&(shards[control]), ONE_R1, -ONE_R1);
         return;
     }
@@ -1488,8 +1488,8 @@ void QUnit::ApplyControlledSinglePhase(const bitLenInt* cControls, const bitLenI
             std::swap(controls[0], target);
         }
         TransformBasis1Qb(false, controls[0]);
-        RevertBasis2Qb(controls[0], ONLY_INVERT, ONLY_TARGETS, { target }, {});
-        RevertBasis2Qb(target, ONLY_INVERT, ONLY_TARGETS, {}, { controls[0] });
+        RevertBasis2Qb(controls[0], ONLY_INVERT, CONTROLS_AND_TARGETS, { target }, {});
+        RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, {}, { controls[0] });
         shards[target].AddPhaseAngles(&(shards[controls[0]]), topLeft, bottomRight);
         delete[] controls;
         return;

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1160,7 +1160,7 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
         return;
     }
 
-    if (!freezeBasis && (isCachedInvert || !QUEUED_PHASE(cShard))) {
+    if (!freezeBasis) {
         TransformBasis1Qb(false, control);
         TransformBasis1Qb(false, target);
         RevertBasis2Qb(control, NONEXCLUSIVE, true, { target }, {});

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1138,8 +1138,6 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
     bitLenInt controls[1] = { control };
     bitLenInt controlLen = 1;
 
-    bool isCachedInvert = cShard.IsInvertControlOf(&tShard);
-
     // We're free to transform gates to any orthonormal basis of the Hilbert space.
     // For a 2 qubit system, if the control is the lefthand bit, it's easy to verify the following truth table for CNOT:
     // |++> -> |++>
@@ -1149,7 +1147,7 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
     // Under the Jacobian transformation between these two bases for defining the truth table, the matrix representation
     // is equivalent to the gate with bits flipped. We just let ApplyEitherControlled() know to leave the current basis
     // alone, by way of the last optional "true" argument in the call.
-    if (!isCachedInvert && cShard.isPlusMinus && tShard.isPlusMinus) {
+    if (cShard.isPlusMinus && tShard.isPlusMinus) {
         RevertBasis2Qb(control);
         RevertBasis2Qb(target);
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1161,11 +1161,9 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
     }
 
     if (!freezeBasis) {
-        TransformBasis1Qb(false, control);
-        TransformBasis1Qb(false, target);
-        RevertBasis2Qb(control, NONEXCLUSIVE, true, { target }, {});
-        RevertBasis2Qb(target, NONEXCLUSIVE, false, {}, { control });
-        tShard.AddInversionAngles(&cShard, ONE_CMPLX, ONE_CMPLX);
+        H(target);
+        CZ(control, target);
+        H(target);
         return;
     }
 
@@ -1266,11 +1264,11 @@ void QUnit::CZ(bitLenInt control, bitLenInt target)
     }
 
     if (!freezeBasis) {
-        if (tShard.IsInvertControl()) {
+        if (tShard.IsInvertControlOf(&cShard)) {
             std::swap(control, target);
         }
         TransformBasis1Qb(false, control);
-        RevertBasis2Qb(control, ONLY_INVERT, true, { target }, {});
+        RevertBasis2Qb(control, ONLY_INVERT, false, { target }, {});
         RevertBasis2Qb(target, ONLY_INVERT, false, {}, { control });
         shards[target].AddPhaseAngles(&(shards[control]), ONE_R1, -ONE_R1);
         return;
@@ -1505,11 +1503,11 @@ void QUnit::ApplyControlledSinglePhase(const bitLenInt* cControls, const bitLenI
     }
 
     if (!freezeBasis && (controlLen == 1U)) {
-        if (IS_ONE_CMPLX(topLeft) && tShard.IsInvertControl()) {
+        if (IS_ONE_CMPLX(topLeft) && tShard.IsInvertControlOf(&(shards[controls[0]]))) {
             std::swap(controls[0], target);
         }
         TransformBasis1Qb(false, controls[0]);
-        RevertBasis2Qb(controls[0], ONLY_INVERT, true, { target }, {});
+        RevertBasis2Qb(controls[0], ONLY_INVERT, false, { target }, {});
         RevertBasis2Qb(target, ONLY_INVERT, false, {}, { controls[0] });
         shards[target].AddPhaseAngles(&(shards[controls[0]]), topLeft, bottomRight);
         delete[] controls;
@@ -3082,7 +3080,8 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
             ApplyBuffer(phaseShard, control, bitIndex);
             shard.RemovePhaseControl(partner);
         } else if (isOpposite) {
-            RevertBasis2Qb(bitIndex, NONEXCLUSIVE, true);
+            RevertBasis2Qb(bitIndex, NONEXCLUSIVE);
+            break;
         }
     }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -3054,7 +3054,7 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
     ShardToPhaseMap targetOfShards = shard.targetOfShards;
 
     bool isSame = false, isOpposite = false;
-    bitLenInt oppositeControl;
+    bitLenInt oppositeControl = 0;
 
     for (phaseShard = targetOfShards.begin(); phaseShard != targetOfShards.end(); phaseShard++) {
         partner = phaseShard->first;

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1763,6 +1763,12 @@ void QUnit::ApplyEitherControlled(const bitLenInt* controls, const bitLenInt& co
         return;
     }
 
+    if (!inCurrentBasis) {
+        for (i = 0; i < controlVec.size(); i++) {
+            RevertBasis2Qb(controlVec[i]);
+        }
+    }
+
     // TODO: If controls that survive the "first order" check above start out entangled,
     // then it might be worth checking whether there is any intra-unit chance of control bits
     // being conditionally all 0 or all 1, in any unit, due to entanglement.
@@ -3085,7 +3091,7 @@ void QUnit::RevertBasis2Qb(const bitLenInt& i, const RevertExclusivity& exclusiv
 
     shard.CombineGates();
 
-    if ((controlExclusivity == ONLY_CONTROLS) && !(exclusivity == ONLY_INVERT)) {
+    if ((controlExclusivity == ONLY_CONTROLS) && (exclusivity != ONLY_INVERT)) {
         shard.OptimizeControls();
     }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1163,7 +1163,7 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
     if (!freezeBasis && (isCachedInvert || (!QUEUED_PHASE(cShard) && !QUEUED_PHASE(tShard)))) {
         TransformBasis1Qb(false, control);
         TransformBasis1Qb(false, target);
-        RevertBasis2Qb(control, NONEXCLUSIVE, false, { target }, {});
+        RevertBasis2Qb(control, NONEXCLUSIVE, true, { target }, {});
         RevertBasis2Qb(target, NONEXCLUSIVE, false, {}, { control });
         tShard.AddInversionAngles(&cShard, ONE_CMPLX, ONE_CMPLX);
         return;
@@ -1270,7 +1270,7 @@ void QUnit::CZ(bitLenInt control, bitLenInt target)
             std::swap(control, target);
         }
         TransformBasis1Qb(false, control);
-        RevertBasis2Qb(control, ONLY_INVERT, false, { target }, {});
+        RevertBasis2Qb(control, ONLY_INVERT, true, { target }, {});
         RevertBasis2Qb(target, ONLY_INVERT, false, {}, { control });
         shards[target].AddPhaseAngles(&(shards[control]), ONE_R1, -ONE_R1);
         return;
@@ -1509,7 +1509,7 @@ void QUnit::ApplyControlledSinglePhase(const bitLenInt* cControls, const bitLenI
             std::swap(controls[0], target);
         }
         TransformBasis1Qb(false, controls[0]);
-        RevertBasis2Qb(controls[0], ONLY_INVERT, false, { target }, {});
+        RevertBasis2Qb(controls[0], ONLY_INVERT, true, { target }, {});
         RevertBasis2Qb(target, ONLY_INVERT, false, {}, { controls[0] });
         shards[target].AddPhaseAngles(&(shards[controls[0]]), topLeft, bottomRight);
         delete[] controls;
@@ -3082,8 +3082,7 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
             ApplyBuffer(phaseShard, control, bitIndex);
             shard.RemovePhaseControl(partner);
         } else if (isOpposite) {
-            RevertBasis2Qb(bitIndex, NONEXCLUSIVE, false, {}, { control });
-            break;
+            RevertBasis2Qb(bitIndex, NONEXCLUSIVE, true);
         }
     }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -731,12 +731,8 @@ void QUnit::Swap(bitLenInt qubit1, bitLenInt qubit2)
         return;
     }
 
-    if (shards[qubit1].IsInvert() || shards[qubit2].IsInvert()) {
-        TransformBasis1Qb(false, qubit1);
-        TransformBasis1Qb(false, qubit2);
-    }
-    RevertBasis2Qb(qubit1, ONLY_INVERT);
-    RevertBasis2Qb(qubit2, ONLY_INVERT);
+    RevertBasis2Qb(qubit1);
+    RevertBasis2Qb(qubit2);
 
     // Simply swap the bit mapping.
     std::swap(shards[qubit1], shards[qubit2]);


### PR DESCRIPTION
While the random universal circuit benchmark happened to be running correctly as exactly defined, there was a bug in the handling of "inversion" buffers, which that benchmark could never trip. Since this affects general correctness, we'll be iterating to release 5.1 with this, after due scrutiny.