### PR TITLE
SWAP() buffer dumps; add "identity gate" option to cross entropy test

### DIFF
--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -777,7 +777,7 @@ void QUnit::ISwap(bitLenInt qubit1, bitLenInt qubit2)
             if (!randGlobalPhase) {
                 // Under the preconditions, this has no effect on Hermitian expectation values, but we track it, if the
                 // QUnit is tracking arbitrary numerical phase.
-                ApplySinglePhase(I_CMPLX, I_CMPLX, 0);
+                ApplySinglePhase(I_CMPLX, I_CMPLX, qubit1);
             }
         }
         return;

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -731,6 +731,19 @@ void QUnit::Swap(bitLenInt qubit1, bitLenInt qubit2)
         return;
     }
 
+    RevertBasis2Qb(qubit1, ONLY_INVERT);
+    RevertBasis2Qb(qubit2, ONLY_INVERT);
+
+    QEngineShard& shard1 = shards[qubit1];
+    QEngineShard& shard2 = shards[qubit2];
+
+    if (UNSAFE_CACHED_ZERO(shard1)) {
+        shard1.DumpControlOf();
+    }
+    if (UNSAFE_CACHED_ZERO(shard2)) {
+        shard2.DumpControlOf();
+    }
+
     RevertBasis2Qb(qubit1);
     RevertBasis2Qb(qubit2);
 

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -4582,7 +4582,7 @@ struct MultiQubitGate {
 
 TEST_CASE("test_universal_circuit_digital_cross_entropy", "[supreme]")
 {
-    const int GateCount1Qb = 4;
+    const int GateCount1Qb = 5;
     const int GateCountMultiQb = 4;
     const int Depth = 3;
 
@@ -4652,8 +4652,10 @@ TEST_CASE("test_universal_circuit_digital_cross_entropy", "[supreme]")
                     goldStandard->X(i);
                 } else if (gate1Qb == 2) {
                     goldStandard->Y(i);
-                } else {
+                } else if (gate1Qb == 3) {
                     goldStandard->T(i);
+                } else {
+                    // Identity test
                 }
             }
 
@@ -4690,8 +4692,10 @@ TEST_CASE("test_universal_circuit_digital_cross_entropy", "[supreme]")
                     testCase->X(i);
                 } else if (gate1Qb == 2) {
                     testCase->Y(i);
-                } else {
+                } else if (gate1Qb == 3) {
                     testCase->T(i);
+                } else {
+                    // Identity test
                 }
             }
 


### PR DESCRIPTION
As in all cases where "inversion" buffers are flushed, `Swap` can potentially avoid applying cached phase gates. Also, as I was debugging with it over the weekend, I have added an "identity gate" option to one of the cross entropy tests, which makes it cover a much more general set of circuits.

I believe we're tagging this as v5.1, when this is merged, due to the bug fix in `Swap`.