### PR TITLE
Ease buffer commutation restrictions, subsequent to Swap() bug fix

### DIFF
--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -930,7 +930,6 @@ protected:
 
     void FlipPhaseAnti(const bitLenInt& target)
     {
-        RevertBasis2Qb(target, ONLY_INVERT);
         RevertBasis2Qb(target, INVERT_AND_PHASE, ONLY_CONTROLS);
         shards[target].FlipPhaseAnti();
     }

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -352,6 +352,20 @@ public:
         });
     }
 
+    void CommutePhase(const complex& topLeft, const complex& bottomRight)
+    {
+        par_for(0, targetOfShards.size(), [&](const bitCapInt lcv, const int cpu) {
+            ShardToPhaseMap::iterator phaseShard = targetOfShards.begin();
+            std::advance(phaseShard, lcv);
+            if (!phaseShard->second->isInvert) {
+                return;
+            }
+
+            phaseShard->second->cmplx0 *= topLeft / bottomRight;
+            phaseShard->second->cmplx1 *= bottomRight / topLeft;
+        });
+    }
+
     void RemoveTargetIdentityBuffers()
     {
         PhaseShardPtr buffer;


### PR DESCRIPTION
Now that the bug in Swap() has been fixed, many buffer commutation rules I expected to work, but had kludged over to cover the cross entropy failures, have started to work as expected.