### PR TITLE
Issue 342 - "Anti-controlled" buffers

### DIFF
--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -1093,9 +1093,6 @@ protected:
         return shards.size();
     }
 
-    bool TryCnotOptimize(const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& target,
-        const complex& topRight, const complex& bottomLeft, const bool& anti);
-
     void CommuteH(const bitLenInt& bitIndex);
 
     /* Debugging and diagnostic routines. */

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -787,14 +787,17 @@ protected:
 
     void TransformBasis1Qb(const bool& toPlusMinus, const bitLenInt& i);
 
-    void ApplyBuffer(ShardToPhaseMap::iterator phaseShard, const bitLenInt& control, const bitLenInt& target);
-
     enum RevertExclusivity { INVERT_AND_PHASE = 0, ONLY_INVERT = 1, ONLY_PHASE = 2 };
     enum RevertControl { CONTROLS_AND_TARGETS = 0, ONLY_CONTROLS = 1, ONLY_TARGETS = 2 };
 
+    void ApplyBuffer(
+        ShardToPhaseMap::iterator phaseShard, const bitLenInt& control, const bitLenInt& target, const bool& isAnti);
+    void ApplyBufferMap(const bitLenInt& bitIndex, ShardToPhaseMap bufferMap, const RevertExclusivity& exclusivity,
+        const bool& isControl, const bool& isAnti, std::set<bitLenInt> exceptPartners, const bool& dumpSkipped);
     void RevertBasis2Qb(const bitLenInt& i, const RevertExclusivity& exclusivity = INVERT_AND_PHASE,
         const RevertControl& controlExclusivity = CONTROLS_AND_TARGETS, std::set<bitLenInt> exceptControlling = {},
         std::set<bitLenInt> exceptTargetedBy = {}, const bool& dumpSkipped = false);
+
     void ToPermBasis(const bitLenInt& i)
     {
         TransformBasis1Qb(false, i);

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -55,6 +55,12 @@ typedef std::map<QEngineShardPtr, PhaseShardPtr> ShardToPhaseMap;
 
 /** Associates a QInterface object with a set of bits. */
 class QEngineShard : public ParallelFor {
+protected:
+    typedef ShardToPhaseMap& (QEngineShard::*GetBufferFn)();
+    typedef void (QEngineShard::*OptimizeFn)();
+    typedef void (QEngineShard::*AddRemoveFn)(QEngineShardPtr);
+    typedef void (QEngineShard::*AddAnglesFn)(QEngineShardPtr control, const complex& cmplx0, const complex& cmplx1);
+
 public:
     QInterfacePtr unit;
     bitLenInt mapped;
@@ -67,9 +73,21 @@ public:
     bool isPlusMinus;
     // Shards which this shard controls
     ShardToPhaseMap controlsShards;
+    // Shards which this shard (anti-)controls
+    ShardToPhaseMap antiControlsShards;
     // Shards of which this shard is a target
     ShardToPhaseMap targetOfShards;
+    // Shards of which this shard is an (anti-controlled) target
+    ShardToPhaseMap antiTargetOfShards;
 
+protected:
+    // We'd rather not have these getters at all, but we need their function pointers.
+    ShardToPhaseMap& GetControlsShards() { return controlsShards; }
+    ShardToPhaseMap& GetAntiControlsShards() { return antiControlsShards; }
+    ShardToPhaseMap& GetTargetOfShards() { return targetOfShards; }
+    ShardToPhaseMap& GetAntiTargetOfShards() { return antiTargetOfShards; }
+
+public:
     QEngineShard(const real1 amp_thresh = min_norm)
         : unit(NULL)
         , mapped(0)
@@ -81,7 +99,9 @@ public:
         , amp1(ZERO_CMPLX)
         , isPlusMinus(false)
         , controlsShards()
+        , antiControlsShards()
         , targetOfShards()
+        , antiTargetOfShards()
     {
     }
 
@@ -96,7 +116,9 @@ public:
         , amp1(ZERO_CMPLX)
         , isPlusMinus(false)
         , controlsShards()
+        , antiControlsShards()
         , targetOfShards()
+        , antiTargetOfShards()
     {
         amp0 = set ? ZERO_CMPLX : ONE_CMPLX;
         amp1 = set ? ONE_CMPLX : ZERO_CMPLX;
@@ -114,7 +136,9 @@ public:
         , amp1(ZERO_CMPLX)
         , isPlusMinus(false)
         , controlsShards()
+        , antiControlsShards()
         , targetOfShards()
+        , antiTargetOfShards()
     {
     }
 
@@ -145,95 +169,109 @@ public:
         return didClamp;
     }
 
-    /// Remove another qubit as being a cached control of a phase gate buffer, for "this" as target bit.
-    void RemovePhaseControl(QEngineShardPtr p)
+protected:
+    void RemoveBuffer(QEngineShardPtr p, ShardToPhaseMap& localMap, GetBufferFn remoteMapGet)
     {
-        ShardToPhaseMap::iterator phaseShard = targetOfShards.find(p);
-        if (phaseShard != targetOfShards.end()) {
-            phaseShard->first->controlsShards.erase(this);
-            targetOfShards.erase(phaseShard);
+        ShardToPhaseMap::iterator phaseShard = localMap.find(p);
+        if (phaseShard != localMap.end()) {
+            ((*phaseShard->first).*remoteMapGet)().erase(this);
+            localMap.erase(phaseShard);
         }
     }
 
-    /// Remove another qubit as being a cached target of a phase gate buffer, for "this" as control bit.
-    void RemovePhaseTarget(QEngineShardPtr p)
+public:
+    void RemovePhaseControl(QEngineShardPtr p) { RemoveBuffer(p, targetOfShards, &QEngineShard::GetControlsShards); }
+    void RemovePhaseTarget(QEngineShardPtr p) { RemoveBuffer(p, controlsShards, &QEngineShard::GetTargetOfShards); }
+    void RemovePhaseAntiControl(QEngineShardPtr p)
     {
-        ShardToPhaseMap::iterator phaseShard = controlsShards.find(p);
-        if (phaseShard != controlsShards.end()) {
-            phaseShard->first->targetOfShards.erase(this);
-            controlsShards.erase(phaseShard);
+        RemoveBuffer(p, antiTargetOfShards, &QEngineShard::GetAntiControlsShards);
+    }
+    void RemovePhaseAntiTarget(QEngineShardPtr p)
+    {
+        RemoveBuffer(p, antiControlsShards, &QEngineShard::GetAntiTargetOfShards);
+    }
+
+protected:
+    void DumpBuffer(OptimizeFn optimizeFn, ShardToPhaseMap& localMap, AddRemoveFn remoteFn)
+    {
+        ((*this).*optimizeFn)();
+        ShardToPhaseMap::iterator phaseShard = localMap.begin();
+        while (phaseShard != localMap.end()) {
+            ((*this).*remoteFn)(phaseShard->first);
+            phaseShard = localMap.begin();
         }
     }
 
+public:
     void DumpControlOf()
     {
-        OptimizeTargets();
-
-        ShardToPhaseMap::iterator phaseShard = controlsShards.begin();
-        while (phaseShard != controlsShards.end()) {
-            RemovePhaseTarget(phaseShard->first);
-            phaseShard = controlsShards.begin();
-        }
+        DumpBuffer(&QEngineShard::OptimizeTargets, controlsShards, &QEngineShard::RemovePhaseTarget);
     }
-
     void DumpTargetOf()
     {
-        OptimizeControls();
-
-        ShardToPhaseMap::iterator phaseShard = targetOfShards.begin();
-        while (phaseShard != targetOfShards.end()) {
-            RemovePhaseControl(phaseShard->first);
-            phaseShard = targetOfShards.begin();
-        }
+        DumpBuffer(&QEngineShard::OptimizeControls, targetOfShards, &QEngineShard::RemovePhaseControl);
     }
-
     void DumpBuffers()
     {
         DumpControlOf();
         DumpTargetOf();
     }
 
-    /// Initialize a phase gate buffer, with "this" as target bit and a another qubit "p" as control
-    void MakePhaseControlledBy(QEngineShardPtr p)
+protected:
+    void AddBuffer(QEngineShardPtr p, ShardToPhaseMap& localMap, GetBufferFn remoteFn)
     {
-        if (p && (targetOfShards.find(p) == targetOfShards.end())) {
+        if (p && (localMap.find(p) == localMap.end())) {
             PhaseShardPtr ps = std::make_shared<PhaseShard>();
-            targetOfShards[p] = ps;
-            p->controlsShards[this] = ps;
+            localMap[p] = ps;
+            ((*p).*remoteFn)()[this] = ps;
         }
     }
 
-    /// Initialize a phase gate buffer, with "this" as control bit and a another qubit "p" as target
-    void MakePhaseControlOf(QEngineShardPtr p)
+public:
+    void MakePhaseControlledBy(QEngineShardPtr p) { AddBuffer(p, targetOfShards, &QEngineShard::GetControlsShards); }
+    void MakePhaseControlOf(QEngineShardPtr p) { AddBuffer(p, controlsShards, &QEngineShard::GetTargetOfShards); }
+    void MakePhaseAntiControlledBy(QEngineShardPtr p)
     {
-        if (p && (controlsShards.find(p) == controlsShards.end())) {
-            PhaseShardPtr ps = std::make_shared<PhaseShard>();
-            controlsShards[p] = ps;
-            p->targetOfShards[this] = ps;
-        }
+        AddBuffer(p, antiTargetOfShards, &QEngineShard::GetAntiControlsShards);
+    }
+    void MakePhaseAntiControlOf(QEngineShardPtr p)
+    {
+        AddBuffer(p, antiControlsShards, &QEngineShard::GetAntiTargetOfShards);
     }
 
-    /// "Fuse" phase gate buffer angles, (and initialize the buffer, if necessary,) for the buffer with "this" as target
-    /// bit and a another qubit as control
-    void AddPhaseAngles(QEngineShardPtr control, const complex& cmplx0, const complex& cmplx1)
+protected:
+    void AddAngles(QEngineShardPtr control, const complex& cmplx0, const complex& cmplx1, AddRemoveFn localFn,
+        ShardToPhaseMap& localMap, AddRemoveFn remoteFn)
     {
-        MakePhaseControlledBy(control);
+        ((*this).*localFn)(control);
 
-        PhaseShardPtr targetOfShard = targetOfShards[control];
+        PhaseShardPtr targetOfShard = localMap[control];
 
         complex nCmplx0 = targetOfShard->cmplx0 * cmplx0;
         nCmplx0 /= abs(nCmplx0);
         complex nCmplx1 = targetOfShard->cmplx1 * cmplx1;
         nCmplx1 /= abs(nCmplx1);
 
-        if (!targetOfShard->isInvert && IS_ARG_0(nCmplx0) && IS_ARG_0(nCmplx1)) {
-            // The buffer is equal to the identity operator, and it can be removed.
-            RemovePhaseControl(control);
+        if (!targetOfShard->isInvert && IS_ARG_0(nCmplx0) &&
+            IS_ARG_0(nCmplx1)) { /* The buffer is equal to the identity operator, and it can be removed. */
+            ((*this).*remoteFn)(control);
             return;
         }
 
         targetOfShard->cmplx0 = nCmplx0;
         targetOfShard->cmplx1 = nCmplx1;
+    }
+
+public:
+    void AddPhaseAngles(QEngineShardPtr control, const complex& cmplx0, const complex& cmplx1)
+    {
+        AddAngles(control, cmplx0, cmplx1, &QEngineShard::MakePhaseControlledBy, targetOfShards,
+            &QEngineShard::RemovePhaseControl);
+    }
+    void AddAntiPhaseAngles(QEngineShardPtr control, const complex& cmplx0, const complex& cmplx1)
+    {
+        AddAngles(control, cmplx0, cmplx1, &QEngineShard::MakePhaseAntiControlledBy, antiTargetOfShards,
+            &QEngineShard::RemovePhaseAntiControl);
     }
 
     void AddInversionAngles(QEngineShardPtr control, complex cmplx0, complex cmplx1)
@@ -247,62 +285,59 @@ public:
         AddPhaseAngles(control, cmplx0, cmplx1);
     }
 
-    /// Take ambiguous control/target operations, and reintrepret them as targeting this bit
+protected:
+    void OptimizeBuffer(ShardToPhaseMap& localMap, GetBufferFn remoteMapGet, AddAnglesFn phaseFn, bool makeThisControl)
+    {
+        PhaseShardPtr buffer;
+        QEngineShardPtr partner;
+        complex partnerAngle;
+
+        ShardToPhaseMap::iterator phaseShard;
+        ShardToPhaseMap tempLocalMap = localMap;
+
+        for (phaseShard = tempLocalMap.begin(); phaseShard != tempLocalMap.end(); phaseShard++) {
+            buffer = phaseShard->second;
+            partner = phaseShard->first;
+
+            if (buffer->isInvert || (isPlusMinus != partner->isPlusMinus) || !IS_ARG_0(buffer->cmplx0)) {
+                continue;
+            }
+
+            partnerAngle = buffer->cmplx1;
+
+            ((*phaseShard->first).*remoteMapGet)().erase(this);
+            localMap.erase(partner);
+
+            if (makeThisControl) {
+                ((*partner).*phaseFn)(this, ONE_CMPLX, partnerAngle);
+            } else {
+                ((*this).*phaseFn)(partner, ONE_CMPLX, partnerAngle);
+            }
+        }
+    }
+
+public:
     void OptimizeControls()
     {
-        PhaseShardPtr buffer;
-        QEngineShardPtr partner;
-        complex partnerAngle;
-
-        ShardToPhaseMap::iterator phaseShard;
-        ShardToPhaseMap tempControls = controlsShards;
-
-        for (phaseShard = tempControls.begin(); phaseShard != tempControls.end(); phaseShard++) {
-            buffer = phaseShard->second;
-            partner = phaseShard->first;
-
-            if (buffer->isInvert || (isPlusMinus != partner->isPlusMinus) || !IS_ARG_0(buffer->cmplx0)) {
-                continue;
-            }
-
-            partnerAngle = buffer->cmplx1;
-
-            phaseShard->first->targetOfShards.erase(this);
-            controlsShards.erase(partner);
-
-            AddPhaseAngles(partner, ONE_CMPLX, partnerAngle);
-        }
+        OptimizeBuffer(controlsShards, &QEngineShard::GetTargetOfShards, &QEngineShard::AddPhaseAngles, false);
     }
-
-    /// Take ambiguous control/target operations, and reintrepret them as controlled by this bit
     void OptimizeTargets()
     {
-        PhaseShardPtr buffer;
-        QEngineShardPtr partner;
-        complex partnerAngle;
-
-        ShardToPhaseMap::iterator phaseShard;
-        ShardToPhaseMap tempTargetOf = targetOfShards;
-
-        for (phaseShard = tempTargetOf.begin(); phaseShard != tempTargetOf.end(); phaseShard++) {
-            buffer = phaseShard->second;
-            partner = phaseShard->first;
-
-            if (buffer->isInvert || (isPlusMinus != partner->isPlusMinus) || !IS_ARG_0(buffer->cmplx0)) {
-                continue;
-            }
-
-            partnerAngle = buffer->cmplx1;
-
-            phaseShard->first->controlsShards.erase(this);
-            targetOfShards.erase(partner);
-
-            partner->AddPhaseAngles(this, ONE_CMPLX, partnerAngle);
-        }
+        OptimizeBuffer(targetOfShards, &QEngineShard::GetControlsShards, &QEngineShard::AddPhaseAngles, true);
+    }
+    void OptimizeAntiControls()
+    {
+        OptimizeBuffer(
+            antiControlsShards, &QEngineShard::GetAntiTargetOfShards, &QEngineShard::AddAntiPhaseAngles, false);
+    }
+    void OptimizeAntiTargets()
+    {
+        OptimizeBuffer(
+            antiTargetOfShards, &QEngineShard::GetAntiControlsShards, &QEngineShard::AddAntiPhaseAngles, true);
     }
 
-    /// If this bit is both control and target of another bit, try to combine the operations into one gate.
-    void CombineGates()
+protected:
+    void CombineBuffers(GetBufferFn targetMapGet, GetBufferFn controlMapGet, AddAnglesFn angleFn)
     {
         PhaseShardPtr buffer1, buffer2;
         ShardToPhaseMap::iterator partnerShard;
@@ -310,11 +345,10 @@ public:
         complex partnerAngle;
 
         ShardToPhaseMap::iterator phaseShard;
-        ShardToPhaseMap tempControls = controlsShards;
-        ShardToPhaseMap tempTargets = targetOfShards;
+        ShardToPhaseMap tempControls = ((*this).*controlMapGet)();
+        ShardToPhaseMap tempTargets = ((*this).*targetMapGet)();
 
         for (phaseShard = tempControls.begin(); phaseShard != tempControls.end(); phaseShard++) {
-
             partner = phaseShard->first;
 
             partnerShard = tempTargets.find(partner);
@@ -328,23 +362,56 @@ public:
             if (!buffer1->isInvert && IS_ARG_0(buffer1->cmplx0)) {
                 partnerAngle = buffer1->cmplx1;
 
-                partner->targetOfShards.erase(this);
-                controlsShards.erase(partner);
+                ((*partner).*targetMapGet)().erase(this);
+                ((*this).*controlMapGet)().erase(partner);
 
-                AddPhaseAngles(partner, ONE_CMPLX, partnerAngle);
+                ((*this).*angleFn)(partner, ONE_CMPLX, partnerAngle);
             } else if (!buffer2->isInvert && IS_ARG_0(buffer2->cmplx0)) {
                 partnerAngle = buffer2->cmplx1;
 
-                partner->controlsShards.erase(this);
-                targetOfShards.erase(partner);
+                ((*partner).*controlMapGet)().erase(this);
+                ((*this).*targetMapGet)().erase(partner);
 
-                partner->AddPhaseAngles(this, ONE_CMPLX, partnerAngle);
+                ((*partner).*angleFn)(this, ONE_CMPLX, partnerAngle);
             }
         }
     }
 
+public:
+    /// If this bit is both control and target of another bit, try to combine the operations into one gate.
+    void CombineGates()
+    {
+        CombineBuffers(
+            &QEngineShard::GetTargetOfShards, &QEngineShard::GetControlsShards, &QEngineShard::AddPhaseAngles);
+        CombineBuffers(&QEngineShard::GetAntiTargetOfShards, &QEngineShard::GetAntiControlsShards,
+            &QEngineShard::AddAntiPhaseAngles);
+    }
+
+    void MakeTargetAnti(QEngineShardPtr control)
+    {
+        ShardToPhaseMap::iterator phaseShard = targetOfShards.find(control);
+        antiTargetOfShards[phaseShard->first] = phaseShard->second;
+        targetOfShards.erase(phaseShard);
+    }
+
+    void MakeTargetNotAnti(QEngineShardPtr control)
+    {
+        ShardToPhaseMap::iterator phaseShard = antiTargetOfShards.find(control);
+        targetOfShards[phaseShard->first] = phaseShard->second;
+        antiTargetOfShards.erase(phaseShard);
+    }
+
     void FlipPhaseAnti()
     {
+        ShardToPhaseMap::iterator phaseShard;
+        for (phaseShard = controlsShards.begin(); phaseShard != controlsShards.end(); phaseShard++) {
+            phaseShard->first->MakeTargetAnti(this);
+        }
+        for (phaseShard = antiControlsShards.begin(); phaseShard != antiControlsShards.end(); phaseShard++) {
+            phaseShard->first->MakeTargetNotAnti(this);
+        }
+        std::swap(controlsShards, antiControlsShards);
+
         par_for(0, targetOfShards.size(), [&](const bitCapInt lcv, const int cpu) {
             ShardToPhaseMap::iterator phaseShard = targetOfShards.begin();
             std::advance(phaseShard, lcv);
@@ -354,6 +421,17 @@ public:
 
     void CommutePhase(const complex& topLeft, const complex& bottomRight)
     {
+        par_for(0, antiTargetOfShards.size(), [&](const bitCapInt lcv, const int cpu) {
+            ShardToPhaseMap::iterator phaseShard = antiTargetOfShards.begin();
+            std::advance(phaseShard, lcv);
+            if (!phaseShard->second->isInvert) {
+                return;
+            }
+
+            phaseShard->second->cmplx0 *= topLeft / bottomRight;
+            phaseShard->second->cmplx1 *= bottomRight / topLeft;
+        });
+
         par_for(0, targetOfShards.size(), [&](const bitCapInt lcv, const int cpu) {
             ShardToPhaseMap::iterator phaseShard = targetOfShards.begin();
             std::advance(phaseShard, lcv);
@@ -410,44 +488,92 @@ public:
 
     bool IsInvertControlOf(QEngineShardPtr target)
     {
+        bool toRet = false;
+
         ShardToPhaseMap::iterator phaseShard = controlsShards.find(target);
         if (phaseShard != controlsShards.end()) {
-            return phaseShard->second->isInvert;
+            toRet = phaseShard->second->isInvert;
         }
 
-        return false;
+        if (toRet) {
+            return true;
+        }
+
+        phaseShard = antiControlsShards.find(target);
+        if (phaseShard != antiControlsShards.end()) {
+            toRet |= phaseShard->second->isInvert;
+        }
+
+        return toRet;
     }
 
     bool IsInvertTargetOf(QEngineShardPtr control)
     {
+        bool toRet = false;
+
         ShardToPhaseMap::iterator phaseShard = targetOfShards.find(control);
         if (phaseShard != targetOfShards.end()) {
-            return phaseShard->second->isInvert;
+            toRet = phaseShard->second->isInvert;
         }
 
-        return false;
+        if (toRet) {
+            return true;
+        }
+
+        phaseShard = antiTargetOfShards.find(control);
+        if (phaseShard != antiTargetOfShards.end()) {
+            toRet |= phaseShard->second->isInvert;
+        }
+
+        return toRet;
     }
 
     bool IsInvertControl()
     {
+        bool toRet = false;
         ShardToPhaseMap::iterator phaseShard;
 
         for (phaseShard = controlsShards.begin(); phaseShard != controlsShards.end(); phaseShard++) {
             if (phaseShard->second->isInvert) {
-                return true;
+                toRet = true;
+                break;
             }
         }
 
-        return false;
+        if (toRet) {
+            return true;
+        }
+
+        for (phaseShard = antiControlsShards.begin(); phaseShard != antiControlsShards.end(); phaseShard++) {
+            if (phaseShard->second->isInvert) {
+                toRet = true;
+                break;
+            }
+        }
+
+        return toRet;
     }
 
     bool IsInvertTarget()
     {
+        bool toRet = false;
         ShardToPhaseMap::iterator phaseShard;
 
         for (phaseShard = targetOfShards.begin(); phaseShard != targetOfShards.end(); phaseShard++) {
             if (phaseShard->second->isInvert) {
-                return true;
+                toRet = true;
+                break;
+            }
+        }
+
+        if (toRet) {
+            return true;
+        }
+
+        for (phaseShard = antiTargetOfShards.begin(); phaseShard != antiTargetOfShards.end(); phaseShard++) {
+            if (phaseShard->second->isInvert) {
+                toRet = true;
+                break;
             }
         }
 
@@ -789,13 +915,15 @@ protected:
 
     enum RevertExclusivity { INVERT_AND_PHASE = 0, ONLY_INVERT = 1, ONLY_PHASE = 2 };
     enum RevertControl { CONTROLS_AND_TARGETS = 0, ONLY_CONTROLS = 1, ONLY_TARGETS = 2 };
+    enum RevertAnti { CTRL_AND_ANTI = 0, ONLY_CTRL = 1, ONLY_ANTI = 2 };
 
     void ApplyBuffer(
         ShardToPhaseMap::iterator phaseShard, const bitLenInt& control, const bitLenInt& target, const bool& isAnti);
     void ApplyBufferMap(const bitLenInt& bitIndex, ShardToPhaseMap bufferMap, const RevertExclusivity& exclusivity,
         const bool& isControl, const bool& isAnti, std::set<bitLenInt> exceptPartners, const bool& dumpSkipped);
     void RevertBasis2Qb(const bitLenInt& i, const RevertExclusivity& exclusivity = INVERT_AND_PHASE,
-        const RevertControl& controlExclusivity = CONTROLS_AND_TARGETS, std::set<bitLenInt> exceptControlling = {},
+        const RevertControl& controlExclusivity = CONTROLS_AND_TARGETS,
+        const RevertAnti& antiExclusivity = CTRL_AND_ANTI, std::set<bitLenInt> exceptControlling = {},
         std::set<bitLenInt> exceptTargetedBy = {}, const bool& dumpSkipped = false);
 
     void ToPermBasis(const bitLenInt& i)
@@ -833,7 +961,8 @@ protected:
         }
         for (i = 0; i < length; i++) {
             RevertBasis2Qb(start + i, ONLY_INVERT);
-            RevertBasis2Qb(start + i, INVERT_AND_PHASE, CONTROLS_AND_TARGETS, exceptBits, exceptBits, true);
+            RevertBasis2Qb(
+                start + i, INVERT_AND_PHASE, CONTROLS_AND_TARGETS, CTRL_AND_ANTI, exceptBits, exceptBits, true);
         }
     }
     void ToPermBasisAllMeasure()
@@ -843,7 +972,7 @@ protected:
             TransformBasis1Qb(i, false);
         }
         for (i = 0; i < qubitCount; i++) {
-            RevertBasis2Qb(i, ONLY_INVERT, CONTROLS_AND_TARGETS, {}, {}, true);
+            RevertBasis2Qb(i, ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI, {}, {}, true);
         }
     }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1133,19 +1133,7 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
 
 void QUnit::AntiCNOT(bitLenInt control, bitLenInt target)
 {
-    QEngineShard& tShard = shards[target];
-    if (CACHED_PLUS_MINUS(tShard)) {
-        if (IS_NORM_ZERO(tShard.amp1)) {
-            return;
-        }
-        if (IS_NORM_ZERO(tShard.amp0)) {
-            Z(control);
-            return;
-        }
-    }
-
     QEngineShard& cShard = shards[control];
-
     if (CACHED_PROB(cShard)) {
         if (IS_NORM_ZERO(cShard.amp1)) {
             X(target);
@@ -1156,21 +1144,8 @@ void QUnit::AntiCNOT(bitLenInt control, bitLenInt target)
         }
     }
 
-    bool isCachedInvert = !freezeBasis && tShard.IsInvertTargetOf(&cShard);
-
     bitLenInt controls[1] = { control };
     bitLenInt controlLen = 1;
-
-    if (!isCachedInvert && cShard.isPlusMinus && tShard.isPlusMinus) {
-        RevertBasis2Qb(control);
-        RevertBasis2Qb(target);
-
-        std::swap(controls[0], target);
-        ApplyEitherControlled(controls, controlLen, { target }, true,
-            [&](QInterfacePtr unit, std::vector<bitLenInt> mappedControls) { unit->AntiCNOT(CTRL_1_ARGS); },
-            [&]() { XBase(target); }, true);
-        return;
-    }
 
     if (!freezeBasis) {
         X(control);
@@ -1215,11 +1190,6 @@ void QUnit::CCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target)
 
 void QUnit::AntiCCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target)
 {
-    QEngineShard& tShard = shards[target];
-    if (CACHED_PLUS(tShard)) {
-        return;
-    }
-
     bitLenInt controls[2] = { control1, control2 };
 
     ApplyEitherControlled(controls, 2, { target }, true,

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -970,7 +970,6 @@ void QUnit::X(bitLenInt target)
 {
     QEngineShard& shard = shards[target];
 
-    RevertBasis2Qb(target, INVERT_AND_PHASE, ONLY_CONTROLS);
     shard.FlipPhaseAnti();
 
     if (!shard.isPlusMinus) {
@@ -1454,7 +1453,6 @@ void QUnit::ApplySingleInvert(const complex topRight, const complex bottomLeft, 
         return;
     }
 
-    RevertBasis2Qb(target, INVERT_AND_PHASE, ONLY_CONTROLS);
     shard.FlipPhaseAnti();
 
     if (!shard.isPlusMinus) {
@@ -3134,9 +3132,17 @@ void QUnit::ApplyBufferMap(const bitLenInt& bitIndex, ShardToPhaseMap bufferMap,
         bufferMap.erase(phaseShard);
 
         if (isControl) {
-            shard.RemovePhaseTarget(partner);
+            if (isAnti) {
+                shard.RemovePhaseAntiTarget(partner);
+            } else {
+                shard.RemovePhaseTarget(partner);
+            }
         } else {
-            shard.RemovePhaseControl(partner);
+            if (isAnti) {
+                shard.RemovePhaseAntiControl(partner);
+            } else {
+                shard.RemovePhaseControl(partner);
+            }
         }
     }
 }
@@ -3156,9 +3162,19 @@ void QUnit::RevertBasis2Qb(const bitLenInt& i, const RevertExclusivity& exclusiv
     shard.CombineGates();
 
     if ((controlExclusivity == ONLY_CONTROLS) && (exclusivity != ONLY_INVERT)) {
-        shard.OptimizeControls();
+        if (antiExclusivity != ONLY_ANTI) {
+            shard.OptimizeControls();
+        }
+        if (antiExclusivity != ONLY_CTRL) {
+            shard.OptimizeAntiControls();
+        }
     } else if ((controlExclusivity == ONLY_TARGETS) && (exclusivity != ONLY_INVERT)) {
-        shard.OptimizeTargets();
+        if (antiExclusivity != ONLY_ANTI) {
+            shard.OptimizeTargets();
+        }
+        if (antiExclusivity != ONLY_CTRL) {
+            shard.OptimizeAntiTargets();
+        }
     }
 
     if (controlExclusivity != ONLY_TARGETS) {

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -696,8 +696,7 @@ bool QUnit::ForceM(bitLenInt qubit, bool res, bool doForce, bool doApply)
     // This is critical: it's the "nonlocal correlation" of "wave function collapse".
     for (bitLenInt i = 0; i < qubitCount; i++) {
         if (shards[i].unit == shard.unit) {
-            shards[i].isProbDirty = true;
-            shards[i].isPhaseDirty = true;
+            shards[i].MakeDirty();
         }
     }
 
@@ -788,10 +787,8 @@ void QUnit::ISwap(bitLenInt qubit1, bitLenInt qubit2)
 
     // TODO: If we multiply out cached amplitudes, we can optimize this.
 
-    shards[qubit1].isProbDirty = true;
-    shards[qubit1].isPhaseDirty = true;
-    shards[qubit2].isProbDirty = true;
-    shards[qubit2].isPhaseDirty = true;
+    shards[qubit1].MakeDirty();
+    shards[qubit2].MakeDirty();
 }
 
 void QUnit::SqrtSwap(bitLenInt qubit1, bitLenInt qubit2)
@@ -819,10 +816,8 @@ void QUnit::SqrtSwap(bitLenInt qubit1, bitLenInt qubit2)
 
     // TODO: If we multiply out cached amplitudes, we can optimize this.
 
-    shards[qubit1].isProbDirty = true;
-    shards[qubit1].isPhaseDirty = true;
-    shards[qubit2].isProbDirty = true;
-    shards[qubit2].isPhaseDirty = true;
+    shards[qubit1].MakeDirty();
+    shards[qubit2].MakeDirty();
 }
 
 void QUnit::ISqrtSwap(bitLenInt qubit1, bitLenInt qubit2)
@@ -850,10 +845,8 @@ void QUnit::ISqrtSwap(bitLenInt qubit1, bitLenInt qubit2)
 
     // TODO: If we multiply out cached amplitudes, we can optimize this.
 
-    shards[qubit1].isProbDirty = true;
-    shards[qubit1].isPhaseDirty = true;
-    shards[qubit2].isProbDirty = true;
-    shards[qubit2].isPhaseDirty = true;
+    shards[qubit1].MakeDirty();
+    shards[qubit2].MakeDirty();
 }
 
 void QUnit::UniformlyControlledSingleBit(const bitLenInt* controls, const bitLenInt& controlLen, bitLenInt qubitIndex,
@@ -913,8 +906,7 @@ void QUnit::UniformlyControlledSingleBit(const bitLenInt* controls, const bitLen
     unit->UniformlyControlledSingleBit(mappedControls, trimmedControls.size(), shards[qubitIndex].mapped, mtrxs,
         &(skipPowers[0]), skipPowers.size(), skipValueMask);
 
-    shards[qubitIndex].isProbDirty = true;
-    shards[qubitIndex].isPhaseDirty = true;
+    shards[qubitIndex].MakeDirty();
 
     delete[] mappedControls;
 }
@@ -1869,8 +1861,7 @@ void QUnit::ApplyEitherControlled(const bitLenInt* controls, const bitLenInt& co
     cfn(unit, controlsMapped);
 
     for (i = 0; i < targets.size(); i++) {
-        shards[targets[i]].isProbDirty = true;
-        shards[targets[i]].isPhaseDirty = true;
+        shards[targets[i]].MakeDirty();
     }
 }
 
@@ -1989,8 +1980,7 @@ void QUnit::INCx(INCxFn fn, bitCapInt toMod, bitLenInt start, bitLenInt length, 
     ((*unit).*fn)(toMod, shards[start].mapped, length, shards[flagIndex].mapped);
 
     DirtyShardRange(start, length);
-    shards[flagIndex].isProbDirty = true;
-    shards[flagIndex].isPhaseDirty = true;
+    shards[flagIndex].MakeDirty();
 }
 
 void QUnit::INCxx(
@@ -2004,10 +1994,8 @@ void QUnit::INCxx(
     ((*unit).*fn)(toMod, shards[start].mapped, length, shards[flag1Index].mapped, shards[flag2Index].mapped);
 
     DirtyShardRange(start, length);
-    shards[flag1Index].isProbDirty = true;
-    shards[flag2Index].isProbDirty = true;
-    shards[flag1Index].isPhaseDirty = true;
-    shards[flag2Index].isPhaseDirty = true;
+    shards[flag1Index].MakeDirty();
+    shards[flag2Index].MakeDirty();
 }
 
 /// Check if overflow arithmetic can be optimized
@@ -2869,8 +2857,7 @@ bitCapInt QUnit::IndexedADC(bitLenInt indexStart, bitLenInt indexLength, bitLenI
 
     DirtyShardRangePhase(indexStart, indexLength);
     DirtyShardRange(valueStart, valueLength);
-    shards[carryIndex].isProbDirty = true;
-    shards[carryIndex].isPhaseDirty = true;
+    shards[carryIndex].MakeDirty();
 
     return toRet;
 }
@@ -2909,8 +2896,7 @@ bitCapInt QUnit::IndexedSBC(bitLenInt indexStart, bitLenInt indexLength, bitLenI
 
     DirtyShardRangePhase(indexStart, indexLength);
     DirtyShardRange(valueStart, valueLength);
-    shards[carryIndex].isProbDirty = true;
-    shards[carryIndex].isPhaseDirty = true;
+    shards[carryIndex].MakeDirty();
 
     return toRet;
 }

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1613,10 +1613,6 @@ void QUnit::ApplyAntiControlledSingleInvert(const bitLenInt* controls, const bit
         return;
     }
 
-    if ((controlLen > 1U) && TryCnotOptimize(controls, controlLen, target, topRight, bottomLeft, true)) {
-        return;
-    }
-
     CTRLED_PHASE_INVERT_WRAP(ApplyAntiControlledSingleInvert(CTRL_I_ARGS), ApplyAntiControlledSingleBit(CTRL_GEN_ARGS),
         ApplySingleInvert(topRight, bottomLeft, target), true, true, topRight, bottomLeft);
 }


### PR DESCRIPTION
Per issue #342, "anti-controlled" buffers have been added to QUnit. This allows for full commutation between "inversion" gates (like `X`) and QUnit controlled phase buffers. The full ramifications for optimization have not been fleshed out, but the backbone of the new functionality and the library in general is working and passing cross entropy benchmarks and unit tests.