### PR TITLE
QUnit refactor

### DIFF
--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -45,8 +45,10 @@ struct PhaseShard {
     }
 };
 
-#define IS_ARG_0(c) (norm(c - ONE_CMPLX) <= amplitudeFloor)
-#define IS_ARG_PI(c) (norm(c + ONE_CMPLX) <= amplitudeFloor)
+#define IS_SAME(c1, c2) (norm((c1) - (c2)) <= amplitudeFloor)
+#define IS_OPPOSITE(c1, c2) (norm((c1) + (c2)) <= amplitudeFloor)
+#define IS_ARG_0(c) IS_SAME(c, ONE_CMPLX)
+#define IS_ARG_PI(c) IS_OPPOSITE(c, ONE_CMPLX)
 
 class QEngineShard;
 typedef QEngineShard* QEngineShardPtr;
@@ -208,7 +210,7 @@ protected:
         ShardToPhaseMap::iterator phaseShard = localMap.begin();
         int lcv = 0;
         while (phaseShard != localMap.end()) {
-            if (!phaseShard->second->isInvert && (phaseShard->second->cmplx0 == phaseShard->second->cmplx1)) {
+            if (!phaseShard->second->isInvert && IS_SAME(phaseShard->second->cmplx0, phaseShard->second->cmplx1)) {
                 ((*this).*remoteFn)(phaseShard->first);
             } else {
                 lcv++;

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -966,6 +966,16 @@ protected:
         const RevertAnti& antiExclusivity = CTRL_AND_ANTI, std::set<bitLenInt> exceptControlling = {},
         std::set<bitLenInt> exceptTargetedBy = {}, const bool& dumpSkipped = false);
 
+    void Flush0Eigenstate(const bitLenInt& i)
+    {
+        shards[i].DumpControlOf();
+        RevertBasis2Qb(i, INVERT_AND_PHASE, ONLY_CONTROLS, ONLY_ANTI);
+    }
+    void Flush1Eigenstate(const bitLenInt& i)
+    {
+        shards[i].DumpAntiControlOf();
+        RevertBasis2Qb(i, INVERT_AND_PHASE, ONLY_CONTROLS, ONLY_CTRL);
+    }
     void ToPermBasis(const bitLenInt& i)
     {
         TransformBasis1Qb(false, i);

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -997,9 +997,7 @@ protected:
         if (randGlobalPhase) {
             shards[i].DumpSamePhaseAntiControlOf();
         }
-        CheckShardSeparable(i);
-        // If all bits were separable, this would be "free."
-        // RevertBasis2Qb(i, INVERT_AND_PHASE, ONLY_CONTROLS, ONLY_ANTI);
+        RevertBasis2Qb(i, INVERT_AND_PHASE, ONLY_CONTROLS, ONLY_ANTI);
     }
     void Flush1Eigenstate(const bitLenInt& i)
     {
@@ -1007,9 +1005,7 @@ protected:
         if (randGlobalPhase) {
             shards[i].DumpSamePhaseControlOf();
         }
-        CheckShardSeparable(i);
-        // If all bits were separable, this would be "free."
-        // RevertBasis2Qb(i, INVERT_AND_PHASE, ONLY_CONTROLS, ONLY_CTRL);
+        RevertBasis2Qb(i, INVERT_AND_PHASE, ONLY_CONTROLS, ONLY_CTRL);
     }
     void ToPermBasis(const bitLenInt& i)
     {

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -206,6 +206,9 @@ public:
     void DumpControlOf()
     {
         DumpBuffer(&QEngineShard::OptimizeTargets, controlsShards, &QEngineShard::RemovePhaseTarget);
+    }
+    void DumpAntiControlOf()
+    {
         DumpBuffer(&QEngineShard::OptimizeAntiTargets, antiControlsShards, &QEngineShard::RemovePhaseAntiTarget);
     }
     void DumpTargetOf()
@@ -216,6 +219,7 @@ public:
     void DumpBuffers()
     {
         DumpControlOf();
+        DumpAntiControlOf();
         DumpTargetOf();
     }
 

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -994,7 +994,9 @@ protected:
     void Flush0Eigenstate(const bitLenInt& i)
     {
         shards[i].DumpControlOf();
-        shards[i].DumpSamePhaseAntiControlOf();
+        if (randGlobalPhase) {
+            shards[i].DumpSamePhaseAntiControlOf();
+        }
         CheckShardSeparable(i);
         // If all bits were separable, this would be "free."
         // RevertBasis2Qb(i, INVERT_AND_PHASE, ONLY_CONTROLS, ONLY_ANTI);
@@ -1002,7 +1004,9 @@ protected:
     void Flush1Eigenstate(const bitLenInt& i)
     {
         shards[i].DumpAntiControlOf();
-        shards[i].DumpSamePhaseControlOf();
+        if (randGlobalPhase) {
+            shards[i].DumpSamePhaseControlOf();
+        }
         CheckShardSeparable(i);
         // If all bits were separable, this would be "free."
         // RevertBasis2Qb(i, INVERT_AND_PHASE, ONLY_CONTROLS, ONLY_CTRL);

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1240,8 +1240,8 @@ void QUnit::CZ(bitLenInt control, bitLenInt target)
             std::swap(control, target);
         }
         TransformBasis1Qb(false, control);
-        RevertBasis2Qb(control, ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI, { target }, {});
-        RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI, {}, { control });
+        RevertBasis2Qb(control, ONLY_INVERT, ONLY_CONTROLS, CTRL_AND_ANTI, { target }, {});
+        RevertBasis2Qb(target, ONLY_INVERT, ONLY_CONTROLS, CTRL_AND_ANTI, {}, { control });
         shards[target].AddPhaseAngles(&(shards[control]), ONE_R1, -ONE_R1);
         return;
     }
@@ -1499,8 +1499,8 @@ void QUnit::ApplyControlledSinglePhase(const bitLenInt* cControls, const bitLenI
             std::swap(controls[0], target);
         }
         TransformBasis1Qb(false, controls[0]);
-        RevertBasis2Qb(controls[0], ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI, { target }, {});
-        RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI, {}, { controls[0] });
+        RevertBasis2Qb(controls[0], ONLY_INVERT, ONLY_CONTROLS, CTRL_AND_ANTI, { target }, {});
+        RevertBasis2Qb(target, ONLY_INVERT, ONLY_CONTROLS, CTRL_AND_ANTI, {}, { controls[0] });
         shards[target].AddPhaseAngles(&(shards[controls[0]]), topLeft, bottomRight);
         delete[] controls;
         return;
@@ -3087,9 +3087,17 @@ void QUnit::ApplyBufferMap(const bitLenInt& bitIndex, ShardToPhaseMap bufferMap,
             bufferMap.erase(phaseShard);
             if (dumpSkipped) {
                 if (isControl) {
-                    shard.RemovePhaseTarget(partner);
+                    if (isAnti) {
+                        shard.RemovePhaseAntiTarget(partner);
+                    } else {
+                        shard.RemovePhaseTarget(partner);
+                    }
                 } else {
-                    shard.RemovePhaseControl(partner);
+                    if (isAnti) {
+                        shard.RemovePhaseAntiControl(partner);
+                    } else {
+                        shard.RemovePhaseControl(partner);
+                    }
                 }
             }
             continue;

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1252,8 +1252,8 @@ void QUnit::CZ(bitLenInt control, bitLenInt target)
             std::swap(control, target);
         }
         TransformBasis1Qb(false, control);
-        RevertBasis2Qb(control, ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI, { target }, {});
-        RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI, {}, { control });
+        RevertBasis2Qb(control, ONLY_INVERT, ONLY_CONTROLS, CTRL_AND_ANTI, { target }, {});
+        RevertBasis2Qb(target, ONLY_INVERT, ONLY_CONTROLS, CTRL_AND_ANTI, {}, { control });
         shards[target].AddPhaseAngles(&(shards[control]), ONE_CMPLX, -ONE_CMPLX);
         return;
     }
@@ -1504,18 +1504,12 @@ void QUnit::ApplyControlledSinglePhase(const bitLenInt* cControls, const bitLenI
     }
 
     if (!freezeBasis && (controlLen == 1U)) {
-        QEngineShard& cShard = shards[controls[0]];
-        if (!cShard.IsInvertTarget() && UNSAFE_CACHED_CLASSICAL(cShard)) {
-            ApplySinglePhase(topLeft, bottomRight, target);
-            return;
-        }
-
         if (IS_ONE_CMPLX(topLeft) && tShard.IsInvertControlOf(&(shards[controls[0]]))) {
             std::swap(controls[0], target);
         }
         TransformBasis1Qb(false, controls[0]);
-        RevertBasis2Qb(controls[0], ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI, { target }, {});
-        RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI, {}, { controls[0] });
+        RevertBasis2Qb(controls[0], ONLY_INVERT, ONLY_CONTROLS, CTRL_AND_ANTI, { target }, {});
+        RevertBasis2Qb(target, ONLY_INVERT, ONLY_CONTROLS, CTRL_AND_ANTI, {}, { controls[0] });
         shards[target].AddPhaseAngles(&(shards[controls[0]]), topLeft, bottomRight);
         delete[] controls;
         return;

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -970,6 +970,10 @@ void QUnit::X(bitLenInt target)
 {
     QEngineShard& shard = shards[target];
 
+    if (CACHED_PLUS(shard)) {
+        return;
+    }
+
     shard.FlipPhaseAnti();
 
     if (!shard.isPlusMinus) {
@@ -1131,7 +1135,7 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
     }
 
     CTRLED_PHASE_INVERT_WRAP(
-        CNOT(CTRL_1_ARGS), ApplyControlledSingleBit(CTRL_GEN_ARGS), X(target), false, true, ONE_R1, ONE_R1);
+        CNOT(CTRL_1_ARGS), ApplyControlledSingleBit(CTRL_GEN_ARGS), X(target), false, true, ONE_CMPLX, ONE_CMPLX);
 }
 
 void QUnit::AntiCNOT(bitLenInt control, bitLenInt target)
@@ -1162,8 +1166,8 @@ void QUnit::AntiCNOT(bitLenInt control, bitLenInt target)
         return;
     }
 
-    CTRLED_PHASE_INVERT_WRAP(
-        AntiCNOT(CTRL_1_ARGS), ApplyAntiControlledSingleBit(CTRL_GEN_ARGS), X(target), true, true, ONE_R1, ONE_R1);
+    CTRLED_PHASE_INVERT_WRAP(AntiCNOT(CTRL_1_ARGS), ApplyAntiControlledSingleBit(CTRL_GEN_ARGS), X(target), true, true,
+        ONE_CMPLX, ONE_CMPLX);
 }
 
 void QUnit::CCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target)
@@ -1248,7 +1252,7 @@ void QUnit::CZ(bitLenInt control, bitLenInt target)
         TransformBasis1Qb(false, control);
         RevertBasis2Qb(control, ONLY_INVERT, ONLY_CONTROLS, CTRL_AND_ANTI, { target }, {});
         RevertBasis2Qb(target, ONLY_INVERT, ONLY_CONTROLS, CTRL_AND_ANTI, {}, { control });
-        shards[target].AddPhaseAngles(&(shards[control]), ONE_R1, -ONE_R1);
+        shards[target].AddPhaseAngles(&(shards[control]), ONE_CMPLX, -ONE_CMPLX);
         return;
     }
 
@@ -1256,7 +1260,7 @@ void QUnit::CZ(bitLenInt control, bitLenInt target)
     bitLenInt controlLen = 1;
 
     CTRLED_PHASE_INVERT_WRAP(
-        CZ(CTRL_1_ARGS), ApplyControlledSingleBit(CTRL_GEN_ARGS), Z(target), false, false, ONE_R1, -ONE_R1);
+        CZ(CTRL_1_ARGS), ApplyControlledSingleBit(CTRL_GEN_ARGS), Z(target), false, false, ONE_CMPLX, -ONE_CMPLX);
 }
 
 void QUnit::CCZ(bitLenInt control1, bitLenInt control2, bitLenInt target)
@@ -2748,7 +2752,7 @@ void QUnit::CPhaseFlipIfLess(bitCapInt greaterPerm, bitLenInt start, bitLenInt l
         real1 prob = Prob(flagIndex);
         if (IS_ZERO_R1(prob)) {
             return;
-        } else if (IS_ONE_R1(prob) == ONE_R1) {
+        } else if (IS_ONE_R1(prob)) {
             PhaseFlipIfLess(greaterPerm, start, length);
             return;
         }
@@ -3010,8 +3014,8 @@ QInterfacePtr QUnit::Clone()
     ToPermBasisAll();
     EndAllEmulation();
 
-    QUnitPtr copyPtr = std::make_shared<QUnit>(engine, subengine, qubitCount, 0, rand_generator,
-        complex(ONE_R1, ZERO_R1), doNormalize, randGlobalPhase, useHostRam);
+    QUnitPtr copyPtr = std::make_shared<QUnit>(
+        engine, subengine, qubitCount, 0, rand_generator, ONE_CMPLX, doNormalize, randGlobalPhase, useHostRam);
 
     return CloneBody(copyPtr);
 }

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -3181,7 +3181,7 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
 
     ShardToPhaseMap targetOfShards = shard.targetOfShards;
 
-    bool isSame = false, isOpposite, isAnti, alreadyOpposite = false;
+    bool isSame = false, isOpposite = false, anyOpposite = false, isAnti = false;
     bitLenInt oppositeControl = 0;
 
     for (phaseShard = targetOfShards.begin(); phaseShard != targetOfShards.end(); phaseShard++) {
@@ -3202,14 +3202,14 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
         // case that we could produce one of either.
         if (isOpposite) {
             QEngineShard& cShard = shards[control];
-            if (alreadyOpposite || (!cShard.IsInvertTarget() && UNSAFE_CACHED_CLASSICAL(cShard))) {
+            if (!cShard.IsInvertTarget() && UNSAFE_CACHED_CLASSICAL(cShard)) {
                 // "Free" to apply the buffer right now:
                 ApplyBuffer(phaseShard, control, bitIndex, false);
                 shard.RemovePhaseControl(partner);
             } else {
-                alreadyOpposite = true;
-                oppositeControl = control;
                 isAnti = false;
+                anyOpposite = true;
+                oppositeControl = control;
             }
         }
     }
@@ -3234,19 +3234,19 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
         // case that we could produce one of either.
         if (isOpposite) {
             QEngineShard& cShard = shards[control];
-            if (alreadyOpposite || (!cShard.IsInvertTarget() && UNSAFE_CACHED_CLASSICAL(cShard))) {
+            if (!cShard.IsInvertTarget() && UNSAFE_CACHED_CLASSICAL(cShard)) {
                 // "Free" to apply the buffer right now:
                 ApplyBuffer(phaseShard, control, bitIndex, true);
                 shard.RemovePhaseAntiControl(partner);
             } else {
-                alreadyOpposite = true;
-                oppositeControl = control;
                 isAnti = true;
+                anyOpposite = true;
+                oppositeControl = control;
             }
         }
     }
 
-    if (alreadyOpposite && !isSame) {
+    if (anyOpposite && !isSame) {
         RevertBasis2Qb(bitIndex, INVERT_AND_PHASE, CONTROLS_AND_TARGETS, isAnti ? ONLY_CTRL : ONLY_ANTI);
         RevertBasis2Qb(
             bitIndex, INVERT_AND_PHASE, CONTROLS_AND_TARGETS, isAnti ? ONLY_ANTI : ONLY_CTRL, { oppositeControl }, {});

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1252,8 +1252,8 @@ void QUnit::CZ(bitLenInt control, bitLenInt target)
             std::swap(control, target);
         }
         TransformBasis1Qb(false, control);
-        RevertBasis2Qb(control, ONLY_INVERT, ONLY_CONTROLS, CTRL_AND_ANTI, { target }, {});
-        RevertBasis2Qb(target, ONLY_INVERT, ONLY_CONTROLS, CTRL_AND_ANTI, {}, { control });
+        RevertBasis2Qb(control, ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI, { target }, {});
+        RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI, {}, { control });
         shards[target].AddPhaseAngles(&(shards[control]), ONE_CMPLX, -ONE_CMPLX);
         return;
     }
@@ -1514,8 +1514,8 @@ void QUnit::ApplyControlledSinglePhase(const bitLenInt* cControls, const bitLenI
             std::swap(controls[0], target);
         }
         TransformBasis1Qb(false, controls[0]);
-        RevertBasis2Qb(controls[0], ONLY_INVERT, ONLY_CONTROLS, CTRL_AND_ANTI, { target }, {});
-        RevertBasis2Qb(target, ONLY_INVERT, ONLY_CONTROLS, CTRL_AND_ANTI, {}, { controls[0] });
+        RevertBasis2Qb(controls[0], ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI, { target }, {});
+        RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI, {}, { controls[0] });
         shards[target].AddPhaseAngles(&(shards[controls[0]]), topLeft, bottomRight);
         delete[] controls;
         return;

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -970,10 +970,6 @@ void QUnit::X(bitLenInt target)
 {
     QEngineShard& shard = shards[target];
 
-    if (CACHED_PLUS(shard)) {
-        return;
-    }
-
     shard.FlipPhaseAnti();
 
     if (!shard.isPlusMinus) {
@@ -991,7 +987,9 @@ void QUnit::Z(bitLenInt target)
         shard.CommutePhase(ONE_CMPLX, -ONE_CMPLX);
     } else {
         if (UNSAFE_CACHED_ZERO(shard)) {
-            shard.DumpControlOf();
+            if (!cShard.IsInvertControl()) {
+                shard.DumpControlOf();
+            }
             return;
         }
     }
@@ -1362,6 +1360,9 @@ void QUnit::ApplySinglePhase(const complex topLeft, const complex bottomRight, b
         shard.CommutePhase(topLeft, bottomRight);
     } else {
         if (IS_ONE_CMPLX(topLeft) && UNSAFE_CACHED_ZERO(shard)) {
+            if (!shard.IsInvertControl()) {
+                shard.DumpControlOf();
+            }
             return;
         }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1504,6 +1504,17 @@ void QUnit::ApplyControlledSinglePhase(const bitLenInt* cControls, const bitLenI
     }
 
     if (!freezeBasis && (controlLen == 1U)) {
+        QEngineShard& cShard = shards[controls[0]];
+        if (!cShard.IsInvertTarget() && UNSAFE_CACHED_CLASSICAL(cShard)) {
+            if (SHARD_STATE(cShard)) {
+                Flush1Eigenstate(controls[0]);
+                ApplySinglePhase(topLeft, bottomRight, target);
+            } else {
+                Flush0Eigenstate(controls[0]);
+            }
+            return;
+        }
+
         if (IS_ONE_CMPLX(topLeft) && tShard.IsInvertControlOf(&(shards[controls[0]]))) {
             std::swap(controls[0], target);
         }

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -740,16 +740,16 @@ void QUnit::Swap(bitLenInt qubit1, bitLenInt qubit2)
 
     if (UNSAFE_CACHED_CLASSICAL(shard1)) {
         if (SHARD_STATE(shard1)) {
-            shard1.DumpAntiControlOf();
+            Flush1Eigenstate(qubit1);
         } else {
-            shard1.DumpControlOf();
+            Flush0Eigenstate(qubit1);
         }
     }
     if (UNSAFE_CACHED_CLASSICAL(shard2)) {
         if (SHARD_STATE(shard2)) {
-            shard2.DumpAntiControlOf();
+            Flush1Eigenstate(qubit2);
         } else {
-            shard2.DumpControlOf();
+            Flush0Eigenstate(qubit2);
         }
     }
 
@@ -995,7 +995,7 @@ void QUnit::Z(bitLenInt target)
         shard.CommutePhase(ONE_CMPLX, -ONE_CMPLX);
     } else {
         if (UNSAFE_CACHED_ZERO(shard)) {
-            shard.DumpControlOf();
+            Flush0Eigenstate(target);
             return;
         }
     }
@@ -1095,11 +1095,11 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
 
     if (!cShard.IsInvertTarget() && UNSAFE_CACHED_CLASSICAL(cShard)) {
         if (IS_NORM_ZERO(cShard.amp1)) {
-            cShard.DumpControlOf();
+            Flush0Eigenstate(control);
             return;
         }
         if (IS_NORM_ZERO(cShard.amp0)) {
-            cShard.DumpAntiControlOf();
+            Flush1Eigenstate(control);
             X(target);
             return;
         }
@@ -1146,12 +1146,12 @@ void QUnit::AntiCNOT(bitLenInt control, bitLenInt target)
     QEngineShard& cShard = shards[control];
     if (!cShard.IsInvertTarget() && UNSAFE_CACHED_CLASSICAL(cShard)) {
         if (IS_NORM_ZERO(cShard.amp1)) {
-            cShard.DumpControlOf();
+            Flush0Eigenstate(control);
             X(target);
             return;
         }
         if (IS_NORM_ZERO(cShard.amp0)) {
-            cShard.DumpAntiControlOf();
+            Flush1Eigenstate(control);
             return;
         }
     }
@@ -1231,20 +1231,20 @@ void QUnit::CZ(bitLenInt control, bitLenInt target)
 
     if (!tShard.IsInvertTarget() && UNSAFE_CACHED_CLASSICAL(tShard)) {
         if (SHARD_STATE(tShard)) {
-            tShard.DumpAntiControlOf();
+            Flush1Eigenstate(target);
             Z(control);
         } else {
-            tShard.DumpControlOf();
+            Flush0Eigenstate(target);
         }
         return;
     }
 
     if (!cShard.IsInvertTarget() && UNSAFE_CACHED_CLASSICAL(cShard)) {
         if (SHARD_STATE(cShard)) {
-            cShard.DumpAntiControlOf();
+            Flush1Eigenstate(control);
             Z(target);
         } else {
-            cShard.DumpControlOf();
+            Flush0Eigenstate(control);
         }
         return;
     }
@@ -1284,11 +1284,11 @@ void QUnit::CCZ(bitLenInt control1, bitLenInt control2, bitLenInt target)
     if (!c1Shard.IsInvertTarget()) {
         if (UNSAFE_CACHED_CLASSICAL(c1Shard)) {
             if (IS_NORM_ZERO(c1Shard.amp1)) {
-                c1Shard.DumpControlOf();
+                Flush0Eigenstate(control1);
                 return;
             }
             if (IS_NORM_ZERO(c1Shard.amp0)) {
-                c1Shard.DumpAntiControlOf();
+                Flush1Eigenstate(control1);
                 CZ(control2, target);
                 return;
             }
@@ -1298,11 +1298,11 @@ void QUnit::CCZ(bitLenInt control1, bitLenInt control2, bitLenInt target)
     if (!c2Shard.IsInvertTarget()) {
         if (UNSAFE_CACHED_CLASSICAL(c2Shard)) {
             if (IS_NORM_ZERO(c2Shard.amp1)) {
-                c2Shard.DumpControlOf();
+                Flush0Eigenstate(control2);
                 return;
             }
             if (IS_NORM_ZERO(c2Shard.amp0)) {
-                c2Shard.DumpAntiControlOf();
+                Flush1Eigenstate(control2);
                 CZ(control1, target);
                 return;
             }
@@ -1312,11 +1312,11 @@ void QUnit::CCZ(bitLenInt control1, bitLenInt control2, bitLenInt target)
     if (!tShard.IsInvertTarget()) {
         if (UNSAFE_CACHED_CLASSICAL(tShard)) {
             if (IS_NORM_ZERO(tShard.amp1)) {
-                tShard.DumpControlOf();
+                Flush0Eigenstate(target);
                 return;
             }
             if (IS_NORM_ZERO(tShard.amp0)) {
-                tShard.DumpAntiControlOf();
+                Flush1Eigenstate(target);
                 CZ(control1, control2);
                 return;
             }
@@ -1363,12 +1363,12 @@ void QUnit::ApplySinglePhase(const complex topLeft, const complex bottomRight, b
         shard.CommutePhase(topLeft, bottomRight);
     } else {
         if (IS_ONE_CMPLX(topLeft) && UNSAFE_CACHED_ZERO(shard)) {
-            shard.DumpControlOf();
+            Flush0Eigenstate(target);
             return;
         }
 
         if (IS_ONE_CMPLX(bottomRight) && UNSAFE_CACHED_ONE(shard)) {
-            shard.DumpAntiControlOf();
+            Flush1Eigenstate(target);
             return;
         }
     }
@@ -1481,7 +1481,7 @@ void QUnit::ApplyControlledSinglePhase(const bitLenInt* cControls, const bitLenI
 
     if (IS_ONE_CMPLX(topLeft)) {
         if (!tShard.IsInvertTarget() && UNSAFE_CACHED_ZERO(tShard)) {
-            tShard.DumpControlOf();
+            Flush0Eigenstate(target);
             delete[] controls;
             return;
         }
@@ -1567,7 +1567,7 @@ void QUnit::ApplyAntiControlledSinglePhase(const bitLenInt* cControls, const bit
 
     if (IS_ONE_CMPLX(topLeft)) {
         if (!tShard.IsInvertTarget() && UNSAFE_CACHED_ZERO(tShard)) {
-            tShard.DumpControlOf();
+            Flush0Eigenstate(target);
             delete[] controls;
             return;
         }
@@ -1763,7 +1763,7 @@ void QUnit::ApplyEitherControlled(const bitLenInt* controls, const bitLenInt& co
             shard = shards[controls[i]];
             if (IS_NORM_ZERO(shard.amp1)) {
                 if (!inCurrentBasis) {
-                    shard.DumpControlOf();
+                    Flush0Eigenstate(controls[i]);
                 }
                 if (!anti) {
                     /* This gate does nothing, so return without applying anything. */
@@ -1773,7 +1773,7 @@ void QUnit::ApplyEitherControlled(const bitLenInt* controls, const bitLenInt& co
                 isEigenstate = true;
             } else if (IS_NORM_ZERO(shard.amp0)) {
                 if (!inCurrentBasis) {
-                    shard.DumpAntiControlOf();
+                    Flush1Eigenstate(controls[i]);
                 }
                 if (anti) {
                     /* This gate does nothing, so return without applying anything. */

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -987,9 +987,7 @@ void QUnit::Z(bitLenInt target)
         shard.CommutePhase(ONE_CMPLX, -ONE_CMPLX);
     } else {
         if (UNSAFE_CACHED_ZERO(shard)) {
-            if (!cShard.IsInvertControl()) {
-                shard.DumpControlOf();
-            }
+            shard.DumpControlOf();
             return;
         }
     }
@@ -1089,9 +1087,7 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
 
     if (!cShard.IsInvertTarget() && UNSAFE_CACHED_CLASSICAL(cShard)) {
         if (IS_NORM_ZERO(cShard.amp1)) {
-            if (!cShard.IsInvertControl()) {
-                cShard.DumpControlOf();
-            }
+            cShard.DumpControlOf();
             return;
         }
         if (IS_NORM_ZERO(cShard.amp0)) {
@@ -1141,13 +1137,11 @@ void QUnit::AntiCNOT(bitLenInt control, bitLenInt target)
     QEngineShard& cShard = shards[control];
     if (!cShard.IsInvertTarget() && UNSAFE_CACHED_CLASSICAL(cShard)) {
         if (IS_NORM_ZERO(cShard.amp1)) {
+            cShard.DumpControlOf();
             X(target);
             return;
         }
         if (IS_NORM_ZERO(cShard.amp0)) {
-            if (!cShard.IsInvertControl()) {
-                cShard.DumpControlOf();
-            }
             return;
         }
     }
@@ -1228,7 +1222,7 @@ void QUnit::CZ(bitLenInt control, bitLenInt target)
     if (!tShard.IsInvertTarget() && UNSAFE_CACHED_CLASSICAL(tShard)) {
         if (SHARD_STATE(tShard)) {
             Z(control);
-        } else if (!tShard.IsInvertControl()) {
+        } else {
             tShard.DumpControlOf();
         }
         return;
@@ -1237,7 +1231,7 @@ void QUnit::CZ(bitLenInt control, bitLenInt target)
     if (!cShard.IsInvertTarget() && UNSAFE_CACHED_CLASSICAL(cShard)) {
         if (SHARD_STATE(cShard)) {
             Z(target);
-        } else if (!cShard.IsInvertControl()) {
+        } else {
             cShard.DumpControlOf();
         }
         return;
@@ -1278,9 +1272,7 @@ void QUnit::CCZ(bitLenInt control1, bitLenInt control2, bitLenInt target)
     if (!c1Shard.IsInvertTarget()) {
         if (UNSAFE_CACHED_CLASSICAL(c1Shard)) {
             if (IS_NORM_ZERO(c1Shard.amp1)) {
-                if (!c1Shard.IsInvertControl()) {
-                    c1Shard.DumpControlOf();
-                }
+                c1Shard.DumpControlOf();
                 return;
             }
             if (IS_NORM_ZERO(c1Shard.amp0)) {
@@ -1293,9 +1285,7 @@ void QUnit::CCZ(bitLenInt control1, bitLenInt control2, bitLenInt target)
     if (!c2Shard.IsInvertTarget()) {
         if (UNSAFE_CACHED_CLASSICAL(c2Shard)) {
             if (IS_NORM_ZERO(c2Shard.amp1)) {
-                if (!c2Shard.IsInvertControl()) {
-                    c2Shard.DumpControlOf();
-                }
+                c2Shard.DumpControlOf();
                 return;
             }
             if (IS_NORM_ZERO(c2Shard.amp0)) {
@@ -1308,9 +1298,7 @@ void QUnit::CCZ(bitLenInt control1, bitLenInt control2, bitLenInt target)
     if (!tShard.IsInvertTarget()) {
         if (UNSAFE_CACHED_CLASSICAL(tShard)) {
             if (IS_NORM_ZERO(tShard.amp1)) {
-                if (!tShard.IsInvertControl()) {
-                    tShard.DumpControlOf();
-                }
+                tShard.DumpControlOf();
                 return;
             }
             if (IS_NORM_ZERO(tShard.amp0)) {
@@ -1360,9 +1348,7 @@ void QUnit::ApplySinglePhase(const complex topLeft, const complex bottomRight, b
         shard.CommutePhase(topLeft, bottomRight);
     } else {
         if (IS_ONE_CMPLX(topLeft) && UNSAFE_CACHED_ZERO(shard)) {
-            if (!shard.IsInvertControl()) {
-                shard.DumpControlOf();
-            }
+            shard.DumpControlOf();
             return;
         }
 
@@ -1479,9 +1465,7 @@ void QUnit::ApplyControlledSinglePhase(const bitLenInt* cControls, const bitLenI
 
     if (IS_ONE_CMPLX(topLeft)) {
         if (!tShard.IsInvertTarget() && UNSAFE_CACHED_ZERO(tShard)) {
-            if (!tShard.IsInvertControl()) {
-                tShard.DumpControlOf();
-            }
+            tShard.DumpControlOf();
             delete[] controls;
             return;
         }
@@ -1567,9 +1551,7 @@ void QUnit::ApplyAntiControlledSinglePhase(const bitLenInt* cControls, const bit
 
     if (IS_ONE_CMPLX(topLeft)) {
         if (!tShard.IsInvertTarget() && UNSAFE_CACHED_ZERO(tShard)) {
-            if (!tShard.IsInvertControl()) {
-                tShard.DumpControlOf();
-            }
+            tShard.DumpControlOf();
             delete[] controls;
             return;
         }

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -4582,6 +4582,8 @@ struct MultiQubitGate {
 
 TEST_CASE("test_universal_circuit_digital_cross_entropy", "[supreme]")
 {
+    std::cout << ">>> 'test_universal_circuit_digital_cross_entropy':" << std::endl;
+
     const int GateCount1Qb = 5;
     const int GateCountMultiQb = 4;
     const int Depth = 3;
@@ -4744,6 +4746,8 @@ TEST_CASE("test_universal_circuit_digital_cross_entropy", "[supreme]")
 
 TEST_CASE("test_quantum_supremacy_cross_entropy", "[supreme]")
 {
+    std::cout << ">>> 'test_quantum_supremacy_cross_entropy':" << std::endl;
+
     // "1/6 of a full CZ" is read to indicate the 6th root of the gate operator.
     complex sixthRoot = std::pow(-ONE_CMPLX, (real1)(1.0 / 6.0));
 


### PR DESCRIPTION
I cut a dead macro from QUnit, encapsulated eigenstate buffer flushes in inline methods, and removed CheckShardSeparable() from all places except ProbBase(), which is currently the only place where it can make a difference. I believe the series of CI failures is due to putting in a buffer commutation optimization attempt first thing in the branch, then never noticing it was repeatedly failing CI, but we'll see when the last commit clears.