### PR TITLE
Debugging CZ/CNOT buffer commutation and anti-controlled buffers

### DIFF
--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -517,14 +517,14 @@ public:
             PhaseShardPtr buffer = phaseShard->second;
             if (norm(buffer->cmplxDiff - buffer->cmplxSame) < ONE_R1) {
                 if (buffer->isInvert) {
-                    buffer->cmplxSame = -buffer->cmplxDiff;
+                    buffer->cmplxDiff = -buffer->cmplxSame;
                     buffer->isInvert = false;
                 }
             } else {
                 if (buffer->isInvert) {
                     std::swap(buffer->cmplxDiff, buffer->cmplxSame);
                 } else {
-                    buffer->cmplxSame = buffer->cmplxDiff;
+                    buffer->cmplxDiff = buffer->cmplxSame;
                     buffer->isInvert = true;
                 }
             }

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -595,7 +595,7 @@ public:
         return toRet;
     }
 
-    bool IsCnotControl()
+    bool IsInvertSamePhaseControl()
     {
         bool toRet = false;
         ShardToPhaseMap::iterator phaseShard;
@@ -603,7 +603,7 @@ public:
 
         for (phaseShard = controlsShards.begin(); phaseShard != controlsShards.end(); phaseShard++) {
             buffer = phaseShard->second;
-            if (buffer->isInvert && IS_ARG_0(buffer->cmplx0) && IS_ARG_0(buffer->cmplx1)) {
+            if (buffer->isInvert && IS_SAME(buffer->cmplx0, buffer->cmplx1)) {
                 toRet = true;
                 break;
             }
@@ -615,7 +615,7 @@ public:
 
         for (phaseShard = antiControlsShards.begin(); phaseShard != antiControlsShards.end(); phaseShard++) {
             buffer = phaseShard->second;
-            if (buffer->isInvert && IS_ARG_0(buffer->cmplx0) && IS_ARG_0(buffer->cmplx1)) {
+            if (buffer->isInvert && IS_SAME(buffer->cmplx0, buffer->cmplx1)) {
                 toRet = true;
                 break;
             }

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -208,11 +208,11 @@ protected:
 
     void DumpSamePhaseBuffer(OptimizeFn optimizeFn, ShardToPhaseMap& localMap, AddRemoveFn remoteFn)
     {
+        ((*this).*optimizeFn)();
+
         PhaseShardPtr buffer;
         ShardToPhaseMap::iterator phaseShard = localMap.begin();
         int lcv = 0;
-
-        ((*this).*optimizeFn)();
 
         while (phaseShard != localMap.end()) {
             buffer = phaseShard->second;

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -302,7 +302,8 @@ public:
     }
 
 protected:
-    void OptimizeBuffer(ShardToPhaseMap& localMap, GetBufferFn remoteMapGet, AddAnglesFn phaseFn, bool makeThisControl)
+    void OptimizeBuffer(
+        ShardToPhaseMap& localMap, GetBufferFn remoteMapGet, AddAnglesFn phaseFn, bool makeThisControl, bool isAnti)
     {
         PhaseShardPtr buffer;
         QEngineShardPtr partner;
@@ -315,7 +316,8 @@ protected:
             buffer = phaseShard->second;
             partner = phaseShard->first;
 
-            if (buffer->isInvert || (isPlusMinus != partner->isPlusMinus) || !IS_ARG_0(buffer->cmplx0)) {
+            if (buffer->isInvert || (isPlusMinus != partner->isPlusMinus) ||
+                ((isAnti && !IS_ARG_0(buffer->cmplx1)) || (!isAnti && !IS_ARG_0(buffer->cmplx0)))) {
                 continue;
             }
 
@@ -335,21 +337,21 @@ protected:
 public:
     void OptimizeControls()
     {
-        OptimizeBuffer(controlsShards, &QEngineShard::GetTargetOfShards, &QEngineShard::AddPhaseAngles, false);
+        OptimizeBuffer(controlsShards, &QEngineShard::GetTargetOfShards, &QEngineShard::AddPhaseAngles, false, false);
     }
     void OptimizeTargets()
     {
-        OptimizeBuffer(targetOfShards, &QEngineShard::GetControlsShards, &QEngineShard::AddPhaseAngles, true);
+        OptimizeBuffer(targetOfShards, &QEngineShard::GetControlsShards, &QEngineShard::AddPhaseAngles, true, false);
     }
     void OptimizeAntiControls()
     {
         OptimizeBuffer(
-            antiControlsShards, &QEngineShard::GetAntiTargetOfShards, &QEngineShard::AddAntiPhaseAngles, false);
+            antiControlsShards, &QEngineShard::GetAntiTargetOfShards, &QEngineShard::AddAntiPhaseAngles, false, true);
     }
     void OptimizeAntiTargets()
     {
         OptimizeBuffer(
-            antiTargetOfShards, &QEngineShard::GetAntiControlsShards, &QEngineShard::AddAntiPhaseAngles, true);
+            antiTargetOfShards, &QEngineShard::GetAntiControlsShards, &QEngineShard::AddAntiPhaseAngles, true, true);
     }
 
 protected:

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -14,6 +14,7 @@
 
 #include <cfloat>
 #include <random>
+#include <unordered_set>
 
 #include "qinterface.hpp"
 
@@ -437,19 +438,20 @@ public:
 
     void FlipPhaseAnti()
     {
-        // TODO: Totally bugged
-        /*std::vector<QEngineShardPtr> alreadySwapped;
-        ShardToPhaseMap::iterator phaseShard;
-        for (phaseShard = controlsShards.begin(); phaseShard != controlsShards.end(); phaseShard++) {
-            phaseShard->first->SwapTargetAnti(this);
-            alreadySwapped.push_back(phaseShard->first);
+        std::unordered_set<QEngineShardPtr> toSwap;
+        ShardToPhaseMap::iterator ctrlPhaseShard;
+        for (ctrlPhaseShard = controlsShards.begin(); ctrlPhaseShard != controlsShards.end(); ctrlPhaseShard++) {
+            toSwap.insert(ctrlPhaseShard->first);
         }
-        for (phaseShard = antiControlsShards.begin(); phaseShard != antiControlsShards.end(); phaseShard++) {
-            if (std::find(alreadySwapped.begin(), alreadySwapped.end(), phaseShard->first) == alreadySwapped.end()) {
-                phaseShard->first->SwapTargetAnti(this);
-            }
+        for (ctrlPhaseShard = antiControlsShards.begin(); ctrlPhaseShard != antiControlsShards.end();
+             ctrlPhaseShard++) {
+            toSwap.insert(ctrlPhaseShard->first);
         }
-        std::swap(controlsShards, antiControlsShards);*/
+        std::unordered_set<QEngineShardPtr>::iterator swapShard;
+        for (swapShard = toSwap.begin(); swapShard != toSwap.end(); swapShard++) {
+            (*swapShard)->SwapTargetAnti(this);
+        }
+        std::swap(controlsShards, antiControlsShards);
 
         par_for(0, targetOfShards.size(), [&](const bitCapInt lcv, const int cpu) {
             ShardToPhaseMap::iterator phaseShard = targetOfShards.begin();

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -47,7 +47,9 @@ struct PhaseShard {
 };
 
 #define IS_SAME(c1, c2) (norm((c1) - (c2)) <= amplitudeFloor)
+#define IS_OPPOSITE(c1, c2) (norm((c1) + (c2)) <= amplitudeFloor)
 #define IS_ARG_0(c) IS_SAME(c, ONE_CMPLX)
+#define IS_ARG_PI(c) IS_OPPOSITE(c, ONE_CMPLX)
 
 class QEngineShard;
 typedef QEngineShard* QEngineShardPtr;

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -438,7 +438,7 @@ public:
     void FlipPhaseAnti()
     {
         // TODO: Totally bugged
-        std::vector<QEngineShardPtr> alreadySwapped;
+        /*std::vector<QEngineShardPtr> alreadySwapped;
         ShardToPhaseMap::iterator phaseShard;
         for (phaseShard = controlsShards.begin(); phaseShard != controlsShards.end(); phaseShard++) {
             phaseShard->first->SwapTargetAnti(this);
@@ -449,7 +449,7 @@ public:
                 phaseShard->first->SwapTargetAnti(this);
             }
         }
-        std::swap(controlsShards, antiControlsShards);
+        std::swap(controlsShards, antiControlsShards);*/
 
         par_for(0, targetOfShards.size(), [&](const bitCapInt lcv, const int cpu) {
             ShardToPhaseMap::iterator phaseShard = targetOfShards.begin();

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -595,6 +595,35 @@ public:
         return toRet;
     }
 
+    bool IsCnotControl()
+    {
+        bool toRet = false;
+        ShardToPhaseMap::iterator phaseShard;
+        PhaseShardPtr buffer;
+
+        for (phaseShard = controlsShards.begin(); phaseShard != controlsShards.end(); phaseShard++) {
+            buffer = phaseShard->second;
+            if (buffer->isInvert && IS_ARG_0(buffer->cmplx0) && IS_ARG_0(buffer->cmplx1)) {
+                toRet = true;
+                break;
+            }
+        }
+
+        if (toRet) {
+            return true;
+        }
+
+        for (phaseShard = antiControlsShards.begin(); phaseShard != antiControlsShards.end(); phaseShard++) {
+            buffer = phaseShard->second;
+            if (buffer->isInvert && IS_ARG_0(buffer->cmplx0) && IS_ARG_0(buffer->cmplx1)) {
+                toRet = true;
+                break;
+            }
+        }
+
+        return toRet;
+    }
+
     bool IsInvertControl()
     {
         bool toRet = false;

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -558,121 +558,70 @@ public:
 
     bool IsInvertControlOf(QEngineShardPtr target)
     {
-        bool toRet = false;
-
         ShardToPhaseMap::iterator phaseShard = controlsShards.find(target);
-        if (phaseShard != controlsShards.end()) {
-            toRet = phaseShard->second->isInvert;
-        }
-
-        if (toRet) {
-            return true;
-        }
-
-        phaseShard = antiControlsShards.find(target);
-        if (phaseShard != antiControlsShards.end()) {
-            toRet |= phaseShard->second->isInvert;
-        }
-
-        return toRet;
+        return phaseShard != controlsShards.end();
     }
 
-    bool IsInvertTargetOf(QEngineShardPtr control)
+    bool IsInvertAntiControlOf(QEngineShardPtr target)
     {
-        bool toRet = false;
-
-        ShardToPhaseMap::iterator phaseShard = targetOfShards.find(control);
-        if (phaseShard != targetOfShards.end()) {
-            toRet = phaseShard->second->isInvert;
-        }
-
-        if (toRet) {
-            return true;
-        }
-
-        phaseShard = antiTargetOfShards.find(control);
-        if (phaseShard != antiTargetOfShards.end()) {
-            toRet |= phaseShard->second->isInvert;
-        }
-
-        return toRet;
+        ShardToPhaseMap::iterator phaseShard = controlsShards.find(target);
+        return phaseShard != controlsShards.end();
     }
 
     bool IsInvertSamePhaseControl()
     {
-        bool toRet = false;
         ShardToPhaseMap::iterator phaseShard;
         PhaseShardPtr buffer;
 
         for (phaseShard = controlsShards.begin(); phaseShard != controlsShards.end(); phaseShard++) {
             buffer = phaseShard->second;
             if (buffer->isInvert && IS_SAME(buffer->cmplx0, buffer->cmplx1)) {
-                toRet = true;
-                break;
+                return true;
             }
-        }
-
-        if (toRet) {
-            return true;
         }
 
         for (phaseShard = antiControlsShards.begin(); phaseShard != antiControlsShards.end(); phaseShard++) {
             buffer = phaseShard->second;
             if (buffer->isInvert && IS_SAME(buffer->cmplx0, buffer->cmplx1)) {
-                toRet = true;
-                break;
+                return true;
             }
         }
 
-        return toRet;
+        return false;
     }
 
     bool IsInvertControl()
     {
-        bool toRet = false;
         ShardToPhaseMap::iterator phaseShard;
 
         for (phaseShard = controlsShards.begin(); phaseShard != controlsShards.end(); phaseShard++) {
             if (phaseShard->second->isInvert) {
-                toRet = true;
-                break;
+                return true;
             }
-        }
-
-        if (toRet) {
-            return true;
         }
 
         for (phaseShard = antiControlsShards.begin(); phaseShard != antiControlsShards.end(); phaseShard++) {
             if (phaseShard->second->isInvert) {
-                toRet = true;
-                break;
+                return true;
             }
         }
 
-        return toRet;
+        return false;
     }
 
     bool IsInvertTarget()
     {
-        bool toRet = false;
         ShardToPhaseMap::iterator phaseShard;
 
         for (phaseShard = targetOfShards.begin(); phaseShard != targetOfShards.end(); phaseShard++) {
             if (phaseShard->second->isInvert) {
-                toRet = true;
-                break;
+                return true;
             }
-        }
-
-        if (toRet) {
-            return true;
         }
 
         for (phaseShard = antiTargetOfShards.begin(); phaseShard != antiTargetOfShards.end(); phaseShard++) {
             if (phaseShard->second->isInvert) {
-                toRet = true;
-                break;
+                return true;
             }
         }
 

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -437,6 +437,7 @@ public:
 
     void FlipPhaseAnti()
     {
+        // TODO: Totally bugged
         std::vector<QEngineShardPtr> alreadySwapped;
         ShardToPhaseMap::iterator phaseShard;
         for (phaseShard = controlsShards.begin(); phaseShard != controlsShards.end(); phaseShard++) {
@@ -460,6 +461,31 @@ public:
             ShardToPhaseMap::iterator phaseShard = antiTargetOfShards.begin();
             std::advance(phaseShard, lcv);
             std::swap(phaseShard->second->cmplx0, phaseShard->second->cmplx1);
+        });
+    }
+
+    void CommutePhase(const complex& topLeft, const complex& bottomRight)
+    {
+        par_for(0, targetOfShards.size(), [&](const bitCapInt lcv, const int cpu) {
+            ShardToPhaseMap::iterator phaseShard = targetOfShards.begin();
+            std::advance(phaseShard, lcv);
+            if (!phaseShard->second->isInvert) {
+                return;
+            }
+
+            phaseShard->second->cmplx0 *= topLeft / bottomRight;
+            phaseShard->second->cmplx1 *= bottomRight / topLeft;
+        });
+
+        par_for(0, antiTargetOfShards.size(), [&](const bitCapInt lcv, const int cpu) {
+            ShardToPhaseMap::iterator phaseShard = antiTargetOfShards.begin();
+            std::advance(phaseShard, lcv);
+            if (!phaseShard->second->isInvert) {
+                return;
+            }
+
+            phaseShard->second->cmplx0 *= topLeft / bottomRight;
+            phaseShard->second->cmplx1 *= bottomRight / topLeft;
         });
     }
 

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -628,8 +628,6 @@ public:
         return false;
     }
 
-    bool IsInvert() { return IsInvertControl() || IsInvertTarget(); }
-
     bool operator==(const QEngineShard& rhs) { return (mapped == rhs.mapped) && (unit == rhs.unit); }
     bool operator!=(const QEngineShard& rhs) { return (mapped != rhs.mapped) || (unit != rhs.unit); }
 };

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -463,31 +463,6 @@ public:
         });
     }
 
-    void CommutePhase(const complex& topLeft, const complex& bottomRight)
-    {
-        par_for(0, targetOfShards.size(), [&](const bitCapInt lcv, const int cpu) {
-            ShardToPhaseMap::iterator phaseShard = targetOfShards.begin();
-            std::advance(phaseShard, lcv);
-            if (!phaseShard->second->isInvert) {
-                return;
-            }
-
-            phaseShard->second->cmplx0 *= topLeft / bottomRight;
-            phaseShard->second->cmplx1 *= bottomRight / topLeft;
-        });
-
-        par_for(0, antiTargetOfShards.size(), [&](const bitCapInt lcv, const int cpu) {
-            ShardToPhaseMap::iterator phaseShard = antiTargetOfShards.begin();
-            std::advance(phaseShard, lcv);
-            if (!phaseShard->second->isInvert) {
-                return;
-            }
-
-            phaseShard->second->cmplx0 *= topLeft / bottomRight;
-            phaseShard->second->cmplx1 *= bottomRight / topLeft;
-        });
-    }
-
 protected:
     void RemoveIdentityBuffers(ShardToPhaseMap& localMap, GetBufferFn remoteMapGet)
     {
@@ -516,7 +491,7 @@ public:
             PhaseShardPtr buffer = phaseShard->second;
             if (norm(buffer->cmplx0 - buffer->cmplx1) < ONE_R1) {
                 if (buffer->isInvert) {
-                    buffer->cmplx1 *= -ONE_CMPLX;
+                    buffer->cmplx1 = -buffer->cmplx0;
                     buffer->isInvert = false;
                 }
             } else {
@@ -537,7 +512,7 @@ public:
             PhaseShardPtr buffer = phaseShard->second;
             if (norm(buffer->cmplx0 - buffer->cmplx1) < ONE_R1) {
                 if (buffer->isInvert) {
-                    buffer->cmplx1 *= -ONE_CMPLX;
+                    buffer->cmplx1 = -buffer->cmplx0;
                     buffer->isInvert = false;
                 }
             } else {

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1141,6 +1141,11 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
 
 void QUnit::AntiCNOT(bitLenInt control, bitLenInt target)
 {
+    QEngineShard& tShard = shards[target];
+    if (CACHED_PLUS(tShard)) {
+        return;
+    }
+
     QEngineShard& cShard = shards[control];
     if (!cShard.IsInvertTarget() && UNSAFE_CACHED_CLASSICAL(cShard)) {
         if (IS_NORM_ZERO(cShard.amp1)) {
@@ -1177,57 +1182,6 @@ void QUnit::CCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target)
         return;
     }
 
-    QEngineShard& c1Shard = shards[control1];
-    QEngineShard& c2Shard = shards[control2];
-
-    if (!c1Shard.IsInvertTarget()) {
-        if (UNSAFE_CACHED_CLASSICAL(c1Shard)) {
-            if (IS_NORM_ZERO(c1Shard.amp1)) {
-                Flush0Eigenstate(control1);
-                return;
-            }
-            if (IS_NORM_ZERO(c1Shard.amp0)) {
-                Flush1Eigenstate(control1);
-                CNOT(control2, target);
-                return;
-            }
-        }
-    }
-
-    if (!c2Shard.IsInvertTarget()) {
-        if (UNSAFE_CACHED_CLASSICAL(c2Shard)) {
-            if (IS_NORM_ZERO(c2Shard.amp1)) {
-                Flush0Eigenstate(control2);
-                return;
-            }
-            if (IS_NORM_ZERO(c2Shard.amp0)) {
-                Flush1Eigenstate(control2);
-                CNOT(control1, target);
-                return;
-            }
-        }
-    }
-
-    if ((tShard.unit->GetQubitCount() == 1U) && (c1Shard.unit->GetQubitCount() == 1U) &&
-        (c2Shard.unit->GetQubitCount() == 1U)) {
-        H(target);
-        CNOT(control2, target);
-        IT(target);
-        CNOT(control1, target);
-        T(target);
-        CNOT(control2, target);
-        IT(target);
-        CNOT(control1, target);
-        T(control2);
-        T(target);
-        CNOT(control1, control2);
-        T(control1);
-        IT(control2);
-        CNOT(control1, control2);
-        H(target);
-        return;
-    }
-
     bitLenInt controls[2] = { control1, control2 };
 
     ApplyEitherControlled(controls, 2, { target }, false,
@@ -1251,6 +1205,11 @@ void QUnit::CCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target)
 
 void QUnit::AntiCCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target)
 {
+    QEngineShard& tShard = shards[target];
+    if (CACHED_PLUS(tShard)) {
+        return;
+    }
+
     bitLenInt controls[2] = { control1, control2 };
 
     ApplyEitherControlled(controls, 2, { target }, true,
@@ -1370,24 +1329,6 @@ void QUnit::CCZ(bitLenInt control1, bitLenInt control2, bitLenInt target)
                 return;
             }
         }
-    }
-
-    if ((tShard.unit->GetQubitCount() == 1U) && (c1Shard.unit->GetQubitCount() == 1U) &&
-        (c2Shard.unit->GetQubitCount() == 1U)) {
-        CNOT(control2, target);
-        IT(target);
-        CNOT(control1, target);
-        T(target);
-        CNOT(control2, target);
-        IT(target);
-        CNOT(control1, target);
-        T(control2);
-        T(target);
-        CNOT(control1, control2);
-        T(control1);
-        IT(control2);
-        CNOT(control1, control2);
-        return;
     }
 
     bitLenInt controls[2] = { control1, control2 };

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -29,7 +29,6 @@
 #include "qunit.hpp"
 
 #define DIRTY(shard) (shard.isPhaseDirty || shard.isProbDirty)
-#define IS_ONE_CMPLX(c) (c == ONE_CMPLX)
 #define IS_NORM_ZERO(c) (c == ZERO_CMPLX)
 #define IS_ZERO_R1(r) (r == ZERO_R1)
 #define IS_ONE_R1(r) (r == ONE_R1)
@@ -1354,11 +1353,11 @@ void QUnit::CCZ(bitLenInt control1, bitLenInt control2, bitLenInt target)
 
 void QUnit::ApplySinglePhase(const complex topLeft, const complex bottomRight, bitLenInt target)
 {
-    if ((topLeft == bottomRight) && (randGlobalPhase || IS_ONE_CMPLX(topLeft))) {
+    if ((topLeft == bottomRight) && (randGlobalPhase || IS_ARG_0(topLeft))) {
         return;
     }
 
-    if (IS_ONE_CMPLX(topLeft) && IS_ONE_CMPLX(-bottomRight)) {
+    if (IS_ARG_0(topLeft) && IS_ARG_PI(bottomRight)) {
         Z(target);
         return;
     }
@@ -1368,12 +1367,12 @@ void QUnit::ApplySinglePhase(const complex topLeft, const complex bottomRight, b
     if (shard.IsInvertTarget()) {
         shard.CommutePhase(topLeft, bottomRight);
     } else {
-        if (IS_ONE_CMPLX(topLeft) && UNSAFE_CACHED_ZERO(shard)) {
+        if (IS_ARG_0(topLeft) && UNSAFE_CACHED_ZERO(shard)) {
             Flush0Eigenstate(target);
             return;
         }
 
-        if (IS_ONE_CMPLX(bottomRight) && UNSAFE_CACHED_ONE(shard)) {
+        if (IS_ARG_0(bottomRight) && UNSAFE_CACHED_ONE(shard)) {
             Flush1Eigenstate(target);
             return;
         }
@@ -1476,19 +1475,19 @@ void QUnit::ApplyControlledSinglePhase(const bitLenInt* cControls, const bitLenI
 
     QEngineShard& tShard = shards[target];
 
-    if (IS_ONE_CMPLX(bottomRight) && (!tShard.IsInvertTarget() && UNSAFE_CACHED_ONE(tShard))) {
+    if (IS_ARG_0(bottomRight) && (!tShard.IsInvertTarget() && UNSAFE_CACHED_ONE(tShard))) {
         delete[] controls;
         return;
     }
 
-    if (IS_ONE_CMPLX(topLeft)) {
+    if (IS_ARG_0(topLeft)) {
         if (!tShard.IsInvertTarget() && UNSAFE_CACHED_ZERO(tShard)) {
             Flush0Eigenstate(target);
             delete[] controls;
             return;
         }
 
-        if (IS_ONE_CMPLX(-bottomRight)) {
+        if (IS_ARG_PI(bottomRight)) {
             if (controlLen == 2U) {
                 CCZ(controls[0], controls[1], target);
                 delete[] controls;
@@ -1523,7 +1522,7 @@ void QUnit::ApplyControlledSinglePhase(const bitLenInt* cControls, const bitLenI
             return;
         }
 
-        if (IS_ONE_CMPLX(topLeft) && tShard.IsInvertControlOf(&(shards[controls[0]]))) {
+        if (IS_ARG_0(topLeft) && tShard.IsInvertControlOf(&(shards[controls[0]]))) {
             std::swap(controls[0], target);
         }
         TransformBasis1Qb(false, controls[0]);
@@ -1543,7 +1542,7 @@ void QUnit::ApplyControlledSinglePhase(const bitLenInt* cControls, const bitLenI
 void QUnit::ApplyControlledSingleInvert(const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& target,
     const complex topRight, const complex bottomLeft)
 {
-    if ((controlLen == 1U) && IS_ONE_CMPLX(topRight) && IS_ONE_CMPLX(bottomLeft)) {
+    if ((controlLen == 1U) && IS_ARG_0(topRight) && IS_ARG_0(bottomLeft)) {
         CNOT(controls[0], target);
         return;
     }
@@ -1567,12 +1566,12 @@ void QUnit::ApplyAntiControlledSinglePhase(const bitLenInt* cControls, const bit
 
     QEngineShard& tShard = shards[target];
 
-    if (IS_ONE_CMPLX(bottomRight) && (!tShard.IsInvertTarget() && UNSAFE_CACHED_ONE(tShard))) {
+    if (IS_ARG_0(bottomRight) && (!tShard.IsInvertTarget() && UNSAFE_CACHED_ONE(tShard))) {
         delete[] controls;
         return;
     }
 
-    if (IS_ONE_CMPLX(topLeft)) {
+    if (IS_ARG_0(topLeft)) {
         if (!tShard.IsInvertTarget() && UNSAFE_CACHED_ZERO(tShard)) {
             Flush0Eigenstate(target);
             delete[] controls;
@@ -1590,7 +1589,7 @@ void QUnit::ApplyAntiControlledSinglePhase(const bitLenInt* cControls, const bit
     }
 
     if (!freezeBasis && (controlLen == 1U)) {
-        if (IS_ONE_CMPLX(topLeft) && tShard.IsInvertControlOf(&(shards[controls[0]]))) {
+        if (IS_ARG_0(topLeft) && tShard.IsInvertControlOf(&(shards[controls[0]]))) {
             std::swap(controls[0], target);
         }
         TransformBasis1Qb(false, controls[0]);
@@ -1610,7 +1609,7 @@ void QUnit::ApplyAntiControlledSinglePhase(const bitLenInt* cControls, const bit
 void QUnit::ApplyAntiControlledSingleInvert(const bitLenInt* controls, const bitLenInt& controlLen,
     const bitLenInt& target, const complex topRight, const complex bottomLeft)
 {
-    if ((controlLen == 1U) && IS_ONE_CMPLX(topRight) && IS_ONE_CMPLX(bottomLeft)) {
+    if ((controlLen == 1U) && IS_ARG_0(topRight) && IS_ARG_0(bottomLeft)) {
         AntiCNOT(controls[0], target);
         return;
     }

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1636,14 +1636,14 @@ void QUnit::ApplyAntiControlledSinglePhase(const bitLenInt* cControls, const bit
             std::swap(control, target);
         }
 
-        TransformBasis1Qb(false, control);
+        /*TransformBasis1Qb(false, control);
 
         RevertBasis2Qb(control, ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI, { target }, {});
         RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI, {}, { control });
 
         shards[target].AddAntiPhaseAngles(&(shards[control]), bottomRight, topLeft);
         delete[] controls;
-        return;
+        return;*/
     }
 
     CTRLED_PHASE_INVERT_WRAP(ApplyAntiControlledSinglePhase(CTRL_P_ARGS), ApplyAntiControlledSingleBit(CTRL_GEN_ARGS),

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -20,7 +20,6 @@
 // Licensed under the GNU Lesser General Public License V3.
 // See LICENSE.md in the project root or https://www.gnu.org/licenses/lgpl-3.0.en.html
 // for details.
-
 #include <ctime>
 #include <initializer_list>
 #include <map>
@@ -1292,8 +1291,8 @@ void QUnit::CZ(bitLenInt control, bitLenInt target)
 
         TransformBasis1Qb(false, control);
 
-        RevertBasis2Qb(control, ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI);
-        RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI);
+        RevertBasis2Qb(control, ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI, { target }, {});
+        RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI, {}, { control });
 
         shards[target].AddPhaseAngles(&(shards[control]), ONE_CMPLX, -ONE_CMPLX);
         return;
@@ -1561,8 +1560,8 @@ void QUnit::ApplyControlledSinglePhase(const bitLenInt* cControls, const bitLenI
 
         TransformBasis1Qb(false, control);
 
-        RevertBasis2Qb(control, ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI);
-        RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI);
+        RevertBasis2Qb(control, ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI, { target }, {});
+        RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI, {}, { control });
 
         shards[target].AddPhaseAngles(&(shards[control]), topLeft, bottomRight);
         delete[] controls;
@@ -3253,7 +3252,7 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
         isSame = norm(polar0 - polar1) <= ampThreshold;
         isOpposite = norm(polar0 + polar1) <= ampThreshold;
 
-        if (!isSame && !isOpposite) {
+        if ((!isSame || !buffer->isInvert) && (!isOpposite || buffer->isInvert)) {
             ApplyBuffer(phaseShard, control, bitIndex, false);
             shard.RemovePhaseControl(partner);
         }
@@ -3272,7 +3271,7 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
         isSame = norm(polar0 - polar1) <= ampThreshold;
         isOpposite = norm(polar0 + polar1) <= ampThreshold;
 
-        if (!isSame && !isOpposite) {
+        if ((!isSame || !buffer->isInvert) && (!isOpposite || buffer->isInvert)) {
             ApplyBuffer(phaseShard, control, bitIndex, true);
             shard.RemovePhaseAntiControl(partner);
         }

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -988,6 +988,13 @@ void QUnit::Z(bitLenInt target)
 {
     QEngineShard& shard = shards[target];
 
+    if (shard.IsInvertSamePhaseControl()) {
+        // "CommutePhase()" can handle this case, but we do this to avoid a case that breaks theoretical CHP, (i.e.
+        // efficiency over a purely Clifford algebra).
+        shard.isPlusMinus = !shard.isPlusMinus;
+        H(target);
+    }
+
     if (shard.IsInvertTarget()) {
         shard.CommutePhase(ONE_CMPLX, -ONE_CMPLX);
     } else {
@@ -1407,6 +1414,13 @@ void QUnit::ApplySinglePhase(const complex topLeft, const complex bottomRight, b
     }
 
     QEngineShard& shard = shards[target];
+
+    if (shard.IsInvertSamePhaseControl()) {
+        // "CommutePhase()" can handle this case, but we do this to avoid a case that breaks theoretical CHP, (i.e.
+        // efficiency over a purely Clifford algebra).
+        shard.isPlusMinus = !shard.isPlusMinus;
+        H(target);
+    }
 
     if (shard.IsInvertTarget()) {
         shard.CommutePhase(topLeft, bottomRight);

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -975,8 +975,7 @@ void QUnit::X(bitLenInt target)
 {
     QEngineShard& shard = shards[target];
 
-    RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI);
-    RevertBasis2Qb(target, INVERT_AND_PHASE, ONLY_CONTROLS, CTRL_AND_ANTI);
+    RevertBasis2Qb(target, ONLY_INVERT, ONLY_TARGETS, CTRL_AND_ANTI);
     shard.FlipPhaseAnti();
 
     if (!shard.isPlusMinus) {
@@ -1456,8 +1455,7 @@ void QUnit::ApplySingleInvert(const complex topRight, const complex bottomLeft, 
         return;
     }
 
-    RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI);
-    RevertBasis2Qb(target, INVERT_AND_PHASE, ONLY_CONTROLS, CTRL_AND_ANTI);
+    RevertBasis2Qb(target, ONLY_INVERT, ONLY_TARGETS, CTRL_AND_ANTI);
     shard.FlipPhaseAnti();
 
     if (!shard.isPlusMinus) {

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1455,10 +1455,8 @@ void QUnit::ApplySingleInvert(const complex topRight, const complex bottomLeft, 
         return;
     }
 
-    RevertBasis2Qb(target, ONLY_INVERT, ONLY_TARGETS, CTRL_AND_ANTI);
-    // These arguments are intentionally flipped, because we're commuting phase at this point in the logic for an
-    // inversion gate.
-    shard.CommutePhase(bottomLeft, topRight);
+    // TODO: Incorporate phase effects, to commute isInvert controls.
+    RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI);
     shard.FlipPhaseAnti();
 
     if (!shard.isPlusMinus) {

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1353,7 +1353,7 @@ void QUnit::CCZ(bitLenInt control1, bitLenInt control2, bitLenInt target)
 
 void QUnit::ApplySinglePhase(const complex topLeft, const complex bottomRight, bitLenInt target)
 {
-    if ((topLeft == bottomRight) && (randGlobalPhase || IS_ARG_0(topLeft))) {
+    if (IS_SAME(topLeft, bottomRight) && (randGlobalPhase || IS_ARG_0(topLeft))) {
         return;
     }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1455,8 +1455,6 @@ void QUnit::ApplySingleInvert(const complex topRight, const complex bottomLeft, 
         return;
     }
 
-    // Should only let through controlled phase gates.
-    RevertBasis2Qb(target, INVERT_AND_PHASE, ONLY_CONTROLS, CTRL_AND_ANTI);
     RevertBasis2Qb(target, ONLY_INVERT, ONLY_TARGETS, CTRL_AND_ANTI);
     shard.FlipPhaseAnti();
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1455,8 +1455,10 @@ void QUnit::ApplySingleInvert(const complex topRight, const complex bottomLeft, 
         return;
     }
 
-    // TODO: Incorporate phase effects, to commute isInvert controls.
-    RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI);
+    RevertBasis2Qb(target, ONLY_INVERT, ONLY_TARGETS, CTRL_AND_ANTI);
+    // These arguments are intentionally flipped, because we're commuting phase at this point in the logic for an
+    // inversion gate.
+    shard.CommutePhase(bottomLeft, topRight);
     shard.FlipPhaseAnti();
 
     if (!shard.isPlusMinus) {

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -3292,7 +3292,7 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
         polar1 = buffer->cmplx1;
 
         isSame = (norm(polar0 - polar1) <= ampThreshold) && (!needToCommute || !buffer->isInvert);
-        isOpposite = (norm(polar0 + polar1) <= ampThreshold) && (!needToCommute || !buffer->isInvert);
+        isOpposite = (norm(polar0 + polar1) <= ampThreshold) && !buffer->isInvert;
 
         if (!isSame && !isOpposite) {
             ApplyBuffer(phaseShard, control, bitIndex, false);
@@ -3309,7 +3309,7 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
         polar1 = buffer->cmplx1;
 
         isSame = (norm(polar0 - polar1) <= ampThreshold) && (!needToCommute || !buffer->isInvert);
-        isOpposite = (norm(polar0 + polar1) <= ampThreshold) && (!needToCommute || !buffer->isInvert);
+        isOpposite = (norm(polar0 + polar1) <= ampThreshold) && !buffer->isInvert;
 
         if (!isSame && !isOpposite) {
             ApplyBuffer(phaseShard, control, bitIndex, true);

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1288,21 +1288,23 @@ void QUnit::CZ(bitLenInt control, bitLenInt target)
     }
 
     if (!freezeBasis) {
-        if (tShard.IsInvertControlOf(&cShard)) {
-            std::swap(control, target);
-        }
-        TransformBasis1Qb(false, control);
-
         if (cShard.IsCnotControl()) {
             cShard.isPlusMinus = !cShard.isPlusMinus;
             H(control);
         }
-        RevertBasis2Qb(control, ONLY_INVERT, ONLY_CONTROLS, CTRL_AND_ANTI, { target }, {});
 
         if (tShard.IsCnotControl()) {
             tShard.isPlusMinus = !tShard.isPlusMinus;
             H(target);
         }
+
+        if (tShard.IsInvertControlOf(&cShard)) {
+            std::swap(control, target);
+        }
+        TransformBasis1Qb(false, control);
+
+        RevertBasis2Qb(control, ONLY_INVERT, ONLY_CONTROLS, CTRL_AND_ANTI, { target }, {});
+
         RevertBasis2Qb(target, ONLY_INVERT, ONLY_CONTROLS, CTRL_AND_ANTI, {}, { control });
 
         shards[target].AddPhaseAngles(&(shards[control]), ONE_CMPLX, -ONE_CMPLX);
@@ -1565,21 +1567,23 @@ void QUnit::ApplyControlledSinglePhase(const bitLenInt* cControls, const bitLenI
             return;
         }
 
-        if (IS_ARG_0(topLeft) && tShard.IsInvertControlOf(&(shards[controls[0]]))) {
-            std::swap(control, target);
-        }
-        TransformBasis1Qb(false, control);
-
         if (shards[control].IsCnotControl()) {
             shards[control].isPlusMinus = !shards[control].isPlusMinus;
             H(control);
         }
-        RevertBasis2Qb(control, ONLY_INVERT, ONLY_CONTROLS, CTRL_AND_ANTI, { target }, {});
 
         if (shards[target].IsCnotControl()) {
             shards[target].isPlusMinus = !shards[target].isPlusMinus;
             H(target);
         }
+
+        if (IS_ARG_0(topLeft) && tShard.IsInvertControlOf(&(shards[controls[0]]))) {
+            std::swap(control, target);
+        }
+        TransformBasis1Qb(false, control);
+
+        RevertBasis2Qb(control, ONLY_INVERT, ONLY_CONTROLS, CTRL_AND_ANTI, { target }, {});
+
         RevertBasis2Qb(target, ONLY_INVERT, ONLY_CONTROLS, CTRL_AND_ANTI, {}, { control });
 
         shards[target].AddPhaseAngles(&(shards[control]), topLeft, bottomRight);

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1455,7 +1455,8 @@ void QUnit::ApplySingleInvert(const complex topRight, const complex bottomLeft, 
         return;
     }
 
-    RevertBasis2Qb(target, ONLY_INVERT, ONLY_TARGETS, CTRL_AND_ANTI);
+    // TODO: Incorporate phase effects, to commute isInvert controls.
+    RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI);
     shard.FlipPhaseAnti();
 
     if (!shard.isPlusMinus) {

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1292,8 +1292,8 @@ void QUnit::CZ(bitLenInt control, bitLenInt target)
 
         TransformBasis1Qb(false, control);
 
-        RevertBasis2Qb(control, ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI, { target }, {});
-        RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI, {}, { control });
+        RevertBasis2Qb(control, ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI);
+        RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI);
 
         shards[target].AddPhaseAngles(&(shards[control]), ONE_CMPLX, -ONE_CMPLX);
         return;
@@ -1561,8 +1561,8 @@ void QUnit::ApplyControlledSinglePhase(const bitLenInt* cControls, const bitLenI
 
         TransformBasis1Qb(false, control);
 
-        RevertBasis2Qb(control, ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI, { target }, {});
-        RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI, {}, { control });
+        RevertBasis2Qb(control, ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI);
+        RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI);
 
         shards[target].AddPhaseAngles(&(shards[control]), topLeft, bottomRight);
         delete[] controls;

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1641,7 +1641,7 @@ void QUnit::ApplyAntiControlledSinglePhase(const bitLenInt* cControls, const bit
         RevertBasis2Qb(control, ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI, { target }, {});
         RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI, {}, { control });
 
-        shards[target].AddAntiPhaseAngles(&(shards[control]), topLeft, bottomRight);
+        shards[target].AddAntiPhaseAngles(&(shards[control]), bottomRight, topLeft);
         delete[] controls;
         return;
     }
@@ -3083,21 +3083,21 @@ void QUnit::ApplyBuffer(
 {
     const bitLenInt controls[1] = { control };
 
-    complex polar0 = phaseShard->second->cmplx0;
-    complex polar1 = phaseShard->second->cmplx1;
+    complex polarDiff = phaseShard->second->cmplxDiff;
+    complex polarSame = phaseShard->second->cmplxSame;
 
     freezeBasis = true;
     if (phaseShard->second->isInvert) {
         if (isAnti) {
-            ApplyAntiControlledSingleInvert(controls, 1U, target, polar0, polar1);
+            ApplyAntiControlledSingleInvert(controls, 1U, target, polarSame, polarDiff);
         } else {
-            ApplyControlledSingleInvert(controls, 1U, target, polar0, polar1);
+            ApplyControlledSingleInvert(controls, 1U, target, polarDiff, polarSame);
         }
     } else {
         if (isAnti) {
-            ApplyAntiControlledSinglePhase(controls, 1U, target, polar0, polar1);
+            ApplyAntiControlledSinglePhase(controls, 1U, target, polarSame, polarDiff);
         } else {
-            ApplyControlledSinglePhase(controls, 1U, target, polar0, polar1);
+            ApplyControlledSinglePhase(controls, 1U, target, polarDiff, polarSame);
         }
     }
     freezeBasis = false;
@@ -3228,7 +3228,7 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
 
     real1 ampThreshold = doNormalize ? amplitudeFloor : ZERO_R1;
 
-    complex polar0, polar1;
+    complex polarDiff, polarSame;
     ShardToPhaseMap::iterator phaseShard, oppositeShard;
     QEngineShardPtr partner;
     PhaseShardPtr buffer;
@@ -3242,10 +3242,10 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
         partner = phaseShard->first;
         buffer = phaseShard->second;
 
-        polar0 = buffer->cmplx0;
-        polar1 = buffer->cmplx1;
+        polarDiff = buffer->cmplxDiff;
+        polarSame = buffer->cmplxSame;
 
-        isOpposite = (norm(polar0 + polar1) <= ampThreshold) && !buffer->isInvert;
+        isOpposite = (norm(polarDiff + polarSame) <= ampThreshold) && !buffer->isInvert;
 
         if (isOpposite) {
             needToCommute = true;
@@ -3260,10 +3260,10 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
             partner = phaseShard->first;
             buffer = phaseShard->second;
 
-            polar0 = buffer->cmplx0;
-            polar1 = buffer->cmplx1;
+            polarDiff = buffer->cmplxDiff;
+            polarSame = buffer->cmplxSame;
 
-            isOpposite = (norm(polar0 + polar1) <= ampThreshold) && !buffer->isInvert;
+            isOpposite = (norm(polarDiff + polarSame) <= ampThreshold) && !buffer->isInvert;
 
             if (isOpposite) {
                 needToCommute = true;
@@ -3277,11 +3277,11 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
         control = FindShardIndex(*partner);
         buffer = phaseShard->second;
 
-        polar0 = buffer->cmplx0;
-        polar1 = buffer->cmplx1;
+        polarDiff = buffer->cmplxDiff;
+        polarSame = buffer->cmplxSame;
 
-        isSame = (norm(polar0 - polar1) <= ampThreshold) && (!needToCommute || !buffer->isInvert);
-        isOpposite = (norm(polar0 + polar1) <= ampThreshold) && !buffer->isInvert;
+        isSame = (norm(polarDiff - polarSame) <= ampThreshold) && (!needToCommute || !buffer->isInvert);
+        isOpposite = (norm(polarDiff + polarSame) <= ampThreshold) && !buffer->isInvert;
 
         if (!isSame && !isOpposite) {
             ApplyBuffer(phaseShard, control, bitIndex, false);
@@ -3294,11 +3294,11 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
         control = FindShardIndex(*partner);
         buffer = phaseShard->second;
 
-        polar0 = buffer->cmplx0;
-        polar1 = buffer->cmplx1;
+        polarDiff = buffer->cmplxDiff;
+        polarSame = buffer->cmplxSame;
 
-        isSame = (norm(polar0 - polar1) <= ampThreshold) && (!needToCommute || !buffer->isInvert);
-        isOpposite = (norm(polar0 + polar1) <= ampThreshold) && !buffer->isInvert;
+        isSame = (norm(polarDiff - polarSame) <= ampThreshold) && (!needToCommute || !buffer->isInvert);
+        isOpposite = (norm(polarDiff + polarSame) <= ampThreshold) && !buffer->isInvert;
 
         if (!isSame && !isOpposite) {
             ApplyBuffer(phaseShard, control, bitIndex, true);

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -975,8 +975,6 @@ void QUnit::X(bitLenInt target)
 {
     QEngineShard& shard = shards[target];
 
-    // Should only let through controlled phase gates.
-    RevertBasis2Qb(target, INVERT_AND_PHASE, ONLY_CONTROLS, CTRL_AND_ANTI);
     RevertBasis2Qb(target, ONLY_INVERT, ONLY_TARGETS, CTRL_AND_ANTI);
     shard.FlipPhaseAnti();
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1636,14 +1636,14 @@ void QUnit::ApplyAntiControlledSinglePhase(const bitLenInt* cControls, const bit
             std::swap(control, target);
         }
 
-        /*TransformBasis1Qb(false, control);
+        TransformBasis1Qb(false, control);
 
         RevertBasis2Qb(control, ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI, { target }, {});
         RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI, {}, { control });
 
         shards[target].AddAntiPhaseAngles(&(shards[control]), bottomRight, topLeft);
         delete[] controls;
-        return;*/
+        return;
     }
 
     CTRLED_PHASE_INVERT_WRAP(ApplyAntiControlledSinglePhase(CTRL_P_ARGS), ApplyAntiControlledSingleBit(CTRL_GEN_ARGS),

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1288,12 +1288,12 @@ void QUnit::CZ(bitLenInt control, bitLenInt target)
     }
 
     if (!freezeBasis) {
-        if (cShard.IsCnotControl()) {
+        if (cShard.IsInvertSamePhaseControl()) {
             cShard.isPlusMinus = !cShard.isPlusMinus;
             H(control);
         }
 
-        if (tShard.IsCnotControl()) {
+        if (tShard.IsInvertSamePhaseControl()) {
             tShard.isPlusMinus = !tShard.isPlusMinus;
             H(target);
         }
@@ -1567,12 +1567,12 @@ void QUnit::ApplyControlledSinglePhase(const bitLenInt* cControls, const bitLenI
             return;
         }
 
-        if (shards[control].IsCnotControl()) {
+        if (shards[control].IsInvertSamePhaseControl()) {
             shards[control].isPlusMinus = !shards[control].isPlusMinus;
             H(control);
         }
 
-        if (shards[target].IsCnotControl()) {
+        if (shards[target].IsInvertSamePhaseControl()) {
             shards[target].isPlusMinus = !shards[target].isPlusMinus;
             H(target);
         }

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -976,6 +976,7 @@ void QUnit::X(bitLenInt target)
     QEngineShard& shard = shards[target];
 
     RevertBasis2Qb(target, ONLY_INVERT, ONLY_TARGETS, CTRL_AND_ANTI);
+    RevertBasis2Qb(target, INVERT_AND_PHASE, ONLY_CONTROLS, CTRL_AND_ANTI);
     shard.FlipPhaseAnti();
 
     if (!shard.isPlusMinus) {
@@ -1456,6 +1457,7 @@ void QUnit::ApplySingleInvert(const complex topRight, const complex bottomLeft, 
     }
 
     RevertBasis2Qb(target, ONLY_INVERT, ONLY_TARGETS, CTRL_AND_ANTI);
+    RevertBasis2Qb(target, INVERT_AND_PHASE, ONLY_CONTROLS, CTRL_AND_ANTI);
     shard.FlipPhaseAnti();
 
     if (!shard.isPlusMinus) {

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -20,6 +20,7 @@
 // Licensed under the GNU Lesser General Public License V3.
 // See LICENSE.md in the project root or https://www.gnu.org/licenses/lgpl-3.0.en.html
 // for details.
+
 #include <ctime>
 #include <initializer_list>
 #include <map>
@@ -974,8 +975,8 @@ void QUnit::X(bitLenInt target)
 {
     QEngineShard& shard = shards[target];
 
-    RevertBasis2Qb(target, ONLY_INVERT, ONLY_TARGETS, CTRL_AND_ANTI);
-    shard.FlipPhaseAnti();
+    RevertBasis2Qb(target);
+    // shard.FlipPhaseAnti();
 
     if (!shard.isPlusMinus) {
         XBase(target);
@@ -988,8 +989,9 @@ void QUnit::Z(bitLenInt target)
 {
     QEngineShard& shard = shards[target];
 
-    RevertBasis2Qb(target, ONLY_INVERT, ONLY_TARGETS, CTRL_AND_ANTI);
-    if (!shard.IsInvert()) {
+    if (shard.IsInvertTarget()) {
+        shard.CommutePhase(ONE_CMPLX, -ONE_CMPLX);
+    } else {
         if (UNSAFE_CACHED_ZERO(shard)) {
             Flush0Eigenstate(target);
             return;
@@ -1395,8 +1397,9 @@ void QUnit::ApplySinglePhase(const complex topLeft, const complex bottomRight, b
 
     QEngineShard& shard = shards[target];
 
-    RevertBasis2Qb(target, ONLY_INVERT, ONLY_TARGETS, CTRL_AND_ANTI);
-    if (!shard.IsInvert()) {
+    if (shard.IsInvertTarget()) {
+        shard.CommutePhase(topLeft, bottomRight);
+    } else {
         if (IS_ARG_0(topLeft) && UNSAFE_CACHED_ZERO(shard)) {
             Flush0Eigenstate(target);
             return;
@@ -1452,8 +1455,8 @@ void QUnit::ApplySingleInvert(const complex topRight, const complex bottomLeft, 
         return;
     }
 
-    RevertBasis2Qb(target, ONLY_INVERT, ONLY_TARGETS, CTRL_AND_ANTI);
-    shard.FlipPhaseAnti();
+    RevertBasis2Qb(target);
+    // shard.FlipPhaseAnti();
 
     if (!shard.isPlusMinus) {
         ApplyOrEmulate(

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -3253,25 +3253,6 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
         }
     }
 
-    ShardToPhaseMap antiTargetOfShards = shard.antiTargetOfShards;
-
-    if (!needToCommute) {
-        for (phaseShard = antiTargetOfShards.begin(); phaseShard != antiTargetOfShards.end(); phaseShard++) {
-            partner = phaseShard->first;
-            buffer = phaseShard->second;
-
-            polarDiff = buffer->cmplxDiff;
-            polarSame = buffer->cmplxSame;
-
-            isOpposite = (norm(polarDiff + polarSame) <= ampThreshold) && !buffer->isInvert;
-
-            if (isOpposite) {
-                needToCommute = true;
-                break;
-            }
-        }
-    }
-
     for (phaseShard = targetOfShards.begin(); phaseShard != targetOfShards.end(); phaseShard++) {
         partner = phaseShard->first;
         control = FindShardIndex(*partner);
@@ -3289,7 +3270,26 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
         }
     }
 
-    for (phaseShard = antiTargetOfShards.begin(); phaseShard != antiTargetOfShards.end(); phaseShard++) {
+    targetOfShards = shard.antiTargetOfShards;
+
+    needToCommute = false;
+
+    for (phaseShard = targetOfShards.begin(); phaseShard != targetOfShards.end(); phaseShard++) {
+        partner = phaseShard->first;
+        buffer = phaseShard->second;
+
+        polarDiff = buffer->cmplxDiff;
+        polarSame = buffer->cmplxSame;
+
+        isOpposite = (norm(polarDiff + polarSame) <= ampThreshold) && !buffer->isInvert;
+
+        if (isOpposite) {
+            needToCommute = true;
+            break;
+        }
+    }
+
+    for (phaseShard = targetOfShards.begin(); phaseShard != targetOfShards.end(); phaseShard++) {
         partner = phaseShard->first;
         control = FindShardIndex(*partner);
         buffer = phaseShard->second;

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1177,6 +1177,57 @@ void QUnit::CCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target)
         return;
     }
 
+    QEngineShard& c1Shard = shards[control1];
+    QEngineShard& c2Shard = shards[control2];
+
+    if (!c1Shard.IsInvertTarget()) {
+        if (UNSAFE_CACHED_CLASSICAL(c1Shard)) {
+            if (IS_NORM_ZERO(c1Shard.amp1)) {
+                Flush0Eigenstate(control1);
+                return;
+            }
+            if (IS_NORM_ZERO(c1Shard.amp0)) {
+                Flush1Eigenstate(control1);
+                CNOT(control2, target);
+                return;
+            }
+        }
+    }
+
+    if (!c2Shard.IsInvertTarget()) {
+        if (UNSAFE_CACHED_CLASSICAL(c2Shard)) {
+            if (IS_NORM_ZERO(c2Shard.amp1)) {
+                Flush0Eigenstate(control2);
+                return;
+            }
+            if (IS_NORM_ZERO(c2Shard.amp0)) {
+                Flush1Eigenstate(control2);
+                CNOT(control1, target);
+                return;
+            }
+        }
+    }
+
+    if ((tShard.unit->GetQubitCount() == 1U) && (c1Shard.unit->GetQubitCount() == 1U) &&
+        (c2Shard.unit->GetQubitCount() == 1U)) {
+        H(target);
+        CNOT(control2, target);
+        IT(target);
+        CNOT(control1, target);
+        T(target);
+        CNOT(control2, target);
+        IT(target);
+        CNOT(control1, target);
+        T(control2);
+        T(target);
+        CNOT(control1, control2);
+        T(control1);
+        IT(control2);
+        CNOT(control1, control2);
+        H(target);
+        return;
+    }
+
     bitLenInt controls[2] = { control1, control2 };
 
     ApplyEitherControlled(controls, 2, { target }, false,
@@ -1319,6 +1370,24 @@ void QUnit::CCZ(bitLenInt control1, bitLenInt control2, bitLenInt target)
                 return;
             }
         }
+    }
+
+    if ((tShard.unit->GetQubitCount() == 1U) && (c1Shard.unit->GetQubitCount() == 1U) &&
+        (c2Shard.unit->GetQubitCount() == 1U)) {
+        CNOT(control2, target);
+        IT(target);
+        CNOT(control1, target);
+        T(target);
+        CNOT(control2, target);
+        IT(target);
+        CNOT(control1, target);
+        T(control2);
+        T(target);
+        CNOT(control1, control2);
+        T(control1);
+        IT(control2);
+        CNOT(control1, control2);
+        return;
     }
 
     bitLenInt controls[2] = { control1, control2 };

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -975,8 +975,11 @@ void QUnit::X(bitLenInt target)
 {
     QEngineShard& shard = shards[target];
 
-    RevertBasis2Qb(target);
-    // shard.FlipPhaseAnti();
+    // Should only let through (not anti-)controlled phase gates.
+    RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI);
+    RevertBasis2Qb(target, INVERT_AND_PHASE, CONTROLS_AND_TARGETS, ONLY_ANTI);
+    RevertBasis2Qb(target, INVERT_AND_PHASE, ONLY_CONTROLS, CTRL_AND_ANTI);
+    shard.FlipPhaseAnti();
 
     if (!shard.isPlusMinus) {
         XBase(target);
@@ -1455,8 +1458,11 @@ void QUnit::ApplySingleInvert(const complex topRight, const complex bottomLeft, 
         return;
     }
 
-    RevertBasis2Qb(target);
-    // shard.FlipPhaseAnti();
+    // Should only let through (not anti-)controlled phase gates.
+    RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI);
+    RevertBasis2Qb(target, INVERT_AND_PHASE, CONTROLS_AND_TARGETS, ONLY_ANTI);
+    RevertBasis2Qb(target, INVERT_AND_PHASE, ONLY_CONTROLS, CTRL_AND_ANTI);
+    shard.FlipPhaseAnti();
 
     if (!shard.isPlusMinus) {
         ApplyOrEmulate(

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1512,6 +1512,7 @@ void QUnit::ApplyControlledSinglePhase(const bitLenInt* cControls, const bitLenI
     QEngineShard& tShard = shards[target];
 
     if (IS_ARG_0(bottomRight) && (!tShard.IsInvertTarget() && UNSAFE_CACHED_ONE(tShard))) {
+        Flush1Eigenstate(target);
         delete[] controls;
         return;
     }
@@ -1606,26 +1607,16 @@ void QUnit::ApplyAntiControlledSinglePhase(const bitLenInt* cControls, const bit
 
     QEngineShard& tShard = shards[target];
 
-    if (IS_ARG_0(bottomRight) && (!tShard.IsInvertTarget() && UNSAFE_CACHED_ONE(tShard))) {
+    if (IS_ARG_0(topLeft) && (!tShard.IsInvertTarget() && UNSAFE_CACHED_ZERO(tShard))) {
+        Flush0Eigenstate(target);
         delete[] controls;
         return;
     }
 
-    if (IS_ARG_0(topLeft)) {
-        if (!tShard.IsInvertTarget() && UNSAFE_CACHED_ZERO(tShard)) {
-            Flush0Eigenstate(target);
-            delete[] controls;
-            return;
-        }
-
-        if (!shards[target].isPlusMinus) {
-            for (bitLenInt i = 0; i < controlLen; i++) {
-                if (shards[controls[i]].isPlusMinus) {
-                    std::swap(controls[i], target);
-                    break;
-                }
-            }
-        }
+    if (IS_ARG_0(bottomRight) && (!tShard.IsInvertTarget() && UNSAFE_CACHED_ONE(tShard))) {
+        Flush1Eigenstate(target);
+        delete[] controls;
+        return;
     }
 
     if (!freezeBasis && (controlLen == 1U)) {
@@ -1641,7 +1632,7 @@ void QUnit::ApplyAntiControlledSinglePhase(const bitLenInt* cControls, const bit
             return;
         }
 
-        if (IS_ARG_0(topLeft) && tShard.IsInvertAntiControlOf(&(shards[control]))) {
+        if (IS_ARG_0(bottomRight) && tShard.IsInvertAntiControlOf(&(shards[control]))) {
             std::swap(control, target);
         }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -976,8 +976,8 @@ void QUnit::X(bitLenInt target)
     QEngineShard& shard = shards[target];
 
     // Should only let through controlled phase gates.
-    RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI);
     RevertBasis2Qb(target, INVERT_AND_PHASE, ONLY_CONTROLS, CTRL_AND_ANTI);
+    RevertBasis2Qb(target, ONLY_INVERT, ONLY_TARGETS, CTRL_AND_ANTI);
     shard.FlipPhaseAnti();
 
     if (!shard.isPlusMinus) {
@@ -1458,8 +1458,8 @@ void QUnit::ApplySingleInvert(const complex topRight, const complex bottomLeft, 
     }
 
     // Should only let through controlled phase gates.
-    RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI);
     RevertBasis2Qb(target, INVERT_AND_PHASE, ONLY_CONTROLS, CTRL_AND_ANTI);
+    RevertBasis2Qb(target, ONLY_INVERT, ONLY_TARGETS, CTRL_AND_ANTI);
     shard.FlipPhaseAnti();
 
     if (!shard.isPlusMinus) {
@@ -1643,7 +1643,7 @@ void QUnit::ApplyAntiControlledSinglePhase(const bitLenInt* cControls, const bit
             return;
         }
 
-        if (IS_ARG_0(topLeft) && tShard.IsInvertControlOf(&(shards[control]))) {
+        if (IS_ARG_0(topLeft) && tShard.IsInvertAntiControlOf(&(shards[control]))) {
             std::swap(control, target);
         }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1181,6 +1181,37 @@ void QUnit::CCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target)
         return;
     }
 
+    QEngineShard& c1Shard = shards[control1];
+    QEngineShard& c2Shard = shards[control2];
+
+    if (!c1Shard.IsInvertTarget()) {
+        if (UNSAFE_CACHED_CLASSICAL(c1Shard)) {
+            if (IS_NORM_ZERO(c1Shard.amp1)) {
+                Flush0Eigenstate(control1);
+                return;
+            }
+            if (IS_NORM_ZERO(c1Shard.amp0)) {
+                Flush1Eigenstate(control1);
+                CNOT(control2, target);
+                return;
+            }
+        }
+    }
+
+    if (!c2Shard.IsInvertTarget()) {
+        if (UNSAFE_CACHED_CLASSICAL(c2Shard)) {
+            if (IS_NORM_ZERO(c2Shard.amp1)) {
+                Flush0Eigenstate(control2);
+                return;
+            }
+            if (IS_NORM_ZERO(c2Shard.amp0)) {
+                Flush1Eigenstate(control2);
+                CNOT(control1, target);
+                return;
+            }
+        }
+    }
+
     bitLenInt controls[2] = { control1, control2 };
 
     ApplyEitherControlled(controls, 2, { target }, false,

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -975,9 +975,8 @@ void QUnit::X(bitLenInt target)
 {
     QEngineShard& shard = shards[target];
 
-    // Should only let through (not anti-)controlled phase gates.
+    // Should only let through controlled phase gates.
     RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI);
-    RevertBasis2Qb(target, INVERT_AND_PHASE, CONTROLS_AND_TARGETS, ONLY_ANTI);
     RevertBasis2Qb(target, INVERT_AND_PHASE, ONLY_CONTROLS, CTRL_AND_ANTI);
     shard.FlipPhaseAnti();
 
@@ -1458,9 +1457,8 @@ void QUnit::ApplySingleInvert(const complex topRight, const complex bottomLeft, 
         return;
     }
 
-    // Should only let through (not anti-)controlled phase gates.
+    // Should only let through controlled phase gates.
     RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI);
-    RevertBasis2Qb(target, INVERT_AND_PHASE, CONTROLS_AND_TARGETS, ONLY_ANTI);
     RevertBasis2Qb(target, INVERT_AND_PHASE, ONLY_CONTROLS, CTRL_AND_ANTI);
     shard.FlipPhaseAnti();
 
@@ -1563,7 +1561,7 @@ void QUnit::ApplyControlledSinglePhase(const bitLenInt* cControls, const bitLenI
             return;
         }
 
-        if (IS_ARG_0(topLeft) && tShard.IsInvertControlOf(&(shards[controls[0]]))) {
+        if (IS_ARG_0(topLeft) && tShard.IsInvertControlOf(&(shards[control]))) {
             std::swap(control, target);
         }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -975,7 +975,7 @@ void QUnit::X(bitLenInt target)
 {
     QEngineShard& shard = shards[target];
 
-    RevertBasis2Qb(target, ONLY_INVERT, ONLY_TARGETS, CTRL_AND_ANTI);
+    RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI);
     RevertBasis2Qb(target, INVERT_AND_PHASE, ONLY_CONTROLS, CTRL_AND_ANTI);
     shard.FlipPhaseAnti();
 
@@ -1456,7 +1456,7 @@ void QUnit::ApplySingleInvert(const complex topRight, const complex bottomLeft, 
         return;
     }
 
-    RevertBasis2Qb(target, ONLY_INVERT, ONLY_TARGETS, CTRL_AND_ANTI);
+    RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI);
     RevertBasis2Qb(target, INVERT_AND_PHASE, ONLY_CONTROLS, CTRL_AND_ANTI);
     shard.FlipPhaseAnti();
 

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -741,11 +741,11 @@ TEST_CASE("test_universal_circuit_analog", "[supreme]")
         false, false, testEngineType == QINTERFACE_QUNIT);
 }
 
-TEST_CASE("test_ccz_h", "[supreme]")
+TEST_CASE("test_ccz_ccx_h", "[supreme]")
 {
 
-    const int GateCount1Qb = 2;
-    const int GateCountMultiQb = 3;
+    const int GateCount1Qb = 4;
+    const int GateCountMultiQb = 4;
     const int Depth = 20;
 
     benchmarkLoop(
@@ -760,11 +760,15 @@ TEST_CASE("test_ccz_h", "[supreme]")
             for (d = 0; d < Depth; d++) {
 
                 for (i = 0; i < n; i++) {
-                    gateRand = qReg->Rand();
-                    if (gateRand < (ONE_R1 / GateCount1Qb)) {
+                    gateRand = GateCount1Qb * qReg->Rand();
+                    if (gateRand < 1) {
                         qReg->H(i);
-                    } else {
+                    } else if (gateRand < 2) {
                         qReg->Z(i);
+                    } else if (gateRand < 3) {
+                        qReg->X(i);
+                    } else {
+                        // Identity;
                     }
                 }
 
@@ -782,18 +786,21 @@ TEST_CASE("test_ccz_h", "[supreme]")
                     if (unusedBits.size() > 0) {
                         maxGates = GateCountMultiQb;
                     } else {
-                        maxGates = GateCountMultiQb - 1U;
+                        maxGates = GateCountMultiQb - 2U;
                     }
 
                     gateRand = maxGates * qReg->Rand();
 
                     if (gateRand < ONE_R1) {
-                        qReg->Swap(b1, b2);
-                    } else if ((gateRand < (2 * ONE_R1)) || (maxGates < 3)) {
                         qReg->CZ(b1, b2);
-                    } else {
+                    } else if (gateRand < 2) {
+                        qReg->CNOT(b1, b2);
+                    } else if (gateRand < 3) {
                         b3 = pickRandomBit(qReg, &unusedBits);
                         qReg->CCZ(b1, b2, b3);
+                    } else {
+                        b3 = pickRandomBit(qReg, &unusedBits);
+                        qReg->CCNOT(b1, b2, b3);
                     }
                 }
             }

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -4586,11 +4586,11 @@ TEST_CASE("test_universal_circuit_digital_cross_entropy", "[supreme]")
 
     const int GateCount1Qb = 5;
     const int GateCountMultiQb = 4;
-    const int Depth = 3;
+    const int Depth = 4;
 
-    const int TRIALS = 200;
+    const int TRIALS = 300;
     const int ITERATIONS = 60000;
-    const int n = 8;
+    const int n = 10;
     bitCapInt permCount = pow2(n);
     bitCapInt perm;
 

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -4584,11 +4584,6 @@ TEST_CASE("test_universal_circuit_digital_cross_entropy", "[supreme]")
 {
     std::cout << ">>> 'test_universal_circuit_digital_cross_entropy':" << std::endl;
 
-    if (sparse) {
-        std::cout << "Skipped for sparse engine types (known accuracy issue)" << std::endl;
-        return;
-    }
-
     const int GateCount1Qb = 5;
     const int GateCountMultiQb = 4;
     const int Depth = 4;

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -4584,6 +4584,11 @@ TEST_CASE("test_universal_circuit_digital_cross_entropy", "[supreme]")
 {
     std::cout << ">>> 'test_universal_circuit_digital_cross_entropy':" << std::endl;
 
+    if (sparse) {
+        std::cout << "Skipped for sparse engine types (known accuracy issue)" << std::endl;
+        return;
+    }
+
     const int GateCount1Qb = 5;
     const int GateCountMultiQb = 4;
     const int Depth = 4;


### PR DESCRIPTION
The controlled gate buffer code wasn't actually using most of its intended capabilities, but the commutation rules planned were luckily on fairly solid footing. Now, CZ/CNOT commutation and "anti-controlled" buffers are actually utilized in this code, as originally intended. Eased restrictions on commutation relations for buffers will hopefully follow soon.