### PR TITLE
Optimized controlled-H gate for XACC interface

### DIFF
--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -777,6 +777,14 @@ public:
     virtual void CCZ(bitLenInt control1, bitLenInt control2, bitLenInt target);
 
     /**
+     * Controlled H gate
+     *
+     * If the "control" bit is set to 1, then the "H" Walsh-Hadamard transform operator is applied
+     * to "target."
+     */
+    virtual void CH(bitLenInt control, bitLenInt target);
+
+    /**
      * Controlled S gate
      *
      * If the "control" bit is set to 1, then the S gate is applied
@@ -1410,6 +1418,14 @@ public:
      * to "target."
      */
     virtual void CCZ(bitLenInt control1, bitLenInt control2, bitLenInt target, bitLenInt length);
+
+    /**
+     * Bitwise controlled H gate
+     *
+     * If the "control" bit is set to 1, then the "H" Walsh-Hadamard transform operator is applied
+     * to "target."
+     */
+    virtual void CH(bitLenInt control, bitLenInt target, bitLenInt length);
 
     /**
      * Bitwise controlled S gate

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -663,6 +663,8 @@ public:
     virtual void CZ(bitLenInt control, bitLenInt target);
     using QInterface::CCZ;
     virtual void CCZ(bitLenInt control1, bitLenInt control2, bitLenInt target);
+    using QInterface::CH;
+    virtual void CH(bitLenInt control, bitLenInt target);
 
     virtual void ApplySinglePhase(const complex topLeft, const complex bottomRight, bitLenInt qubitIndex);
     virtual void ApplySingleInvert(const complex topRight, const complex bottomLeft, bitLenInt qubitIndex);

--- a/src/qinterface/gates.cpp
+++ b/src/qinterface/gates.cpp
@@ -212,6 +212,15 @@ void QInterface::CCZ(bitLenInt control1, bitLenInt control2, bitLenInt target)
     ApplyControlledSinglePhase(controls, 2, target, ONE_CMPLX, -ONE_CMPLX);
 }
 
+/// Apply controlled Pauli Z matrix to bit
+void QInterface::CH(bitLenInt control, bitLenInt target)
+{
+    bitLenInt controls[1] = { control };
+    const complex h[4] = { complex(ONE_R1 / sqrt((real1)2), ZERO_R1), complex(ONE_R1 / sqrt((real1)2), ZERO_R1),
+        complex(ONE_R1 / sqrt((real1)2), ZERO_R1), complex(-ONE_R1 / sqrt((real1)2), ZERO_R1) };
+    ApplyControlledSingleBit(controls, 1, target, h);
+}
+
 /// Doubly-controlled not
 void QInterface::CCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target)
 {

--- a/src/qinterface/qinterface.cpp
+++ b/src/qinterface/qinterface.cpp
@@ -173,6 +173,9 @@ REG_GATE_C1_1(CY);
 /// Apply controlled Pauli Z matrix to each bit
 REG_GATE_C1_1(CZ);
 
+/// Apply controlled H gate to each bit
+REG_GATE_C1_1(CH);
+
 /// Apply controlled S gate to each bit
 REG_GATE_C1_1(CS);
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1306,6 +1306,17 @@ void QUnit::CZ(bitLenInt control, bitLenInt target)
         CZ(CTRL_1_ARGS), ApplyControlledSingleBit(CTRL_GEN_ARGS), Z(target), false, false, ONE_CMPLX, -ONE_CMPLX);
 }
 
+void QUnit::CH(bitLenInt control, bitLenInt target)
+{
+    const complex mtrx[4] = { complex(ONE_R1 / sqrt((real1)2), ZERO_R1), complex(ONE_R1 / sqrt((real1)2), ZERO_R1),
+        complex(ONE_R1 / sqrt((real1)2), ZERO_R1), complex(-ONE_R1 / sqrt((real1)2), ZERO_R1) };
+
+    bitLenInt controls[1] = { control };
+    bitLenInt controlLen = 1;
+
+    CTRLED_GEN_WRAP(ApplyControlledSingleBit(CTRL_GEN_ARGS), H(target), false);
+}
+
 void QUnit::CCZ(bitLenInt control1, bitLenInt control2, bitLenInt target)
 {
     if (shards[control1].isPlusMinus && !shards[target].isPlusMinus) {

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -1277,6 +1277,29 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_cz_reg")
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x36));
 }
 
+TEST_CASE_METHOD(QInterfaceTestFixture, "test_ch")
+{
+    qftReg->SetReg(0, 8, 0x35);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x35));
+    qftReg->CH(4, 0);
+    qftReg->CH(5, 1);
+    qftReg->CH(6, 2);
+    qftReg->CH(7, 3);
+    qftReg->Z(0, 4);
+    qftReg->H(0, 2);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x36));
+}
+
+TEST_CASE_METHOD(QInterfaceTestFixture, "test_ch_reg")
+{
+    qftReg->SetReg(0, 8, 0x35);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x35));
+    qftReg->CH(4, 0, 4);
+    qftReg->Z(0, 4);
+    qftReg->H(0, 2);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x36));
+}
+
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_and")
 {
     qftReg->SetPermutation(0x0e);


### PR DESCRIPTION
We're expanding stack support, again. XACC has some demand for a controlled `H` gate. As can be seen in this diff, it's trivial to add this gate. `QUnit` can immediately optimize it, at least to first pass, so I'd like this in the public API, rather than implemented via decomposition.