### PR TITLE
VQE debugging

### DIFF
--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -995,8 +995,8 @@ void QUnit::Z(bitLenInt target)
         }
     }
 
-    RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI);
-    // shard.CommutePhase(ONE_CMPLX, -ONE_CMPLX);
+    RevertBasis2Qb(target, ONLY_INVERT, ONLY_TARGETS, CTRL_AND_ANTI);
+    //shard.CommutePhase(ONE_CMPLX, -ONE_CMPLX);
 
     if (!shard.isPlusMinus) {
         ZBase(target);
@@ -1421,8 +1421,8 @@ void QUnit::ApplySinglePhase(const complex topLeft, const complex bottomRight, b
         }
     }
 
-    RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI);
-    // shard.CommutePhase(topLeft, bottomRight);
+    RevertBasis2Qb(target, ONLY_INVERT, ONLY_TARGETS, CTRL_AND_ANTI);
+    //shard.CommutePhase(topLeft, bottomRight);
 
     if (!shard.isPlusMinus) {
         ApplyOrEmulate(

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1102,12 +1102,12 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
         }
     }
 
-    if (!freezeBasis) {
+    /*if (!freezeBasis) {
         H(target);
         CZ(control, target);
         H(target);
         return;
-    }
+    }*/
 
     bitLenInt controls[1] = { control };
     bitLenInt controlLen = 1;
@@ -1294,6 +1294,7 @@ void QUnit::CZ(bitLenInt control, bitLenInt target)
 
         RevertBasis2Qb(control, ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI, { target }, {});
         RevertBasis2Qb(target, ONLY_INVERT, ONLY_CONTROLS, CTRL_AND_ANTI, {}, { control });
+        RevertBasis2Qb(control, ONLY_INVERT, ONLY_TARGETS, ONLY_ANTI);
 
         shards[target].AddPhaseAngles(&(shards[control]), ONE_CMPLX, -ONE_CMPLX);
         return;

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -993,10 +993,11 @@ void QUnit::Z(bitLenInt target)
             Flush0Eigenstate(target);
             return;
         }
+    } else if (shard.isPlusMinus) {
+        TransformBasis1Qb(false, target);
     }
 
-    RevertBasis2Qb(target, ONLY_INVERT, ONLY_TARGETS, CTRL_AND_ANTI);
-    //shard.CommutePhase(ONE_CMPLX, -ONE_CMPLX);
+    shard.CommutePhase(ONE_CMPLX, -ONE_CMPLX);
 
     if (!shard.isPlusMinus) {
         ZBase(target);
@@ -1419,10 +1420,11 @@ void QUnit::ApplySinglePhase(const complex topLeft, const complex bottomRight, b
             Flush1Eigenstate(target);
             return;
         }
+    } else if (shard.isPlusMinus) {
+        TransformBasis1Qb(false, target);
     }
 
-    RevertBasis2Qb(target, ONLY_INVERT, ONLY_TARGETS, CTRL_AND_ANTI);
-    //shard.CommutePhase(topLeft, bottomRight);
+    shard.CommutePhase(topLeft, bottomRight);
 
     if (!shard.isPlusMinus) {
         ApplyOrEmulate(
@@ -3296,8 +3298,8 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
         polarDiff = buffer->cmplxDiff;
         polarSame = buffer->cmplxSame;
 
-        isSame = (norm(polarDiff - polarSame) <= ampThreshold) && (!needToCommute || !buffer->isInvert);
-        isOpposite = (norm(polarDiff + polarSame) <= ampThreshold) && !buffer->isInvert;
+        isSame = !needToCommute && (norm(polarDiff - polarSame) <= ampThreshold);
+        isOpposite = !buffer->isInvert && (norm(polarDiff + polarSame) <= ampThreshold);
 
         if (!isSame && !isOpposite) {
             ApplyBuffer(phaseShard, control, bitIndex, false);
@@ -3332,8 +3334,8 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
         polarDiff = buffer->cmplxDiff;
         polarSame = buffer->cmplxSame;
 
-        isSame = (norm(polarDiff - polarSame) <= ampThreshold) && (!needToCommute || !buffer->isInvert);
-        isOpposite = (norm(polarDiff + polarSame) <= ampThreshold) && !buffer->isInvert;
+        isSame = !needToCommute && (norm(polarDiff - polarSame) <= ampThreshold);
+        isOpposite = !buffer->isInvert && (norm(polarDiff + polarSame) <= ampThreshold);
 
         if (!isSame && !isOpposite) {
             ApplyBuffer(phaseShard, control, bitIndex, true);

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1293,7 +1293,7 @@ void QUnit::CZ(bitLenInt control, bitLenInt target)
         TransformBasis1Qb(false, control);
 
         RevertBasis2Qb(control, ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI, { target }, {});
-        RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI, {}, { control });
+        RevertBasis2Qb(target, ONLY_INVERT, ONLY_CONTROLS, CTRL_AND_ANTI, {}, { control });
 
         shards[target].AddPhaseAngles(&(shards[control]), ONE_CMPLX, -ONE_CMPLX);
         return;

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -3298,7 +3298,7 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
         polarDiff = buffer->cmplxDiff;
         polarSame = buffer->cmplxSame;
 
-        isSame = !needToCommute && (norm(polarDiff - polarSame) <= ampThreshold);
+        isSame = (!needToCommute || !buffer->isInvert) && (norm(polarDiff - polarSame) <= ampThreshold);
         isOpposite = !buffer->isInvert && (norm(polarDiff + polarSame) <= ampThreshold);
 
         if (!isSame && !isOpposite) {
@@ -3334,7 +3334,7 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
         polarDiff = buffer->cmplxDiff;
         polarSame = buffer->cmplxSame;
 
-        isSame = !needToCommute && (norm(polarDiff - polarSame) <= ampThreshold);
+        isSame = (!needToCommute || !buffer->isInvert) && (norm(polarDiff - polarSame) <= ampThreshold);
         isOpposite = !buffer->isInvert && (norm(polarDiff + polarSame) <= ampThreshold);
 
         if (!isSame && !isOpposite) {

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -988,16 +988,15 @@ void QUnit::Z(bitLenInt target)
 {
     QEngineShard& shard = shards[target];
 
-    if (!shard.IsInvertTarget()) {
+    if (shard.IsInvertTarget()) {
+        TransformBasis1Qb(false, target);
+        shard.CommutePhase(ONE_CMPLX, -ONE_CMPLX);
+    } else {
         if (UNSAFE_CACHED_ZERO(shard)) {
             Flush0Eigenstate(target);
             return;
         }
-    } else if (shard.isPlusMinus) {
-        TransformBasis1Qb(false, target);
     }
-
-    shard.CommutePhase(ONE_CMPLX, -ONE_CMPLX);
 
     if (!shard.isPlusMinus) {
         ZBase(target);
@@ -1410,7 +1409,10 @@ void QUnit::ApplySinglePhase(const complex topLeft, const complex bottomRight, b
 
     QEngineShard& shard = shards[target];
 
-    if (!shard.IsInvertTarget()) {
+    if (shard.IsInvertTarget()) {
+        TransformBasis1Qb(false, target);
+        shard.CommutePhase(topLeft, bottomRight);
+    } else {
         if (IS_ARG_0(topLeft) && UNSAFE_CACHED_ZERO(shard)) {
             Flush0Eigenstate(target);
             return;
@@ -1420,11 +1422,7 @@ void QUnit::ApplySinglePhase(const complex topLeft, const complex bottomRight, b
             Flush1Eigenstate(target);
             return;
         }
-    } else if (shard.isPlusMinus) {
-        TransformBasis1Qb(false, target);
     }
-
-    shard.CommutePhase(topLeft, bottomRight);
 
     if (!shard.isPlusMinus) {
         ApplyOrEmulate(


### PR DESCRIPTION
While testing Qrack with the VQE in the XACC plugin under development, we weren't reaching the ground state of deuterium H3, (if I understand the point of the test case). This appears to have been due to a bug in single qubit phase gate commutation, implicating commuting "inversion" targets while being in |+>/|-> basis at the same time.