### PR TITLE
Adding "fSim" gate

### DIFF
--- a/include/qengine.hpp
+++ b/include/qengine.hpp
@@ -99,6 +99,8 @@ public:
     virtual void SqrtSwap(bitLenInt qubit1, bitLenInt qubit2);
     using QInterface::ISqrtSwap;
     virtual void ISqrtSwap(bitLenInt qubit1, bitLenInt qubit2);
+    using QInterface::FSim;
+    virtual void FSim(real1 theta, real1 phi, bitLenInt qubitIndex1, bitLenInt qubitIndex2);
 
     virtual real1 ProbReg(const bitLenInt& start, const bitLenInt& length, const bitCapInt& permutation) = 0;
     virtual void ProbRegAll(const bitLenInt& start, const bitLenInt& length, real1* probsArray);

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -1858,6 +1858,12 @@ public:
     /** Bitwise inverse square root of swap */
     virtual void ISqrtSwap(bitLenInt start1, bitLenInt start2, bitLenInt length);
 
+    /** The 2-qubit "fSim" gate, (useful in the simulation of particles with fermionic statistics) */
+    virtual void FSim(real1 theta, real1 phi, bitLenInt qubitIndex1, bitLenInt qubitIndex2) = 0;
+
+    /** Bitwise "fSim" */
+    virtual void FSim(real1 theta, real1 phi, bitLenInt start1, bitLenInt start2, bitLenInt length);
+
     /** Reverse all of the bits in a sequence. */
     virtual void Reverse(bitLenInt first, bitLenInt last)
     {

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -788,6 +788,7 @@ public:
     virtual void ISwap(bitLenInt qubit1, bitLenInt qubit2);
     virtual void SqrtSwap(bitLenInt qubit1, bitLenInt qubit2);
     virtual void ISqrtSwap(bitLenInt qubit1, bitLenInt qubit2);
+    virtual void FSim(real1 theta, real1 phi, bitLenInt qubit1, bitLenInt qubit2);
 
     /** @} */
 

--- a/src/qengine/qengine.cpp
+++ b/src/qengine/qengine.cpp
@@ -437,6 +437,30 @@ void QEngine::ISqrtSwap(bitLenInt qubit1, bitLenInt qubit2)
     Apply2x2(qPowersSorted[0], qPowersSorted[1], iSqrtX, 2, qPowersSorted, false);
 }
 
+/// "fSim" gate, (useful in the simulation of particles with fermionic statistics)
+void QEngine::FSim(real1 theta, real1 phi, bitLenInt qubit1, bitLenInt qubit2)
+{
+    real1 cosTheta = cos(theta);
+    real1 sinTheta = sin(theta);
+
+    if (cosTheta != ONE_R1) {
+        const complex fSimSwap[4] = { complex(cosTheta, ZERO_R1), complex(ZERO_R1, sinTheta),
+            complex(ZERO_R1, sinTheta), complex(cosTheta, ZERO_R1) };
+        bitCapInt qPowersSorted[2];
+        qPowersSorted[0] = pow2(qubit1);
+        qPowersSorted[1] = pow2(qubit2);
+        std::sort(qPowersSorted, qPowersSorted + 2);
+        Apply2x2(qPowersSorted[0], qPowersSorted[1], fSimSwap, 2, qPowersSorted, false);
+    }
+
+    if (phi == ZERO_R1) {
+        return;
+    }
+
+    bitLenInt controls[1] = { qubit1 };
+    ApplyControlledSinglePhase(controls, 1, qubit2, ONE_CMPLX, exp(complex(ZERO_R1, phi)));
+}
+
 void QEngine::ProbRegAll(const bitLenInt& start, const bitLenInt& length, real1* probsArray)
 {
     bitCapIntOcl lengthPower = pow2Ocl(length);

--- a/src/qinterface/qinterface.cpp
+++ b/src/qinterface/qinterface.cpp
@@ -107,6 +107,13 @@ REG_GATE_2(SqrtSwap);
 /// Bit-wise apply inverse square root of swap to two registers
 REG_GATE_2(ISqrtSwap);
 
+void QInterface::FSim(real1 theta, real1 phi, bitLenInt qubit1, bitLenInt qubit2, bitLenInt length)
+{
+    for (bitLenInt bit = 0; bit < length; bit++) {
+        FSim(theta, phi, qubit1 + bit, qubit2 + bit);
+    }
+}
+
 /// Bit-wise apply doubly-controlled-z to two control registers and one target register
 REG_GATE_C2_1(CCZ);
 

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -552,6 +552,48 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_anticisqrtswap")
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x001));
 }
 
+TEST_CASE_METHOD(QInterfaceTestFixture, "test_fsim")
+{
+    real1 theta = 3 * M_PI / 2;
+
+    qftReg->SetPermutation(1);
+    qftReg->FSim(theta, ZERO_R1, 0, 1);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x02));
+
+    qftReg->SetPermutation(0);
+    qftReg->H(0, 2);
+    qftReg->FSim(theta, ZERO_R1, 0, 1);
+    qftReg->FSim(theta, ZERO_R1, 0, 1);
+    qftReg->H(0, 2);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x03));
+
+    qftReg->SetPermutation(0);
+    qftReg->H(0, 4);
+    qftReg->FSim(theta, ZERO_R1, 0, 2, 2);
+    qftReg->FSim(theta, ZERO_R1, 0, 2, 2);
+    qftReg->H(0, 4);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x0F));
+
+    real1 phi = M_PI;
+
+    qftReg->SetReg(0, 8, 0x35);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x35));
+    qftReg->H(0, 4);
+    qftReg->FSim(ZERO_R1, phi, 4, 0);
+    qftReg->FSim(ZERO_R1, phi, 5, 1);
+    qftReg->FSim(ZERO_R1, phi, 6, 2);
+    qftReg->FSim(ZERO_R1, phi, 7, 3);
+    qftReg->H(0, 4);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x36));
+
+    qftReg->SetPermutation(0x03);
+    qftReg->H(0);
+    qftReg->FSim(ZERO_R1, phi, 0, 1);
+    qftReg->FSim(ZERO_R1, phi, 0, 1);
+    qftReg->H(0);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x03));
+}
+
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_apply_single_bit")
 {
     complex pauliX[4] = { complex(0.0, 0.0), complex(1.0, 0.0), complex(1.0, 0.0), complex(0.0, 0.0) };


### PR DESCRIPTION
The "fSim" gate is useful in the simulation of quantum particles with fermionic statistics. XACC natively supports it, and I would like to take its implementation behind Qrack's public API layer. (I have made a substantial first pass at QUnit optimization, for it.)