### PR TITLE
Analagous fix for inversions, as 1e0dfd2

### DIFF
--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1510,7 +1510,11 @@ void QUnit::ApplySingleInvert(const complex topRight, const complex bottomLeft, 
         return;
     }
 
-    shard.CommutePhase(bottomLeft, topRight);
+    if (shard.IsInvertTarget()) {
+        TransformBasis1Qb(false, target);
+        shard.CommutePhase(bottomLeft, topRight);
+    }
+
     shard.FlipPhaseAnti();
 
     if (!shard.isPlusMinus) {


### PR DESCRIPTION
It occurred to after 1e0dfd2 that the `CommutePhase()` call in `ApplySingleInversion()` probably needed the same fix; commuting phase effects with inversion targets requires first transforming out of |+>/|-> basis to |0>/|1> basis. (It's not immediately obvious to me why this shouldn't work in |+>/|-> basis, but it seems it doesn't.) I'm testing this further, now.