### PR TITLE
Issue #357: Fixing CommuteH() bug

### DIFF
--- a/cmake/Format.cmake
+++ b/cmake/Format.cmake
@@ -1,6 +1,6 @@
 set( FORMAT_EXCLUDE_FILES "catch.hpp" "_build")
 
-find_program ( CLANG_FORMAT clang-format-5.0 )
+find_program ( CLANG_FORMAT clang-format-9 )
 file (GLOB_RECURSE ALL_SOURCE_FILES *.cpp *.hpp)
 
 foreach (SOURCE_FILE ${ALL_SOURCE_FILES})

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -12,6 +12,8 @@
 
 #pragma once
 
+#include <iostream>
+
 #include <cfloat>
 #include <random>
 #include <unordered_set>

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -12,8 +12,6 @@
 
 #pragma once
 
-#include <iostream>
-
 #include <cfloat>
 #include <random>
 #include <unordered_set>

--- a/src/common/parallel_for.cpp
+++ b/src/common/parallel_for.cpp
@@ -115,12 +115,14 @@ void ParallelFor::par_for_inc(const bitCapInt begin, const bitCapInt itemCount, 
 
 void ParallelFor::par_for(const bitCapInt begin, const bitCapInt end, ParallelFunc fn)
 {
-    par_for_inc(begin, end - begin, [](const bitCapInt i, int cpu) { return i; }, fn);
+    par_for_inc(
+        begin, end - begin, [](const bitCapInt i, int cpu) { return i; }, fn);
 }
 
 void ParallelFor::par_for_set(const std::set<bitCapInt>& sparseSet, ParallelFunc fn)
 {
-    par_for_inc(0, sparseSet.size(),
+    par_for_inc(
+        0, sparseSet.size(),
         [&sparseSet](const bitCapInt i, int cpu) {
             auto it = sparseSet.begin();
             std::advance(it, i);
@@ -131,7 +133,8 @@ void ParallelFor::par_for_set(const std::set<bitCapInt>& sparseSet, ParallelFunc
 
 void ParallelFor::par_for_set(const std::vector<bitCapInt>& sparseSet, ParallelFunc fn)
 {
-    par_for_inc(0, sparseSet.size(),
+    par_for_inc(
+        0, sparseSet.size(),
         [&sparseSet](const bitCapInt i, int cpu) {
             auto it = sparseSet.begin();
             std::advance(it, i);
@@ -144,7 +147,8 @@ void ParallelFor::par_for_sparse_compose(const std::vector<bitCapInt>& lowSet, c
     const bitLenInt& highStart, ParallelFunc fn)
 {
     bitCapInt lowSize = lowSet.size();
-    par_for_inc(0, lowSize * highSet.size(),
+    par_for_inc(
+        0, lowSize * highSet.size(),
         [&lowSize, &highStart, &lowSet, &highSet](const bitCapInt i, int cpu) {
             bitCapInt lowPerm = i % lowSize;
             bitCapInt highPerm = (i - lowPerm) / lowSize;

--- a/src/qengine/arithmetic.cpp
+++ b/src/qengine/arithmetic.cpp
@@ -1068,7 +1068,6 @@ void QEngineCPU::FullAdd(bitLenInt inputBit1, bitLenInt inputBit2, bitLenInt car
     std::sort(qPowers, qPowers + 2);
 
     par_for_mask(0, maxQPower, qPowers, 2, [&](const bitCapInt lcv, const int cpu) {
-
         // Carry-in, sum bit in
         complex ins0c0 = stateVec->read(lcv);
         complex ins0c1 = stateVec->read(lcv | carryInSumOutMask);
@@ -1133,7 +1132,6 @@ void QEngineCPU::IFullAdd(bitLenInt inputBit1, bitLenInt inputBit2, bitLenInt ca
     std::sort(qPowers, qPowers + 2);
 
     par_for_mask(0, maxQPower, qPowers, 2, [&](const bitCapInt lcv, const int cpu) {
-
         // Carry-in, sum bit out
         complex outs0c0 = stateVec->read(lcv);
         complex outs0c1 = stateVec->read(lcv | carryOutMask);

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -2356,7 +2356,7 @@ complex* QEngineOCL::AllocStateVec(bitCapInt elemCount, bool doForceAlloc)
         return NULL;
     }
 
-        // elemCount is always a power of two, but might be smaller than QRACK_ALIGN_SIZE
+    // elemCount is always a power of two, but might be smaller than QRACK_ALIGN_SIZE
 #if defined(__APPLE__)
     void* toRet;
     posix_memalign(&toRet, QRACK_ALIGN_SIZE,

--- a/src/qengine/state.cpp
+++ b/src/qengine/state.cpp
@@ -121,11 +121,11 @@ void QEngineCPU::GetProbs(real1* outputProbs)
     stateVec->get_probs(outputProbs);
 }
 
-    /**
-     * Apply a 2x2 matrix to the state vector
-     *
-     * A fundamental operation used by almost all gates.
-     */
+/**
+ * Apply a 2x2 matrix to the state vector
+ *
+ * A fundamental operation used by almost all gates.
+ */
 
 #if ENABLE_COMPLEX_X2
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1072,7 +1072,8 @@ void QUnit::TransformInvert(const complex& topRight, const complex& bottomLeft, 
 }
 
 #define CTRLED_GEN_WRAP(ctrld, bare, anti)                                                                             \
-    ApplyEitherControlled(controls, controlLen, { target }, anti,                                                      \
+    ApplyEitherControlled(                                                                                             \
+        controls, controlLen, { target }, anti,                                                                        \
         [&](QInterfacePtr unit, std::vector<bitLenInt> mappedControls) {                                               \
             complex trnsMtrx[4] = { ZERO_CMPLX, ZERO_CMPLX, ZERO_CMPLX, ZERO_CMPLX };                                  \
             if (!shards[target].isPlusMinus) {                                                                         \
@@ -1085,7 +1086,8 @@ void QUnit::TransformInvert(const complex& topRight, const complex& bottomLeft, 
         [&]() { bare; });
 
 #define CTRLED_PHASE_INVERT_WRAP(ctrld, ctrldgen, bare, anti, isInvert, top, bottom)                                   \
-    ApplyEitherControlled(controls, controlLen, { target }, anti,                                                      \
+    ApplyEitherControlled(                                                                                             \
+        controls, controlLen, { target }, anti,                                                                        \
         [&](QInterfacePtr unit, std::vector<bitLenInt> mappedControls) {                                               \
             if (!shards[target].isPlusMinus) {                                                                         \
                 unit->ctrld;                                                                                           \
@@ -1107,7 +1109,8 @@ void QUnit::TransformInvert(const complex& topRight, const complex& bottomLeft, 
     }                                                                                                                  \
     ToPermBasis(qubit1);                                                                                               \
     ToPermBasis(qubit2);                                                                                               \
-    ApplyEitherControlled(controls, controlLen, { qubit1, qubit2 }, anti,                                              \
+    ApplyEitherControlled(                                                                                             \
+        controls, controlLen, { qubit1, qubit2 }, anti,                                                                \
         [&](QInterfacePtr unit, std::vector<bitLenInt> mappedControls) { unit->ctrld; }, [&]() { bare; })
 #define CTRL_GEN_ARGS &(mappedControls[0]), mappedControls.size(), shards[target].mapped, trnsMtrx
 #define CTRL_ARGS &(mappedControls[0]), mappedControls.size(), shards[target].mapped, mtrx
@@ -1169,7 +1172,8 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
         RevertBasis2Qb(target);
 
         std::swap(controls[0], target);
-        ApplyEitherControlled(controls, controlLen, { target }, false,
+        ApplyEitherControlled(
+            controls, controlLen, { target }, false,
             [&](QInterfacePtr unit, std::vector<bitLenInt> mappedControls) { unit->CNOT(CTRL_1_ARGS); },
             [&]() { XBase(target); }, true);
         return;
@@ -1255,7 +1259,8 @@ void QUnit::CCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target)
 
     bitLenInt controls[2] = { control1, control2 };
 
-    ApplyEitherControlled(controls, 2, { target }, false,
+    ApplyEitherControlled(
+        controls, 2, { target }, false,
         [&](QInterfacePtr unit, std::vector<bitLenInt> mappedControls) {
             if (shards[target].isPlusMinus) {
                 if (mappedControls.size() == 2) {
@@ -1283,7 +1288,8 @@ void QUnit::AntiCCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target)
 
     bitLenInt controls[2] = { control1, control2 };
 
-    ApplyEitherControlled(controls, 2, { target }, true,
+    ApplyEitherControlled(
+        controls, 2, { target }, true,
         [&](QInterfacePtr unit, std::vector<bitLenInt> mappedControls) {
             if (shards[target].isPlusMinus) {
                 unit->ApplyAntiControlledSinglePhase(
@@ -1419,7 +1425,8 @@ void QUnit::CCZ(bitLenInt control1, bitLenInt control2, bitLenInt target)
 
     bitLenInt controls[2] = { control1, control2 };
 
-    ApplyEitherControlled(controls, 2, { target }, false,
+    ApplyEitherControlled(
+        controls, 2, { target }, false,
         [&](QInterfacePtr unit, std::vector<bitLenInt> mappedControls) {
             if (shards[target].isPlusMinus) {
                 if (mappedControls.size() == 2) {
@@ -3358,7 +3365,8 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
         for (phaseShard = targetOfShards.begin(); phaseShard != targetOfShards.end(); phaseShard++) {
             buffer = phaseShard->second;
 
-            if (phaseShard->second->isInvert != anyInvert || (anyInvert && norm(polarDiff + polarSame) <= ampThreshold)) {
+            if (phaseShard->second->isInvert != anyInvert ||
+                (anyInvert && norm(polarDiff + polarSame) <= ampThreshold)) {
                 partner = phaseShard->first;
                 control = FindShardIndex(*partner);
 
@@ -3412,7 +3420,8 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
         for (phaseShard = targetOfShards.begin(); phaseShard != targetOfShards.end(); phaseShard++) {
             buffer = phaseShard->second;
 
-            if (phaseShard->second->isInvert != anyInvert || (anyInvert && norm(polarDiff + polarSame) <= ampThreshold)) {
+            if (phaseShard->second->isInvert != anyInvert ||
+                (anyInvert && norm(polarDiff + polarSame) <= ampThreshold)) {
                 partner = phaseShard->first;
                 control = FindShardIndex(*partner);
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -3375,15 +3375,14 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
     // TODO: Should be able to commute these:
     if (anyInvert || anyAntiInvert) {
         if (shard.targetOfShards.size() >= shard.antiTargetOfShards.size()) {
-            RevertBasis2Qb(bitIndex, INVERT_AND_PHASE, ONLY_TARGETS, ONLY_ANTI);
+            RevertBasis2Qb(bitIndex, INVERT_AND_PHASE, CONTROLS_AND_TARGETS, ONLY_ANTI);
         } else {
-            RevertBasis2Qb(bitIndex, INVERT_AND_PHASE, ONLY_TARGETS, ONLY_CTRL);
+            RevertBasis2Qb(bitIndex, INVERT_AND_PHASE, CONTROLS_AND_TARGETS, ONLY_CTRL);
         }
     }
 
-    targetOfShards = shard.targetOfShards;
-
-    if (targetOfShards.size() > 1U) {
+    if (shard.targetOfShards.size() > 1U || shard.antiTargetOfShards.size() > 0U) {
+        targetOfShards = shard.targetOfShards;
         for (phaseShard = targetOfShards.begin(); phaseShard != targetOfShards.end(); phaseShard++) {
             buffer = phaseShard->second;
 
@@ -3398,9 +3397,8 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
         }
     }
 
-    targetOfShards = shard.antiTargetOfShards;
-
-    if (targetOfShards.size() > 1U) {
+    if (shard.antiTargetOfShards.size() > 1U || shard.targetOfShards.size() > 0U) {
+        targetOfShards = shard.antiTargetOfShards;
         for (phaseShard = targetOfShards.begin(); phaseShard != targetOfShards.end(); phaseShard++) {
             buffer = phaseShard->second;
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -3381,35 +3381,30 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
         }
     }
 
-    if (shard.targetOfShards.size() > 1U || shard.antiTargetOfShards.size() > 0U) {
-        targetOfShards = shard.targetOfShards;
-        for (phaseShard = targetOfShards.begin(); phaseShard != targetOfShards.end(); phaseShard++) {
-            buffer = phaseShard->second;
+    targetOfShards = shard.targetOfShards;
+    for (phaseShard = targetOfShards.begin(); phaseShard != targetOfShards.end(); phaseShard++) {
+        buffer = phaseShard->second;
 
-            if (phaseShard->second->isInvert != anyInvert ||
-                (anyInvert && norm(polarDiff + polarSame) <= ampThreshold)) {
-                partner = phaseShard->first;
-                control = FindShardIndex(*partner);
+        if (phaseShard->second->isInvert != anyInvert || (anyInvert && norm(polarDiff + polarSame) <= ampThreshold)) {
+            partner = phaseShard->first;
+            control = FindShardIndex(*partner);
 
-                ApplyBuffer(phaseShard, control, bitIndex, false);
-                shard.RemovePhaseControl(partner);
-            }
+            ApplyBuffer(phaseShard, control, bitIndex, false);
+            shard.RemovePhaseControl(partner);
         }
     }
 
-    if (shard.antiTargetOfShards.size() > 1U || shard.targetOfShards.size() > 0U) {
-        targetOfShards = shard.antiTargetOfShards;
-        for (phaseShard = targetOfShards.begin(); phaseShard != targetOfShards.end(); phaseShard++) {
-            buffer = phaseShard->second;
+    targetOfShards = shard.antiTargetOfShards;
+    for (phaseShard = targetOfShards.begin(); phaseShard != targetOfShards.end(); phaseShard++) {
+        buffer = phaseShard->second;
 
-            if (phaseShard->second->isInvert != anyAntiInvert ||
-                (anyAntiInvert && norm(polarDiff + polarSame) <= ampThreshold)) {
-                partner = phaseShard->first;
-                control = FindShardIndex(*partner);
+        if (phaseShard->second->isInvert != anyAntiInvert ||
+            (anyAntiInvert && norm(polarDiff + polarSame) <= ampThreshold)) {
+            partner = phaseShard->first;
+            control = FindShardIndex(*partner);
 
-                ApplyBuffer(phaseShard, control, bitIndex, true);
-                shard.RemovePhaseAntiControl(partner);
-            }
+            ApplyBuffer(phaseShard, control, bitIndex, true);
+            shard.RemovePhaseAntiControl(partner);
         }
     }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -3314,6 +3314,13 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
 
     QEngineShard& shard = shards[bitIndex];
 
+    // TODO: Should be able to commute these:
+    if (shard.targetOfShards.size() >= shard.antiTargetOfShards.size()) {
+        RevertBasis2Qb(bitIndex, INVERT_AND_PHASE, ONLY_TARGETS, ONLY_ANTI);
+    } else {
+        RevertBasis2Qb(bitIndex, INVERT_AND_PHASE, ONLY_TARGETS, ONLY_CTRL);
+    }
+
     if (!QUEUED_PHASE(shard)) {
         return;
     }

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1341,8 +1341,8 @@ void QUnit::CZ(bitLenInt control, bitLenInt target)
 
         TransformBasis1Qb(false, control);
 
-        RevertBasis2Qb(control, ONLY_INVERT, CONTROLS_AND_TARGETS, ONLY_CTRL, { target }, {});
-        RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, ONLY_CTRL, {}, { control });
+        RevertBasis2Qb(control, ONLY_INVERT, CONTROLS_AND_TARGETS, ONLY_CTRL);
+        RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, ONLY_CTRL);
         RevertBasis2Qb(control, ONLY_INVERT, ONLY_TARGETS, ONLY_ANTI);
 
         shards[target].AddPhaseAngles(&(shards[control]), ONE_CMPLX, -ONE_CMPLX);
@@ -1636,8 +1636,8 @@ void QUnit::ApplyControlledSinglePhase(const bitLenInt* cControls, const bitLenI
 
         TransformBasis1Qb(false, control);
 
-        RevertBasis2Qb(control, ONLY_INVERT, CONTROLS_AND_TARGETS, ONLY_CTRL, { target }, {});
-        RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, ONLY_CTRL, {}, { control });
+        RevertBasis2Qb(control, ONLY_INVERT, CONTROLS_AND_TARGETS, ONLY_CTRL);
+        RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, ONLY_CTRL);
         if (!IS_ARG_0(bottomRight)) {
             RevertBasis2Qb(control, ONLY_INVERT, ONLY_TARGETS, ONLY_ANTI);
         }

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1341,8 +1341,8 @@ void QUnit::CZ(bitLenInt control, bitLenInt target)
 
         TransformBasis1Qb(false, control);
 
-        RevertBasis2Qb(control, ONLY_INVERT, CONTROLS_AND_TARGETS, ONLY_CTRL);
-        RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, ONLY_CTRL);
+        RevertBasis2Qb(control, ONLY_INVERT, CONTROLS_AND_TARGETS, ONLY_CTRL, { target }, {});
+        RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, ONLY_CTRL, {}, { control });
         RevertBasis2Qb(control, ONLY_INVERT, ONLY_TARGETS, ONLY_ANTI);
 
         shards[target].AddPhaseAngles(&(shards[control]), ONE_CMPLX, -ONE_CMPLX);
@@ -1636,8 +1636,8 @@ void QUnit::ApplyControlledSinglePhase(const bitLenInt* cControls, const bitLenI
 
         TransformBasis1Qb(false, control);
 
-        RevertBasis2Qb(control, ONLY_INVERT, CONTROLS_AND_TARGETS, ONLY_CTRL);
-        RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, ONLY_CTRL);
+        RevertBasis2Qb(control, ONLY_INVERT, CONTROLS_AND_TARGETS, ONLY_CTRL, { target }, {});
+        RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, ONLY_CTRL, {}, { control });
         if (!IS_ARG_0(bottomRight)) {
             RevertBasis2Qb(control, ONLY_INVERT, ONLY_TARGETS, ONLY_ANTI);
         }

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -500,7 +500,6 @@ TEST_CASE("test_universal_circuit_continuous", "[supreme]")
 
     benchmarkLoop(
         [&](QInterfacePtr qReg, bitLenInt n) {
-
             int d;
             bitLenInt i;
             real1 theta, phi, lambda;
@@ -548,7 +547,6 @@ TEST_CASE("test_universal_circuit_discrete", "[supreme]")
 
     benchmarkLoop(
         [&](QInterfacePtr qReg, bitLenInt n) {
-
             int d;
             bitLenInt i;
             real1 gateRand;
@@ -606,7 +604,6 @@ TEST_CASE("test_universal_circuit_digital", "[supreme]")
 
     benchmarkLoop(
         [&](QInterfacePtr qReg, bitLenInt n) {
-
             int d;
             bitLenInt i;
             real1 gateRand;
@@ -673,7 +670,6 @@ TEST_CASE("test_universal_circuit_analog", "[supreme]")
 
     benchmarkLoop(
         [&](QInterfacePtr qReg, bitLenInt n) {
-
             int d;
             bitLenInt i;
             real1 gateRand;
@@ -750,7 +746,6 @@ TEST_CASE("test_ccz_ccx_h", "[supreme]")
 
     benchmarkLoop(
         [&](QInterfacePtr qReg, bitLenInt n) {
-
             int d;
             bitLenInt i;
             real1 gateRand;
@@ -818,7 +813,6 @@ TEST_CASE("test_quantum_supremacy", "[supreme]")
     const int depth = 20;
 
     benchmarkLoop([&](QInterfacePtr qReg, bitLenInt n) {
-
         // The test runs 2 bit gates according to a tiling sequence.
         // The 1 bit indicates +/- column offset.
         // The 2 bit indicates +/- row offset.

--- a/test/benchmarks_main.cpp
+++ b/test/benchmarks_main.cpp
@@ -132,10 +132,10 @@ int main(int argc, char* argv[])
                 max_qubits = log2(maxMem / QEngineOCL::OclMemDenom);
             }
 #else
-        // With OpenCL tests disabled, it's ambiguous what device we want to set the limit by.
-        // If we're not talking about the OpenCL resources of a single device,
-        // maximum allocation becomes a notoriously thorny matter.
-        // For any case besides the above, we just use the default.
+            // With OpenCL tests disabled, it's ambiguous what device we want to set the limit by.
+            // If we're not talking about the OpenCL resources of a single device,
+            // maximum allocation becomes a notoriously thorny matter.
+            // For any case besides the above, we just use the default.
 #endif
         }
     } else {

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -73,9 +73,9 @@ int main(int argc, char* argv[])
         return returnCode;
     }
 
-        // If we're talking about a particular OpenCL device,
-        // we have an API designed to tell us device capabilities and limitations,
-        // like maximum RAM allocation.
+    // If we're talking about a particular OpenCL device,
+    // we have an API designed to tell us device capabilities and limitations,
+    // like maximum RAM allocation.
 #if ENABLE_OPENCL
     if (opencl_single) {
         // Make sure the context singleton is initialized.


### PR DESCRIPTION
I identified and fixed a bug, per #357, caused by commuting an inversion gate with opposite phase angles around an `H` gate. This is probably the least well-behaved of the cases that commute at all, (basically 4 cases of single-parameter families in total,) although it's not clear to me why this fails. To first consideration, there's no problem with the commutation itself, but maybe this causes something disallowed to happen downstream, with other commutativity considerations. I'll poke at it for a few minutes, and I'll see if I can restore the case under other conditions.