### PR TITLE
QUnit buffer debug

### DIFF
--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -305,6 +305,10 @@ public:
 protected:
     void OptimizeBuffer(ShardToPhaseMap& localMap, GetBufferFn remoteMapGet, AddAnglesFn phaseFn, bool makeThisControl)
     {
+        if (IsInvertTarget()) {
+            return;
+        }
+
         PhaseShardPtr buffer;
         QEngineShardPtr partner;
 
@@ -315,7 +319,8 @@ protected:
             buffer = phaseShard->second;
             partner = phaseShard->first;
 
-            if (buffer->isInvert || (isPlusMinus != partner->isPlusMinus) || !IS_ARG_0(buffer->cmplxDiff)) {
+            if (buffer->isInvert || (isPlusMinus != partner->isPlusMinus) || !IS_ARG_0(buffer->cmplxDiff) ||
+                partner->IsInvertTarget()) {
                 continue;
             }
 

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -305,7 +305,7 @@ public:
 protected:
     void OptimizeBuffer(ShardToPhaseMap& localMap, GetBufferFn remoteMapGet, AddAnglesFn phaseFn, bool makeThisControl)
     {
-        if (IsInvertTarget()) {
+        if (IsInvert()) {
             return;
         }
 
@@ -320,7 +320,7 @@ protected:
             partner = phaseShard->first;
 
             if (buffer->isInvert || (isPlusMinus != partner->isPlusMinus) || !IS_ARG_0(buffer->cmplxDiff) ||
-                partner->IsInvertTarget()) {
+                partner->IsInvert()) {
                 continue;
             }
 
@@ -524,6 +524,7 @@ public:
                 if (buffer->isInvert) {
                     buffer->cmplxDiff = -buffer->cmplxSame;
                     buffer->isInvert = false;
+                } else {
                 }
             } else {
                 if (buffer->isInvert) {
@@ -582,6 +583,8 @@ public:
 
         return false;
     }
+
+    bool IsInvert() { return IsInvertTarget() || IsInvertControl(); }
 
     bool operator==(const QEngineShard& rhs) { return (mapped == rhs.mapped) && (unit == rhs.unit); }
     bool operator!=(const QEngineShard& rhs) { return (mapped != rhs.mapped) || (unit != rhs.unit); }
@@ -928,7 +931,7 @@ protected:
     void RevertBasis2Qb(const bitLenInt& i, const RevertExclusivity& exclusivity = INVERT_AND_PHASE,
         const RevertControl& controlExclusivity = CONTROLS_AND_TARGETS,
         const RevertAnti& antiExclusivity = CTRL_AND_ANTI, std::set<bitLenInt> exceptControlling = {},
-        std::set<bitLenInt> exceptTargetedBy = {}, const bool& dumpSkipped = false);
+        std::set<bitLenInt> exceptTargetedBy = {}, const bool& dumpSkipped = false, const bool& skipOptimized = false);
 
     void Flush0Eigenstate(const bitLenInt& i)
     {

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -12,8 +12,6 @@
 
 #pragma once
 
-#include <iostream>
-
 #include <cfloat>
 #include <random>
 #include <unordered_set>
@@ -925,7 +923,7 @@ protected:
     void RevertBasis2Qb(const bitLenInt& i, const RevertExclusivity& exclusivity = INVERT_AND_PHASE,
         const RevertControl& controlExclusivity = CONTROLS_AND_TARGETS,
         const RevertAnti& antiExclusivity = CTRL_AND_ANTI, std::set<bitLenInt> exceptControlling = {},
-        std::set<bitLenInt> exceptTargetedBy = {}, const bool& dumpSkipped = false, const bool& skipOptimized = false);
+        std::set<bitLenInt> exceptTargetedBy = {}, const bool& dumpSkipped = false);
 
     void Flush0Eigenstate(const bitLenInt& i)
     {

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -12,6 +12,8 @@
 
 #pragma once
 
+#include <iostream>
+
 #include <cfloat>
 #include <random>
 #include <unordered_set>
@@ -923,7 +925,7 @@ protected:
     void RevertBasis2Qb(const bitLenInt& i, const RevertExclusivity& exclusivity = INVERT_AND_PHASE,
         const RevertControl& controlExclusivity = CONTROLS_AND_TARGETS,
         const RevertAnti& antiExclusivity = CTRL_AND_ANTI, std::set<bitLenInt> exceptControlling = {},
-        std::set<bitLenInt> exceptTargetedBy = {}, const bool& dumpSkipped = false);
+        std::set<bitLenInt> exceptTargetedBy = {}, const bool& dumpSkipped = false, const bool& skipOptimized = false);
 
     void Flush0Eigenstate(const bitLenInt& i)
     {

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -3400,12 +3400,10 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
     }
 
     // TODO: Should be able to commute these:
-    if (anyInvert != anyAntiInvert) {
-        if (shard.targetOfShards.size() >= shard.antiTargetOfShards.size()) {
-            RevertBasis2Qb(bitIndex, INVERT_AND_PHASE, CONTROLS_AND_TARGETS, ONLY_ANTI);
-        } else {
-            RevertBasis2Qb(bitIndex, INVERT_AND_PHASE, CONTROLS_AND_TARGETS, ONLY_CTRL);
-        }
+    if (shard.targetOfShards.size() >= shard.antiTargetOfShards.size()) {
+        RevertBasis2Qb(bitIndex, INVERT_AND_PHASE, CONTROLS_AND_TARGETS, ONLY_ANTI);
+    } else {
+        RevertBasis2Qb(bitIndex, INVERT_AND_PHASE, CONTROLS_AND_TARGETS, ONLY_CTRL);
     }
 
     shard.CommuteH();

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1341,8 +1341,8 @@ void QUnit::CZ(bitLenInt control, bitLenInt target)
 
         TransformBasis1Qb(false, control);
 
-        RevertBasis2Qb(control, ONLY_INVERT, CONTROLS_AND_TARGETS, ONLY_CTRL, { target }, {});
-        RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, ONLY_CTRL, {}, { control });
+        RevertBasis2Qb(control, ONLY_INVERT, CONTROLS_AND_TARGETS, ONLY_CTRL);
+        RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, ONLY_CTRL);
         RevertBasis2Qb(control, ONLY_INVERT, ONLY_TARGETS, ONLY_ANTI);
 
         shards[target].AddPhaseAngles(&(shards[control]), ONE_CMPLX, -ONE_CMPLX);
@@ -1636,8 +1636,8 @@ void QUnit::ApplyControlledSinglePhase(const bitLenInt* cControls, const bitLenI
 
         TransformBasis1Qb(false, control);
 
-        RevertBasis2Qb(control, ONLY_INVERT, CONTROLS_AND_TARGETS, ONLY_CTRL, { target }, {});
-        RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, ONLY_CTRL, {}, { control });
+        RevertBasis2Qb(control, ONLY_INVERT, CONTROLS_AND_TARGETS, ONLY_CTRL);
+        RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, ONLY_CTRL);
         if (!IS_ARG_0(bottomRight)) {
             RevertBasis2Qb(control, ONLY_INVERT, ONLY_TARGETS, ONLY_ANTI);
         }
@@ -1720,8 +1720,8 @@ void QUnit::ApplyAntiControlledSinglePhase(const bitLenInt* cControls, const bit
 
         TransformBasis1Qb(false, control);
 
-        RevertBasis2Qb(control, ONLY_INVERT, CONTROLS_AND_TARGETS, ONLY_ANTI, { target }, {});
-        RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, ONLY_ANTI, {}, { control });
+        RevertBasis2Qb(control, ONLY_INVERT, CONTROLS_AND_TARGETS, ONLY_ANTI);
+        RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, ONLY_ANTI);
         if (!IS_ARG_0(topLeft)) {
             RevertBasis2Qb(control, ONLY_INVERT, ONLY_TARGETS, ONLY_CTRL);
         }

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1341,8 +1341,8 @@ void QUnit::CZ(bitLenInt control, bitLenInt target)
 
         TransformBasis1Qb(false, control);
 
-        RevertBasis2Qb(control, ONLY_INVERT, CONTROLS_AND_TARGETS, ONLY_CTRL);
-        RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, ONLY_CTRL);
+        RevertBasis2Qb(control, ONLY_INVERT, CONTROLS_AND_TARGETS, ONLY_CTRL, { target }, {});
+        RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, ONLY_CTRL, {}, { control });
         RevertBasis2Qb(control, ONLY_INVERT, ONLY_TARGETS, ONLY_ANTI);
 
         shards[target].AddPhaseAngles(&(shards[control]), ONE_CMPLX, -ONE_CMPLX);
@@ -1636,8 +1636,8 @@ void QUnit::ApplyControlledSinglePhase(const bitLenInt* cControls, const bitLenI
 
         TransformBasis1Qb(false, control);
 
-        RevertBasis2Qb(control, ONLY_INVERT, CONTROLS_AND_TARGETS, ONLY_CTRL);
-        RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, ONLY_CTRL);
+        RevertBasis2Qb(control, ONLY_INVERT, CONTROLS_AND_TARGETS, ONLY_CTRL, { target }, {});
+        RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, ONLY_CTRL, {}, { control });
         if (!IS_ARG_0(bottomRight)) {
             RevertBasis2Qb(control, ONLY_INVERT, ONLY_TARGETS, ONLY_ANTI);
         }
@@ -1720,8 +1720,8 @@ void QUnit::ApplyAntiControlledSinglePhase(const bitLenInt* cControls, const bit
 
         TransformBasis1Qb(false, control);
 
-        RevertBasis2Qb(control, ONLY_INVERT, CONTROLS_AND_TARGETS, ONLY_ANTI);
-        RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, ONLY_ANTI);
+        RevertBasis2Qb(control, ONLY_INVERT, CONTROLS_AND_TARGETS, ONLY_ANTI, { target }, {});
+        RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, ONLY_ANTI, {}, { control });
         if (!IS_ARG_0(topLeft)) {
             RevertBasis2Qb(control, ONLY_INVERT, ONLY_TARGETS, ONLY_CTRL);
         }
@@ -3259,7 +3259,7 @@ void QUnit::ApplyBufferMap(const bitLenInt& bitIndex, ShardToPhaseMap bufferMap,
 
 void QUnit::RevertBasis2Qb(const bitLenInt& i, const RevertExclusivity& exclusivity,
     const RevertControl& controlExclusivity, const RevertAnti& antiExclusivity, std::set<bitLenInt> exceptControlling,
-    std::set<bitLenInt> exceptTargetedBy, const bool& dumpSkipped)
+    std::set<bitLenInt> exceptTargetedBy, const bool& dumpSkipped, const bool& skipOptimize)
 {
     QEngineShard& shard = shards[i];
 
@@ -3271,14 +3271,14 @@ void QUnit::RevertBasis2Qb(const bitLenInt& i, const RevertExclusivity& exclusiv
 
     shard.CombineGates();
 
-    if ((controlExclusivity == ONLY_CONTROLS) && (exclusivity != ONLY_INVERT)) {
+    if (!skipOptimize && (controlExclusivity == ONLY_CONTROLS) && (exclusivity != ONLY_INVERT)) {
         if (antiExclusivity != ONLY_ANTI) {
             shard.OptimizeControls();
         }
         if (antiExclusivity != ONLY_CTRL) {
             shard.OptimizeAntiControls();
         }
-    } else if ((controlExclusivity == ONLY_TARGETS) && (exclusivity != ONLY_INVERT)) {
+    } else if (!skipOptimize && (controlExclusivity == ONLY_TARGETS) && (exclusivity != ONLY_INVERT)) {
         if (antiExclusivity != ONLY_ANTI) {
             shard.OptimizeTargets();
         }
@@ -3310,7 +3310,7 @@ void QUnit::RevertBasis2Qb(const bitLenInt& i, const RevertExclusivity& exclusiv
 
 void QUnit::CommuteH(const bitLenInt& bitIndex)
 {
-    RevertBasis2Qb(bitIndex, INVERT_AND_PHASE, ONLY_CONTROLS);
+    RevertBasis2Qb(bitIndex, INVERT_AND_PHASE, ONLY_CONTROLS, CTRL_AND_ANTI, {}, {}, false, true);
 
     QEngineShard& shard = shards[bitIndex];
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1341,9 +1341,8 @@ void QUnit::CZ(bitLenInt control, bitLenInt target)
 
         TransformBasis1Qb(false, control);
 
-        RevertBasis2Qb(control, ONLY_INVERT, CONTROLS_AND_TARGETS, ONLY_CTRL, { target }, {});
-        RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, ONLY_CTRL, {}, { control });
-        RevertBasis2Qb(control, ONLY_INVERT, ONLY_TARGETS, ONLY_ANTI);
+        RevertBasis2Qb(control, ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI, { target }, {});
+        RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI, {}, { control });
 
         shards[target].AddPhaseAngles(&(shards[control]), ONE_CMPLX, -ONE_CMPLX);
         return;
@@ -1636,14 +1635,8 @@ void QUnit::ApplyControlledSinglePhase(const bitLenInt* cControls, const bitLenI
 
         TransformBasis1Qb(false, control);
 
-        RevertBasis2Qb(control, ONLY_INVERT, CONTROLS_AND_TARGETS, ONLY_CTRL, { target }, {});
-        RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, ONLY_CTRL, {}, { control });
-        if (!IS_ARG_0(bottomRight)) {
-            RevertBasis2Qb(control, ONLY_INVERT, ONLY_TARGETS, ONLY_ANTI);
-        }
-        if (!IS_ARG_0(topLeft)) {
-            RevertBasis2Qb(target, ONLY_INVERT, ONLY_CONTROLS, ONLY_ANTI);
-        }
+        RevertBasis2Qb(control, ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI, { target }, {});
+        RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI, {}, { control });
 
         shards[target].AddPhaseAngles(&(shards[control]), topLeft, bottomRight);
         delete[] controls;
@@ -1720,14 +1713,8 @@ void QUnit::ApplyAntiControlledSinglePhase(const bitLenInt* cControls, const bit
 
         TransformBasis1Qb(false, control);
 
-        RevertBasis2Qb(control, ONLY_INVERT, CONTROLS_AND_TARGETS, ONLY_ANTI, { target }, {});
-        RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, ONLY_ANTI, {}, { control });
-        if (!IS_ARG_0(topLeft)) {
-            RevertBasis2Qb(control, ONLY_INVERT, ONLY_TARGETS, ONLY_CTRL);
-        }
-        if (!IS_ARG_0(bottomRight)) {
-            RevertBasis2Qb(target, ONLY_INVERT, ONLY_CONTROLS, ONLY_CTRL);
-        }
+        RevertBasis2Qb(control, ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI, { target }, {});
+        RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI, {}, { control });
 
         shards[target].AddAntiPhaseAngles(&(shards[control]), bottomRight, topLeft);
         delete[] controls;
@@ -3259,7 +3246,7 @@ void QUnit::ApplyBufferMap(const bitLenInt& bitIndex, ShardToPhaseMap bufferMap,
 
 void QUnit::RevertBasis2Qb(const bitLenInt& i, const RevertExclusivity& exclusivity,
     const RevertControl& controlExclusivity, const RevertAnti& antiExclusivity, std::set<bitLenInt> exceptControlling,
-    std::set<bitLenInt> exceptTargetedBy, const bool& dumpSkipped)
+    std::set<bitLenInt> exceptTargetedBy, const bool& dumpSkipped, const bool& skipOptimize)
 {
     QEngineShard& shard = shards[i];
 
@@ -3271,14 +3258,14 @@ void QUnit::RevertBasis2Qb(const bitLenInt& i, const RevertExclusivity& exclusiv
 
     shard.CombineGates();
 
-    if ((controlExclusivity == ONLY_CONTROLS) && (exclusivity != ONLY_INVERT)) {
+    if (!skipOptimize && (controlExclusivity == ONLY_CONTROLS) && (exclusivity != ONLY_INVERT)) {
         if (antiExclusivity != ONLY_ANTI) {
             shard.OptimizeControls();
         }
         if (antiExclusivity != ONLY_CTRL) {
             shard.OptimizeAntiControls();
         }
-    } else if ((controlExclusivity == ONLY_TARGETS) && (exclusivity != ONLY_INVERT)) {
+    } else if (!skipOptimize && (controlExclusivity == ONLY_TARGETS) && (exclusivity != ONLY_INVERT)) {
         if (antiExclusivity != ONLY_ANTI) {
             shard.OptimizeTargets();
         }
@@ -3310,7 +3297,7 @@ void QUnit::RevertBasis2Qb(const bitLenInt& i, const RevertExclusivity& exclusiv
 
 void QUnit::CommuteH(const bitLenInt& bitIndex)
 {
-    RevertBasis2Qb(bitIndex, INVERT_AND_PHASE, ONLY_CONTROLS);
+    RevertBasis2Qb(bitIndex, INVERT_AND_PHASE, ONLY_CONTROLS, CTRL_AND_ANTI, {}, {}, false, true);
 
     QEngineShard& shard = shards[bitIndex];
 
@@ -3372,38 +3359,45 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
         }
     }
 
-    targetOfShards = shard.targetOfShards;
-    for (phaseShard = targetOfShards.begin(); phaseShard != targetOfShards.end(); phaseShard++) {
-        buffer = phaseShard->second;
+    if (shard.targetOfShards.size() > 1U || shard.antiTargetOfShards.size() > 0U) {
+        targetOfShards = shard.targetOfShards;
+        for (phaseShard = targetOfShards.begin(); phaseShard != targetOfShards.end(); phaseShard++) {
+            buffer = phaseShard->second;
 
-        if (phaseShard->second->isInvert != anyInvert || (anyInvert && norm(polarDiff + polarSame) <= ampThreshold)) {
-            partner = phaseShard->first;
-            control = FindShardIndex(*partner);
+            if (phaseShard->second->isInvert != anyInvert ||
+                (anyInvert && norm(polarDiff + polarSame) <= ampThreshold)) {
+                partner = phaseShard->first;
+                control = FindShardIndex(*partner);
 
-            ApplyBuffer(phaseShard, control, bitIndex, false);
-            shard.RemovePhaseControl(partner);
+                ApplyBuffer(phaseShard, control, bitIndex, false);
+                shard.RemovePhaseControl(partner);
+            }
         }
     }
 
-    targetOfShards = shard.antiTargetOfShards;
-    for (phaseShard = targetOfShards.begin(); phaseShard != targetOfShards.end(); phaseShard++) {
-        buffer = phaseShard->second;
+    if (shard.antiTargetOfShards.size() > 1U || shard.targetOfShards.size() > 0U) {
+        targetOfShards = shard.antiTargetOfShards;
+        for (phaseShard = targetOfShards.begin(); phaseShard != targetOfShards.end(); phaseShard++) {
+            buffer = phaseShard->second;
 
-        if (phaseShard->second->isInvert != anyAntiInvert ||
-            (anyAntiInvert && norm(polarDiff + polarSame) <= ampThreshold)) {
-            partner = phaseShard->first;
-            control = FindShardIndex(*partner);
+            if (phaseShard->second->isInvert != anyAntiInvert ||
+                (anyAntiInvert && norm(polarDiff + polarSame) <= ampThreshold)) {
+                partner = phaseShard->first;
+                control = FindShardIndex(*partner);
 
-            ApplyBuffer(phaseShard, control, bitIndex, true);
-            shard.RemovePhaseAntiControl(partner);
+                ApplyBuffer(phaseShard, control, bitIndex, true);
+                shard.RemovePhaseAntiControl(partner);
+            }
         }
     }
 
     // TODO: Should be able to commute these:
-    if (shard.targetOfShards.size() >= shard.antiTargetOfShards.size()) {
-        RevertBasis2Qb(bitIndex, INVERT_AND_PHASE, CONTROLS_AND_TARGETS, ONLY_ANTI);
-    } else {
-        RevertBasis2Qb(bitIndex, INVERT_AND_PHASE, CONTROLS_AND_TARGETS, ONLY_CTRL);
+    if (anyInvert != anyAntiInvert) {
+        if (shard.targetOfShards.size() >= shard.antiTargetOfShards.size()) {
+            RevertBasis2Qb(bitIndex, INVERT_AND_PHASE, CONTROLS_AND_TARGETS, ONLY_ANTI);
+        } else {
+            RevertBasis2Qb(bitIndex, INVERT_AND_PHASE, CONTROLS_AND_TARGETS, ONLY_CTRL);
+        }
     }
 
     shard.CommuteH();

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -4736,11 +4736,8 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_inversion_buffers")
     qftReg->H(1);
     qftReg->CNOT(0, 3);
     qftReg->CNOT(1, 2);
-    qftReg->T(2);
-    qftReg->T(3);
     qftReg->CZ(2, 3);
     qftReg->CZ(1, 0);
-    qftReg->T(3);
     qftReg->CNOT(0, 1);
     qftReg->H(0);
     qftReg->H(2);
@@ -4752,11 +4749,8 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_inversion_buffers")
     goldStandard->H(1);
     goldStandard->CNOT(0, 3);
     goldStandard->CNOT(1, 2);
-    goldStandard->T(2);
-    goldStandard->T(3);
     goldStandard->CZ(2, 3);
     goldStandard->CZ(1, 0);
-    goldStandard->T(3);
     goldStandard->CNOT(0, 1);
     goldStandard->H(0);
     goldStandard->H(2);

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -4780,13 +4780,15 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_inversion_buffers")
     crossEntropy = ONE_R1 - sqrt(crossEntropy) / 10000;
     REQUIRE(crossEntropy > 0.97);
 
+    std::cout << "Start test." << std::endl;
+
     qftReg->SetPermutation(0);
     qftReg->H(0, 5);
     qftReg->CZ(0, 2);
     qftReg->CZ(2, 1);
     qftReg->CZ(4, 3);
     qftReg->H(3);
-    qftReg->Y(4);
+    qftReg->X(4);
     qftReg->CZ(2, 3);
     qftReg->H(2);
     testCaseResult = qftReg->MultiShotMeasureMask(qPowers, 8, 10000);
@@ -4797,7 +4799,7 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_inversion_buffers")
     goldStandard->CZ(2, 1);
     goldStandard->CZ(4, 3);
     goldStandard->H(3);
-    goldStandard->Y(4);
+    goldStandard->X(4);
     goldStandard->CZ(2, 3);
     goldStandard->H(2);
     goldStandardResult = goldStandard->MultiShotMeasureMask(qPowers, 8, 10000);

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -4730,6 +4730,61 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_inversion_buffers")
     }
     crossEntropy = ONE_R1 - sqrt(crossEntropy) / 10000;
     REQUIRE(crossEntropy > 0.97);
+
+    qftReg->SetPermutation(0);
+    qftReg->H(0);
+    qftReg->H(1);
+    qftReg->CNOT(0, 3);
+    qftReg->CNOT(1, 2);
+    qftReg->T(2);
+    qftReg->T(3);
+    qftReg->CZ(2, 3);
+    qftReg->CZ(1, 0);
+    qftReg->T(3);
+    qftReg->CNOT(0, 1);
+    qftReg->H(0);
+    qftReg->H(2);
+    qftReg->H(3);
+    testCaseResult = qftReg->MultiShotMeasureMask(qPowers, 8, 10000);
+
+    goldStandard->SetPermutation(0);
+    goldStandard->H(0);
+    goldStandard->H(1);
+    goldStandard->CNOT(0, 3);
+    goldStandard->CNOT(1, 2);
+    goldStandard->T(2);
+    goldStandard->T(3);
+    goldStandard->CZ(2, 3);
+    goldStandard->CZ(1, 0);
+    goldStandard->T(3);
+    goldStandard->CNOT(0, 1);
+    goldStandard->H(0);
+    goldStandard->H(2);
+    goldStandard->H(3);
+    goldStandardResult = goldStandard->MultiShotMeasureMask(qPowers, 8, 10000);
+
+    crossEntropy = ZERO_R1;
+    for (int perm = 0; perm < 256; perm++) {
+        measurementBin = goldStandardResult.find(perm);
+        if (measurementBin == goldStandardResult.end()) {
+            goldBinResult = 0;
+        } else {
+            goldBinResult = measurementBin->second;
+        }
+
+        measurementBin = testCaseResult.find(perm);
+        if (measurementBin == testCaseResult.end()) {
+            testBinResult = 0;
+        } else {
+            testBinResult = measurementBin->second;
+        }
+        crossEntropy += (testBinResult - goldBinResult) * (testBinResult - goldBinResult);
+    }
+    if (crossEntropy < ZERO_R1) {
+        crossEntropy = ZERO_R1;
+    }
+    crossEntropy = ONE_R1 - sqrt(crossEntropy) / 10000;
+    REQUIRE(crossEntropy > 0.97);
 }
 
 bitLenInt pickRandomBit(QInterfacePtr qReg, std::set<bitLenInt>* unusedBitsPtr)
@@ -4911,6 +4966,7 @@ TEST_CASE("test_universal_circuit_digital_cross_entropy", "[supreme]")
             crossEntropy = ZERO_R1;
         }
         crossEntropy = ONE_R1 - sqrt(crossEntropy) / ITERATIONS;
+
         REQUIRE(crossEntropy > 0.97);
     }
 }

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -4732,29 +4732,27 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_inversion_buffers")
     REQUIRE(crossEntropy > 0.97);
 
     qftReg->SetPermutation(0);
-    qftReg->H(0);
-    qftReg->H(1);
-    qftReg->CNOT(0, 3);
-    qftReg->CNOT(1, 2);
-    qftReg->CZ(2, 3);
-    qftReg->CZ(1, 0);
-    qftReg->CNOT(0, 1);
-    qftReg->H(0);
+    qftReg->H(0, 4);
+    qftReg->CZ(0, 3);
+    qftReg->CZ(1, 2);
     qftReg->H(2);
-    qftReg->H(3);
+    qftReg->CZ(1, 0);
+    qftReg->CZ(2, 3);
+    qftReg->H(1);
+    qftReg->CZ(0, 1);
+    qftReg->H(0, 4);
     testCaseResult = qftReg->MultiShotMeasureMask(qPowers, 8, 10000);
 
     goldStandard->SetPermutation(0);
-    goldStandard->H(0);
-    goldStandard->H(1);
-    goldStandard->CNOT(0, 3);
-    goldStandard->CNOT(1, 2);
-    goldStandard->CZ(2, 3);
-    goldStandard->CZ(1, 0);
-    goldStandard->CNOT(0, 1);
-    goldStandard->H(0);
+    goldStandard->H(0, 4);
+    goldStandard->CZ(0, 3);
+    goldStandard->CZ(1, 2);
     goldStandard->H(2);
-    goldStandard->H(3);
+    goldStandard->CZ(1, 0);
+    goldStandard->CZ(2, 3);
+    goldStandard->H(1);
+    goldStandard->CZ(0, 1);
+    goldStandard->H(0, 4);
     goldStandardResult = goldStandard->MultiShotMeasureMask(qPowers, 8, 10000);
 
     crossEntropy = ZERO_R1;
@@ -4779,8 +4777,6 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_inversion_buffers")
     }
     crossEntropy = ONE_R1 - sqrt(crossEntropy) / 10000;
     REQUIRE(crossEntropy > 0.97);
-
-    std::cout << "Start test." << std::endl;
 
     qftReg->SetPermutation(0);
     qftReg->H(0, 5);

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -4732,27 +4732,27 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_inversion_buffers")
     REQUIRE(crossEntropy > 0.97);
 
     qftReg->SetPermutation(0);
-    qftReg->H(0, 4);
-    qftReg->CZ(0, 3);
+    qftReg->H(0, 5);
     qftReg->CZ(1, 2);
+    qftReg->CZ(0, 4);
+    qftReg->X(1);
     qftReg->H(2);
-    qftReg->CZ(1, 0);
-    qftReg->CZ(2, 3);
-    qftReg->H(1);
-    qftReg->CZ(0, 1);
-    qftReg->H(0, 4);
+    qftReg->CZ(3, 4);
+    qftReg->CZ(0, 2);
+    qftReg->H(0);
+    qftReg->H(3);
     testCaseResult = qftReg->MultiShotMeasureMask(qPowers, 8, 10000);
 
     goldStandard->SetPermutation(0);
-    goldStandard->H(0, 4);
-    goldStandard->CZ(0, 3);
+    goldStandard->H(0, 5);
     goldStandard->CZ(1, 2);
+    goldStandard->CZ(0, 4);
+    goldStandard->X(1);
     goldStandard->H(2);
-    goldStandard->CZ(1, 0);
-    goldStandard->CZ(2, 3);
-    goldStandard->H(1);
-    goldStandard->CZ(0, 1);
-    goldStandard->H(0, 4);
+    goldStandard->CZ(3, 4);
+    goldStandard->CZ(0, 2);
+    goldStandard->H(0);
+    goldStandard->H(3);
     goldStandardResult = goldStandard->MultiShotMeasureMask(qPowers, 8, 10000);
 
     crossEntropy = ZERO_R1;
@@ -4779,25 +4779,27 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_inversion_buffers")
     REQUIRE(crossEntropy > 0.97);
 
     qftReg->SetPermutation(0);
-    qftReg->H(0, 5);
-    qftReg->CZ(0, 2);
-    qftReg->CZ(2, 1);
-    qftReg->CZ(4, 3);
-    qftReg->H(3);
-    qftReg->X(4);
-    qftReg->CZ(2, 3);
+    qftReg->H(0, 4);
+    qftReg->CZ(0, 3);
+    qftReg->CZ(1, 2);
     qftReg->H(2);
+    qftReg->CZ(1, 0);
+    qftReg->CZ(2, 3);
+    qftReg->H(1);
+    qftReg->CZ(0, 1);
+    qftReg->H(0, 4);
     testCaseResult = qftReg->MultiShotMeasureMask(qPowers, 8, 10000);
 
     goldStandard->SetPermutation(0);
-    goldStandard->H(0, 5);
-    goldStandard->CZ(0, 2);
-    goldStandard->CZ(2, 1);
-    goldStandard->CZ(4, 3);
-    goldStandard->H(3);
-    goldStandard->X(4);
-    goldStandard->CZ(2, 3);
+    goldStandard->H(0, 4);
+    goldStandard->CZ(0, 3);
+    goldStandard->CZ(1, 2);
     goldStandard->H(2);
+    goldStandard->CZ(1, 0);
+    goldStandard->CZ(2, 3);
+    goldStandard->H(1);
+    goldStandard->CZ(0, 1);
+    goldStandard->H(0, 4);
     goldStandardResult = goldStandard->MultiShotMeasureMask(qPowers, 8, 10000);
 
     crossEntropy = ZERO_R1;


### PR DESCRIPTION
In the case that the optimization to compose inversions with phase buffers actually hits, it seems that it fails. (It's tricky to actually trigger this case.) This optimization attempt has been removed.