### PR TITLE
Optimizing QUnit::Swap variants

### DIFF
--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -737,19 +737,13 @@ void QUnit::Swap(bitLenInt qubit1, bitLenInt qubit2)
     QEngineShard& shard1 = shards[qubit1];
     QEngineShard& shard2 = shards[qubit2];
 
-    if (UNSAFE_CACHED_CLASSICAL(shard1)) {
-        if (SHARD_STATE(shard1)) {
-            Flush1Eigenstate(qubit1);
-        } else {
-            Flush0Eigenstate(qubit1);
+    if (UNSAFE_CACHED_CLASSICAL(shard1) && UNSAFE_CACHED_CLASSICAL(shard2)) {
+        // We can avoid dirtying the cache and entangling, since the bits are classical.
+        if (SHARD_STATE(shard1) != SHARD_STATE(shard2)) {
+            X(qubit1);
+            X(qubit2);
         }
-    }
-    if (UNSAFE_CACHED_CLASSICAL(shard2)) {
-        if (SHARD_STATE(shard2)) {
-            Flush1Eigenstate(qubit2);
-        } else {
-            Flush0Eigenstate(qubit2);
-        }
+        return;
     }
 
     RevertBasis2Qb(qubit1);
@@ -781,7 +775,8 @@ void QUnit::ISwap(bitLenInt qubit1, bitLenInt qubit2)
     if (UNSAFE_CACHED_CLASSICAL(shard1) && UNSAFE_CACHED_CLASSICAL(shard2)) {
         // We can avoid dirtying the cache and entangling, since the bits are classical.
         if (SHARD_STATE(shard1) != SHARD_STATE(shard2)) {
-            Swap(qubit1, qubit2);
+            X(qubit1);
+            X(qubit2);
             if (!randGlobalPhase) {
                 // Under the preconditions, this has no effect on Hermitian expectation values, but we track it, if the
                 // QUnit is tracking arbitrary numerical phase.

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -885,11 +885,11 @@ TEST_CASE("test_quantum_supremacy", "[supreme]")
                     gateChoices.erase(gateChoiceIterator);
 
                     gateChoiceIterator = gateChoices.begin();
-                    if (gateRand == 1) {
-                        gateChoice = *(gateChoices.rbegin());
-                    } else {
-                        std::advance(gateChoiceIterator, (int)(gateRand * 2));
+                    gateRand = (int)(gateRand * 2);
+                    if (gateRand > 1) {
+                        gateRand--;
                     }
+                    std::advance(gateChoiceIterator, (int)(gateRand * 2));
                     gateChoice = *gateChoiceIterator;
 
                     if (gateChoice == 0) {


### PR DESCRIPTION
Swap gate variants lost some presumed efficiency, not long ago, to fix their general correctness. They are good targets for attempting optimization, again, under the suite of tests by which they were originally debugged.