### PR TITLE
Fix QBCAPPOW; add test_qft_cosmology_inverse

### DIFF
--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -2265,7 +2265,7 @@ QInterfacePtr QEngineOCL::Clone()
     copyPtr->runningNorm = runningNorm;
 
     EventVecPtr waitVec = ResetWaitEvents();
-    DISPATCH_COPY(waitVec, *stateBuffer, *(copyPtr->stateBuffer), sizeof(complex) * maxQPower);
+    DISPATCH_COPY(waitVec, *stateBuffer, *(copyPtr->stateBuffer), (bitCapIntOcl)(sizeof(complex) * maxQPower));
     Finish();
 
     return copyPtr;


### PR DESCRIPTION
QBCAPPOW should accept an (almost) arbitrarily high "n," where the number of qubits is 2^n, so long as the user does not cause over-allocation due to representational entanglement in QUnit. A type safety bug broke this feature.