### PR TITLE
Option to load random number files from disk

### DIFF
--- a/cmake/RDRand.cmake
+++ b/cmake/RDRand.cmake
@@ -6,3 +6,11 @@ if (ENABLE_RDRAND)
 endif (ENABLE_RDRAND)
 
 message ("Try RDRAND is: ${ENABLE_RDRAND}")
+
+option (ENABLE_RNDFILE "Get random numbers from ~/.qrack/rng directory" OFF)
+
+if (ENABLE_RNDFILE)
+    target_compile_definitions(qrack PUBLIC ENABLE_RNDFILE=1)
+endif (ENABLE_RNDFILE)
+
+message ("RNDFILE is: ${ENABLE_RNDFILE}")

--- a/examples/teleport.cpp
+++ b/examples/teleport.cpp
@@ -72,7 +72,8 @@ int main()
     qReg->CNOT(1, 2);
     std::cout << "Bob received: " << (int)qReg->M(2) << std::endl;
 
-    // Another MWI unitary equivalent:
+    // Another MWI unitary equivalent, with a caveat: This variant would specifically be "decoherent," if measurements
+    // were used instead of unitary gates.
     qReg->SetPermutation(0);
     // Eve prepares a Bell pair.
     qReg->H(1);

--- a/include/common/rdrandwrapper.hpp
+++ b/include/common/rdrandwrapper.hpp
@@ -10,20 +10,24 @@
 // See LICENSE.md in the project root or https://www.gnu.org/licenses/lgpl-3.0.en.html
 // for details.
 
-#if ENABLE_RDRAND
+#pragma once
 
+#if ENABLE_RNDFILE
+#include <future>
+#include <string>
+#include <vector>
+#endif
+
+#if ENABLE_RDRAND
 #if _MSC_VER
 #include <intrin.h>
 #else
 #include <cpuid.h>
 #endif
-
 #include <immintrin.h>
 #endif
 
 #include "qrack_types.hpp"
-
-#pragma once
 
 namespace Qrack {
 
@@ -32,7 +36,18 @@ bool getRdRand(unsigned int* pv);
 class RdRandom {
 public:
     bool SupportsRDRAND();
-
     real1 Next();
+#if ENABLE_RNDFILE
+    std::vector<std::string> ReadDirectory(const std::string& path = std::string());
+
+private:
+    bool didInit;
+    bool isPageTwo;
+    std::vector<char> data1;
+    std::vector<char> data2;
+    std::future<void> future1;
+    std::future<void> future2;
+    int dataOffset;
+#endif
 };
 } // namespace Qrack

--- a/include/common/rdrandwrapper.hpp
+++ b/include/common/rdrandwrapper.hpp
@@ -35,19 +35,28 @@ bool getRdRand(unsigned int* pv);
 
 class RdRandom {
 public:
+#if ENABLE_RNDFILE
+    RdRandom()
+        : didInit(false)
+        , isPageTwo(false)
+        , data1()
+        , data2()
+        , dataOffset(0)
+        , fileOffset(0)
+    {
+    }
+#endif
     bool SupportsRDRAND();
     real1 Next();
 #if ENABLE_RNDFILE
-    std::vector<std::string> ReadDirectory(const std::string& path = std::string());
-
 private:
-    bool didInit;
+    bool didInit = false;
     bool isPageTwo;
     std::vector<char> data1;
     std::vector<char> data2;
-    std::future<void> future1;
-    std::future<void> future2;
-    int dataOffset;
+    std::future<void> readFuture;
+    size_t dataOffset;
+    size_t fileOffset;
 #endif
 };
 } // namespace Qrack

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -186,9 +186,11 @@ public:
 
         if (useHardwareRNG) {
             hardware_rand_generator = std::make_shared<RdRandom>();
+#if !ENABLE_RNDFILE
             if (!(hardware_rand_generator->SupportsRDRAND())) {
                 hardware_rand_generator = NULL;
             }
+#endif
         }
 
         if (rgp == NULL) {

--- a/src/common/rdrandwrapper.cpp
+++ b/src/common/rdrandwrapper.cpp
@@ -63,13 +63,34 @@ std::vector<std::string> _readDirectoryFileNames(const std::string& path)
     return result;
 }
 
+std::string _getDefaultRandomNumberFilePath()
+{
+    if (getenv("QRACK_RNG_PATH")) {
+        std::string toRet = std::string(getenv("QRACK_RNG_PATH"));
+        if ((toRet.back() != '/') && (toRet.back() != '\\')) {
+#if defined(_WIN32) && !defined(__CYGWIN__)
+            toRet += "\\";
+#else
+            toRet += "/";
+#endif
+        }
+        return toRet;
+    }
+#if defined(_WIN32) && !defined(__CYGWIN__)
+    return std::string(getenv("HOMEDRIVE") ? getenv("HOMEDRIVE") : "") +
+        std::string(getenv("HOMEPATH") ? getenv("HOMEPATH") : "") + "\\.qrack\\rng\\";
+#else
+    return std::string(getenv("HOME") ? getenv("HOME") : "") + "/.qrack/rng/";
+#endif
+}
+
 bool _readNextRandDataFile(size_t fileOffset, std::vector<char>& data)
 {
     std::vector<std::string> fileNames = {};
 
-    fileNames = _readDirectoryFileNames("/home/iamu/.qrack/rng");
+    fileNames = _readDirectoryFileNames(_getDefaultRandomNumberFilePath());
     while (fileNames.size() <= fileOffset) {
-        fileNames = _readDirectoryFileNames("/home/iamu/.qrack/rng");
+        fileNames = _readDirectoryFileNames(_getDefaultRandomNumberFilePath());
     }
 
     FILE* dataFile;

--- a/src/common/rdrandwrapper.cpp
+++ b/src/common/rdrandwrapper.cpp
@@ -10,6 +10,8 @@
 // See LICENSE.md in the project root or https://www.gnu.org/licenses/lgpl-3.0.en.html
 // for details.
 
+#include <iostream>
+
 #include <algorithm>
 #include <dirent.h>
 #include <fstream>
@@ -70,10 +72,14 @@ std::vector<std::string> RdRandom::ReadDirectory(const std::string& path)
             if (de == NULL) {
                 break;
             }
-            result.push_back(path + std::string(de->d_name));
+            if (std::string(de->d_name) != "." && std::string(de->d_name) != "..") {
+                result.push_back(path + "/" + std::string(de->d_name));
+            }
         }
         closedir(dp);
-        std::sort(result.begin(), result.end());
+        if (result.size() > 0) {
+            std::sort(result.begin(), result.end());
+        }
     }
     return result;
 }
@@ -88,7 +94,7 @@ real1 RdRandom::Next()
         std::vector<std::string> fileNames = {};
 
         while (fileNames.size() == 0) {
-            fileNames = ReadDirectory("~/.qrack/rng");
+            fileNames = ReadDirectory("/home/iamu/.qrack/rng");
         }
 
         std::ifstream in1(fileNames[0]);
@@ -100,7 +106,7 @@ real1 RdRandom::Next()
 
         future2 = std::async(std::launch::async, [&]() {
             while (fileNames.size() == 0) {
-                fileNames = ReadDirectory("~/.qrack/rng");
+                fileNames = ReadDirectory("/home/iamu/.qrack/rng");
             }
 
             std::ifstream in2(fileNames[0]);
@@ -119,7 +125,7 @@ real1 RdRandom::Next()
                 std::vector<std::string> fileNames;
 
                 while (fileNames.size() == 0) {
-                    fileNames = ReadDirectory("~/.qrack/rng");
+                    fileNames = ReadDirectory("/home/iamu/.qrack/rng");
                 }
 
                 std::ifstream in2(fileNames[0]);
@@ -134,7 +140,7 @@ real1 RdRandom::Next()
                 std::vector<std::string> fileNames = {};
 
                 while (fileNames.size() == 0) {
-                    fileNames = ReadDirectory("~/.qrack/rng");
+                    fileNames = ReadDirectory("/home/iamu/.qrack/rng");
                 }
 
                 std::ifstream in1(fileNames[0]);

--- a/src/common/rdrandwrapper.cpp
+++ b/src/common/rdrandwrapper.cpp
@@ -10,14 +10,15 @@
 // See LICENSE.md in the project root or https://www.gnu.org/licenses/lgpl-3.0.en.html
 // for details.
 
+#if ENABLE_RNDFILE
 #include <chrono>
-#include <iostream>
 #include <thread>
 
 #include <algorithm>
 #include <dirent.h>
 #include <fstream>
 #include <sys/types.h>
+#endif
 
 #include "rdrandwrapper.hpp"
 

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -88,7 +88,7 @@ void benchmarkLoopVariable(std::function<void(QInterfacePtr, bitLenInt)> fn, bit
     if (single_qubit_run) {
         mnQbts = mxQbts;
     } else {
-        mnQbts = 5;
+        mnQbts = 4;
     }
 
     QInterfacePtr qftReg = NULL;


### PR DESCRIPTION
I've thought for a long time that it might be good to have a standard way of loading RNG data from arbitrary system sources, (like Linux' `/dev/random`). A good first pass at a very generic approach is to load binary random number data files from disk. I didn't expect this to be an officially demanded and supported option, but it turns out, if RNG is offloaded to disk I/O, there is a _huge_ speed increase on the QFT, for example, seemingly in excess of maybe an 85% reduction in total execution time by high qubit counts. The feature isn't perfect, but I'll merge this when it's to my standard.