### PR TITLE
Additional H gate commutation

### DIFF
--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -537,6 +537,43 @@ public:
         });
 
         RemoveIdentityBuffers(antiTargetOfShards, &QEngineShard::GetAntiControlsShards);
+
+        /*ShardToPhaseMap tempControls = controlsShards;
+
+        par_for(0, tempControls.size(), [&](const bitCapInt lcv, const int cpu) {
+            ShardToPhaseMap::iterator phaseShard = tempControls.begin();
+            std::advance(phaseShard, lcv);
+            PhaseShardPtr buffer = phaseShard->second;
+            buffer->isInvert = true;
+            if (IS_ARG_PI(buffer->cmplxDiff)) {
+                controlsShards.erase(phaseShard->first);
+                if (IsInvertAntiControlOf(phaseShard->first)) {
+                    std::swap(controlsShards[phaseShard->first], antiControlsShards[phaseShard->first]);
+                    controlsShards[phaseShard->first]->isInvert = true;
+                } else {
+                    antiControlsShards[phaseShard->first] = phaseShard->second;
+                }
+            }
+            buffer->cmplxDiff = ONE_CMPLX;
+            buffer->cmplxSame = ONE_CMPLX;
+        });
+
+        tempControls = antiControlsShards;
+
+        par_for(0, antiControlsShards.size(), [&](const bitCapInt lcv, const int cpu) {
+            ShardToPhaseMap::iterator phaseShard = tempControls.begin();
+            std::advance(phaseShard, lcv);
+            PhaseShardPtr buffer = phaseShard->second;
+            buffer->isInvert = true;
+            if (IS_ARG_PI(buffer->cmplxSame)) {
+                antiControlsShards.erase(phaseShard->first);
+                if (!IsInvertControlOf(phaseShard->first)) {
+                    controlsShards[phaseShard->first] = phaseShard->second;
+                }
+            }
+            buffer->cmplxDiff = ONE_CMPLX;
+            buffer->cmplxSame = ONE_CMPLX;
+        });*/
     }
 
     bool IsInvertControlOf(QEngineShardPtr target) { return (controlsShards.find(target) != controlsShards.end()); }

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -537,43 +537,6 @@ public:
         });
 
         RemoveIdentityBuffers(antiTargetOfShards, &QEngineShard::GetAntiControlsShards);
-
-        /*ShardToPhaseMap tempControls = controlsShards;
-
-        par_for(0, tempControls.size(), [&](const bitCapInt lcv, const int cpu) {
-            ShardToPhaseMap::iterator phaseShard = tempControls.begin();
-            std::advance(phaseShard, lcv);
-            PhaseShardPtr buffer = phaseShard->second;
-            buffer->isInvert = true;
-            if (IS_ARG_PI(buffer->cmplxDiff)) {
-                controlsShards.erase(phaseShard->first);
-                if (IsInvertAntiControlOf(phaseShard->first)) {
-                    std::swap(controlsShards[phaseShard->first], antiControlsShards[phaseShard->first]);
-                    controlsShards[phaseShard->first]->isInvert = true;
-                } else {
-                    antiControlsShards[phaseShard->first] = phaseShard->second;
-                }
-            }
-            buffer->cmplxDiff = ONE_CMPLX;
-            buffer->cmplxSame = ONE_CMPLX;
-        });
-
-        tempControls = antiControlsShards;
-
-        par_for(0, antiControlsShards.size(), [&](const bitCapInt lcv, const int cpu) {
-            ShardToPhaseMap::iterator phaseShard = tempControls.begin();
-            std::advance(phaseShard, lcv);
-            PhaseShardPtr buffer = phaseShard->second;
-            buffer->isInvert = true;
-            if (IS_ARG_PI(buffer->cmplxSame)) {
-                antiControlsShards.erase(phaseShard->first);
-                if (!IsInvertControlOf(phaseShard->first)) {
-                    controlsShards[phaseShard->first] = phaseShard->second;
-                }
-            }
-            buffer->cmplxDiff = ONE_CMPLX;
-            buffer->cmplxSame = ONE_CMPLX;
-        });*/
     }
 
     bool IsInvertControlOf(QEngineShardPtr target) { return (controlsShards.find(target) != controlsShards.end()); }

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -3304,27 +3304,12 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
     PhaseShardPtr buffer;
     bitLenInt control, target;
 
-    bool isDiffNegOne, isSameNegOne, isDiffOne, isSameOne, doCommute;
-
     ShardToPhaseMap controlsShards = shard.controlsShards;
 
     for (phaseShard = controlsShards.begin(); phaseShard != controlsShards.end(); phaseShard++) {
         buffer = phaseShard->second;
 
-        isDiffOne = IS_ARG_0(buffer->cmplxDiff);
-        isDiffNegOne = IS_ARG_PI(buffer->cmplxDiff);
-        doCommute = isDiffOne || isDiffNegOne;
-        isSameOne = IS_ARG_0(buffer->cmplxSame);
-        isSameNegOne = IS_ARG_PI(buffer->cmplxSame);
-        doCommute = isSameOne || isSameNegOne;
-
-        if (buffer->isInvert || !doCommute) {
-            partner = phaseShard->first;
-            target = FindShardIndex(*partner);
-
-            ApplyBuffer(phaseShard, bitIndex, target, false);
-            shard.RemovePhaseTarget(partner);
-        } else if (isDiffNegOne && isSameNegOne) {
+        if (!buffer->isInvert && IS_ARG_PI(buffer->cmplxDiff) && IS_ARG_PI(buffer->cmplxSame)) {
             partner = phaseShard->first;
             target = FindShardIndex(*partner);
 
@@ -3341,20 +3326,7 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
     for (phaseShard = controlsShards.begin(); phaseShard != controlsShards.end(); phaseShard++) {
         buffer = phaseShard->second;
 
-        isDiffOne = IS_ARG_0(buffer->cmplxDiff);
-        isDiffNegOne = IS_ARG_PI(buffer->cmplxDiff);
-        doCommute = isDiffOne || isDiffNegOne;
-        isSameOne = IS_ARG_0(buffer->cmplxSame);
-        isSameNegOne = IS_ARG_PI(buffer->cmplxSame);
-        doCommute = isSameOne || isSameNegOne;
-
-        if (buffer->isInvert || !doCommute) {
-            partner = phaseShard->first;
-            target = FindShardIndex(*partner);
-
-            ApplyBuffer(phaseShard, bitIndex, target, true);
-            shard.RemovePhaseAntiTarget(partner);
-        } else if (isDiffNegOne && isSameNegOne) {
+        if (!buffer->isInvert && IS_ARG_PI(buffer->cmplxDiff) && IS_ARG_PI(buffer->cmplxSame)) {
             partner = phaseShard->first;
             target = FindShardIndex(*partner);
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -3292,21 +3292,83 @@ void QUnit::RevertBasis2Qb(const bitLenInt& i, const RevertExclusivity& exclusiv
 
 void QUnit::CommuteH(const bitLenInt& bitIndex)
 {
-    RevertBasis2Qb(bitIndex, INVERT_AND_PHASE, ONLY_CONTROLS, CTRL_AND_ANTI, {}, {}, false, true);
-
     QEngineShard& shard = shards[bitIndex];
 
     if (!QUEUED_PHASE(shard)) {
         return;
     }
 
-    real1 ampThreshold = doNormalize ? amplitudeFloor : ZERO_R1;
-
     complex polarDiff, polarSame;
     ShardToPhaseMap::iterator phaseShard, oppositeShard;
     QEngineShardPtr partner;
     PhaseShardPtr buffer;
-    bitLenInt control;
+    bitLenInt control, target;
+
+    bool isDiffNegOne, isSameNegOne, isDiffOne, isSameOne, doCommute;
+
+    ShardToPhaseMap controlsShards = shard.controlsShards;
+
+    for (phaseShard = controlsShards.begin(); phaseShard != controlsShards.end(); phaseShard++) {
+        buffer = phaseShard->second;
+
+        isDiffOne = IS_ARG_0(buffer->cmplxDiff);
+        isDiffNegOne = IS_ARG_PI(buffer->cmplxDiff);
+        doCommute = isDiffOne || isDiffNegOne;
+        isSameOne = IS_ARG_0(buffer->cmplxSame);
+        isSameNegOne = IS_ARG_PI(buffer->cmplxSame);
+        doCommute = isSameOne || isSameNegOne;
+
+        if (buffer->isInvert || !doCommute) {
+            partner = phaseShard->first;
+            target = FindShardIndex(*partner);
+
+            ApplyBuffer(phaseShard, bitIndex, target, false);
+            shard.RemovePhaseTarget(partner);
+        } else if (isDiffNegOne && isSameNegOne) {
+            partner = phaseShard->first;
+            target = FindShardIndex(*partner);
+
+            shard.RemovePhaseTarget(partner);
+            X(target);
+            if (!randGlobalPhase) {
+                ApplySinglePhase(-ONE_CMPLX, -ONE_CMPLX, target);
+            }
+        }
+    }
+
+    controlsShards = shard.antiControlsShards;
+
+    for (phaseShard = controlsShards.begin(); phaseShard != controlsShards.end(); phaseShard++) {
+        buffer = phaseShard->second;
+
+        isDiffOne = IS_ARG_0(buffer->cmplxDiff);
+        isDiffNegOne = IS_ARG_PI(buffer->cmplxDiff);
+        doCommute = isDiffOne || isDiffNegOne;
+        isSameOne = IS_ARG_0(buffer->cmplxSame);
+        isSameNegOne = IS_ARG_PI(buffer->cmplxSame);
+        doCommute = isSameOne || isSameNegOne;
+
+        if (buffer->isInvert || !doCommute) {
+            partner = phaseShard->first;
+            target = FindShardIndex(*partner);
+
+            ApplyBuffer(phaseShard, bitIndex, target, true);
+            shard.RemovePhaseAntiTarget(partner);
+        } else if (isDiffNegOne && isSameNegOne) {
+            partner = phaseShard->first;
+            target = FindShardIndex(*partner);
+
+            shard.RemovePhaseAntiTarget(partner);
+            X(target);
+            if (!randGlobalPhase) {
+                ApplySinglePhase(-ONE_CMPLX, -ONE_CMPLX, target);
+            }
+        }
+    }
+
+    RevertBasis2Qb(bitIndex, INVERT_AND_PHASE, ONLY_CONTROLS, CTRL_AND_ANTI, {}, {}, false, true);
+
+    real1 ampThreshold = doNormalize ? amplitudeFloor : ZERO_R1;
 
     bool isSame, isOpposite, anyInvert = false, anyAntiInvert = false;
 


### PR DESCRIPTION
In `QUnit::CommuteH`, limited additional commutation cases are possible with buffered gates that the H gate target qubit controls. (Previously, all commutation was as a target of buffers, flushing the bit as a control.)