### PR TITLE
Loosen RevertBasis2Qb() restrictions in CommuteH()

### DIFF
--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -3292,7 +3292,7 @@ void QUnit::RevertBasis2Qb(const bitLenInt& i, const RevertExclusivity& exclusiv
 
 void QUnit::CommuteH(const bitLenInt& bitIndex)
 {
-    RevertBasis2Qb(bitIndex, INVERT_AND_PHASE, ONLY_CONTROLS, CTRL_AND_ANTI, {}, {}, false, true);
+    RevertBasis2Qb(bitIndex, INVERT_AND_PHASE, ONLY_CONTROLS, CTRL_AND_ANTI);
 
     QEngineShard& shard = shards[bitIndex];
 


### PR DESCRIPTION
After much tinkering, this works, and it might give some significant improvement in H/buffer commutation. Qiskit tests have temporarily been disabled due to Python package dependency issues and surreptitiously failing unitary gate tests. (These tests in the Qiskit Qrack provider are either obsolete, or there is a bug in the Qiskit API.)