### PR TITLE
Swap variants: remove TransformBasis1Qb() calls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ sudo: true
 install:
   - sudo apt-get update
   - sudo apt-get install linuxdoc-tools linuxdoc-tools-info binutils-mingw-w64-i686 gcc-mingw-w64-i686 sshpass cmake
-  - python -m pip install --upgrade pip numpy setuptools wheel
+  - python -m pip install --upgrade pip numpy setuptools==45 wheel
   - python -m pip install cvxpy cython stestr qiskit==0.18.3 pennylane
 script:
   - mkdir _build && cd _build && cmake -DENABLE_OPENCL=OFF -DENABLE_COMPLEX8=OFF .. && make -j 8 all

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ sudo: true
 install:
   - sudo apt-get update
   - sudo apt-get install linuxdoc-tools linuxdoc-tools-info binutils-mingw-w64-i686 gcc-mingw-w64-i686 sshpass cmake
-  - python -m pip install --upgrade pip numpy setuptools==45 wheel
+  - python -m pip install --upgrade pip numpy setuptools wheel
   - python -m pip install cvxpy cython stestr qiskit==0.18.3 pennylane
 script:
   - mkdir _build && cd _build && cmake -DENABLE_OPENCL=OFF -DENABLE_COMPLEX8=OFF .. && make -j 8 all

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -43,9 +43,8 @@
 #define CACHED_ONE(shard) (CACHED_PROB(shard) && IS_NORM_ZERO(shard.amp0))
 #define CACHED_ZERO(shard) (CACHED_PROB(shard) && IS_NORM_ZERO(shard.amp1))
 /* "UNSAFE" variants here do not check whether the bit is in |0>/|1> rather than |+>/|-> basis. */
-#define UNSAFE_CACHED_EIGENSTATE(shard) (!shard.isProbDirty && (IS_NORM_ZERO(shard.amp0) || IS_NORM_ZERO(shard.amp1)))
-#define UNSAFE_CACHED_CLASSICAL(shard) (!shard.isPlusMinus && UNSAFE_CACHED_EIGENSTATE(shard))
-#define UNSAFE_CACHED_PLUS_MINUS(shard) (shard.isPlusMinus && UNSAFE_CACHED_EIGENSTATE(shard))
+#define UNSAFE_CACHED_CLASSICAL(shard)                                                                                 \
+    (!shard.isProbDirty && !shard.isPlusMinus && (IS_NORM_ZERO(shard.amp0) || IS_NORM_ZERO(shard.amp1)))
 #define UNSAFE_CACHED_ONE(shard) (!shard.isProbDirty && !shard.isPlusMinus && IS_NORM_ZERO(shard.amp0))
 #define UNSAFE_CACHED_ZERO(shard) (!shard.isProbDirty && !shard.isPlusMinus && IS_NORM_ZERO(shard.amp1))
 
@@ -750,15 +749,11 @@ void QUnit::Swap(bitLenInt qubit1, bitLenInt qubit2)
     QEngineShard& shard1 = shards[qubit1];
     QEngineShard& shard2 = shards[qubit2];
 
-    if (UNSAFE_CACHED_EIGENSTATE(shard1) && UNSAFE_CACHED_EIGENSTATE(shard2)) {
+    if (UNSAFE_CACHED_CLASSICAL(shard1) && UNSAFE_CACHED_CLASSICAL(shard2)) {
         // We can avoid dirtying the cache and entangling, since the bits are classical.
-        if (shard1.isPlusMinus == shard2.isPlusMinus) {
-            if (SHARD_STATE(shard1) != SHARD_STATE(shard2)) {
-                XBase(qubit1);
-                XBase(qubit2);
-            }
-        } else {
-            std::swap(shard1.isPlusMinus, shard2.isPlusMinus);
+        if (SHARD_STATE(shard1) != SHARD_STATE(shard2)) {
+            X(qubit1);
+            X(qubit2);
         }
         return;
     }
@@ -822,9 +817,12 @@ void QUnit::SqrtSwap(bitLenInt qubit1, bitLenInt qubit2)
     QEngineShard& shard1 = shards[qubit1];
     QEngineShard& shard2 = shards[qubit2];
 
-    if ((shard1.isPlusMinus == shard2.isPlusMinus) && UNSAFE_CACHED_EIGENSTATE(shard1) &&
-        UNSAFE_CACHED_EIGENSTATE(shard2) && (SHARD_STATE(shard1) == SHARD_STATE(shard2))) {
+    if (UNSAFE_CACHED_CLASSICAL(shard1) && UNSAFE_CACHED_CLASSICAL(shard2) &&
+        (SHARD_STATE(shard1) == SHARD_STATE(shard2))) {
         // We can avoid dirtying the cache and entangling, since this gate doesn't swap identical classical bits.
+        return;
+    } else if (CACHED_PLUS_MINUS(shard1) && CACHED_PLUS_MINUS(shard2) && (SHARD_STATE(shard1) == SHARD_STATE(shard2))) {
+        // We can avoid dirtying the cache and entangling, since this gate doesn't swap identical |+>/|-> basis bits.
         return;
     }
 
@@ -849,9 +847,12 @@ void QUnit::ISqrtSwap(bitLenInt qubit1, bitLenInt qubit2)
     QEngineShard& shard1 = shards[qubit1];
     QEngineShard& shard2 = shards[qubit2];
 
-    if (UNSAFE_CACHED_EIGENSTATE(shard1) && UNSAFE_CACHED_EIGENSTATE(shard2) &&
+    if (UNSAFE_CACHED_CLASSICAL(shard1) && UNSAFE_CACHED_CLASSICAL(shard2) &&
         (SHARD_STATE(shard1) == SHARD_STATE(shard2))) {
         // We can avoid dirtying the cache and entangling, since this gate doesn't swap identical classical bits.
+        return;
+    } else if (CACHED_PLUS_MINUS(shard1) && CACHED_PLUS_MINUS(shard2) && (SHARD_STATE(shard1) == SHARD_STATE(shard2))) {
+        // We can avoid dirtying the cache and entangling, since this gate doesn't swap identical |+>/|-> basis bits.
         return;
     }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -776,8 +776,6 @@ void QUnit::ISwap(bitLenInt qubit1, bitLenInt qubit2)
         return;
     }
 
-    TransformBasis1Qb(false, qubit1);
-    TransformBasis1Qb(false, qubit2);
     RevertBasis2Qb(qubit1, ONLY_INVERT);
     RevertBasis2Qb(qubit2, ONLY_INVERT);
 
@@ -813,8 +811,6 @@ void QUnit::SqrtSwap(bitLenInt qubit1, bitLenInt qubit2)
         return;
     }
 
-    TransformBasis1Qb(false, qubit1);
-    TransformBasis1Qb(false, qubit2);
     RevertBasis2Qb(qubit1, ONLY_INVERT);
     RevertBasis2Qb(qubit2, ONLY_INVERT);
 
@@ -842,8 +838,6 @@ void QUnit::ISqrtSwap(bitLenInt qubit1, bitLenInt qubit2)
         return;
     }
 
-    TransformBasis1Qb(false, qubit1);
-    TransformBasis1Qb(false, qubit2);
     RevertBasis2Qb(qubit1, ONLY_INVERT);
     RevertBasis2Qb(qubit2, ONLY_INVERT);
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -821,9 +821,6 @@ void QUnit::SqrtSwap(bitLenInt qubit1, bitLenInt qubit2)
         (SHARD_STATE(shard1) == SHARD_STATE(shard2))) {
         // We can avoid dirtying the cache and entangling, since this gate doesn't swap identical classical bits.
         return;
-    } else if (CACHED_PLUS_MINUS(shard1) && CACHED_PLUS_MINUS(shard2) && (SHARD_STATE(shard1) == SHARD_STATE(shard2))) {
-        // We can avoid dirtying the cache and entangling, since this gate doesn't swap identical |+>/|-> basis bits.
-        return;
     }
 
     QInterfacePtr unit = Entangle({ qubit1, qubit2 });
@@ -850,9 +847,6 @@ void QUnit::ISqrtSwap(bitLenInt qubit1, bitLenInt qubit2)
     if (UNSAFE_CACHED_CLASSICAL(shard1) && UNSAFE_CACHED_CLASSICAL(shard2) &&
         (SHARD_STATE(shard1) == SHARD_STATE(shard2))) {
         // We can avoid dirtying the cache and entangling, since this gate doesn't swap identical classical bits.
-        return;
-    } else if (CACHED_PLUS_MINUS(shard1) && CACHED_PLUS_MINUS(shard2) && (SHARD_STATE(shard1) == SHARD_STATE(shard2))) {
-        // We can avoid dirtying the cache and entangling, since this gate doesn't swap identical |+>/|-> basis bits.
         return;
     }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -43,8 +43,8 @@
 #define CACHED_ONE(shard) (CACHED_PROB(shard) && IS_NORM_ZERO(shard.amp0))
 #define CACHED_ZERO(shard) (CACHED_PROB(shard) && IS_NORM_ZERO(shard.amp1))
 /* "UNSAFE" variants here do not check whether the bit is in |0>/|1> rather than |+>/|-> basis. */
-#define UNSAFE_CACHED_CLASSICAL(shard)                                                                                 \
-    (!shard.isProbDirty && !shard.isPlusMinus && (IS_NORM_ZERO(shard.amp0) || IS_NORM_ZERO(shard.amp1)))
+#define UNSAFE_CACHED_EIGENSTATE(shard) (!shard.isProbDirty && (IS_NORM_ZERO(shard.amp0) || IS_NORM_ZERO(shard.amp1)))
+#define UNSAFE_CACHED_CLASSICAL(shard) (!shard.isPlusMinus && UNSAFE_CACHED_EIGENSTATE(shard))
 #define UNSAFE_CACHED_ONE(shard) (!shard.isProbDirty && !shard.isPlusMinus && IS_NORM_ZERO(shard.amp0))
 #define UNSAFE_CACHED_ZERO(shard) (!shard.isProbDirty && !shard.isPlusMinus && IS_NORM_ZERO(shard.amp1))
 
@@ -749,11 +749,11 @@ void QUnit::Swap(bitLenInt qubit1, bitLenInt qubit2)
     QEngineShard& shard1 = shards[qubit1];
     QEngineShard& shard2 = shards[qubit2];
 
-    if (UNSAFE_CACHED_CLASSICAL(shard1) && UNSAFE_CACHED_CLASSICAL(shard2)) {
+    if (UNSAFE_CACHED_EIGENSTATE(shard1) && UNSAFE_CACHED_EIGENSTATE(shard2)) {
         // We can avoid dirtying the cache and entangling, since the bits are classical.
         if (SHARD_STATE(shard1) != SHARD_STATE(shard2)) {
-            X(qubit1);
-            X(qubit2);
+            XBase(qubit1);
+            XBase(qubit2);
         }
         return;
     }
@@ -782,11 +782,11 @@ void QUnit::ISwap(bitLenInt qubit1, bitLenInt qubit2)
     QEngineShard& shard1 = shards[qubit1];
     QEngineShard& shard2 = shards[qubit2];
 
-    if (UNSAFE_CACHED_CLASSICAL(shard1) && UNSAFE_CACHED_CLASSICAL(shard2)) {
+    if (UNSAFE_CACHED_EIGENSTATE(shard1) && UNSAFE_CACHED_EIGENSTATE(shard2)) {
         // We can avoid dirtying the cache and entangling, since the bits are classical.
         if (SHARD_STATE(shard1) != SHARD_STATE(shard2)) {
-            X(qubit1);
-            X(qubit2);
+            XBase(qubit1);
+            XBase(qubit2);
             if (!randGlobalPhase) {
                 // Under the preconditions, this has no effect on Hermitian expectation values, but we track it, if the
                 // QUnit is tracking arbitrary numerical phase.
@@ -817,7 +817,7 @@ void QUnit::SqrtSwap(bitLenInt qubit1, bitLenInt qubit2)
     QEngineShard& shard1 = shards[qubit1];
     QEngineShard& shard2 = shards[qubit2];
 
-    if (UNSAFE_CACHED_CLASSICAL(shard1) && UNSAFE_CACHED_CLASSICAL(shard2) &&
+    if (UNSAFE_CACHED_EIGENSTATE(shard1) && UNSAFE_CACHED_EIGENSTATE(shard2) &&
         (SHARD_STATE(shard1) == SHARD_STATE(shard2))) {
         // We can avoid dirtying the cache and entangling, since this gate doesn't swap identical classical bits.
         return;
@@ -844,7 +844,7 @@ void QUnit::ISqrtSwap(bitLenInt qubit1, bitLenInt qubit2)
     QEngineShard& shard1 = shards[qubit1];
     QEngineShard& shard2 = shards[qubit2];
 
-    if (UNSAFE_CACHED_CLASSICAL(shard1) && UNSAFE_CACHED_CLASSICAL(shard2) &&
+    if (UNSAFE_CACHED_EIGENSTATE(shard1) && UNSAFE_CACHED_EIGENSTATE(shard2) &&
         (SHARD_STATE(shard1) == SHARD_STATE(shard2))) {
         // We can avoid dirtying the cache and entangling, since this gate doesn't swap identical classical bits.
         return;

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -782,7 +782,7 @@ void QUnit::ISwap(bitLenInt qubit1, bitLenInt qubit2)
     QEngineShard& shard1 = shards[qubit1];
     QEngineShard& shard2 = shards[qubit2];
 
-    if (UNSAFE_CACHED_EIGENSTATE(shard1) && UNSAFE_CACHED_EIGENSTATE(shard2)) {
+    if (UNSAFE_CACHED_CLASSICAL(shard1) && UNSAFE_CACHED_CLASSICAL(shard2)) {
         // We can avoid dirtying the cache and entangling, since the bits are classical.
         if (SHARD_STATE(shard1) != SHARD_STATE(shard2)) {
             XBase(qubit1);


### PR DESCRIPTION
Because of the reliance on `QUnit` public API methods, given the original state of the `Swap()` method without `TransformBasis1Qb()` calls, it does not seem to be necessary to always first make these calls in swap method variants.