### PR TITLE
Fix bug in OptimizeBuffer(), and extra commutation as a result

### DIFF
--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -305,7 +305,7 @@ public:
 protected:
     void OptimizeBuffer(ShardToPhaseMap& localMap, GetBufferFn remoteMapGet, AddAnglesFn phaseFn, bool makeThisControl)
     {
-        if (IsInvert()) {
+        if (isPlusMinus || IsInvert()) {
             return;
         }
 
@@ -319,8 +319,7 @@ protected:
             buffer = phaseShard->second;
             partner = phaseShard->first;
 
-            if (buffer->isInvert || (isPlusMinus != partner->isPlusMinus) || !IS_ARG_0(buffer->cmplxDiff) ||
-                partner->IsInvert()) {
+            if (buffer->isInvert || partner->isPlusMinus || !IS_ARG_0(buffer->cmplxDiff) || partner->IsInvert()) {
                 continue;
             }
 
@@ -931,7 +930,7 @@ protected:
     void RevertBasis2Qb(const bitLenInt& i, const RevertExclusivity& exclusivity = INVERT_AND_PHASE,
         const RevertControl& controlExclusivity = CONTROLS_AND_TARGETS,
         const RevertAnti& antiExclusivity = CTRL_AND_ANTI, std::set<bitLenInt> exceptControlling = {},
-        std::set<bitLenInt> exceptTargetedBy = {}, const bool& dumpSkipped = false, const bool& skipOptimized = false);
+        std::set<bitLenInt> exceptTargetedBy = {}, const bool& dumpSkipped = false);
 
     void Flush0Eigenstate(const bitLenInt& i)
     {

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -3247,7 +3247,7 @@ void QUnit::ApplyBufferMap(const bitLenInt& bitIndex, ShardToPhaseMap bufferMap,
 
 void QUnit::RevertBasis2Qb(const bitLenInt& i, const RevertExclusivity& exclusivity,
     const RevertControl& controlExclusivity, const RevertAnti& antiExclusivity, std::set<bitLenInt> exceptControlling,
-    std::set<bitLenInt> exceptTargetedBy, const bool& dumpSkipped, const bool& skipOptimize)
+    std::set<bitLenInt> exceptTargetedBy, const bool& dumpSkipped)
 {
     QEngineShard& shard = shards[i];
 
@@ -3259,14 +3259,14 @@ void QUnit::RevertBasis2Qb(const bitLenInt& i, const RevertExclusivity& exclusiv
 
     shard.CombineGates();
 
-    if (!skipOptimize && (controlExclusivity == ONLY_CONTROLS) && (exclusivity != ONLY_INVERT)) {
+    if ((controlExclusivity == ONLY_CONTROLS) && (exclusivity != ONLY_INVERT)) {
         if (antiExclusivity != ONLY_ANTI) {
             shard.OptimizeControls();
         }
         if (antiExclusivity != ONLY_CTRL) {
             shard.OptimizeAntiControls();
         }
-    } else if (!skipOptimize && (controlExclusivity == ONLY_TARGETS) && (exclusivity != ONLY_INVERT)) {
+    } else if ((controlExclusivity == ONLY_TARGETS) && (exclusivity != ONLY_INVERT)) {
         if (antiExclusivity != ONLY_ANTI) {
             shard.OptimizeTargets();
         }
@@ -3298,7 +3298,7 @@ void QUnit::RevertBasis2Qb(const bitLenInt& i, const RevertExclusivity& exclusiv
 
 void QUnit::CommuteH(const bitLenInt& bitIndex)
 {
-    RevertBasis2Qb(bitIndex, INVERT_AND_PHASE, ONLY_CONTROLS, CTRL_AND_ANTI, {}, {}, false, true);
+    RevertBasis2Qb(bitIndex, INVERT_AND_PHASE, ONLY_CONTROLS, CTRL_AND_ANTI);
 
     QEngineShard& shard = shards[bitIndex];
 

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -50,7 +50,7 @@ QInterfacePtr MakeRandQubit()
     QInterfacePtr qubit = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 1U, 0, rng,
         ONE_CMPLX, enable_normalization, true, false, device_id, !disable_hardware_rng);
 
-    real1 theta = 2 * M_PI * qubit->Rand();
+    real1 theta = 4 * M_PI * qubit->Rand();
     real1 phi = 2 * M_PI * qubit->Rand();
     real1 lambda = 2 * M_PI * qubit->Rand();
 


### PR DESCRIPTION
It didn't make any sense to me, that it should _ever_ be necessary to skip optimization between ambiguous controls and targets in QUnit buffers. This suggested that there was a bug in `OptimizeBuffer()`. If we always skip this method when `isPlusMinus` is set from a buffered `H` gate, then we can always use this optimization.