### PR TITLE
Loosen restrictions on OptimizeBuffer()

### DIFF
--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -305,10 +305,6 @@ public:
 protected:
     void OptimizeBuffer(ShardToPhaseMap& localMap, GetBufferFn remoteMapGet, AddAnglesFn phaseFn, bool makeThisControl)
     {
-        if (IsInvert()) {
-            return;
-        }
-
         PhaseShardPtr buffer;
         QEngineShardPtr partner;
 
@@ -319,8 +315,7 @@ protected:
             buffer = phaseShard->second;
             partner = phaseShard->first;
 
-            if (buffer->isInvert || (isPlusMinus != partner->isPlusMinus) || !IS_ARG_0(buffer->cmplxDiff) ||
-                partner->IsInvert()) {
+            if (buffer->isInvert || !IS_ARG_0(buffer->cmplxDiff)) {
                 continue;
             }
 


### PR DESCRIPTION
Certain restrictions on `OptimizeBuffer()` were either never necessary or are no longer necessary as kludges. These changes theoretically increase the optimization gains of calls to `OptimizeBuffer()`.