### PR TITLE
WIP: Remove unnecessary commutation restrictions

### DIFF
--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -3315,7 +3315,6 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
     bitLenInt control;
 
     bool isSame, isOpposite;
-    bitLenInt phaseCount = 0, invertCount = 0;
 
     ShardToPhaseMap targetOfShards = shard.targetOfShards;
 
@@ -3329,11 +3328,6 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
         isOpposite = !buffer->isInvert && norm(polarDiff + polarSame) <= ampThreshold;
 
         if (isSame || isOpposite) {
-            if (buffer->isInvert) {
-                invertCount++;
-            } else {
-                phaseCount++;
-            }
             continue;
         }
 
@@ -3355,11 +3349,6 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
         isOpposite = !buffer->isInvert && norm(polarDiff + polarSame) <= ampThreshold;
 
         if (isSame || isOpposite) {
-            if (buffer->isInvert) {
-                invertCount++;
-            } else {
-                phaseCount++;
-            }
             continue;
         }
 
@@ -3367,46 +3356,6 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
         control = FindShardIndex(*partner);
         ApplyBuffer(phaseShard, control, bitIndex, true);
         shard.RemovePhaseAntiControl(partner);
-    }
-
-    bool saveInvert = (invertCount >= phaseCount);
-
-    if (shard.targetOfShards.size() > 1U || shard.antiTargetOfShards.size() > 0U) {
-        targetOfShards = shard.targetOfShards;
-        for (phaseShard = targetOfShards.begin(); phaseShard != targetOfShards.end(); phaseShard++) {
-            buffer = phaseShard->second;
-
-            polarDiff = buffer->cmplxDiff;
-            polarSame = buffer->cmplxSame;
-
-            if (buffer->isInvert == saveInvert || !(saveInvert && norm(polarDiff + polarSame) <= ampThreshold)) {
-                continue;
-            }
-
-            partner = phaseShard->first;
-            control = FindShardIndex(*partner);
-            ApplyBuffer(phaseShard, control, bitIndex, false);
-            shard.RemovePhaseControl(partner);
-        }
-    }
-
-    if (shard.antiTargetOfShards.size() > 1U || shard.targetOfShards.size() > 0U) {
-        targetOfShards = shard.antiTargetOfShards;
-        for (phaseShard = targetOfShards.begin(); phaseShard != targetOfShards.end(); phaseShard++) {
-            buffer = phaseShard->second;
-
-            polarDiff = buffer->cmplxDiff;
-            polarSame = buffer->cmplxSame;
-
-            if (buffer->isInvert == saveInvert || !(saveInvert && norm(polarDiff + polarSame) <= ampThreshold)) {
-                continue;
-            }
-
-            partner = phaseShard->first;
-            control = FindShardIndex(*partner);
-            ApplyBuffer(phaseShard, control, bitIndex, true);
-            shard.RemovePhaseAntiControl(partner);
-        }
     }
 
     shard.CommuteH();

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -3298,7 +3298,7 @@ void QUnit::RevertBasis2Qb(const bitLenInt& i, const RevertExclusivity& exclusiv
 
 void QUnit::CommuteH(const bitLenInt& bitIndex)
 {
-    RevertBasis2Qb(bitIndex, INVERT_AND_PHASE, ONLY_CONTROLS, CTRL_AND_ANTI);
+    RevertBasis2Qb(bitIndex, INVERT_AND_PHASE, ONLY_CONTROLS, CTRL_AND_ANTI, {}, {}, false, true);
 
     QEngineShard& shard = shards[bitIndex];
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -3314,7 +3314,8 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
     PhaseShardPtr buffer;
     bitLenInt control;
 
-    bool isSame, isOpposite, anyInvert = false;
+    bool isSame, isOpposite;
+    bitLenInt phaseCount = 0, invertCount = 0;
 
     ShardToPhaseMap targetOfShards = shard.targetOfShards;
 
@@ -3328,7 +3329,11 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
         isOpposite = !buffer->isInvert && norm(polarDiff + polarSame) <= ampThreshold;
 
         if (isSame || isOpposite) {
-            anyInvert |= buffer->isInvert;
+            if (buffer->isInvert) {
+                invertCount++;
+            } else {
+                phaseCount++;
+            }
             continue;
         }
 
@@ -3350,7 +3355,11 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
         isOpposite = !buffer->isInvert && norm(polarDiff + polarSame) <= ampThreshold;
 
         if (isSame || isOpposite) {
-            anyInvert |= buffer->isInvert;
+            if (buffer->isInvert) {
+                invertCount++;
+            } else {
+                phaseCount++;
+            }
             continue;
         }
 
@@ -3360,12 +3369,17 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
         shard.RemovePhaseAntiControl(partner);
     }
 
+    bool saveInvert = (invertCount >= phaseCount);
+
     if (shard.targetOfShards.size() > 1U || shard.antiTargetOfShards.size() > 0U) {
         targetOfShards = shard.targetOfShards;
         for (phaseShard = targetOfShards.begin(); phaseShard != targetOfShards.end(); phaseShard++) {
             buffer = phaseShard->second;
 
-            if (buffer->isInvert == anyInvert) {
+            polarDiff = buffer->cmplxDiff;
+            polarSame = buffer->cmplxSame;
+
+            if (buffer->isInvert == saveInvert || !(saveInvert && norm(polarDiff + polarSame) <= ampThreshold)) {
                 continue;
             }
 
@@ -3381,7 +3395,10 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
         for (phaseShard = targetOfShards.begin(); phaseShard != targetOfShards.end(); phaseShard++) {
             buffer = phaseShard->second;
 
-            if (buffer->isInvert == anyInvert) {
+            polarDiff = buffer->cmplxDiff;
+            polarSame = buffer->cmplxSame;
+
+            if (buffer->isInvert == saveInvert || !(saveInvert && norm(polarDiff + polarSame) <= ampThreshold)) {
                 continue;
             }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -3392,6 +3392,14 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
         }
     }
 
+    if (anyInvert != anyAntiInvert) {
+        if (shard.targetOfShards.size() >= shard.antiTargetOfShards.size()) {
+            RevertBasis2Qb(bitIndex, INVERT_AND_PHASE, CONTROLS_AND_TARGETS, ONLY_ANTI);
+        } else {
+            RevertBasis2Qb(bitIndex, INVERT_AND_PHASE, CONTROLS_AND_TARGETS, ONLY_CTRL);
+        }
+    }
+
     shard.CommuteH();
 }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -3314,7 +3314,7 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
     PhaseShardPtr buffer;
     bitLenInt control;
 
-    bool isSame, isOpposite, anyInvert = false, anyAntiInvert = false;
+    bool isSame, isOpposite, anyInvert = false;
 
     ShardToPhaseMap targetOfShards = shard.targetOfShards;
 
@@ -3350,7 +3350,7 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
         isOpposite = !buffer->isInvert && norm(polarDiff + polarSame) <= ampThreshold;
 
         if (isSame || isOpposite) {
-            anyAntiInvert |= buffer->isInvert;
+            anyInvert |= buffer->isInvert;
             continue;
         }
 
@@ -3381,7 +3381,7 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
         for (phaseShard = targetOfShards.begin(); phaseShard != targetOfShards.end(); phaseShard++) {
             buffer = phaseShard->second;
 
-            if (buffer->isInvert == anyAntiInvert) {
+            if (buffer->isInvert == anyInvert) {
                 continue;
             }
 
@@ -3389,14 +3389,6 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
             control = FindShardIndex(*partner);
             ApplyBuffer(phaseShard, control, bitIndex, true);
             shard.RemovePhaseAntiControl(partner);
-        }
-    }
-
-    if (anyInvert != anyAntiInvert) {
-        if (shard.targetOfShards.size() >= shard.antiTargetOfShards.size()) {
-            RevertBasis2Qb(bitIndex, INVERT_AND_PHASE, CONTROLS_AND_TARGETS, ONLY_ANTI);
-        } else {
-            RevertBasis2Qb(bitIndex, INVERT_AND_PHASE, CONTROLS_AND_TARGETS, ONLY_CTRL);
         }
     }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1342,8 +1342,8 @@ void QUnit::CZ(bitLenInt control, bitLenInt target)
 
         TransformBasis1Qb(false, control);
 
-        RevertBasis2Qb(control, ONLY_INVERT, ONLY_TARGETS, CTRL_AND_ANTI, { target }, {});
-        RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI, {}, { control });
+        RevertBasis2Qb(control, ONLY_INVERT, ONLY_TARGETS, CTRL_AND_ANTI);
+        RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI);
 
         shards[target].AddPhaseAngles(&(shards[control]), ONE_CMPLX, -ONE_CMPLX);
         return;
@@ -1636,8 +1636,8 @@ void QUnit::ApplyControlledSinglePhase(const bitLenInt* cControls, const bitLenI
 
         TransformBasis1Qb(false, control);
 
-        RevertBasis2Qb(control, ONLY_INVERT, ONLY_TARGETS, CTRL_AND_ANTI, { target }, {});
-        RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI, {}, { control });
+        RevertBasis2Qb(control, ONLY_INVERT, ONLY_TARGETS, CTRL_AND_ANTI);
+        RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI);
 
         shards[target].AddPhaseAngles(&(shards[control]), topLeft, bottomRight);
         delete[] controls;
@@ -1714,8 +1714,8 @@ void QUnit::ApplyAntiControlledSinglePhase(const bitLenInt* cControls, const bit
 
         TransformBasis1Qb(false, control);
 
-        RevertBasis2Qb(control, ONLY_INVERT, ONLY_TARGETS, CTRL_AND_ANTI, { target }, {});
-        RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI, {}, { control });
+        RevertBasis2Qb(control, ONLY_INVERT, ONLY_TARGETS, CTRL_AND_ANTI);
+        RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI);
 
         shards[target].AddAntiPhaseAngles(&(shards[control]), bottomRight, topLeft);
         delete[] controls;
@@ -3298,7 +3298,7 @@ void QUnit::RevertBasis2Qb(const bitLenInt& i, const RevertExclusivity& exclusiv
 
 void QUnit::CommuteH(const bitLenInt& bitIndex)
 {
-    RevertBasis2Qb(bitIndex, INVERT_AND_PHASE, ONLY_CONTROLS, CTRL_AND_ANTI, {}, {}, false, true);
+    RevertBasis2Qb(bitIndex, INVERT_AND_PHASE, ONLY_CONTROLS, CTRL_AND_ANTI);
 
     QEngineShard& shard = shards[bitIndex];
 
@@ -3325,7 +3325,7 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
         polarSame = buffer->cmplxSame;
 
         isSame = norm(polarDiff - polarSame) <= ampThreshold;
-        isOpposite = !buffer->isInvert && norm(polarDiff + polarSame) <= ampThreshold;
+        isOpposite = !buffer->isInvert && (norm(polarDiff + polarSame) <= ampThreshold);
 
         if (isSame || isOpposite) {
             continue;
@@ -3346,7 +3346,7 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
         polarSame = buffer->cmplxSame;
 
         isSame = norm(polarDiff - polarSame) <= ampThreshold;
-        isOpposite = !buffer->isInvert && norm(polarDiff + polarSame) <= ampThreshold;
+        isOpposite = !buffer->isInvert && (norm(polarDiff + polarSame) <= ampThreshold);
 
         if (isSame || isOpposite) {
             continue;

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -4825,20 +4825,22 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_inversion_buffers")
     crossEntropy = ONE_R1 - sqrt(crossEntropy) / 10000;
     REQUIRE(crossEntropy > 0.97);
 
+    qftReg->SetPermutation(0);
     qftReg->H(0);
     qftReg->H(1);
     qftReg->H(2);
-    qftReg->CCZ(0, 1, 4);
+    qftReg->CCZ(0, 1, 2);
     qftReg->CZ(0, 1);
     qftReg->H(1);
     qftReg->CZ(0, 1);
     qftReg->H(0);
     testCaseResult = qftReg->MultiShotMeasureMask(qPowers, 8, 10000);
 
+    goldStandard->SetPermutation(0);
     goldStandard->H(0);
     goldStandard->H(1);
-    goldStandard->H(4);
-    goldStandard->CCZ(0, 1, 4);
+    goldStandard->H(2);
+    goldStandard->CCZ(0, 1, 2);
     goldStandard->CZ(0, 1);
     goldStandard->H(1);
     goldStandard->CZ(0, 1);

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -4851,9 +4851,9 @@ TEST_CASE("test_universal_circuit_digital_cross_entropy", "[supreme]")
 
     const int GateCount1Qb = 5;
     const int GateCountMultiQb = 4;
-    const int Depth = 3;
+    const int Depth = 5;
 
-    const int TRIALS = 200;
+    const int TRIALS = 2000;
     const int ITERATIONS = 60000;
     const int n = 8;
     bitCapInt permCount = pow2(n);

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -4826,22 +4826,22 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_inversion_buffers")
     REQUIRE(crossEntropy > 0.97);
 
     qftReg->H(0);
+    qftReg->H(1);
     qftReg->H(2);
-    qftReg->H(4);
-    qftReg->CCZ(2, 0, 4);
-    qftReg->CZ(0, 2);
-    qftReg->H(2);
-    qftReg->CZ(0, 2);
+    qftReg->CCZ(0, 1, 4);
+    qftReg->CZ(0, 1);
+    qftReg->H(1);
+    qftReg->CZ(0, 1);
     qftReg->H(0);
     testCaseResult = qftReg->MultiShotMeasureMask(qPowers, 8, 10000);
 
     goldStandard->H(0);
-    goldStandard->H(2);
+    goldStandard->H(1);
     goldStandard->H(4);
-    goldStandard->CCZ(2, 0, 4);
-    goldStandard->CZ(0, 2);
-    goldStandard->H(2);
-    goldStandard->CZ(0, 2);
+    goldStandard->CCZ(0, 1, 4);
+    goldStandard->CZ(0, 1);
+    goldStandard->H(1);
+    goldStandard->CZ(0, 1);
     goldStandard->H(0);
     goldStandardResult = goldStandard->MultiShotMeasureMask(qPowers, 8, 10000);
 

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -4896,9 +4896,9 @@ TEST_CASE("test_universal_circuit_digital_cross_entropy", "[supreme]")
 
     const int GateCount1Qb = 5;
     const int GateCountMultiQb = 4;
-    const int Depth = 5;
+    const int Depth = 3;
 
-    const int TRIALS = 6000;
+    const int TRIALS = 200;
     const int ITERATIONS = 60000;
     const int n = 8;
     bitCapInt permCount = pow2(n);

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -4827,6 +4827,7 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_inversion_buffers")
 
     qftReg->H(0);
     qftReg->H(2);
+    qftReg->H(4);
     qftReg->CCZ(2, 0, 4);
     qftReg->CZ(0, 2);
     qftReg->H(2);
@@ -4836,6 +4837,7 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_inversion_buffers")
 
     goldStandard->H(0);
     goldStandard->H(2);
+    goldStandard->H(4);
     goldStandard->CCZ(2, 0, 4);
     goldStandard->CZ(0, 2);
     goldStandard->H(2);

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -4851,9 +4851,9 @@ TEST_CASE("test_universal_circuit_digital_cross_entropy", "[supreme]")
 
     const int GateCount1Qb = 5;
     const int GateCountMultiQb = 4;
-    const int Depth = 5;
+    const int Depth = 3;
 
-    const int TRIALS = 2000;
+    const int TRIALS = 200;
     const int ITERATIONS = 60000;
     const int n = 8;
     bitCapInt permCount = pow2(n);


### PR DESCRIPTION
Certain commutation restrictions put in place along the way to a general pass on random universal circuit cross entropy tests can be backed off, as kludges which are no longer necessary.