### PR TITLE
Directly "AddInversionAngles()" for CNOT

### DIFF
--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -301,6 +301,20 @@ public:
         AddAngles(control, cmplxDiff, cmplxSame, &QEngineShard::MakePhaseAntiControlledBy, antiTargetOfShards,
             &QEngineShard::RemovePhaseAntiControl);
     }
+    void AddInversionAngles(QEngineShardPtr control, const complex& cmplxDiff, const complex& cmplxSame)
+    {
+        MakePhaseControlledBy(control);
+        targetOfShards[control]->isInvert = !targetOfShards[control]->isInvert;
+        std::swap(targetOfShards[control]->cmplxDiff, targetOfShards[control]->cmplxSame);
+        AddPhaseAngles(control, cmplxDiff, cmplxSame);
+    }
+    void AddAntiInversionAngles(QEngineShardPtr control, const complex& cmplxDiff, const complex& cmplxSame)
+    {
+        MakePhaseAntiControlledBy(control);
+        antiTargetOfShards[control]->isInvert = !antiTargetOfShards[control]->isInvert;
+        std::swap(antiTargetOfShards[control]->cmplxDiff, antiTargetOfShards[control]->cmplxSame);
+        AddAntiPhaseAngles(control, cmplxDiff, cmplxSame);
+    }
 
 protected:
     void OptimizeBuffer(ShardToPhaseMap& localMap, GetBufferFn remoteMapGet, AddAnglesFn phaseFn, bool makeThisControl)

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1151,9 +1151,13 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
     }
 
     if (!freezeBasis) {
-        H(target);
-        CZ(control, target);
-        H(target);
+        TransformBasis1Qb(false, control);
+
+        RevertBasis2Qb(control, INVERT_AND_PHASE, ONLY_TARGETS);
+        RevertBasis2Qb(target, ONLY_PHASE, CONTROLS_AND_TARGETS);
+        RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, {}, { control });
+
+        shards[target].AddInversionAngles(&(shards[control]), ONE_CMPLX, ONE_CMPLX);
         return;
     }
 
@@ -1209,11 +1213,13 @@ void QUnit::AntiCNOT(bitLenInt control, bitLenInt target)
     bitLenInt controlLen = 1;
 
     if (!freezeBasis) {
-        X(control);
-        H(target);
-        CZ(control, target);
-        H(target);
-        X(control);
+        TransformBasis1Qb(false, control);
+
+        RevertBasis2Qb(control, INVERT_AND_PHASE, ONLY_TARGETS);
+        RevertBasis2Qb(target, ONLY_PHASE, CONTROLS_AND_TARGETS);
+        RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, {}, { control });
+
+        shards[target].AddAntiInversionAngles(&(shards[control]), ONE_CMPLX, ONE_CMPLX);
         return;
     }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1337,10 +1337,6 @@ void QUnit::CZ(bitLenInt control, bitLenInt target)
     }
 
     if (!freezeBasis) {
-        if (tShard.IsInvertControlOf(&cShard)) {
-            std::swap(control, target);
-        }
-
         TransformBasis1Qb(false, control);
 
         RevertBasis2Qb(control, ONLY_INVERT, ONLY_TARGETS, CTRL_AND_ANTI);
@@ -1631,10 +1627,6 @@ void QUnit::ApplyControlledSinglePhase(const bitLenInt* cControls, const bitLenI
             return;
         }
 
-        if (IS_ARG_0(topLeft) && tShard.IsInvertControlOf(&(shards[control]))) {
-            std::swap(control, target);
-        }
-
         TransformBasis1Qb(false, control);
 
         RevertBasis2Qb(control, ONLY_INVERT, ONLY_TARGETS, CTRL_AND_ANTI);
@@ -1707,10 +1699,6 @@ void QUnit::ApplyAntiControlledSinglePhase(const bitLenInt* cControls, const bit
             }
             delete[] controls;
             return;
-        }
-
-        if (IS_ARG_0(bottomRight) && tShard.IsInvertAntiControlOf(&(shards[control]))) {
-            std::swap(control, target);
         }
 
         TransformBasis1Qb(false, control);

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1154,8 +1154,7 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
         TransformBasis1Qb(false, control);
 
         RevertBasis2Qb(control, INVERT_AND_PHASE, ONLY_TARGETS);
-        RevertBasis2Qb(target, ONLY_PHASE, CONTROLS_AND_TARGETS);
-        RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, {}, { control });
+        RevertBasis2Qb(target, INVERT_AND_PHASE, CONTROLS_AND_TARGETS, {}, { control });
 
         shards[target].AddInversionAngles(&(shards[control]), ONE_CMPLX, ONE_CMPLX);
         return;
@@ -1216,8 +1215,7 @@ void QUnit::AntiCNOT(bitLenInt control, bitLenInt target)
         TransformBasis1Qb(false, control);
 
         RevertBasis2Qb(control, INVERT_AND_PHASE, ONLY_TARGETS);
-        RevertBasis2Qb(target, ONLY_PHASE, CONTROLS_AND_TARGETS);
-        RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, {}, { control });
+        RevertBasis2Qb(target, INVERT_AND_PHASE, CONTROLS_AND_TARGETS, {}, { control });
 
         shards[target].AddAntiInversionAngles(&(shards[control]), ONE_CMPLX, ONE_CMPLX);
         return;


### PR DESCRIPTION
Because of the current inability to compose phase buffers with inversion buffers, it seems like some commutativity could be saved by directly buffering inversion gates, instead of composing them from H, CZ, H patterns.