### PR TITLE
Flush buffers when efficient; better default PSTRIDE setting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ include ("cmake/Format.cmake")
 
 include_directories ("include" "include/common")
 
-set(PSTRIDE "16" CACHE STRING "Stride of parallel for loops (must be power of 2)")
+set(PSTRIDE "64" CACHE STRING "Stride of parallel for loops (must be power of 2)")
 
 set(QBCAPPOW "6" CACHE STRING "Log2 of maximum qubit capacity of a single QInterface (must be at least 5, equivalent to >= 32 qubits)")
 if (QBCAPPOW LESS 5)

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1151,13 +1151,9 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
     }
 
     if (!freezeBasis) {
-        TransformBasis1Qb(false, control);
-
-        RevertBasis2Qb(control, INVERT_AND_PHASE, ONLY_TARGETS);
-        RevertBasis2Qb(target, ONLY_PHASE, CONTROLS_AND_TARGETS);
-        RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI, {}, { control });
-
-        shards[target].AddInversionAngles(&(shards[control]), ONE_CMPLX, ONE_CMPLX);
+        H(target);
+        CZ(control, target);
+        H(target);
         return;
     }
 
@@ -1213,13 +1209,11 @@ void QUnit::AntiCNOT(bitLenInt control, bitLenInt target)
     bitLenInt controlLen = 1;
 
     if (!freezeBasis) {
-        TransformBasis1Qb(false, control);
-
-        RevertBasis2Qb(control, INVERT_AND_PHASE, ONLY_TARGETS);
-        RevertBasis2Qb(target, ONLY_PHASE, CONTROLS_AND_TARGETS);
-        RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI, {}, { control });
-
-        shards[target].AddAntiInversionAngles(&(shards[control]), ONE_CMPLX, ONE_CMPLX);
+        X(control);
+        H(target);
+        CZ(control, target);
+        H(target);
+        X(control);
         return;
     }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1220,7 +1220,6 @@ void QUnit::AntiCNOT(bitLenInt control, bitLenInt target)
         RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI, {}, { control });
 
         shards[target].AddAntiInversionAngles(&(shards[control]), ONE_CMPLX, ONE_CMPLX);
-
         return;
     }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -3359,15 +3359,17 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
         polarDiff = buffer->cmplxDiff;
         polarSame = buffer->cmplxSame;
 
+        partner = phaseShard->first;
+
         // If isSame and !isInvert, application of this buffer is already "efficient."
-        isSame = buffer->isInvert && norm(polarDiff - polarSame) <= ampThreshold;
+        isSame = (buffer->isInvert || !partner->isPlusMinus || !partner->IsInvertTarget()) &&
+            norm(polarDiff - polarSame) <= ampThreshold;
         isOpposite = !buffer->isInvert && (norm(polarDiff + polarSame) <= ampThreshold);
 
         if (isSame || isOpposite) {
             continue;
         }
 
-        partner = phaseShard->first;
         control = FindShardIndex(*partner);
         ApplyBuffer(phaseShard, control, bitIndex, false);
         shard.RemovePhaseControl(partner);
@@ -3381,15 +3383,17 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
         polarDiff = buffer->cmplxDiff;
         polarSame = buffer->cmplxSame;
 
+        partner = phaseShard->first;
+
         // If isSame and !isInvert, application of this buffer is already "efficient."
-        isSame = buffer->isInvert && norm(polarDiff - polarSame) <= ampThreshold;
+        isSame = (buffer->isInvert || !partner->isPlusMinus || !partner->IsInvertTarget()) &&
+            norm(polarDiff - polarSame) <= ampThreshold;
         isOpposite = !buffer->isInvert && (norm(polarDiff + polarSame) <= ampThreshold);
 
         if (isSame || isOpposite) {
             continue;
         }
 
-        partner = phaseShard->first;
         control = FindShardIndex(*partner);
         ApplyBuffer(phaseShard, control, bitIndex, true);
         shard.RemovePhaseAntiControl(partner);

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -3365,7 +3365,8 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
         polarDiff = buffer->cmplxDiff;
         polarSame = buffer->cmplxSame;
 
-        isSame = norm(polarDiff - polarSame) <= ampThreshold;
+        // If isSame and !isInvert, application of this buffer is already "efficient."
+        isSame = buffer->isInvert && norm(polarDiff - polarSame) <= ampThreshold;
         isOpposite = !buffer->isInvert && (norm(polarDiff + polarSame) <= ampThreshold);
 
         if (isSame || isOpposite) {
@@ -3386,7 +3387,8 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
         polarDiff = buffer->cmplxDiff;
         polarSame = buffer->cmplxSame;
 
-        isSame = norm(polarDiff - polarSame) <= ampThreshold;
+        // If isSame and !isInvert, application of this buffer is already "efficient."
+        isSame = buffer->isInvert && norm(polarDiff - polarSame) <= ampThreshold;
         isOpposite = !buffer->isInvert && (norm(polarDiff + polarSame) <= ampThreshold);
 
         if (isSame || isOpposite) {

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1151,9 +1151,13 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
     }
 
     if (!freezeBasis) {
-        H(target);
-        CZ(control, target);
-        H(target);
+        TransformBasis1Qb(false, control);
+
+        RevertBasis2Qb(control, INVERT_AND_PHASE, ONLY_TARGETS);
+        RevertBasis2Qb(target, ONLY_PHASE, CONTROLS_AND_TARGETS);
+        RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI, {}, { control });
+
+        shards[target].AddInversionAngles(&(shards[control]), ONE_CMPLX, ONE_CMPLX);
         return;
     }
 
@@ -1209,11 +1213,14 @@ void QUnit::AntiCNOT(bitLenInt control, bitLenInt target)
     bitLenInt controlLen = 1;
 
     if (!freezeBasis) {
-        X(control);
-        H(target);
-        CZ(control, target);
-        H(target);
-        X(control);
+        TransformBasis1Qb(false, control);
+
+        RevertBasis2Qb(control, INVERT_AND_PHASE, ONLY_TARGETS);
+        RevertBasis2Qb(target, ONLY_PHASE, CONTROLS_AND_TARGETS);
+        RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI, {}, { control });
+
+        shards[target].AddAntiInversionAngles(&(shards[control]), ONE_CMPLX, ONE_CMPLX);
+
         return;
     }
 


### PR DESCRIPTION
The recent changes in CNOT/AntiCNOT hurt performance and are reverted here, though I consistently find myself reaching back for AddInversionAngles(), which has been verified in its current form. Also, it is often efficient to flush certain "isSame" phase gates on commutation with H.