### PR TITLE
CI update (Qiskit)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ install:
   - sudo apt-get update
   - sudo apt-get install linuxdoc-tools linuxdoc-tools-info binutils-mingw-w64-i686 gcc-mingw-w64-i686 sshpass cmake
   - python -m pip install --upgrade pip numpy setuptools==45 wheel
-  - python -m pip install cvxpy Cython stestr qiskit pennylane
+  - python -m pip install cvxpy cython stestr qiskit pennylane
 script:
   - mkdir _build && cd _build && cmake -DENABLE_OPENCL=OFF -DENABLE_COMPLEX8=OFF .. && make -j 8 all
   - sudo make install
@@ -20,9 +20,9 @@ script:
   - cd ../.. && git clone https://github.com/vm6502q/qiskit-qrack-provider.git && cd qiskit-qrack-provider
   - python -m pip install .
   - python -m stestr run
-  - cd .. && git clone https://github.com/XanaduAI/pennylane-pq.git && cd pennylane-pq
-  - python -m pip install .
-  - python -m pytest .
+#  - cd .. && git clone https://github.com/XanaduAI/pennylane-pq.git && cd pennylane-pq
+#  - python -m pip install .
+#  - python -m pytest .
   - cd .. && git clone https://github.com/vm6502q/pennylane-qiskit.git && cd pennylane-qiskit
   - python -m pip install .
   - python -m pytest .

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ install:
   - sudo apt-get update
   - sudo apt-get install linuxdoc-tools linuxdoc-tools-info binutils-mingw-w64-i686 gcc-mingw-w64-i686 sshpass cmake
   - python -m pip install --upgrade pip numpy setuptools==45 wheel
-  - python -m pip install cvxpy cython stestr qiskit pennylane
+  - python -m pip install cvxpy Cython stestr qiskit pennylane
 script:
   - mkdir _build && cd _build && cmake -DENABLE_OPENCL=OFF -DENABLE_COMPLEX8=OFF .. && make -j 8 all
   - sudo make install

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ install:
   - sudo apt-get update
   - sudo apt-get install linuxdoc-tools linuxdoc-tools-info binutils-mingw-w64-i686 gcc-mingw-w64-i686 sshpass cmake
   - python -m pip install --upgrade pip numpy setuptools==45 wheel
-  - python -m pip install cvxpy cython stestr qiskit==0.18.3 pennylane
+  - python -m pip install cvxpy cython stestr qiskit pennylane
 script:
   - mkdir _build && cd _build && cmake -DENABLE_OPENCL=OFF -DENABLE_COMPLEX8=OFF .. && make -j 8 all
   - sudo make install
@@ -19,10 +19,10 @@ script:
   - cd build && python -m pytest .
   - cd ../.. && git clone https://github.com/vm6502q/qiskit-qrack-provider.git && cd qiskit-qrack-provider
   - python -m pip install .
-#  - python -m stestr run
-#  - cd .. && git clone https://github.com/XanaduAI/pennylane-pq.git && cd pennylane-pq
-#  - python -m pip install .
-#  - python -m pytest .
+  - python -m stestr run
+  - cd .. && git clone https://github.com/XanaduAI/pennylane-pq.git && cd pennylane-pq
+  - python -m pip install .
+  - python -m pytest .
   - cd .. && git clone https://github.com/vm6502q/pennylane-qiskit.git && cd pennylane-qiskit
   - python -m pip install .
   - python -m pytest .


### PR DESCRIPTION
In the Qrack/Qiskit plugin repository, I replaced the unit tests with the subset of the new IBM tests that we currently support. Basically, we support almost everything except noise, snapshots, and certain custom unitary gate operations. Qiskit has also improved their case coverage for sampling optimizations, and replicating this behavior in the Qrack plugin is on my list, but it's not top priority because the new cases seem to be entirely covered by exactly equivalent rearrangement of instructions in the circuits it covers, (i.e. "It's the optimizing compiler's job," or the programmers').