### PR TITLE
bitLenInt/bitCapInt bug in QNeuron classification example

### DIFF
--- a/examples/qneuron_classification.cpp
+++ b/examples/qneuron_classification.cpp
@@ -198,7 +198,7 @@ std::vector<dfObservation> predict(
             qReg->H(permH[i]);
         }
 
-        for (bitLenInt i = 0; i < outputLayer.size(); i++) {
+        for (bitCapInt i = 0; i < outputLayer.size(); i++) {
             outputLayer[i]->Predict();
         }
 


### PR DESCRIPTION
This doesn't affect the example as exactly written, but I confused a conceptual `bitCapInt` for a `bitLenInt`. This is important if the example is adapted, such as to include more than 255 neurons.