### PR TITLE
Flush H on target to compose phase/invert buffers

### DIFF
--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1145,6 +1145,11 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
 
         RevertBasis2Qb(control, ONLY_INVERT, ONLY_TARGETS);
         RevertBasis2Qb(target, ONLY_PHASE, CONTROLS_AND_TARGETS);
+
+        if (cShard.IsInvertControlOf(&tShard)) {
+            TransformBasis1Qb(false, target);
+        }
+
         RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI, {}, { control });
 
         shards[target].AddInversionAngles(&(shards[control]), ONE_CMPLX, ONE_CMPLX);
@@ -1336,9 +1341,14 @@ void QUnit::CZ(bitLenInt control, bitLenInt target)
         TransformBasis1Qb(false, control);
 
         RevertBasis2Qb(control, ONLY_INVERT, ONLY_TARGETS, CTRL_AND_ANTI);
-        RevertBasis2Qb(target, ONLY_INVERT, ONLY_TARGETS, CTRL_AND_ANTI);
 
-        shards[target].AddPhaseAngles(&(shards[control]), ONE_CMPLX, -ONE_CMPLX);
+        if (cShard.IsInvertControlOf(&tShard)) {
+            TransformBasis1Qb(false, target);
+        }
+
+        RevertBasis2Qb(target, ONLY_INVERT, ONLY_TARGETS, CTRL_AND_ANTI, {}, { control });
+
+        tShard.AddPhaseAngles(&cShard, ONE_CMPLX, -ONE_CMPLX);
         return;
     }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1144,13 +1144,12 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
         TransformBasis1Qb(false, control);
 
         RevertBasis2Qb(control, ONLY_INVERT, ONLY_TARGETS);
-        RevertBasis2Qb(target, ONLY_PHASE, CONTROLS_AND_TARGETS);
 
         if (cShard.IsInvertControlOf(&tShard)) {
             TransformBasis1Qb(false, target);
         }
 
-        RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI, {}, { control });
+        RevertBasis2Qb(target, INVERT_AND_PHASE, CONTROLS_AND_TARGETS, CTRL_AND_ANTI, {}, { control });
 
         shards[target].AddInversionAngles(&(shards[control]), ONE_CMPLX, ONE_CMPLX);
         return;

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1205,7 +1205,7 @@ void QUnit::AntiCNOT(bitLenInt control, bitLenInt target)
     if (!freezeBasis) {
         TransformBasis1Qb(false, control);
 
-        RevertBasis2Qb(control, INVERT_AND_PHASE, ONLY_TARGETS);
+        RevertBasis2Qb(control, ONLY_INVERT, ONLY_TARGETS);
         RevertBasis2Qb(target, ONLY_PHASE, CONTROLS_AND_TARGETS);
         RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI, {}, { control });
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -3374,7 +3374,8 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
         partner = phaseShard->first;
 
         // If isSame and !isInvert, application of this buffer is already "efficient."
-        isSame = (buffer->isInvert || !partner->isPlusMinus) && norm(polarDiff - polarSame) <= ampThreshold;
+        isSame = (buffer->isInvert || !partner->isPlusMinus || !partner->IsInvertTarget()) &&
+            norm(polarDiff - polarSame) <= ampThreshold;
         isOpposite = norm(polarDiff + polarSame) <= ampThreshold;
 
         if (isSame || isOpposite) {
@@ -3397,7 +3398,8 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
         partner = phaseShard->first;
 
         // If isSame and !isInvert, application of this buffer is already "efficient."
-        isSame = (buffer->isInvert || !partner->isPlusMinus) && norm(polarDiff - polarSame) <= ampThreshold;
+        isSame = (buffer->isInvert || !partner->isPlusMinus || !partner->IsInvertTarget()) &&
+            norm(polarDiff - polarSame) <= ampThreshold;
         isOpposite = norm(polarDiff + polarSame) <= ampThreshold;
 
         if (isSame || isOpposite) {

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1336,7 +1336,8 @@ void QUnit::CZ(bitLenInt control, bitLenInt target)
         TransformBasis1Qb(false, control);
 
         RevertBasis2Qb(control, ONLY_INVERT, ONLY_TARGETS, CTRL_AND_ANTI);
-        RevertBasis2Qb(target, ONLY_INVERT, ONLY_TARGETS, CTRL_AND_ANTI);
+        RevertBasis2Qb(target, ONLY_INVERT, ONLY_TARGETS, ONLY_ANTI);
+        RevertBasis2Qb(target, ONLY_INVERT, ONLY_TARGETS, ONLY_CTRL);
 
         shards[target].AddPhaseAngles(&(shards[control]), ONE_CMPLX, -ONE_CMPLX);
         return;
@@ -3356,6 +3357,10 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
 
     RevertBasis2Qb(bitIndex, INVERT_AND_PHASE, ONLY_CONTROLS, CTRL_AND_ANTI, {}, {}, false, true);
 
+    if (!QUEUED_PHASE(shard)) {
+        return;
+    }
+
     bool isSame, isOpposite;
 
     ShardToPhaseMap targetOfShards = shard.targetOfShards;
@@ -3369,9 +3374,8 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
         partner = phaseShard->first;
 
         // If isSame and !isInvert, application of this buffer is already "efficient."
-        isSame = (buffer->isInvert || !partner->isPlusMinus || !partner->IsInvertTarget()) &&
-            norm(polarDiff - polarSame) <= ampThreshold;
-        isOpposite = !buffer->isInvert && (norm(polarDiff + polarSame) <= ampThreshold);
+        isSame = (buffer->isInvert || !partner->isPlusMinus) && norm(polarDiff - polarSame) <= ampThreshold;
+        isOpposite = norm(polarDiff + polarSame) <= ampThreshold;
 
         if (isSame || isOpposite) {
             continue;
@@ -3393,9 +3397,8 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
         partner = phaseShard->first;
 
         // If isSame and !isInvert, application of this buffer is already "efficient."
-        isSame = (buffer->isInvert || !partner->isPlusMinus || !partner->IsInvertTarget()) &&
-            norm(polarDiff - polarSame) <= ampThreshold;
-        isOpposite = !buffer->isInvert && (norm(polarDiff + polarSame) <= ampThreshold);
+        isSame = (buffer->isInvert || !partner->isPlusMinus) && norm(polarDiff - polarSame) <= ampThreshold;
+        isOpposite = norm(polarDiff + polarSame) <= ampThreshold;
 
         if (isSame || isOpposite) {
             continue;

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1336,8 +1336,7 @@ void QUnit::CZ(bitLenInt control, bitLenInt target)
         TransformBasis1Qb(false, control);
 
         RevertBasis2Qb(control, ONLY_INVERT, ONLY_TARGETS, CTRL_AND_ANTI);
-        RevertBasis2Qb(target, ONLY_INVERT, ONLY_TARGETS, ONLY_ANTI);
-        RevertBasis2Qb(target, ONLY_INVERT, ONLY_TARGETS, ONLY_CTRL);
+        RevertBasis2Qb(target, ONLY_INVERT, ONLY_TARGETS, CTRL_AND_ANTI);
 
         shards[target].AddPhaseAngles(&(shards[control]), ONE_CMPLX, -ONE_CMPLX);
         return;

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1677,10 +1677,21 @@ void QUnit::ApplyAntiControlledSinglePhase(const bitLenInt* cControls, const bit
         return;
     }
 
-    if (IS_ARG_0(bottomRight) && (!tShard.IsInvertTarget() && UNSAFE_CACHED_ONE(tShard))) {
-        Flush1Eigenstate(target);
-        delete[] controls;
-        return;
+    if (IS_ARG_0(bottomRight)) {
+        if (!tShard.IsInvertTarget() && UNSAFE_CACHED_ZERO(tShard)) {
+            Flush0Eigenstate(target);
+            delete[] controls;
+            return;
+        }
+
+        if (!shards[target].isPlusMinus) {
+            for (bitLenInt i = 0; i < controlLen; i++) {
+                if (shards[controls[i]].isPlusMinus) {
+                    std::swap(controls[i], target);
+                    break;
+                }
+            }
+        }
     }
 
     if (!freezeBasis && (controlLen == 1U)) {

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1678,8 +1678,8 @@ void QUnit::ApplyAntiControlledSinglePhase(const bitLenInt* cControls, const bit
     }
 
     if (IS_ARG_0(bottomRight)) {
-        if (!tShard.IsInvertTarget() && UNSAFE_CACHED_ZERO(tShard)) {
-            Flush0Eigenstate(target);
+        if (!tShard.IsInvertTarget() && UNSAFE_CACHED_ONE(tShard)) {
+            Flush1Eigenstate(target);
             delete[] controls;
             return;
         }


### PR DESCRIPTION
It's preferable, if flushing an H gate can prevent the application of a 2-qubit gate.