### PR TITLE
Flush phase buffers when efficient (and fix CommuteH isOpposite bug)

### DIFF
--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -46,8 +46,8 @@ struct PhaseShard {
     }
 };
 
-#define IS_SAME(c1, c2) (norm((c1) - (c2)) <= amplitudeFloor)
-#define IS_OPPOSITE(c1, c2) (norm((c1) + (c2)) <= amplitudeFloor)
+#define IS_SAME(c1, c2) (norm((c1) - (c2)) <= amplitudeThreshold)
+#define IS_OPPOSITE(c1, c2) (norm((c1) + (c2)) <= amplitudeThreshold)
 #define IS_ARG_0(c) IS_SAME(c, ONE_CMPLX)
 #define IS_ARG_PI(c) IS_OPPOSITE(c, ONE_CMPLX)
 
@@ -68,7 +68,7 @@ protected:
 public:
     QInterfacePtr unit;
     bitLenInt mapped;
-    real1 amplitudeFloor;
+    real1 amplitudeThreshold;
     bool isEmulated;
     bool isProbDirty;
     bool isPhaseDirty;
@@ -95,7 +95,7 @@ public:
     QEngineShard(const real1 amp_thresh = min_norm)
         : unit(NULL)
         , mapped(0)
-        , amplitudeFloor(amp_thresh)
+        , amplitudeThreshold(amp_thresh)
         , isEmulated(false)
         , isProbDirty(false)
         , isPhaseDirty(false)
@@ -112,7 +112,7 @@ public:
     QEngineShard(QInterfacePtr u, const bool& set, const real1 amp_thresh = min_norm)
         : unit(u)
         , mapped(0)
-        , amplitudeFloor(amp_thresh)
+        , amplitudeThreshold(amp_thresh)
         , isEmulated(false)
         , isProbDirty(false)
         , isPhaseDirty(false)
@@ -132,7 +132,7 @@ public:
     QEngineShard(QInterfacePtr u, const bitLenInt& mapping, const real1 amp_thresh = min_norm)
         : unit(u)
         , mapped(mapping)
-        , amplitudeFloor(amp_thresh)
+        , amplitudeThreshold(amp_thresh)
         , isEmulated(false)
         , isProbDirty(true)
         , isPhaseDirty(true)
@@ -976,8 +976,7 @@ protected:
     enum RevertControl { CONTROLS_AND_TARGETS = 0, ONLY_CONTROLS = 1, ONLY_TARGETS = 2 };
     enum RevertAnti { CTRL_AND_ANTI = 0, ONLY_CTRL = 1, ONLY_ANTI = 2 };
 
-    void ApplyBuffer(
-        ShardToPhaseMap::iterator phaseShard, const bitLenInt& control, const bitLenInt& target, const bool& isAnti);
+    void ApplyBuffer(PhaseShardPtr phaseShard, const bitLenInt& control, const bitLenInt& target, const bool& isAnti);
     void ApplyBufferMap(const bitLenInt& bitIndex, ShardToPhaseMap bufferMap, const RevertExclusivity& exclusivity,
         const bool& isControl, const bool& isAnti, std::set<bitLenInt> exceptPartners, const bool& dumpSkipped);
     void RevertBasis2Qb(const bitLenInt& i, const RevertExclusivity& exclusivity = INVERT_AND_PHASE,

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1342,7 +1342,6 @@ void QUnit::CZ(bitLenInt control, bitLenInt target)
         RevertBasis2Qb(control, ONLY_INVERT, ONLY_TARGETS, CTRL_AND_ANTI);
 
         bool isInvert = cShard.IsInvertControlOf(&tShard);
-
         if (isInvert) {
             TransformBasis1Qb(false, target);
         }
@@ -1532,7 +1531,7 @@ void QUnit::ApplySingleInvert(const complex topRight, const complex bottomLeft, 
 {
     QEngineShard& shard = shards[target];
 
-    if ((topRight == bottomLeft) && (randGlobalPhase || (topRight == ONE_CMPLX))) {
+    if ((topRight == bottomLeft) && (randGlobalPhase || IS_ONE_CMPLX(topRight))) {
         X(target);
         return;
     }
@@ -1648,6 +1647,7 @@ void QUnit::ApplyControlledSinglePhase(const bitLenInt* cControls, const bitLenI
             } else {
                 Flush0Eigenstate(control);
             }
+
             return;
         }
 
@@ -1656,11 +1656,11 @@ void QUnit::ApplyControlledSinglePhase(const bitLenInt* cControls, const bitLenI
         RevertBasis2Qb(control, ONLY_INVERT, ONLY_TARGETS, CTRL_AND_ANTI);
         RevertBasis2Qb(target, ONLY_INVERT, IS_ONE_CMPLX(topLeft) ? ONLY_TARGETS : CONTROLS_AND_TARGETS, CTRL_AND_ANTI);
 
-        tShard.AddPhaseAngles(&cShard, topLeft, bottomRight);
+        shards[target].AddPhaseAngles(&(shards[control]), topLeft, bottomRight);
 
-        ShardToPhaseMap::iterator phaseShard = tShard.targetOfShards.find(&cShard);
+        ShardToPhaseMap::iterator phaseShard = shards[target].targetOfShards.find(&(shards[control]));
 
-        if (cShard.IsInvertControlOf(&tShard) || (phaseShard == tShard.targetOfShards.end())) {
+        if (cShard.IsInvertControlOf(&tShard) || (phaseShard == shards[target].targetOfShards.end())) {
             return;
         }
 
@@ -1669,7 +1669,7 @@ void QUnit::ApplyControlledSinglePhase(const bitLenInt* cControls, const bitLenI
 
         if (IS_SAME(buffer->cmplxDiff, buffer->cmplxSame)) {
             ApplyBuffer(buffer, control, target, false);
-            tShard.RemovePhaseControl(&cShard);
+            tShard.RemovePhaseControl(&(shards[control]));
         }
 
         return;
@@ -1758,11 +1758,11 @@ void QUnit::ApplyAntiControlledSinglePhase(const bitLenInt* cControls, const bit
         RevertBasis2Qb(
             target, ONLY_INVERT, IS_ONE_CMPLX(bottomRight) ? ONLY_TARGETS : CONTROLS_AND_TARGETS, CTRL_AND_ANTI);
 
-        tShard.AddAntiPhaseAngles(&cShard, bottomRight, topLeft);
+        shards[target].AddAntiPhaseAngles(&(shards[control]), bottomRight, topLeft);
 
-        ShardToPhaseMap::iterator phaseShard = tShard.antiTargetOfShards.find(&cShard);
+        ShardToPhaseMap::iterator phaseShard = shards[target].targetOfShards.find(&(shards[control]));
 
-        if (cShard.IsInvertAntiControlOf(&tShard) || (phaseShard == tShard.antiTargetOfShards.end())) {
+        if (cShard.IsInvertControlOf(&tShard) || (phaseShard == shards[target].targetOfShards.end())) {
             return;
         }
 
@@ -1771,7 +1771,7 @@ void QUnit::ApplyAntiControlledSinglePhase(const bitLenInt* cControls, const bit
 
         if (IS_SAME(buffer->cmplxDiff, buffer->cmplxSame)) {
             ApplyBuffer(buffer, control, target, true);
-            tShard.RemovePhaseAntiControl(&cShard);
+            tShard.RemovePhaseAntiControl(&(shards[control]));
         }
 
         return;

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1351,12 +1351,14 @@ void QUnit::CZ(bitLenInt control, bitLenInt target)
 
         tShard.AddPhaseAngles(&cShard, ONE_CMPLX, -ONE_CMPLX);
 
-        if (isInvert || (tShard.targetOfShards.find(&cShard) == tShard.targetOfShards.end())) {
+        ShardToPhaseMap::iterator phaseShard = tShard.targetOfShards.find(&cShard);
+
+        if (isInvert || (phaseShard == tShard.targetOfShards.end())) {
             return;
         }
 
         real1 amplitudeThreshold = doNormalize ? amplitudeFloor : ZERO_R1;
-        PhaseShardPtr buffer = tShard.targetOfShards[&cShard];
+        PhaseShardPtr buffer = phaseShard->second;
 
         if (IS_SAME(buffer->cmplxDiff, buffer->cmplxSame)) {
             ApplyBuffer(buffer, control, target, false);
@@ -1646,7 +1648,6 @@ void QUnit::ApplyControlledSinglePhase(const bitLenInt* cControls, const bitLenI
             } else {
                 Flush0Eigenstate(control);
             }
-            delete[] controls;
             return;
         }
 
@@ -1657,12 +1658,14 @@ void QUnit::ApplyControlledSinglePhase(const bitLenInt* cControls, const bitLenI
 
         tShard.AddPhaseAngles(&cShard, topLeft, bottomRight);
 
-        if (cShard.IsInvertControlOf(&tShard) || (tShard.targetOfShards.find(&cShard) == tShard.targetOfShards.end())) {
+        ShardToPhaseMap::iterator phaseShard = tShard.targetOfShards.find(&cShard);
+
+        if (cShard.IsInvertControlOf(&tShard) || (phaseShard == tShard.targetOfShards.end())) {
             return;
         }
 
         real1 amplitudeThreshold = doNormalize ? amplitudeFloor : ZERO_R1;
-        PhaseShardPtr buffer = tShard.targetOfShards[&cShard];
+        PhaseShardPtr buffer = phaseShard->second;
 
         if (IS_SAME(buffer->cmplxDiff, buffer->cmplxSame)) {
             ApplyBuffer(buffer, control, target, false);
@@ -1746,7 +1749,6 @@ void QUnit::ApplyAntiControlledSinglePhase(const bitLenInt* cControls, const bit
                 Flush0Eigenstate(control);
                 ApplySinglePhase(topLeft, bottomRight, target);
             }
-            delete[] controls;
             return;
         }
 
@@ -1758,13 +1760,14 @@ void QUnit::ApplyAntiControlledSinglePhase(const bitLenInt* cControls, const bit
 
         tShard.AddAntiPhaseAngles(&cShard, bottomRight, topLeft);
 
-        if (cShard.IsInvertAntiControlOf(&tShard) ||
-            (tShard.antiTargetOfShards.find(&cShard) == tShard.antiTargetOfShards.end())) {
+        ShardToPhaseMap::iterator phaseShard = tShard.antiTargetOfShards.find(&cShard);
+
+        if (cShard.IsInvertAntiControlOf(&tShard) || (phaseShard == tShard.antiTargetOfShards.end())) {
             return;
         }
 
         real1 amplitudeThreshold = doNormalize ? amplitudeFloor : ZERO_R1;
-        PhaseShardPtr buffer = tShard.antiTargetOfShards[&cShard];
+        PhaseShardPtr buffer = phaseShard->second;
 
         if (IS_SAME(buffer->cmplxDiff, buffer->cmplxSame)) {
             ApplyBuffer(buffer, control, target, true);

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -3430,7 +3430,7 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
         // If isSame and !isInvert, application of this buffer is already "efficient."
         isSame =
             (buffer->isInvert || !partner->isPlusMinus || !partner->IsInvertTarget()) && IS_SAME(polarDiff, polarSame);
-        isOpposite = IS_OPPOSITE(polarDiff, polarSame);
+        isOpposite = !buffer->isInvert && IS_OPPOSITE(polarDiff, polarSame);
 
         if (isSame || isOpposite) {
             continue;
@@ -3454,7 +3454,7 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
         // If isSame and !isInvert, application of this buffer is already "efficient."
         isSame =
             (buffer->isInvert || !partner->isPlusMinus || !partner->IsInvertTarget()) && IS_SAME(polarDiff, polarSame);
-        isOpposite = IS_OPPOSITE(polarDiff, polarSame);
+        isOpposite = !buffer->isInvert && IS_OPPOSITE(polarDiff, polarSame);
 
         if (isSame || isOpposite) {
             continue;


### PR DESCRIPTION
While we definitely see some significant general improvements from controlled phase/inversion buffers, the number of possible simultaneous buffers is proportional to the power set of qubits in the QInterface. Therefore, when working close to capacity, there is basically _no_ improvement in "big-O" from buffering. However, we can try to stay as low below buffering capacity as possible by flushing "efficient" gate instances at every reasonable opportunity. One such opportunity is when controlled phase buffers have two identical phase factor arguments, which can be applied as a single qubit phase gate instead, leveraged here.

Also, `isOpposite` optimization for inversion buffers was not previously allowed, in `CommuteH()`. I relaxed this restriction, previously, only because the edge case could not occur, at the time. Now, with improved composition of phase gates with inversion gates, the case can happen, and the restriction needs to be restored.