### PR TITLE
Optimizing OCL work group sizing (tested on NVIDIA Turing)

### DIFF
--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -186,7 +186,6 @@ size_t QEngineOCL::FixGroupSize(size_t wic, size_t gs)
         frac = wic / gs;
     }
     return gs;
-
 }
 
 PoolItemPtr QEngineOCL::GetFreePoolItem()
@@ -360,17 +359,18 @@ void QEngineOCL::SetDevice(const int& dID, const bool& forceReInit)
     maxWorkItems = device_context->device.getInfo<CL_DEVICE_MAX_WORK_ITEM_SIZES>()[0];
 
     // constrain to a power of two
-    size_t groupSizePow = 1;
+    size_t groupSizePow = ONE_BCI;
     while (groupSizePow <= nrmGroupSize) {
         groupSizePow <<= ONE_BCI;
     }
     groupSizePow >>= ONE_BCI;
     nrmGroupSize = groupSizePow;
-    size_t procElemPow = 1;
-    while (procElemPow < procElemCount) {
+    size_t procElemPow = ONE_BCI;
+    while (procElemPow <= procElemCount) {
         procElemPow <<= ONE_BCI;
     }
-    nrmGroupCount = procElemPow * nrmGroupSize;
+    procElemPow >>= ONE_BCI;
+    nrmGroupCount = procElemPow * nrmGroupSize * 2U;
     while (nrmGroupCount > maxWorkItems) {
         nrmGroupCount >>= ONE_BCI;
     }


### PR DESCRIPTION
The acquisition of a Turing architecture NVIDIA card has given me reason to revisit OpenCL work group sizing parameters. Honestly, after reading more guidelines for OpenCL (and CUDA) group sizing based on "warp" SIMD, it's obvious I didn't completely understand `QEngineOCL` group sizing for efficient use of more general architectures.

My primary GPU test case has been the (mobile) GTX 1070, for over a year. The 1070 architecture happens to be very "square" for purpose of quantum computer simulation. (By the way, I think it happens to still be an excellent value buy for Qrack, at the moment.) The RTX 2070 Turing architecture is "lopsided," but this branch returns a small gain on it, over my original 1070 benchmarks, with just a tiny tweak in work group sizing.

I'd even guess that this "tweak" could improve power consumption at low-entangled-qubit counts, by sizing groups no smaller than "warp" width, which is probably the floor for efficient group sizes in our and many cases.