### PR TITLE
OpenCL cleanup

### DIFF
--- a/src/common/qheader32.cl
+++ b/src/common/qheader32.cl
@@ -20,7 +20,7 @@
 #define SineShift M_PI_2_F
 #define PI_R1 M_PI_F
 #define min_norm 1e-13f
-#define bitCapInt uint
-#define bitCapInt2 uint2
-#define bitCapInt4 uint4
+#define bitCapIntOcl uint
+#define bitCapIntOcl2 uint2
+#define bitCapIntOcl4 uint4
 #define bitLenInt unsigned char

--- a/src/common/qheader_double.cl
+++ b/src/common/qheader_double.cl
@@ -21,7 +21,7 @@
 #define SineShift M_PI_2
 #define PI_R1 M_PI
 #define min_norm 1e-30
-#define bitCapInt ulong
-#define bitCapInt2 ulong2
-#define bitCapInt4 ulong4
+#define bitCapIntOcl ulong
+#define bitCapIntOcl2 ulong2
+#define bitCapIntOcl4 ulong4
 #define bitLenInt unsigned char

--- a/src/common/qheader_float.cl
+++ b/src/common/qheader_float.cl
@@ -20,7 +20,7 @@
 #define SineShift M_PI_2_F
 #define PI_R1 M_PI_F
 #define min_norm 1e-14f
-#define bitCapInt ulong
-#define bitCapInt2 ulong2
-#define bitCapInt4 ulong4
+#define bitCapIntOcl ulong
+#define bitCapIntOcl2 ulong2
+#define bitCapIntOcl4 ulong4
 #define bitLenInt unsigned char

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -3446,7 +3446,8 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_clone")
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_decompose")
 {
-    QInterfacePtr qftReg2 = CreateQuantumInterface(testEngineType, testSubEngineType, 4, 0, rng);
+    QInterfacePtr qftReg2 = CreateQuantumInterface(testEngineType, testSubEngineType, 4, 0, rng, ONE_CMPLX,
+        enable_normalization, true, false, device_id, !disable_hardware_rng, sparse);
 
     qftReg->SetPermutation(0x2b);
     qftReg->Decompose(0, 4, qftReg2);
@@ -3457,8 +3458,8 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_decompose")
     qftReg->Compose(qftReg2);
 
     // Try across device/heap allocation case:
-    qftReg2 = CreateQuantumInterface(
-        testEngineType, testSubEngineType, 4, 0, rng, complex(ONE_R1, ZERO_R1), false, true, true);
+    qftReg2 = CreateQuantumInterface(testEngineType, testSubEngineType, 4, 0, rng, complex(ONE_R1, ZERO_R1),
+        enable_normalization, true, true, device_id, !disable_hardware_rng, sparse);
 
     qftReg->SetPermutation(0x2b);
     qftReg->Decompose(0, 4, qftReg2);


### PR DESCRIPTION
The alternative CUDA implementation has helped me identify some unused variables in the OpenCL kernels, and I have run `clang-format` on the file. On my new development machine, it seems like a bug has become apparent in OpenCL `Decompose`, and I'll add a fix for that, here, as well.