### PR TITLE
Removing old OCL kludge

### DIFF
--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -370,7 +370,7 @@ void QEngineOCL::SetDevice(const int& dID, const bool& forceReInit)
         procElemPow <<= ONE_BCI;
     }
     procElemPow >>= ONE_BCI;
-    nrmGroupCount = procElemPow * nrmGroupSize * 2U;
+    nrmGroupCount = procElemPow * nrmGroupSize * 4U;
     while (nrmGroupCount > maxWorkItems) {
         nrmGroupCount >>= ONE_BCI;
     }

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -456,9 +456,6 @@ void QEngineOCL::SetDevice(const int& dID, const bool& forceReInit)
     if ((!didInit) || !isSameContext || (nrmGroupCount != oldNrmGroupCount)) {
         nrmBuffer =
             std::make_shared<cl::Buffer>(context, CL_MEM_USE_HOST_PTR | CL_MEM_READ_WRITE, nrmVecAlignSize, nrmArray);
-        EventVecPtr waitVec = ResetWaitEvents();
-        // GPUs can't always tolerate uninitialized host memory, even if they're not reading from it
-        DISPATCH_FILL(waitVec, *nrmBuffer, sizeof(real1) * nrmGroupCount, ZERO_R1);
     }
 }
 


### PR DESCRIPTION
It never should have been necessary to clear `nrmBuffer` in `QEngineOCL` before using it, but it seemed to be, at one point. I suspect that some instance of summation of results in that buffer iterated over the entire buffer instead of the expected working portion of it for its particular kernel. I checked all instances where the buffer is summed over, and the bounds all seem to be correct.

In any case, there no longer seems to be any problem with removing these lines, which were likely always a kludge.