### PR TITLE
Implicit OpenCL buffer migration; default device env. var.

### DIFF
--- a/src/common/oclengine.cpp
+++ b/src/common/oclengine.cpp
@@ -261,6 +261,9 @@ void OCLEngine::InitOCL(bool buildFromSource, bool saveBinaries, std::string hom
 
     // prefer the last device because that's usually a GPU or accelerator; device[0] is usually the CPU
     int dev = deviceCount - 1;
+    if (getenv("QRACK_OCL_DEFAULT_DEVICE")) {
+        dev = std::stoi(std::string(getenv("QRACK_OCL_DEFAULT_DEVICE")));
+    }
 
     // create the programs that we want to execute on the devices
     cl::Program::Sources sources;

--- a/src/common/oclengine.cpp
+++ b/src/common/oclengine.cpp
@@ -263,6 +263,12 @@ void OCLEngine::InitOCL(bool buildFromSource, bool saveBinaries, std::string hom
     int dev = deviceCount - 1;
     if (getenv("QRACK_OCL_DEFAULT_DEVICE")) {
         dev = std::stoi(std::string(getenv("QRACK_OCL_DEFAULT_DEVICE")));
+        if ((dev < 0) || (dev > (deviceCount - 1))) {
+            std::cout << "WARNING: Invalid QRACK_OCL_DEFAULT_DEVICE selection. (Falling back to highest index device "
+                         "as default.)"
+                      << std::endl;
+            dev = deviceCount - 1;
+        }
     }
 
     // create the programs that we want to execute on the devices

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -374,15 +374,6 @@ void QEngineOCL::SetDevice(const int& dID, const bool& forceReInit)
         throw "Error: State vector exceeds device maximum OpenCL allocation";
     } else if (useHostRam || ((OclMemDenom * stateVecSize) > maxMem)) {
         usingHostRam = true;
-        if (didInit && !stateVec && !nStateVec) {
-            nStateVec = AllocStateVec(maxQPowerOcl, true);
-            BufferPtr nStateBuffer = MakeStateVecBuffer(nStateVec);
-            oldQueue.enqueueCopyBuffer(*stateBuffer, *nStateBuffer, 0, 0, sizeof(complex) * maxQPowerOcl);
-            oldQueue.finish();
-            ResetStateVec(nStateVec);
-            ResetStateBuffer(nStateBuffer);
-            nStateVec = NULL;
-        }
     } else {
         usingHostRam = false;
         if (didInit && stateVec && !nStateVec) {


### PR DESCRIPTION
(You learn something new every day:) Apparently, buffer migration is implicit in OpenCL, when a memory object is used in a different queue/device context. There are APIs which can explicitly handle the migration ahead of time, so that the cost doesn't hit at the point one tries to write to the buffer, but it doesn't seem like we need them. While this might be "6 and half a dozen" compared to our manual handling for platform switching, the OpenCL API is probably better at this under-the-hood than we are, and we might as well save the code complexity.