### PR TITLE
Decompose optimize

### DIFF
--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -185,12 +185,14 @@ public:
 
     void SetBellTarget(QEngineShardPtr target)
     {
+        isEmulated = true;
         bellTarget = target;
         target->bellControl = this;
     }
 
     void SetBellControl(QEngineShardPtr control)
     {
+        isEmulated = true;
         bellControl = control;
         control->bellTarget = this;
     }

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -254,10 +254,8 @@ public:
         std::swap(bellControl, bellTarget);
         std::swap(partner->bellControl, partner->bellTarget);
 
-        // TODO: We assume only separable eigenstates, here,
-        // but we might wish to generalize.
-        if ((norm(amp0) < (ONE_R1 / 2)) && (norm(partner->amp0) < (ONE_R1 / 2))) {
-            amp1 *= -1;
+        if (norm(amp0) < (ONE_R1 / 2)) {
+            partner->amp1 *= -1;
         }
     }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1196,7 +1196,7 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
                 std::swap(cShard.amp0, cShard.amp1);
             }
             return;
-        } else if (isForward && cShard.isPlusMinus && !tShard.isPlusMinus) {
+        } else if (isReverse && !cShard.isPlusMinus && tShard.isPlusMinus) {
             if (!SHARD_STATE(cShard)) {
                 std::swap(tShard.amp0, tShard.amp1);
             }

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -732,13 +732,17 @@ void QUnit::Swap(bitLenInt qubit1, bitLenInt qubit2)
         return;
     }
 
+    QEngineShard& shard1 = shards[qubit1];
+    QEngineShard& shard2 = shards[qubit2];
+
+    if ((shard1.bellTarget == &shard2) || (shard2.bellTarget == &shard1)) {
+        return;
+    }
+
     RevertBellBasis(qubit1);
     RevertBellBasis(qubit2);
     RevertBasis2Qb(qubit1, ONLY_INVERT);
     RevertBasis2Qb(qubit2, ONLY_INVERT);
-
-    QEngineShard& shard1 = shards[qubit1];
-    QEngineShard& shard2 = shards[qubit2];
 
     if (UNSAFE_CACHED_CLASSICAL(shard1) && UNSAFE_CACHED_CLASSICAL(shard2)) {
         // We can avoid dirtying the cache and entangling, since the bits are classical.
@@ -767,13 +771,18 @@ void QUnit::ISwap(bitLenInt qubit1, bitLenInt qubit2)
         return;
     }
 
+    QEngineShard& shard1 = shards[qubit1];
+    QEngineShard& shard2 = shards[qubit2];
+
+    // TODO: Missing phase factor here is nonglobal/nonarbitrary, unless we're limited to eigenstates.
+    if (!randGlobalPhase && ((shard1.bellTarget == &shard2) || (shard2.bellTarget == &shard1))) {
+        return;
+    }
+
     RevertBellBasis(qubit1);
     RevertBellBasis(qubit2);
     RevertBasis2Qb(qubit1, ONLY_INVERT);
     RevertBasis2Qb(qubit2, ONLY_INVERT);
-
-    QEngineShard& shard1 = shards[qubit1];
-    QEngineShard& shard2 = shards[qubit2];
 
     if (UNSAFE_CACHED_CLASSICAL(shard1) && UNSAFE_CACHED_CLASSICAL(shard2)) {
         // We can avoid dirtying the cache and entangling, since the bits are classical.
@@ -804,13 +813,18 @@ void QUnit::SqrtSwap(bitLenInt qubit1, bitLenInt qubit2)
         return;
     }
 
+    QEngineShard& shard1 = shards[qubit1];
+    QEngineShard& shard2 = shards[qubit2];
+
+    // TODO: Missing phase factor here is nonglobal/nonarbitrary, unless we're limited to eigenstates.
+    if (!randGlobalPhase && ((shard1.bellTarget == &shard2) || (shard2.bellTarget == &shard1))) {
+        return;
+    }
+
     RevertBellBasis(qubit1);
     RevertBellBasis(qubit2);
     RevertBasis2Qb(qubit1, ONLY_INVERT);
     RevertBasis2Qb(qubit2, ONLY_INVERT);
-
-    QEngineShard& shard1 = shards[qubit1];
-    QEngineShard& shard2 = shards[qubit2];
 
     if (UNSAFE_CACHED_CLASSICAL(shard1) && UNSAFE_CACHED_CLASSICAL(shard2) &&
         (SHARD_STATE(shard1) == SHARD_STATE(shard2))) {
@@ -833,13 +847,18 @@ void QUnit::ISqrtSwap(bitLenInt qubit1, bitLenInt qubit2)
         return;
     }
 
+    QEngineShard& shard1 = shards[qubit1];
+    QEngineShard& shard2 = shards[qubit2];
+
+    // TODO: Missing phase factor here is nonglobal/nonarbitrary, unless we're limited to eigenstates.
+    if (!randGlobalPhase && ((shard1.bellTarget == &shard2) || (shard2.bellTarget == &shard1))) {
+        return;
+    }
+
     RevertBellBasis(qubit1);
     RevertBellBasis(qubit2);
     RevertBasis2Qb(qubit1, ONLY_INVERT);
     RevertBasis2Qb(qubit2, ONLY_INVERT);
-
-    QEngineShard& shard1 = shards[qubit1];
-    QEngineShard& shard2 = shards[qubit2];
 
     if (UNSAFE_CACHED_CLASSICAL(shard1) && UNSAFE_CACHED_CLASSICAL(shard2) &&
         (SHARD_STATE(shard1) == SHARD_STATE(shard2))) {
@@ -872,13 +891,18 @@ void QUnit::FSim(real1 theta, real1 phi, bitLenInt qubit1, bitLenInt qubit2)
         return;
     }
 
+    QEngineShard& shard1 = shards[qubit1];
+    QEngineShard& shard2 = shards[qubit2];
+
+    // TODO: Missing phase factor here is nonglobal/nonarbitrary, unless we're limited to eigenstates.
+    if (!randGlobalPhase && ((shard1.bellTarget == &shard2) || (shard2.bellTarget == &shard1))) {
+        return;
+    }
+
     RevertPlusMinusBasis(qubit1);
     RevertPlusMinusBasis(qubit2);
     RevertBasis2Qb(qubit1, ONLY_INVERT);
     RevertBasis2Qb(qubit2, ONLY_INVERT);
-
-    QEngineShard& shard1 = shards[qubit1];
-    QEngineShard& shard2 = shards[qubit2];
 
     if (UNSAFE_CACHED_CLASSICAL(shard1) && UNSAFE_CACHED_CLASSICAL(shard2) &&
         (SHARD_STATE(shard1) == SHARD_STATE(shard2))) {
@@ -1029,9 +1053,9 @@ void QUnit::X(bitLenInt target)
 
 void QUnit::Z(bitLenInt target)
 {
-    RevertBellBasis(target);
-
     QEngineShard& shard = shards[target];
+
+    RevertBellBasis(target);
 
     if (shard.IsInvertTarget()) {
         RevertPlusMinusBasis(target);

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -3502,7 +3502,11 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
     if (anyInvert && ((shard.targetOfShards.size() + shard.antiTargetOfShards.size()) > 1U)) {
         control = FindShardIndex(*singlePartner);
         ApplyBuffer(singleBuffer, control, bitIndex, invertAnti);
-        shard.RemovePhaseControl(singlePartner);
+        if (invertAnti) {
+            shard.RemovePhaseAntiControl(singlePartner);
+        } else {
+            shard.RemovePhaseControl(singlePartner);
+        }
     }
 
     shard.CommuteH();

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1183,12 +1183,13 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
     }
 
     if (!freezeBasis) {
-        if (cShard.bellTarget == &tShard) {
-            if (!cShard.isPlusMinus && !tShard.isPlusMinus) {
-                cShard.ClearBellBasis();
-                cShard.isPlusMinus = true;
-                return;
-            }
+        bool isForward = (cShard.bellTarget == &tShard);
+        bool isReverse = (tShard.bellTarget == &cShard);
+        if ((isForward && !cShard.isPlusMinus && !tShard.isPlusMinus) ||
+            (isReverse && cShard.isPlusMinus && tShard.isPlusMinus)) {
+            cShard.ClearBellBasis();
+            cShard.isPlusMinus = true;
+            return;
         }
 
         RevertBellBasis(control);

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1038,9 +1038,22 @@ void QUnit::ZBase(const bitLenInt& target)
 
 void QUnit::X(bitLenInt target)
 {
-    RevertBellBasis(target);
-
     QEngineShard& shard = shards[target];
+
+    if (shard.IsBellBasis()) {
+        QEngineShardPtr partner;
+
+        if (shard.bellControl) {
+            partner = shard.bellControl;
+
+            if (!shard.isPlusMinus && !partner->isPlusMinus) {
+                XBase(target);
+                return;
+            }
+        }
+
+        RevertBellBasis(target);
+    }
 
     shard.FlipPhaseAnti();
 
@@ -1055,7 +1068,20 @@ void QUnit::Z(bitLenInt target)
 {
     QEngineShard& shard = shards[target];
 
-    RevertBellBasis(target);
+    if (shard.IsBellBasis()) {
+        QEngineShardPtr partner;
+
+        if (shard.bellControl) {
+            partner = shard.bellControl;
+
+            if (shard.isPlusMinus || partner->isPlusMinus) {
+                XBase(target);
+                return;
+            }
+        }
+
+        RevertBellBasis(target);
+    }
 
     if (shard.IsInvertTarget()) {
         RevertPlusMinusBasis(target);

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -3446,7 +3446,7 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
         isOpposite = IS_OPPOSITE(polarDiff, polarSame);
 
         if (isOpposite) {
-            if (!anyInvert) {
+            if (!anyInvert || !buffer->isInvert) {
                 if (buffer->isInvert) {
                     singleBuffer = buffer;
                     singlePartner = partner;
@@ -3484,7 +3484,7 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
 
         if (isOpposite) {
             if (!anyInvert) {
-                if (buffer->isInvert) {
+                if (!anyInvert || !buffer->isInvert) {
                     singleBuffer = buffer;
                     singlePartner = partner;
                     invertAnti = true;

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1191,8 +1191,13 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
             cShard.isPlusMinus = true;
             return;
         } else if (isForward && !cShard.isPlusMinus && tShard.isPlusMinus) {
-            if (!SHARD_STATE(cShard)) {
+            if (!SHARD_STATE(tShard)) {
                 std::swap(cShard.amp0, cShard.amp1);
+            }
+            return;
+        } else if (isForward && cShard.isPlusMinus && !tShard.isPlusMinus) {
+            if (!SHARD_STATE(cShard)) {
+                std::swap(tShard.amp0, tShard.amp1);
             }
             return;
         }

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1350,7 +1350,7 @@ void QUnit::CZ(bitLenInt control, bitLenInt target)
 
         tShard.AddPhaseAngles(&cShard, ONE_CMPLX, -ONE_CMPLX);
 
-        if (isInvert || (cShard.unit->GetQubitCount() > 1U)) {
+        if (isInvert) {
             return;
         }
 
@@ -1663,7 +1663,7 @@ void QUnit::ApplyControlledSinglePhase(const bitLenInt* cControls, const bitLenI
 
         shards[target].AddPhaseAngles(&cShard, topLeft, bottomRight);
 
-        if ((cShard.unit->GetQubitCount() > 1U) || cShard.IsInvertControlOf(&(shards[target]))) {
+        if (cShard.IsInvertControlOf(&(shards[target]))) {
             return;
         }
 
@@ -1770,7 +1770,7 @@ void QUnit::ApplyAntiControlledSinglePhase(const bitLenInt* cControls, const bit
 
         shards[target].AddAntiPhaseAngles(&cShard, bottomRight, topLeft);
 
-        if ((cShard.unit->GetQubitCount() > 1U) || cShard.IsInvertAntiControlOf(&(shards[target]))) {
+        if (cShard.IsInvertAntiControlOf(&(shards[target]))) {
             return;
         }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1190,6 +1190,11 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
             cShard.ClearBellBasis();
             cShard.isPlusMinus = true;
             return;
+        } else if (isForward && !cShard.isPlusMinus && tShard.isPlusMinus) {
+            if (!SHARD_STATE(cShard)) {
+                std::swap(cShard.amp0, cShard.amp1);
+            }
+            return;
         }
 
         RevertBellBasis(control);

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -735,6 +735,8 @@ void QUnit::Swap(bitLenInt qubit1, bitLenInt qubit2)
         return;
     }
 
+    RevertBellBasis(qubit1);
+    RevertBellBasis(qubit2);
     RevertBasis2Qb(qubit1, ONLY_INVERT);
     RevertBasis2Qb(qubit2, ONLY_INVERT);
 
@@ -768,6 +770,8 @@ void QUnit::ISwap(bitLenInt qubit1, bitLenInt qubit2)
         return;
     }
 
+    RevertBellBasis(qubit1);
+    RevertBellBasis(qubit2);
     RevertBasis2Qb(qubit1, ONLY_INVERT);
     RevertBasis2Qb(qubit2, ONLY_INVERT);
 
@@ -803,6 +807,8 @@ void QUnit::SqrtSwap(bitLenInt qubit1, bitLenInt qubit2)
         return;
     }
 
+    RevertBellBasis(qubit1);
+    RevertBellBasis(qubit2);
     RevertBasis2Qb(qubit1, ONLY_INVERT);
     RevertBasis2Qb(qubit2, ONLY_INVERT);
 
@@ -830,6 +836,8 @@ void QUnit::ISqrtSwap(bitLenInt qubit1, bitLenInt qubit2)
         return;
     }
 
+    RevertBellBasis(qubit1);
+    RevertBellBasis(qubit2);
     RevertBasis2Qb(qubit1, ONLY_INVERT);
     RevertBasis2Qb(qubit2, ONLY_INVERT);
 
@@ -1397,14 +1405,6 @@ void QUnit::CZ(bitLenInt control, bitLenInt target)
     }
 
     if (!freezeBasis) {
-        if ((CACHED_PLUS_MINUS(cShard) && CACHED_PLUS_MINUS(tShard)) || (cShard.bellTarget == &tShard) ||
-            (cShard.bellControl == &tShard)) {
-            H(target);
-            CNOT(control, target);
-            H(target);
-            return;
-        }
-
         RevertPlusMinusBasis(control);
         RevertBellBasis(target);
 
@@ -2062,6 +2062,15 @@ void QUnit::ApplyEitherControlled(const bitLenInt* controls, const bitLenInt& co
         }
     }
 
+    if (!inCurrentBasis) {
+        for (i = 0; i < controlVec.size(); i++) {
+            RevertBasis2Qb(controlVec[i]);
+        }
+        for (i = 0; i < targets.size(); i++) {
+            RevertBellBasis(targets[i]);
+        }
+    }
+
     for (i = 0; i < targets.size(); i++) {
         RevertBasis2Qb(targets[i]);
     }
@@ -2072,16 +2081,6 @@ void QUnit::ApplyEitherControlled(const bitLenInt* controls, const bitLenInt& co
         fn();
 
         return;
-    }
-
-    if (!inCurrentBasis) {
-        for (i = 0; i < controlVec.size(); i++) {
-            RevertBasis2Qb(controlVec[i]);
-        }
-
-        for (i = 0; i < targets.size(); i++) {
-            RevertBellBasis(targets[i]);
-        }
     }
 
     // TODO: If controls that survive the "first order" check above start out entangled,

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1142,18 +1142,6 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
 
     QEngineShard& cShard = shards[control];
 
-    if (CACHED_PLUS_MINUS(cShard) && CACHED_CLASSICAL(tShard)) {
-        cShard.isPlusMinus = false;
-        cShard.SetBellTarget(&tShard);
-        return;
-    }
-
-    if ((cShard.bellTarget == &tShard) || (cShard.bellControl == &tShard)) {
-        cShard.isPlusMinus = true;
-        cShard.ClearBellBasis();
-        return;
-    }
-
     if (!cShard.IsInvertTarget() && UNSAFE_CACHED_CLASSICAL(cShard)) {
         if (IS_NORM_ZERO(cShard.amp1)) {
             Flush0Eigenstate(control);
@@ -1167,6 +1155,18 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
     }
 
     if (!freezeBasis) {
+        if (CACHED_PLUS_MINUS(cShard) && CACHED_CLASSICAL(tShard)) {
+            cShard.isPlusMinus = false;
+            cShard.SetBellTarget(&tShard);
+            return;
+        }
+
+        if ((cShard.bellTarget == &tShard) || (cShard.bellControl == &tShard)) {
+            cShard.isPlusMinus = true;
+            cShard.ClearBellBasis();
+            return;
+        }
+
         RevertPlusMinusBasis(control);
 
         RevertBasis2Qb(control, ONLY_INVERT, ONLY_TARGETS);
@@ -1364,15 +1364,15 @@ void QUnit::CZ(bitLenInt control, bitLenInt target)
         return;
     }
 
-    if ((CACHED_PLUS_MINUS(cShard) && CACHED_PLUS_MINUS(tShard)) || (cShard.bellTarget == &tShard) ||
-        (cShard.bellControl == &tShard)) {
-        H(target);
-        CNOT(control, target);
-        H(target);
-        return;
-    }
-
     if (!freezeBasis) {
+        if ((CACHED_PLUS_MINUS(cShard) && CACHED_PLUS_MINUS(tShard)) || (cShard.bellTarget == &tShard) ||
+            (cShard.bellControl == &tShard)) {
+            H(target);
+            CNOT(control, target);
+            H(target);
+            return;
+        }
+
         RevertPlusMinusBasis(control);
 
         RevertBasis2Qb(control, ONLY_INVERT, ONLY_TARGETS, CTRL_AND_ANTI);

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1350,9 +1350,13 @@ void QUnit::CZ(bitLenInt control, bitLenInt target)
 
         tShard.AddPhaseAngles(&cShard, ONE_CMPLX, -ONE_CMPLX);
 
+        if (isInvert || (cShard.unit->GetQubitCount() > 1U)) {
+            return;
+        }
+
         ShardToPhaseMap::iterator phaseShard = tShard.targetOfShards.find(&cShard);
 
-        if (isInvert || (phaseShard == tShard.targetOfShards.end())) {
+        if (phaseShard == tShard.targetOfShards.end()) {
             return;
         }
 
@@ -1639,6 +1643,7 @@ void QUnit::ApplyControlledSinglePhase(const bitLenInt* cControls, const bitLenI
     if (!freezeBasis && (controlLen == 1U)) {
         bitLenInt control = controls[0];
         delete[] controls;
+        // Not safe to use tShard from above
         QEngineShard& cShard = shards[control];
         if (!cShard.IsInvertTarget() && UNSAFE_CACHED_CLASSICAL(cShard)) {
             if (SHARD_STATE(cShard)) {
@@ -1656,12 +1661,15 @@ void QUnit::ApplyControlledSinglePhase(const bitLenInt* cControls, const bitLenI
         RevertBasis2Qb(control, ONLY_INVERT, ONLY_TARGETS, CTRL_AND_ANTI);
         RevertBasis2Qb(target, ONLY_INVERT, IS_ONE_CMPLX(topLeft) ? ONLY_TARGETS : CONTROLS_AND_TARGETS, CTRL_AND_ANTI);
 
-        shards[target].AddPhaseAngles(&(shards[control]), topLeft, bottomRight);
+        shards[target].AddPhaseAngles(&cShard, topLeft, bottomRight);
 
-        ShardToPhaseMap::iterator phaseShard = shards[target].targetOfShards.find(&(shards[control]));
+        if ((cShard.unit->GetQubitCount() > 1U) || cShard.IsInvertControlOf(&(shards[target]))) {
+            return;
+        }
 
-        if (shards[control].IsInvertControlOf(&(shards[target])) ||
-            (phaseShard == shards[target].targetOfShards.end())) {
+        ShardToPhaseMap::iterator phaseShard = shards[target].targetOfShards.find(&cShard);
+
+        if (phaseShard == shards[target].targetOfShards.end()) {
             return;
         }
 
@@ -1670,7 +1678,7 @@ void QUnit::ApplyControlledSinglePhase(const bitLenInt* cControls, const bitLenI
 
         if (IS_SAME(buffer->cmplxDiff, buffer->cmplxSame)) {
             ApplyBuffer(buffer, control, target, false);
-            shards[target].RemovePhaseControl(&(shards[control]));
+            shards[target].RemovePhaseControl(&cShard);
         }
 
         return;
@@ -1742,6 +1750,7 @@ void QUnit::ApplyAntiControlledSinglePhase(const bitLenInt* cControls, const bit
     if (!freezeBasis && (controlLen == 1U)) {
         bitLenInt control = controls[0];
         delete[] controls;
+        // Not safe to use tShard from above
         QEngineShard& cShard = shards[control];
         if (!cShard.IsInvertTarget() && UNSAFE_CACHED_CLASSICAL(cShard)) {
             if (SHARD_STATE(cShard)) {
@@ -1759,12 +1768,15 @@ void QUnit::ApplyAntiControlledSinglePhase(const bitLenInt* cControls, const bit
         RevertBasis2Qb(
             target, ONLY_INVERT, IS_ONE_CMPLX(bottomRight) ? ONLY_TARGETS : CONTROLS_AND_TARGETS, CTRL_AND_ANTI);
 
-        shards[target].AddAntiPhaseAngles(&(shards[control]), bottomRight, topLeft);
+        shards[target].AddAntiPhaseAngles(&cShard, bottomRight, topLeft);
 
-        ShardToPhaseMap::iterator phaseShard = shards[target].targetOfShards.find(&(shards[control]));
+        if ((cShard.unit->GetQubitCount() > 1U) || cShard.IsInvertAntiControlOf(&(shards[target]))) {
+            return;
+        }
 
-        if (shards[control].IsInvertAntiControlOf(&(shards[target])) ||
-            (phaseShard == shards[target].targetOfShards.end())) {
+        ShardToPhaseMap::iterator phaseShard = shards[target].antiTargetOfShards.find(&cShard);
+
+        if (phaseShard == shards[target].targetOfShards.end()) {
             return;
         }
 
@@ -1773,7 +1785,7 @@ void QUnit::ApplyAntiControlledSinglePhase(const bitLenInt* cControls, const bit
 
         if (IS_SAME(buffer->cmplxDiff, buffer->cmplxSame)) {
             ApplyBuffer(buffer, control, target, true);
-            shards[target].RemovePhaseAntiControl(&(shards[control]));
+            shards[target].RemovePhaseAntiControl(&cShard);
         }
 
         return;
@@ -3365,7 +3377,7 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
     real1 amplitudeThreshold = doNormalize ? amplitudeFloor : ZERO_R1;
 
     complex polarDiff, polarSame;
-    ShardToPhaseMap::iterator phaseShard, oppositeShard;
+    ShardToPhaseMap::iterator phaseShard;
     QEngineShardPtr partner;
     PhaseShardPtr buffer;
     bitLenInt control;

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1152,6 +1152,19 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
     }
 
     if (!freezeBasis) {
+        if ((cShard.bellTarget == &tShard) || (tShard.bellTarget == &cShard)) {
+            if (cShard.isPlusMinus || tShard.isPlusMinus) {
+                if (!SHARD_STATE(tShard)) {
+                    std::swap(cShard.amp0, cShard.amp1);
+                }
+                return;
+            }
+
+            cShard.isPlusMinus = true;
+            cShard.ClearBellBasis();
+            return;
+        }
+
         RevertBellBasis(control);
         RevertBellBasis(target);
 
@@ -1360,6 +1373,13 @@ void QUnit::CZ(bitLenInt control, bitLenInt target)
     }
 
     if (!freezeBasis) {
+        if ((cShard.bellTarget == &tShard) || (tShard.bellTarget == &cShard)) {
+            H(target);
+            CNOT(control, target);
+            H(target);
+            return;
+        }
+
         RevertPlusMinusBasis(control);
         RevertBellBasis(target);
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1660,7 +1660,8 @@ void QUnit::ApplyControlledSinglePhase(const bitLenInt* cControls, const bitLenI
 
         ShardToPhaseMap::iterator phaseShard = shards[target].targetOfShards.find(&(shards[control]));
 
-        if (cShard.IsInvertControlOf(&tShard) || (phaseShard == shards[target].targetOfShards.end())) {
+        if (shards[control].IsInvertControlOf(&(shards[target])) ||
+            (phaseShard == shards[target].targetOfShards.end())) {
             return;
         }
 
@@ -1669,7 +1670,7 @@ void QUnit::ApplyControlledSinglePhase(const bitLenInt* cControls, const bitLenI
 
         if (IS_SAME(buffer->cmplxDiff, buffer->cmplxSame)) {
             ApplyBuffer(buffer, control, target, false);
-            tShard.RemovePhaseControl(&(shards[control]));
+            shards[target].RemovePhaseControl(&(shards[control]));
         }
 
         return;
@@ -1762,7 +1763,8 @@ void QUnit::ApplyAntiControlledSinglePhase(const bitLenInt* cControls, const bit
 
         ShardToPhaseMap::iterator phaseShard = shards[target].targetOfShards.find(&(shards[control]));
 
-        if (cShard.IsInvertControlOf(&tShard) || (phaseShard == shards[target].targetOfShards.end())) {
+        if (shards[control].IsInvertAntiControlOf(&(shards[target])) ||
+            (phaseShard == shards[target].targetOfShards.end())) {
             return;
         }
 
@@ -1771,7 +1773,7 @@ void QUnit::ApplyAntiControlledSinglePhase(const bitLenInt* cControls, const bit
 
         if (IS_SAME(buffer->cmplxDiff, buffer->cmplxSame)) {
             ApplyBuffer(buffer, control, target, true);
-            tShard.RemovePhaseAntiControl(&(shards[control]));
+            shards[target].RemovePhaseAntiControl(&(shards[control]));
         }
 
         return;

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -3483,8 +3483,8 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
         isOpposite = IS_OPPOSITE(polarDiff, polarSame);
 
         if (isOpposite) {
-            if (!anyInvert) {
-                if (!anyInvert || !buffer->isInvert) {
+            if (!anyInvert || !buffer->isInvert) {
+                if (buffer->isInvert) {
                     singleBuffer = buffer;
                     singlePartner = partner;
                     invertAnti = true;

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -3420,10 +3420,7 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
         return;
     }
 
-    PhaseShardPtr singleBuffer;
-    QEngineShardPtr singlePartner;
-
-    bool isSame, isOpposite, invertAnti, anyInvert = false;
+    bool isSame, isOpposite;
 
     ShardToPhaseMap targetOfShards = shard.targetOfShards;
 
@@ -3438,23 +3435,10 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
         // If isSame and !isInvert, application of this buffer is already "efficient."
         isSame =
             (buffer->isInvert || !partner->isPlusMinus || !partner->IsInvertTarget()) && IS_SAME(polarDiff, polarSame);
+        isOpposite = !buffer->isInvert && IS_OPPOSITE(polarDiff, polarSame);
 
-        if (isSame) {
+        if (isSame || isOpposite) {
             continue;
-        }
-
-        isOpposite = IS_OPPOSITE(polarDiff, polarSame);
-
-        if (isOpposite) {
-            if (!anyInvert || !buffer->isInvert) {
-                if (buffer->isInvert) {
-                    singleBuffer = buffer;
-                    singlePartner = partner;
-                    invertAnti = false;
-                    anyInvert = true;
-                }
-                continue;
-            }
         }
 
         control = FindShardIndex(*partner);
@@ -3475,38 +3459,15 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
         // If isSame and !isInvert, application of this buffer is already "efficient."
         isSame =
             (buffer->isInvert || !partner->isPlusMinus || !partner->IsInvertTarget()) && IS_SAME(polarDiff, polarSame);
+        isOpposite = !buffer->isInvert && IS_OPPOSITE(polarDiff, polarSame);
 
-        if (isSame) {
+        if (isSame || isOpposite) {
             continue;
-        }
-
-        isOpposite = IS_OPPOSITE(polarDiff, polarSame);
-
-        if (isOpposite) {
-            if (!anyInvert || !buffer->isInvert) {
-                if (buffer->isInvert) {
-                    singleBuffer = buffer;
-                    singlePartner = partner;
-                    invertAnti = true;
-                    anyInvert = true;
-                }
-                continue;
-            }
         }
 
         control = FindShardIndex(*partner);
         ApplyBuffer(buffer, control, bitIndex, true);
         shard.RemovePhaseAntiControl(partner);
-    }
-
-    if (anyInvert && ((shard.targetOfShards.size() + shard.antiTargetOfShards.size()) > 1U)) {
-        control = FindShardIndex(*singlePartner);
-        ApplyBuffer(singleBuffer, control, bitIndex, invertAnti);
-        if (invertAnti) {
-            shard.RemovePhaseAntiControl(singlePartner);
-        } else {
-            shard.RemovePhaseControl(singlePartner);
-        }
     }
 
     shard.CommuteH();

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1014,32 +1014,11 @@ void QUnit::ZBase(const bitLenInt& target)
 
 void QUnit::X(bitLenInt target)
 {
+    RevertBellBasis(target);
+
     QEngineShard& shard = shards[target];
 
     shard.FlipPhaseAnti();
-
-    if (shard.IsBellBasis()) {
-        QEngineShardPtr partner;
-        bitLenInt bellTarget, bellControl;
-
-        if (shard.bellTarget) {
-            partner = shard.bellTarget;
-            bellControl = target;
-            bellTarget = FindShardIndex(*partner);
-        } else {
-            partner = shard.bellControl;
-            bellTarget = target;
-            bellControl = FindShardIndex(*partner);
-        }
-
-        if (shard.isPlusMinus || partner->isPlusMinus) {
-            XBase(bellControl);
-        } else {
-            XBase(bellTarget);
-        }
-
-        return;
-    }
 
     if (!shard.isPlusMinus) {
         XBase(target);
@@ -1050,6 +1029,8 @@ void QUnit::X(bitLenInt target)
 
 void QUnit::Z(bitLenInt target)
 {
+    RevertBellBasis(target);
+
     QEngineShard& shard = shards[target];
 
     if (shard.IsInvertTarget()) {
@@ -1060,29 +1041,6 @@ void QUnit::Z(bitLenInt target)
             Flush0Eigenstate(target);
             return;
         }
-    }
-
-    if (shard.IsBellBasis()) {
-        QEngineShardPtr partner;
-        bitLenInt bellTarget, bellControl;
-
-        if (shard.bellTarget) {
-            partner = shard.bellTarget;
-            bellControl = target;
-            bellTarget = FindShardIndex(*partner);
-        } else {
-            partner = shard.bellControl;
-            bellTarget = target;
-            bellControl = FindShardIndex(*partner);
-        }
-
-        if (shard.isPlusMinus || partner->isPlusMinus) {
-            XBase(bellTarget);
-        } else {
-            XBase(bellControl);
-        }
-
-        return;
     }
 
     if (!shard.isPlusMinus) {

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1189,13 +1189,6 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
     }
 
     if (!freezeBasis) {
-        /*if (!cShard.isPlusMinus && !tShard.isPlusMinus &&
-            ((cShard.bellTarget == &tShard) || (cShard.bellControl == &tShard))) {
-            cShard.isPlusMinus = true;
-            cShard.ClearBellBasis();
-            return;
-        }*/
-
         RevertBellBasis(control);
         RevertBellBasis(target);
 
@@ -3392,13 +3385,13 @@ void QUnit::RevertBasis2Qb(const bitLenInt& i, const RevertExclusivity& exclusiv
 {
     QEngineShard& shard = shards[i];
 
+    RevertBellBasis(i);
+
     if (freezeBasis || !QUEUED_PHASE(shard)) {
         // Recursive call that should be blocked,
         // or already in target basis.
         return;
     }
-
-    RevertBellBasis(i);
 
     shard.CombineGates();
 

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -4890,9 +4890,9 @@ TEST_CASE("test_universal_circuit_digital_cross_entropy", "[supreme]")
 
     const int GateCount1Qb = 5;
     const int GateCountMultiQb = 4;
-    const int Depth = 5;
+    const int Depth = 3;
 
-    const int TRIALS = 2000;
+    const int TRIALS = 200;
     const int ITERATIONS = 60000;
     const int n = 8;
     bitCapInt permCount = pow2(n);

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -4890,9 +4890,9 @@ TEST_CASE("test_universal_circuit_digital_cross_entropy", "[supreme]")
 
     const int GateCount1Qb = 5;
     const int GateCountMultiQb = 4;
-    const int Depth = 3;
+    const int Depth = 5;
 
-    const int TRIALS = 200;
+    const int TRIALS = 2000;
     const int ITERATIONS = 60000;
     const int n = 8;
     bitCapInt permCount = pow2(n);


### PR DESCRIPTION
I happened to look at the intermediate representation (assembly) files generated for the OpenCL kernels on my development system. Most of it looks good, but the `decomposeprob` kernel is extremely unwieldy, whereas this is a particularly important API. `QUnit` focuses on proactive reduction of representational entanglement, and it does not frequently `Decompose()` in-flight representations, except after operations like measurement, but we should prioritize the `Decompose()` method for optimization. It's probably a good candidate to simplify, given its current level of complexity.