### PR TITLE
Fixing QPager benchmarks and automatic paging limits

### DIFF
--- a/include/common/oclengine.hpp
+++ b/include/common/oclengine.hpp
@@ -208,21 +208,9 @@ public:
         size_t procElemCount = device.getInfo<CL_DEVICE_MAX_COMPUTE_UNITS>();
         size_t maxWorkItems = device.getInfo<CL_DEVICE_MAX_WORK_ITEM_SIZES>()[0];
 
-        // constrain to a power of two
-        size_t groupSizePow = 1U;
-        while (groupSizePow <= nrmGroupSize) {
-            groupSizePow <<= 1U;
-        }
-        groupSizePow >>= 1U;
-        nrmGroupSize = groupSizePow;
-        size_t procElemPow = 1U;
-        while (procElemPow <= procElemCount) {
-            procElemPow <<= 1U;
-        }
-        procElemPow >>= 1U;
-        size_t nrmGroupCount = procElemPow * nrmGroupSize;
-        while (nrmGroupCount > maxWorkItems) {
-            nrmGroupCount >>= 1U;
+        size_t nrmGroupCount = procElemCount * nrmGroupSize;
+        if (nrmGroupCount > maxWorkItems) {
+            nrmGroupCount = maxWorkItems;
         }
 
         return nrmGroupCount;

--- a/src/qpager.cpp
+++ b/src/qpager.cpp
@@ -45,7 +45,9 @@ QPager::QPager(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState, q
 
 #if ENABLE_OPENCL
     if ((thresholdQubitsPerPage == 0) && (eng == QINTERFACE_OPENCL)) {
-        thresholdQubitsPerPage = log2(OCLEngine::Instance()->GetDeviceContextPtr(devID)->GetPreferredConcurrency());
+        // Single bit gates act pairwise on amplitudes, so add 1 qubit to the log2 of the preferred concurrency.
+        thresholdQubitsPerPage =
+            log2(OCLEngine::Instance()->GetDeviceContextPtr(devID)->GetPreferredConcurrency()) + 1U;
     }
 #endif
 
@@ -78,8 +80,8 @@ QPager::QPager(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState, q
 
 QEnginePtr QPager::MakeEngine(bitLenInt length, bitCapInt perm)
 {
-    return std::dynamic_pointer_cast<QEngine>(CreateQuantumInterface(engine, length, perm, rand_generator, phaseFactor,
-        false, false, useHostRam, devID, useRDRAND, isSparse));
+    return std::dynamic_pointer_cast<QEngine>(CreateQuantumInterface(
+        engine, length, perm, rand_generator, phaseFactor, false, false, useHostRam, devID, useRDRAND, isSparse));
 }
 
 void QPager::CombineEngines(bitLenInt bit)

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -47,8 +47,8 @@ double formatTime(double t, bool logNormal)
 
 QInterfacePtr MakeRandQubit()
 {
-    QInterfacePtr qubit = CreateQuantumInterface(testEngineType, testSubEngineType, 1U, 0, rng, ONE_CMPLX,
-        enable_normalization, true, false, device_id, !disable_hardware_rng);
+    QInterfacePtr qubit = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 1U, 0, rng,
+        ONE_CMPLX, enable_normalization, true, false, device_id, !disable_hardware_rng);
 
     real1 theta = 2 * M_PI * qubit->Rand();
     real1 phi = 2 * M_PI * qubit->Rand();


### PR DESCRIPTION
The `QUnit` with `QPager` benchmarks seem not actually to have dispatched to the intended `QInterface` type. Also, since the single-qubit-gate kernel operates on amplitudes pairwise, per instance, there should be at least an additional factor of 2 on the preferred OpenCL paging size, just to first consideration. Further, the "preferred concurrency" of the OpenCL device shouldn't necessarily have anything to do with powers-of-2 clamping preferred for state vectors, so I have simplified the relevant method in the OCLEngine system.