### PR TITLE
Debug QPager lambda closures; QPager::ApplySingleEither()

### DIFF
--- a/include/qpager.hpp
+++ b/include/qpager.hpp
@@ -68,6 +68,7 @@ protected:
     void CombineAndOpControlled(
         F fn, std::vector<bitLenInt> bits, const bitLenInt* controls, const bitLenInt controlLen);
 
+    void ApplySingleEither(const bool& isInvert, complex top, complex bottom, bitLenInt target);
     void ApplyEitherControlledSingleBit(const bool& anti, const bitLenInt* controls, const bitLenInt& controlLen,
         const bitLenInt& target, const complex* mtrx);
 
@@ -75,7 +76,7 @@ public:
     QPager(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState = 0, qrack_rand_gen_ptr rgp = nullptr,
         complex phaseFac = CMPLX_DEFAULT_ARG, bool ignored = false, bool ignored2 = false, bool useHostMem = false,
         int deviceId = -1, bool useHardwareRNG = true, bool useSparseStateVec = false,
-        real1 norm_thresh = REAL1_DEFAULT_ARG, std::vector<bitLenInt> devList = {}, bitLenInt qubitThreshold = 0);
+        real1 ignored3 = REAL1_DEFAULT_ARG, std::vector<bitLenInt> devList = {}, bitLenInt qubitThreshold = 0);
 
     virtual void SetQuantumState(const complex* inputState);
     virtual void GetQuantumState(complex* outputState);
@@ -110,6 +111,14 @@ public:
     virtual void Dispose(bitLenInt start, bitLenInt length, bitCapInt disposedPerm);
 
     virtual void ApplySingleBit(const complex* mtrx, bitLenInt qubitIndex);
+    virtual void ApplySinglePhase(const complex topLeft, const complex bottomRight, bitLenInt qubitIndex)
+    {
+        ApplySingleEither(false, topLeft, bottomRight, qubitIndex);
+    }
+    virtual void ApplySingleInvert(const complex topRight, const complex bottomLeft, bitLenInt qubitIndex)
+    {
+        ApplySingleEither(true, topRight, bottomLeft, qubitIndex);
+    }
     virtual void ApplyControlledSingleBit(
         const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& target, const complex* mtrx)
     {

--- a/include/qpager.hpp
+++ b/include/qpager.hpp
@@ -216,7 +216,7 @@ public:
 
     virtual bool isFinished()
     {
-        for (bitLenInt i = 0; i < qPages.size(); i++) {
+        for (bitCapInt i = 0; i < qPages.size(); i++) {
             if (!qPages[i]->isFinished()) {
                 return false;
             }


### PR DESCRIPTION
QPager lambda expressions should capture at least their loop control variables by value, so that the value does not change during thread execution. Also, this branch adds an optimization for single-qubit phase/inversion gates in QPager.