### PR TITLE
QPager controlled phase/invert optimization

### DIFF
--- a/include/qpager.hpp
+++ b/include/qpager.hpp
@@ -59,8 +59,7 @@ protected:
 
     template <typename Qubit1Fn> void SingleBitGate(bitLenInt target, Qubit1Fn fn);
     template <typename Qubit1Fn>
-    void MetaControlled(bool anti, std::vector<bitLenInt> controls, bitLenInt target, Qubit1Fn fn,
-        bool isSpecial = false, bool isInvert = false, complex top = ZERO_CMPLX, complex bottom = ZERO_CMPLX);
+    void MetaControlled(bool anti, std::vector<bitLenInt> controls, bitLenInt target, Qubit1Fn fn, const complex* mtrx);
     template <typename Qubit1Fn>
     void SemiMetaControlled(bool anti, std::vector<bitLenInt> controls, bitLenInt target, Qubit1Fn fn);
 

--- a/include/qpager.hpp
+++ b/include/qpager.hpp
@@ -59,7 +59,8 @@ protected:
 
     template <typename Qubit1Fn> void SingleBitGate(bitLenInt target, Qubit1Fn fn);
     template <typename Qubit1Fn>
-    void MetaControlled(bool anti, std::vector<bitLenInt> controls, bitLenInt target, Qubit1Fn fn);
+    void MetaControlled(bool anti, std::vector<bitLenInt> controls, bitLenInt target, Qubit1Fn fn,
+        bool isSpecial = false, bool isInvert = false, complex top = ZERO_CMPLX, complex bottom = ZERO_CMPLX);
     template <typename Qubit1Fn>
     void SemiMetaControlled(bool anti, std::vector<bitLenInt> controls, bitLenInt target, Qubit1Fn fn);
 


### PR DESCRIPTION
Phase and inversion gates can be significantly optimized, under the general strategy of "paging." This PR adds such support for controlled gates.

"Meta-controlled" gates benefit from this, (where the target bit is at inter-page level, rather than intra-page). "Semi-meta-controlled" gates, by the naming convention of `QPager`, (with the opposite case for target bit, intra-page rather than inter-page,) seem to be equivalent in this special case to the already-implemented general gate case.