### PR TITLE
Accept device list argument for QPager multi-accelerator

### DIFF
--- a/include/qengine_cpu.hpp
+++ b/include/qengine_cpu.hpp
@@ -42,7 +42,7 @@ public:
     QEngineCPU(bitLenInt qBitCount, bitCapInt initState, qrack_rand_gen_ptr rgp = nullptr,
         complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = false, bool randomGlobalPhase = true, bool ignored = false,
         int ignored2 = -1, bool useHardwareRNG = true, bool useSparseStateVec = false,
-        real1 norm_thresh = REAL1_DEFAULT_ARG, std::vector<bitLenInt> ignored3 = {}, bitLenInt ignored4 = 0);
+        real1 norm_thresh = REAL1_DEFAULT_ARG, std::vector<int> ignored3 = {}, bitLenInt ignored4 = 0);
 
     virtual ~QEngineCPU()
     {

--- a/include/qengine_opencl.hpp
+++ b/include/qengine_opencl.hpp
@@ -148,7 +148,7 @@ public:
     QEngineOCL(bitLenInt qBitCount, bitCapInt initState, qrack_rand_gen_ptr rgp = nullptr,
         complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = false, bool randomGlobalPhase = true,
         bool useHostMem = false, int devID = -1, bool useHardwareRNG = true, bool ignored = false,
-        real1 norm_thresh = REAL1_DEFAULT_ARG, std::vector<bitLenInt> ignored2 = {}, bitLenInt ignored3 = 0);
+        real1 norm_thresh = REAL1_DEFAULT_ARG, std::vector<int> ignored2 = {}, bitLenInt ignored3 = 0);
 
     virtual ~QEngineOCL()
     {

--- a/include/qpager.hpp
+++ b/include/qpager.hpp
@@ -31,6 +31,7 @@ protected:
     bool useRDRAND;
     bool isSparse;
     std::vector<QEnginePtr> qPages;
+    std::vector<int> deviceIDs;
 
     // TODO: Make this a constructor argument:
     bitLenInt thresholdQubitsPerPage;
@@ -38,7 +39,7 @@ protected:
     bitCapInt basePageCount;
     bitCapIntOcl basePageMaxQPower;
 
-    QEnginePtr MakeEngine(bitLenInt length, bitCapInt perm);
+    QEnginePtr MakeEngine(bitLenInt length, bitCapInt perm, int deviceId);
 
     virtual void SetQubitCount(bitLenInt qb)
     {
@@ -76,7 +77,7 @@ public:
     QPager(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState = 0, qrack_rand_gen_ptr rgp = nullptr,
         complex phaseFac = CMPLX_DEFAULT_ARG, bool ignored = false, bool ignored2 = false, bool useHostMem = false,
         int deviceId = -1, bool useHardwareRNG = true, bool useSparseStateVec = false,
-        real1 ignored3 = REAL1_DEFAULT_ARG, std::vector<bitLenInt> devList = {}, bitLenInt qubitThreshold = 0);
+        real1 ignored3 = REAL1_DEFAULT_ARG, std::vector<int> devList = {}, bitLenInt qubitThreshold = 0);
 
     virtual void SetQuantumState(const complex* inputState);
     virtual void GetQuantumState(complex* outputState);

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -673,12 +673,12 @@ public:
     QUnit(QInterfaceEngine eng, QInterfaceEngine subEng, bitLenInt qBitCount, bitCapInt initState = 0,
         qrack_rand_gen_ptr rgp = nullptr, complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = true,
         bool randomGlobalPhase = true, bool useHostMem = false, int deviceId = -1, bool useHardwareRNG = true,
-        bool useSparseStateVec = false, real1 norm_thresh = REAL1_DEFAULT_ARG, std::vector<bitLenInt> ignored = {},
+        bool useSparseStateVec = false, real1 norm_thresh = REAL1_DEFAULT_ARG, std::vector<int> ignored = {},
         bitLenInt qubitThreshold = 0);
     QUnit(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState = 0, qrack_rand_gen_ptr rgp = nullptr,
         complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = true, bool randomGlobalPhase = true,
         bool useHostMem = false, int deviceId = -1, bool useHardwareRNG = true, bool useSparseStateVec = false,
-        real1 norm_thresh = REAL1_DEFAULT_ARG, std::vector<bitLenInt> ignored = {}, bitLenInt qubitThreshold = 0)
+        real1 norm_thresh = REAL1_DEFAULT_ARG, std::vector<int> ignored = {}, bitLenInt qubitThreshold = 0)
         : QUnit(eng, eng, qBitCount, initState, rgp, phaseFac, doNorm, randomGlobalPhase, useHostMem, deviceId,
               useHardwareRNG, useSparseStateVec, norm_thresh, ignored, qubitThreshold)
     {

--- a/include/qunitmulti.hpp
+++ b/include/qunitmulti.hpp
@@ -71,7 +71,7 @@ public:
     QUnitMulti(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState = 0, qrack_rand_gen_ptr rgp = nullptr,
         complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = true, bool randomGlobalPhase = true,
         bool useHostMem = false, int deviceID = -1, bool useHardwareRNG = true, bool useSparseStateVec = false,
-        real1 norm_thresh = REAL1_DEFAULT_ARG, std::vector<bitLenInt> devList = {}, bitLenInt qubitThreshold = 0)
+        real1 norm_thresh = REAL1_DEFAULT_ARG, std::vector<int> devList = {}, bitLenInt qubitThreshold = 0)
         : QUnitMulti(qBitCount, initState, rgp, phaseFac, doNorm, randomGlobalPhase, useHostMem, -1, useHardwareRNG,
               qubitThreshold)
     {
@@ -80,7 +80,7 @@ public:
     QUnitMulti(bitLenInt qBitCount, bitCapInt initState = 0, qrack_rand_gen_ptr rgp = nullptr,
         complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = true, bool randomGlobalPhase = true,
         bool useHostMem = false, int deviceID = -1, bool useHardwareRNG = true, bool useSparseStateVec = false,
-        real1 norm_thresh = REAL1_DEFAULT_ARG, std::vector<bitLenInt> devList = {}, bitLenInt qubitThreshold = 0);
+        real1 norm_thresh = REAL1_DEFAULT_ARG, std::vector<int> devList = {}, bitLenInt qubitThreshold = 0);
 
     virtual void SetPermutation(bitCapInt perm, complex phaseFac = complex(-999.0, -999.0));
     virtual bool TrySeparate(bitLenInt start, bitLenInt length = 1);

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -78,7 +78,7 @@ namespace Qrack {
 
 QEngineOCL::QEngineOCL(bitLenInt qBitCount, bitCapInt initState, qrack_rand_gen_ptr rgp, complex phaseFac, bool doNorm,
     bool randomGlobalPhase, bool useHostMem, int devID, bool useHardwareRNG, bool ignored, real1 norm_thresh,
-    std::vector<bitLenInt> devList, bitLenInt qubitThreshold)
+    std::vector<int> devList, bitLenInt qubitThreshold)
     : QEngine(qBitCount, rgp, doNorm, randomGlobalPhase, useHostMem, useHardwareRNG, norm_thresh)
     , deviceID(devID)
     , wait_refs()

--- a/src/qengine/state.cpp
+++ b/src/qengine/state.cpp
@@ -43,7 +43,7 @@ namespace Qrack {
  */
 QEngineCPU::QEngineCPU(bitLenInt qBitCount, bitCapInt initState, qrack_rand_gen_ptr rgp, complex phaseFac, bool doNorm,
     bool randomGlobalPhase, bool useHostMem, int deviceID, bool useHardwareRNG, bool useSparseStateVec,
-    real1 norm_thresh, std::vector<bitLenInt> devList, bitLenInt qubitThreshold)
+    real1 norm_thresh, std::vector<int> devList, bitLenInt qubitThreshold)
     : QEngine(qBitCount, rgp, doNorm, randomGlobalPhase, true, useHardwareRNG, norm_thresh)
     , isSparse(useSparseStateVec)
 {

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -53,8 +53,7 @@ namespace Qrack {
 
 QUnit::QUnit(QInterfaceEngine eng, QInterfaceEngine subEng, bitLenInt qBitCount, bitCapInt initState,
     qrack_rand_gen_ptr rgp, complex phaseFac, bool doNorm, bool randomGlobalPhase, bool useHostMem, int deviceID,
-    bool useHardwareRNG, bool useSparseStateVec, real1 norm_thresh, std::vector<bitLenInt> devList,
-    bitLenInt qubitThreshold)
+    bool useHardwareRNG, bool useSparseStateVec, real1 norm_thresh, std::vector<int> devList, bitLenInt qubitThreshold)
     : QInterface(qBitCount, rgp, doNorm, useHardwareRNG, randomGlobalPhase, norm_thresh)
     , engine(eng)
     , subEngine(subEng)

--- a/src/qunitmulti.cpp
+++ b/src/qunitmulti.cpp
@@ -19,7 +19,7 @@ namespace Qrack {
 
 QUnitMulti::QUnitMulti(bitLenInt qBitCount, bitCapInt initState, qrack_rand_gen_ptr rgp, complex phaseFac, bool doNorm,
     bool randomGlobalPhase, bool useHostMem, int deviceID, bool useHardwareRNG, bool useSparseStateVec,
-    real1 norm_thresh, std::vector<bitLenInt> devList, bitLenInt qubitThreshold)
+    real1 norm_thresh, std::vector<int> devList, bitLenInt qubitThreshold)
     : QUnit(QINTERFACE_OPENCL, qBitCount, initState, rgp, phaseFac, doNorm, randomGlobalPhase, useHostMem, -1,
           useHardwareRNG, useSparseStateVec, norm_thresh, devList, qubitThreshold)
 {


### PR DESCRIPTION
QPager can theoretically handle multi-accelerator execution without any particularly complicated modification or configuration. A list of OpenCL device IDs are passed in and, simply, as "pages" are indexed, they are assigned device IDs from this list by ascending modulo repetition. In other words, from 0 page index to highest, device IDs are also assigned from the device list index 0 to highest, repeating the device list as many (full or partial) times as necessary to cover all pages.

Because QPager probably works best initialized with a paging qubit threshold, as it already is, rather than an absolute count of pages, there seems to be no particular complication to this system from `Compose()`, `Decompose()`, or `Dispose()`. Assuming random access of qubits with no particularly preferred indices, there's no theoretical advantage to any different or more complicated manner of assigning device IDs to pages by default, particularly if there is a power of 2 for the device count. However, there need _not_ be a power of 2 devices to use every device on a system, this way, as any odd number of devices is also accepted for entry count in the device list. Also, if a specific qubit index priority is suspected, the user _can_ explicitly specify the entire assignment of device IDs, through the same device ID list argument, including past the total count of pages. The same ID can be specified in the list as many times as desired, such as for totally specific allocation of multiple pages to fewer devices or for _load_ _balancing_, (in a limited but useful way). If one wants to specify the "default device" without looking up its specific ID, an entry of `-1` for device ID in the list selects the default, just as it does in all other references to device ID throughout the library.

The benefits of this virtual "one-liner" change might sound amazing, by now... but I frankly can't promise this will give _any_ advantage over single-accelerator execution, at all. The system is great in theory, but historical precedent for Qrack is that previous similar "paging" over multiple accelerators didn't personally give me a practical return, though my personal resources to test homogeneous many-accelerator cluster distribution are almost entirely nil, for the moment. Hopefully, your experience contradicts mine, but work is at least on-going.