### PR TITLE
Simplify and correct ~QEngineOCL()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,7 +105,6 @@ add_test (NAME qrack_cl_precompile
 
 # Included after the library and other modules have been declared
 option (ENABLE_OPENCL "Use OpenCL optimizations" ON)
-option (ENABLE_SNUCL "Compile for SnuCL cluster execution" OFF)
 include ("cmake/Examples.cmake")
 include ("cmake/UInt128.cmake")
 include ("cmake/OpenCL.cmake" )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,6 +105,7 @@ add_test (NAME qrack_cl_precompile
 
 # Included after the library and other modules have been declared
 option (ENABLE_OPENCL "Use OpenCL optimizations" ON)
+option (ENABLE_SNUCL "Compile for SnuCL cluster execution" OFF)
 include ("cmake/Examples.cmake")
 include ("cmake/UInt128.cmake")
 include ("cmake/OpenCL.cmake" )

--- a/include/qengine_opencl.hpp
+++ b/include/qengine_opencl.hpp
@@ -152,10 +152,7 @@ public:
 
     virtual ~QEngineOCL()
     {
-        clDump();
-        nrmBuffer = NULL;
-        FreeAligned(nrmArray);
-        FreeStateVec();
+        ZeroAmplitudes();
     }
 
     virtual void ZeroAmplitudes()


### PR DESCRIPTION
The `ZeroAmplitudes()` method is better implemented than the original `QEngineOCL` destructor, and it serves the same function.