### PR TITLE
Don't use (OpenCL) host pointer for nrmBuffer

### DIFF
--- a/include/qengine_opencl.hpp
+++ b/include/qengine_opencl.hpp
@@ -151,10 +151,7 @@ public:
         bool useHostMem = false, int devID = -1, bool useHardwareRNG = true, bool ignored = false,
         real1 norm_thresh = REAL1_DEFAULT_ARG, std::vector<int> ignored2 = {}, bitLenInt ignored3 = 0);
 
-    virtual ~QEngineOCL()
-    {
-        ZeroAmplitudes();
-    }
+    virtual ~QEngineOCL() { ZeroAmplitudes(); }
 
     virtual void ZeroAmplitudes()
     {

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -61,10 +61,8 @@ namespace Qrack {
 
 #define WAIT_REAL1_SUM(buff, size, array, sumPtr)                                                                      \
     clFinish();                                                                                                        \
-    queue.enqueueMapBuffer(buff, CL_TRUE, CL_MAP_READ, 0, sizeof(real1) * (size));                                     \
-    *(sumPtr) = ParSum(array, size);                                                                                   \
-    device_context->wait_events->emplace_back();                                                                       \
-    queue.enqueueUnmapMemObject(buff, array, NULL, &(device_context->wait_events->back()));
+    queue.enqueueReadBuffer(buff, CL_TRUE, 0, sizeof(real1) * size, array, NULL, NULL);                                \
+    *(sumPtr) = ParSum(array, size);
 
 #define CHECK_ZERO_SKIP()                                                                                              \
     if (!stateBuffer) {                                                                                                \
@@ -522,8 +520,7 @@ void QEngineOCL::SetDevice(const int& dID, const bool& forceReInit)
         std::make_shared<cl::Buffer>(context, CL_MEM_READ_ONLY, sizeof(bitCapIntOcl) * sizeof(bitCapIntOcl) * 16);
 
     if ((!didInit) || (nrmGroupCount != oldNrmGroupCount)) {
-        nrmBuffer =
-            std::make_shared<cl::Buffer>(context, CL_MEM_USE_HOST_PTR | CL_MEM_READ_WRITE, nrmVecAlignSize, nrmArray);
+        nrmBuffer = std::make_shared<cl::Buffer>(context, CL_MEM_READ_WRITE, nrmVecAlignSize, nrmArray);
     }
 }
 

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -476,8 +476,9 @@ void QEngineOCL::SetDevice(const int& dID, const bool& forceReInit)
         }
     }
 
-    size_t nrmVecAlignSize =
-        ((sizeof(real1) * nrmGroupCount) < QRACK_ALIGN_SIZE) ? QRACK_ALIGN_SIZE : (sizeof(real1) * nrmGroupCount);
+    size_t nrmVecAlignSize = ((sizeof(real1) * nrmGroupCount / nrmGroupSize) < QRACK_ALIGN_SIZE)
+        ? QRACK_ALIGN_SIZE
+        : (sizeof(real1) * nrmGroupCount / nrmGroupSize);
 
     if (didInit && (nrmGroupCount != oldNrmGroupCount)) {
         nrmBuffer = NULL;
@@ -520,7 +521,7 @@ void QEngineOCL::SetDevice(const int& dID, const bool& forceReInit)
         std::make_shared<cl::Buffer>(context, CL_MEM_READ_ONLY, sizeof(bitCapIntOcl) * sizeof(bitCapIntOcl) * 16);
 
     if ((!didInit) || (nrmGroupCount != oldNrmGroupCount)) {
-        nrmBuffer = std::make_shared<cl::Buffer>(context, CL_MEM_READ_WRITE, nrmVecAlignSize, nrmArray);
+        nrmBuffer = std::make_shared<cl::Buffer>(context, CL_MEM_READ_WRITE, nrmVecAlignSize);
     }
 }
 
@@ -2581,8 +2582,9 @@ void QEngineOCL::ReinitBuffer()
     ResetStateVec(AllocStateVec(maxQPower, usingHostRam));
     ResetStateBuffer(MakeStateVecBuffer(stateVec));
 
-    size_t nrmVecAlignSize =
-        ((sizeof(real1) * nrmGroupCount) < QRACK_ALIGN_SIZE) ? QRACK_ALIGN_SIZE : (sizeof(real1) * nrmGroupCount);
+    size_t nrmVecAlignSize = ((sizeof(real1) * nrmGroupCount / nrmGroupSize) < QRACK_ALIGN_SIZE)
+        ? QRACK_ALIGN_SIZE
+        : (sizeof(real1) * nrmGroupCount / nrmGroupSize);
 
 #if defined(__APPLE__)
     posix_memalign((void**)&nrmArray, QRACK_ALIGN_SIZE, nrmVecAlignSize);
@@ -2592,8 +2594,7 @@ void QEngineOCL::ReinitBuffer()
     nrmArray = (real1*)aligned_alloc(QRACK_ALIGN_SIZE, nrmVecAlignSize);
 #endif
 
-    nrmBuffer =
-        std::make_shared<cl::Buffer>(context, CL_MEM_USE_HOST_PTR | CL_MEM_READ_WRITE, nrmVecAlignSize, nrmArray);
+    nrmBuffer = std::make_shared<cl::Buffer>(context, CL_MEM_READ_WRITE, nrmVecAlignSize);
 }
 
 void QEngineOCL::ClearBuffer(BufferPtr buff, bitCapIntOcl offset, bitCapIntOcl size, EventVecPtr waitVec)

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -269,7 +269,7 @@ TEST_CASE("test_exp2x2_log2x2")
     REQUIRE_FLOAT(imag(mtrx1[3]), ZERO_R1);
 }
 
-#if ENABLE_OPENCL
+#if ENABLE_OPENCL && !ENABLE_SNUCL
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_oclengine")
 {
     if (testEngineType == QINTERFACE_OPENCL) {


### PR DESCRIPTION
For a cluster environment, OpenCL "host pointers" (general RAM heap allocation for accelerator device operations) might not be supported at all, or otherwise come at a very high premium in a very limited specific resource pool. However, more generally, use of general heap might give no advantage if it can be totally avoided, except in very specific cases. To a certain extent, transparency of the OpenCL API efficiently and simply manages cases where switching to host pointers becomes necessary, if they are even available in the environment and for the device. Sometimes, (or frequently,) host pointer addressing requires transparent device memory "pinning," anyway, in which case redundancy with device RAM is not even truly avoided, (though my experience is that CPUs directly address general heap in the OpenCL API, which would make sense).

This is likely exactly the common case for `nrmBuffer` in `QEngineOCL`. Device RAM sizing limits in `QEngineOCL` already detect whether there is sufficient space for both the state vector buffer and `nrmBuffer` at once, partly related to segmentation considerations of device RAM, if I recall. The `nrmArray` on host is still allocated, but only of sufficient size (~1/32 of original) to receive a read result from the device-based `nrmBuffer` after parallel addition over group size, (which is basically always "warp" SIMD width). This reduces host heap usage, likely is slightly or significantly faster, and commonly reduces the redundancy of "pinned" device global RAM.