### PR TITLE
Temporarily disable default QPager tests/benchmarks

### DIFF
--- a/test/benchmarks_main.cpp
+++ b/test/benchmarks_main.cpp
@@ -108,10 +108,10 @@ int main(int argc, char* argv[])
 
     if (!qengine && !qpager && !qunit && !qunit_qpager) {
         qunit = true;
+        qengine = true;
         // Unstable:
         // qpager = true;
-        qengine = true;
-        qunit_qpager = true;
+        // qunit_qpager = true;
     }
 
     if (!cpu && !opencl_single && !opencl_multi) {

--- a/test/benchmarks_main.cpp
+++ b/test/benchmarks_main.cpp
@@ -108,7 +108,8 @@ int main(int argc, char* argv[])
 
     if (!qengine && !qpager && !qunit && !qunit_qpager) {
         qunit = true;
-        qpager = true;
+        // Unstable:
+        // qpager = true;
         qengine = true;
         qunit_qpager = true;
     }

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -108,10 +108,10 @@ int main(int argc, char* argv[])
 
     if (!qengine && !qpager && !qunit && !qunit_qpager) {
         qunit = true;
+        qengine = true;
         // Unstable:
         // qpager = true;
-        qengine = true;
-        qunit_qpager = true;
+        // qunit_qpager = true;
     }
 
     if (!cpu && !opencl_single && !opencl_multi) {

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -108,7 +108,8 @@ int main(int argc, char* argv[])
 
     if (!qengine && !qpager && !qunit && !qunit_qpager) {
         qunit = true;
-        qpager = true;
+        // Unstable:
+        // qpager = true;
         qengine = true;
         qunit_qpager = true;
     }


### PR DESCRIPTION
QPager is still unstable, so I am disabling its unit tests and benchmarks by default, so as not to impede existing default test/benchmarks commands. By explicitly selecting QPager through command line options, its tests and benchmarks can still be run.