### PR TITLE
Use different (C++) clock for benchmarks

### DIFF
--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -1323,25 +1323,6 @@ void QEngineOCL::ProbRegAll(const bitLenInt& start, const bitLenInt& length, rea
         return;
     }
 
-#if !ENABLE_SNUCL
-    if ((lengthPower * lengthPower) < nrmGroupCount) {
-        // With "lengthPower" count of threads, compared to a redundancy of "lengthPower" with full utilization, this is
-        // close to the point where it becomes more efficient to rely on iterating through ProbReg calls.
-        if ((start == 0) && length == qubitCount) {
-            if (doNormalize) {
-                NormalizeState();
-            }
-
-            LockSync(CL_MAP_READ);
-            std::transform(stateVec, stateVec + maxQPowerOcl, probsArray, normHelper);
-            UnlockSync();
-        } else {
-            QEngine::ProbRegAll(start, length, probsArray);
-        }
-        return;
-    }
-#endif
-
     bitCapIntOcl bciArgs[BCI_ARG_LEN] = { lengthPower, maxJ, start, length, 0, 0, 0, 0, 0, 0 };
 
     EventVecPtr waitVec = ResetWaitEvents();

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -34,7 +34,7 @@ using namespace Qrack;
         REQUIRE(__tmp_b > (__tmp_b - EPSILON));                                                                        \
     } while (0);
 
-const double clockFactor = 1000.0 / CLOCKS_PER_SEC; // Report in ms
+const double clockFactor = 1.0 / 1000.0; // Report in ms
 
 double formatTime(double t, bool logNormal)
 {
@@ -77,7 +77,6 @@ void benchmarkLoopVariable(std::function<void(QInterfacePtr, bitLenInt)> fn, bit
     std::cout << "3rd Quartile (ms), ";
     std::cout << "Slowest (ms)" << std::endl;
 
-    clock_t tClock, iterClock;
     real1 trialClocks[ITERATIONS];
 
     bitLenInt i, j, numBits;
@@ -136,7 +135,7 @@ void benchmarkLoopVariable(std::function<void(QInterfacePtr, bitLenInt)> fn, bit
             }
             qftReg->Finish();
 
-            iterClock = clock();
+            auto iterClock = std::chrono::high_resolution_clock::now();
 
             // Run loop body
             fn(qftReg, numBits);
@@ -146,11 +145,12 @@ void benchmarkLoopVariable(std::function<void(QInterfacePtr, bitLenInt)> fn, bit
             }
 
             // Collect interval data
-            tClock = clock() - iterClock;
+            auto tClock = std::chrono::duration_cast<std::chrono::microseconds>(
+                std::chrono::high_resolution_clock::now() - iterClock);
             if (logNormal) {
-                trialClocks[i] = log2(tClock * clockFactor);
+                trialClocks[i] = log2(tClock.count() * clockFactor);
             } else {
-                trialClocks[i] = tClock * clockFactor;
+                trialClocks[i] = tClock.count() * clockFactor;
             }
             avgt += trialClocks[i];
 


### PR DESCRIPTION
C++ `std::chrono` seems to be a much better chronometer API for our purposes than (I think, C) `clock`. Benchmarks, so far, appear to return numerical timings that are approximately the same or faster, depending upon previous use case. (I tested `test_qft_cosmology` and `test_universal_circuit_digital`.)