### PR TITLE
Remove usages of OpenCL host pointers

### DIFF
--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -1330,8 +1330,7 @@ void QEngineOCL::ProbRegAll(const bitLenInt& start, const bitLenInt& length, rea
 
     DISPATCH_WRITE(waitVec, *(poolItem->ulongBuffer), sizeof(bitCapIntOcl) * 4, bciArgs);
 
-    BufferPtr probsBuffer =
-        std::make_shared<cl::Buffer>(context, CL_MEM_ALLOC_HOST_PTR | CL_MEM_WRITE_ONLY, sizeof(real1) * lengthPower);
+    BufferPtr probsBuffer = std::make_shared<cl::Buffer>(context, CL_MEM_WRITE_ONLY, sizeof(real1) * lengthPower);
 
     size_t ngc = FixWorkItemCount(lengthPower, nrmGroupCount);
     size_t ngs = FixGroupSize(ngc, nrmGroupSize);
@@ -2229,10 +2228,10 @@ void QEngineOCL::SetQuantumState(const complex* inputState)
         ReinitBuffer();
     }
 
-    LockSync(CL_MAP_WRITE);
-    std::copy(inputState, inputState + maxQPowerOcl, stateVec);
-    runningNorm = ONE_R1;
-    UnlockSync();
+    EventVecPtr waitVec = ResetWaitEvents();
+    device_context->wait_events->emplace_back();
+    queue.enqueueWriteBuffer(*stateBuffer, CL_TRUE, 0, sizeof(complex) * maxQPowerOcl, inputState, waitVec.get(),
+        &(device_context->wait_events->back()));
 
     UpdateRunningNorm();
 }

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -104,8 +104,8 @@ void QEngineOCL::SetAmplitudePage(const complex* pagePtr, const bitCapInt offset
 
     EventVecPtr waitVec = ResetWaitEvents();
     device_context->wait_events->emplace_back();
-    queue.enqueueWriteBuffer(*stateBuffer, CL_TRUE, sizeof(complex) * offset, sizeof(complex) * length, pagePtr,
-        waitVec.get(), &(device_context->wait_events->back()));
+    queue.enqueueWriteBuffer(
+        *stateBuffer, CL_TRUE, sizeof(complex) * offset, sizeof(complex) * length, pagePtr, waitVec.get());
 }
 
 void QEngineOCL::SetAmplitudePage(
@@ -2230,8 +2230,7 @@ void QEngineOCL::SetQuantumState(const complex* inputState)
 
     EventVecPtr waitVec = ResetWaitEvents();
     device_context->wait_events->emplace_back();
-    queue.enqueueWriteBuffer(*stateBuffer, CL_TRUE, 0, sizeof(complex) * maxQPowerOcl, inputState, waitVec.get(),
-        &(device_context->wait_events->back()));
+    queue.enqueueWriteBuffer(*stateBuffer, CL_TRUE, 0, sizeof(complex) * maxQPowerOcl, inputState, waitVec.get());
 
     UpdateRunningNorm();
 }


### PR DESCRIPTION
This removes more usages of OpenCL host pointers. Besides specifically intended cases, dependent on certain API method usages, I think this removes all undesirable host pointer usage. I expect no change in performance, worst case, or a significant performance improvement in certain API methods, best case.