### PR TITLE
QPager swap optimization

### DIFF
--- a/include/qpager.hpp
+++ b/include/qpager.hpp
@@ -63,6 +63,10 @@ protected:
     void MetaControlled(bool anti, std::vector<bitLenInt> controls, bitLenInt target, Qubit1Fn fn, const complex* mtrx);
     template <typename Qubit1Fn>
     void SemiMetaControlled(bool anti, std::vector<bitLenInt> controls, bitLenInt target, Qubit1Fn fn);
+    void MetaControlledSwap(bool anti, const bitLenInt* controls, bitLenInt controlLen, bitLenInt qubit1,
+        bitLenInt qubit2, bool isIPhaseFac);
+    void SemiMetaControlledSwap(bool anti, const bitLenInt* controls, bitLenInt controlLen, bitLenInt qubit1,
+        bitLenInt qubit2, bool isIPhaseFac);
 
     template <typename F> void CombineAndOp(F fn, std::vector<bitLenInt> bits);
     template <typename F>

--- a/src/qpager.cpp
+++ b/src/qpager.cpp
@@ -2,20 +2,7 @@
 //
 // (C) Daniel Strano and the Qrack contributors 2017-2020. All rights reserved.
 //
-// QUnit maintains explicit separability of qubits as an optimization on a QEngine.
-// See https://arxiv.org/abs/1710.05867
-// (The makers of Qrack have no affiliation with the authors of that paper.)
-//
-// When we allocate a quantum register, all bits are in a (re)set state. At this point,
-// we know they are separable, in the sense of full Schmidt decomposability into qubits
-// in the "natural" or "permutation" basis of the register. Many operations can be
-// traced in terms of fewer qubits that the full "Schr\{"o}dinger representation."
-//
-// Based on experimentation, QUnit is designed to avoid increasing representational
-// entanglement for its primary action, and only try to decrease it when inquiries
-// about probability need to be made otherwise anyway. Avoiding introducing the cost of
-// basically any entanglement whatsoever, rather than exponentially costly "garbage
-// collection," should be the first and ultimate concern, in the authors' experience.
+// QPager breaks a QEngine instance into pages of contiguous amplitudes.
 //
 // Licensed under the GNU Lesser General Public License V3.
 // See LICENSE.md in the project root or https://www.gnu.org/licenses/lgpl-3.0.en.html
@@ -571,12 +558,34 @@ void QPager::UniformlyControlledSingleBit(const bitLenInt* controls, const bitLe
 void QPager::CSwap(
     const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& qubit1, const bitLenInt& qubit2)
 {
+    bool isQubit1Meta = qubit1 >= qubitsPerPage();
+    bool isQubit2Meta = qubit2 >= qubitsPerPage();
+    if (isQubit1Meta && isQubit2Meta) {
+        MetaControlledSwap(false, controls, controlLen, qubit1, qubit2, false);
+        return;
+    }
+    if (isQubit1Meta || isQubit2Meta) {
+        SemiMetaControlledSwap(false, controls, controlLen, qubit1, qubit2, false);
+        return;
+    }
+
     CombineAndOpControlled([&](QEnginePtr engine) { engine->CSwap(controls, controlLen, qubit1, qubit2); },
         { qubit1, qubit2 }, controls, controlLen);
 }
 void QPager::AntiCSwap(
     const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& qubit1, const bitLenInt& qubit2)
 {
+    bool isQubit1Meta = qubit1 >= qubitsPerPage();
+    bool isQubit2Meta = qubit2 >= qubitsPerPage();
+    if (isQubit1Meta && isQubit2Meta) {
+        MetaControlledSwap(true, controls, controlLen, qubit1, qubit2, false);
+        return;
+    }
+    if (isQubit1Meta || isQubit2Meta) {
+        SemiMetaControlledSwap(true, controls, controlLen, qubit1, qubit2, false);
+        return;
+    }
+
     CombineAndOpControlled([&](QEnginePtr engine) { engine->AntiCSwap(controls, controlLen, qubit1, qubit2); },
         { qubit1, qubit2 }, controls, controlLen);
 }
@@ -802,12 +811,216 @@ void QPager::Hash(bitLenInt start, bitLenInt length, unsigned char* values)
         { static_cast<bitLenInt>(start + length - 1U) });
 }
 
+void QPager::MetaControlledSwap(
+    bool anti, const bitLenInt* controls, bitLenInt controlLen, bitLenInt qubit1, bitLenInt qubit2, bool isIPhaseFac)
+{
+    bitLenInt qpp = qubitsPerPage();
+    qubit1 -= qpp;
+    qubit2 -= qpp;
+    bitLenInt sqi = qpp - 1U;
+
+    std::vector<bitCapInt> sortedMasks(2U);
+    bitCapInt qubit1Mask = pow2(qubit1);
+    sortedMasks[0] = qubit1Mask;
+    bitCapInt qubit2Mask = pow2(qubit2);
+    sortedMasks[1] = qubit2Mask;
+
+    std::vector<bitLenInt> subcontrols;
+    bitCapInt controlMask = 0;
+    for (bitLenInt i = 0; i < controlLen; i++) {
+        if (controls[i] < qpp) {
+            sortedMasks.push_back(pow2(controls[i] - qpp));
+            if (!anti) {
+                controlMask |= sortedMasks.back();
+            }
+            sortedMasks.back()--;
+        } else {
+            subcontrols.push_back(controls[i]);
+        }
+    }
+    std::sort(sortedMasks.begin(), sortedMasks.end());
+
+    bitCapInt maxLCV = qPages.size() >> sortedMasks.size();
+    std::vector<std::future<void>> futures(maxLCV);
+    bitCapInt i;
+    for (i = 0; i < maxLCV; i++) {
+        futures[i] = std::async(std::launch::async,
+            [this, i, &qubit1Mask, &qubit2Mask, &sortedMasks, &subcontrols, &isIPhaseFac, &sqi, &controlMask]() {
+                bitCapInt j, k, jLo, jHi;
+                jHi = i;
+                j = 0;
+                for (k = 0; k < (sortedMasks.size()); k++) {
+                    jLo = jHi & sortedMasks[k];
+                    jHi = (jHi ^ jLo) << ONE_BCI;
+                    j |= jLo;
+                }
+                j |= jHi;
+
+                QEnginePtr engine1 = qPages[j + qubit1Mask];
+                QEnginePtr engine2 = qPages[j + qubit2Mask];
+
+                if (subcontrols.size()) {
+                    engine1->ShuffleBuffers(engine2);
+
+                    std::future<void> future1, future2;
+
+                    if (isIPhaseFac) {
+                        future1 = std::async(std::launch::async, [engine1, &sqi, &subcontrols]() {
+                            engine1->ApplyControlledSingleInvert(
+                                &(subcontrols[0]), subcontrols.size(), sqi, I_CMPLX, I_CMPLX);
+                        });
+                        future2 = std::async(std::launch::async, [engine2, &sqi, &subcontrols]() {
+                            engine2->ApplyControlledSingleInvert(
+                                &(subcontrols[0]), subcontrols.size(), sqi, I_CMPLX, I_CMPLX);
+                        });
+                    } else {
+                        future1 = std::async(std::launch::async, [engine1, &sqi, &subcontrols]() {
+                            engine1->ApplyControlledSingleInvert(
+                                &(subcontrols[0]), subcontrols.size(), sqi, ONE_CMPLX, ONE_CMPLX);
+                        });
+                        future2 = std::async(std::launch::async, [engine2, &sqi, &subcontrols]() {
+                            engine2->ApplyControlledSingleInvert(
+                                &(subcontrols[0]), subcontrols.size(), sqi, ONE_CMPLX, ONE_CMPLX);
+                        });
+                    }
+
+                    future1.get();
+                    future2.get();
+
+                    engine1->ShuffleBuffers(engine2);
+                } else {
+                    std::swap(qPages[j + qubit1Mask], qPages[j + qubit2Mask]);
+
+                    if (isIPhaseFac) {
+                        std::future<void> future1, future2;
+
+                        future1 = std::async(
+                            std::launch::async, [engine1]() { engine1->ApplySinglePhase(I_CMPLX, I_CMPLX, 0); });
+                        future2 = std::async(
+                            std::launch::async, [engine2]() { engine2->ApplySinglePhase(I_CMPLX, I_CMPLX, 0); });
+
+                        future1.get();
+                        future2.get();
+                    }
+                }
+            });
+    }
+
+    for (i = 0; i < maxLCV; i++) {
+        futures[i].get();
+    }
+}
+
+void QPager::SemiMetaControlledSwap(
+    bool anti, const bitLenInt* controls, bitLenInt controlLen, bitLenInt qubit1, bitLenInt qubit2, bool isIPhaseFac)
+{
+    if (qubit1 > qubit2) {
+        std::swap(qubit1, qubit2);
+    }
+
+    bitLenInt qpp = qubitsPerPage();
+    qubit1 -= qpp;
+    bitLenInt sqi = qpp - 1U;
+
+    std::vector<bitCapInt> sortedMasks(1U);
+    bitCapInt qubit2Mask = pow2(qubit2);
+    sortedMasks[0] = qubit2Mask;
+
+    std::vector<bitLenInt> subcontrols;
+    bitCapInt controlMask = 0;
+    for (bitLenInt i = 0; i < controlLen; i++) {
+        if (controls[i] < qpp) {
+            sortedMasks.push_back(pow2(controls[i] - qpp));
+            if (!anti) {
+                controlMask |= sortedMasks.back();
+            }
+            sortedMasks.back()--;
+        } else {
+            subcontrols.push_back(controls[i]);
+        }
+    }
+    std::sort(sortedMasks.begin(), sortedMasks.end());
+
+    bitCapInt maxLCV = qPages.size() >> sortedMasks.size();
+    std::vector<std::future<void>> futures(maxLCV);
+    bitCapInt i;
+    for (i = 0; i < maxLCV; i++) {
+        futures[i] = std::async(std::launch::async,
+            [this, i, &qubit1, &qubit2Mask, &sortedMasks, &subcontrols, &isIPhaseFac, &sqi, &controlMask]() {
+                bitCapInt j, k, jLo, jHi;
+                jHi = i;
+                j = 0;
+                for (k = 0; k < (sortedMasks.size()); k++) {
+                    jLo = jHi & sortedMasks[k];
+                    jHi = (jHi ^ jLo) << ONE_BCI;
+                    j |= jLo;
+                }
+                j |= jHi | controlMask;
+
+                QEnginePtr engine1 = qPages[j];
+                QEnginePtr engine2 = qPages[j + qubit2Mask];
+
+                engine1->ShuffleBuffers(engine2);
+
+                std::future<void> future1, future2;
+                if (isIPhaseFac) {
+                    future1 = std::async(std::launch::async, [engine1, &qubit1, &sqi, &subcontrols]() {
+                        engine1->CSwap(&(subcontrols[0]), subcontrols.size(), qubit1, sqi);
+                        engine1->ApplySinglePhase(I_CMPLX, I_CMPLX, 0);
+                    });
+                    future2 = std::async(std::launch::async, [engine2, &qubit1, &sqi, &subcontrols]() {
+                        engine2->CSwap(&(subcontrols[0]), subcontrols.size(), qubit1, sqi);
+                        engine2->ApplySinglePhase(I_CMPLX, I_CMPLX, 0);
+                    });
+                } else {
+                    future1 = std::async(std::launch::async, [engine1, &qubit1, &sqi, &subcontrols]() {
+                        engine1->CSwap(&(subcontrols[0]), subcontrols.size(), qubit1, sqi);
+                    });
+                    future2 = std::async(std::launch::async, [engine2, &qubit1, &sqi, &subcontrols]() {
+                        engine2->CSwap(&(subcontrols[0]), subcontrols.size(), qubit1, sqi);
+                    });
+                }
+
+                future1.get();
+                future2.get();
+
+                engine1->ShuffleBuffers(engine2);
+            });
+    }
+
+    for (i = 0; i < maxLCV; i++) {
+        futures[i].get();
+    }
+}
+
 void QPager::Swap(bitLenInt qubit1, bitLenInt qubit2)
 {
+    bool isQubit1Meta = qubit1 >= qubitsPerPage();
+    bool isQubit2Meta = qubit2 >= qubitsPerPage();
+    if (isQubit1Meta && isQubit2Meta) {
+        MetaControlledSwap(false, NULL, 0, qubit1, qubit2, false);
+        return;
+    }
+    if (isQubit1Meta || isQubit2Meta) {
+        SemiMetaControlledSwap(false, NULL, 0, qubit1, qubit2, false);
+        return;
+    }
+
     CombineAndOp([&](QEnginePtr engine) { engine->Swap(qubit1, qubit2); }, { qubit1, qubit2 });
 }
 void QPager::ISwap(bitLenInt qubit1, bitLenInt qubit2)
 {
+    bool isQubit1Meta = qubit1 >= qubitsPerPage();
+    bool isQubit2Meta = qubit2 >= qubitsPerPage();
+    if (isQubit1Meta && isQubit2Meta) {
+        MetaControlledSwap(false, NULL, 0, qubit1, qubit2, true);
+        return;
+    }
+    if (isQubit1Meta || isQubit2Meta) {
+        SemiMetaControlledSwap(false, NULL, 0, qubit1, qubit2, true);
+        return;
+    }
+
     CombineAndOp([&](QEnginePtr engine) { engine->ISwap(qubit1, qubit2); }, { qubit1, qubit2 });
 }
 void QPager::SqrtSwap(bitLenInt qubit1, bitLenInt qubit2)

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -457,6 +457,19 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_cswap")
     qftReg->CSwap(control, 1, 0, 4);
     qftReg->H(8);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x110));
+
+    QInterfacePtr qftReg2 =
+        CreateQuantumInterface(testEngineType, testSubEngineType, 20U, 0, rng, ONE_CMPLX, enable_normalization, true,
+            false, device_id, !disable_hardware_rng, sparse, REAL1_DEFAULT_ARG, (std::vector<int>){}, 10);
+
+    control[0] = 9;
+    qftReg->SetPermutation((1U << 9U) || (1U << 10U));
+    qftReg->CSwap(control, 1, 10, 11);
+    REQUIRE_THAT(qftReg, HasProbability(0, 12, (1U << 9U) || (1U << 11U)));
+
+    qftReg->SetPermutation((1U << 9U) || (1U << 10U));
+    qftReg->CSwap(control, 1, 10, 0);
+    REQUIRE_THAT(qftReg, HasProbability(0, 12, (1U << 9U) || 1U));
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_anticswap")

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -463,13 +463,13 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_cswap")
             false, device_id, !disable_hardware_rng, sparse, REAL1_DEFAULT_ARG, (std::vector<int>){}, 10);
 
     control[0] = 9;
-    qftReg->SetPermutation((1U << 9U) || (1U << 10U));
-    qftReg->CSwap(control, 1, 10, 11);
-    REQUIRE_THAT(qftReg, HasProbability(0, 12, (1U << 9U) || (1U << 11U)));
+    qftReg2->SetPermutation((1U << 9U) || (1U << 10U));
+    qftReg2->CSwap(control, 1, 10, 11);
+    REQUIRE_THAT(qftReg2, HasProbability(0, 12, (1U << 9U) || (1U << 11U)));
 
-    qftReg->SetPermutation((1U << 9U) || (1U << 10U));
-    qftReg->CSwap(control, 1, 10, 0);
-    REQUIRE_THAT(qftReg, HasProbability(0, 12, (1U << 9U) || 1U));
+    qftReg2->SetPermutation((1U << 9U) || (1U << 10U));
+    qftReg2->CSwap(control, 1, 10, 0);
+    REQUIRE_THAT(qftReg2, HasProbability(0, 12, (1U << 9U) || 1U));
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_anticswap")


### PR DESCRIPTION
This PR optimizes SWAP variants in QPager.

Personal note: hurricane Isaias totally knocked out my power and internet. I have a generator, and I tweaked this PR together without internet last night for lack of anything better to do, but most of our town might be without utilities for days. (I put these commits in through the GitHub web interface, but I can't even tether.) Work on Qrack will likely be slow to nil, until we're restored.