### PR TITLE
Debugging QPager Swap variants (and drafting ZeroPhaseFlip)

### DIFF
--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -3250,6 +3250,24 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_zero_phase_flip")
     qftReg->ZeroPhaseFlip(1, 1);
     qftReg->H(1);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x03));
+
+#if 0
+    QInterfacePtr qftReg2 =
+        CreateQuantumInterface(testEngineType, testSubEngineType, 20U, 0, rng, ONE_CMPLX, enable_normalization, true,
+            false, device_id, !disable_hardware_rng, sparse, REAL1_DEFAULT_ARG, (std::vector<int>){}, 10);
+
+    qftReg2->SetPermutation((1U << 9U) || (1U << 10U));
+    qftReg2->H(10);
+    qftReg2->ZeroPhaseFlip(10, 1);
+    qftReg2->H(10);
+    REQUIRE_THAT(qftReg2, HasProbability(0, 12, (1U << 9U)));
+
+    qftReg2->SetPermutation((1U << 9U) || (1U << 10U));
+    qftReg2->H(9, 2);
+    qftReg2->ZeroPhaseFlip(9, 2);
+    qftReg2->H(9, 2);
+    REQUIRE_THAT(qftReg2, HasProbability(0, 12, 0));
+#endif
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_c_phase_flip_if_less")


### PR DESCRIPTION
I fixed a small bug in `QPager::Swap` variants, after fixing a more significant bug in `CSwap`'s unit test.

Also, I drafted almost a complete `QPager::ZeroPhaseFlip` optimized implementation, which has been disabled until I can finish debugging it, tomorrow.