### PR TITLE
QPager Swap debugging, and optimization

### DIFF
--- a/include/qpager.hpp
+++ b/include/qpager.hpp
@@ -64,10 +64,7 @@ protected:
     void MetaControlled(bool anti, std::vector<bitLenInt> controls, bitLenInt target, Qubit1Fn fn, const complex* mtrx);
     template <typename Qubit1Fn>
     void SemiMetaControlled(bool anti, std::vector<bitLenInt> controls, bitLenInt target, Qubit1Fn fn);
-    void MetaControlledSwap(bool anti, const bitLenInt* controls, bitLenInt controlLen, bitLenInt qubit1,
-        bitLenInt qubit2, bool isIPhaseFac);
-    void SemiMetaControlledSwap(bool anti, const bitLenInt* controls, bitLenInt controlLen, bitLenInt qubit1,
-        bitLenInt qubit2, bool isIPhaseFac);
+    void MetaSwap(bitLenInt qubit1, bitLenInt qubit2, bool isIPhaseFac);
 
     template <typename F> void CombineAndOp(F fn, std::vector<bitLenInt> bits);
     template <typename F>

--- a/src/qpager.cpp
+++ b/src/qpager.cpp
@@ -571,20 +571,10 @@ void QPager::CSwap(
         return;
     }
 
-    bitLenInt highestBit = qubit1 > qubit2 ? qubit1 : qubit2;
-    bitLenInt baseQubits = (highestBit < baseQubitsPerPage) ? baseQubitsPerPage : (highestBit + 1U);
-    SeparateEngines(baseQubits);
-
-    bool isQubit1Meta = qubit1 >= qubitsPerPage();
-    bool isQubit2Meta = qubit2 >= qubitsPerPage();
-    if (isQubit1Meta && isQubit2Meta) {
-        MetaControlledSwap(false, controls, controlLen, qubit1, qubit2, false);
+    if (controlLen == 0) {
+        Swap(qubit1, qubit2);
         return;
     }
-    // if (isQubit1Meta || isQubit2Meta) {
-    //    SemiMetaControlledSwap(false, controls, controlLen, qubit1, qubit2, false);
-    //    return;
-    //}
 
     CombineAndOpControlled([&](QEnginePtr engine) { engine->CSwap(controls, controlLen, qubit1, qubit2); },
         { qubit1, qubit2 }, controls, controlLen);
@@ -592,24 +582,14 @@ void QPager::CSwap(
 void QPager::AntiCSwap(
     const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& qubit1, const bitLenInt& qubit2)
 {
+    if (controlLen == 0) {
+        Swap(qubit1, qubit2);
+        return;
+    }
+
     if (qubit1 == qubit2) {
         return;
     }
-
-    bitLenInt highestBit = qubit1 > qubit2 ? qubit1 : qubit2;
-    bitLenInt baseQubits = (highestBit < baseQubitsPerPage) ? baseQubitsPerPage : (highestBit + 1U);
-    SeparateEngines(baseQubits);
-
-    bool isQubit1Meta = qubit1 >= qubitsPerPage();
-    bool isQubit2Meta = qubit2 >= qubitsPerPage();
-    if (isQubit1Meta && isQubit2Meta) {
-        MetaControlledSwap(true, controls, controlLen, qubit1, qubit2, false);
-        return;
-    }
-    // if (isQubit1Meta || isQubit2Meta) {
-    //    SemiMetaControlledSwap(true, controls, controlLen, qubit1, qubit2, false);
-    //    return;
-    //}
 
     CombineAndOpControlled([&](QEnginePtr engine) { engine->AntiCSwap(controls, controlLen, qubit1, qubit2); },
         { qubit1, qubit2 }, controls, controlLen);
@@ -617,24 +597,60 @@ void QPager::AntiCSwap(
 void QPager::CSqrtSwap(
     const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& qubit1, const bitLenInt& qubit2)
 {
+    if (controlLen == 0) {
+        SqrtSwap(qubit1, qubit2);
+        return;
+    }
+
+    if (qubit1 == qubit2) {
+        return;
+    }
+
     CombineAndOpControlled([&](QEnginePtr engine) { engine->CSqrtSwap(controls, controlLen, qubit1, qubit2); },
         { qubit1, qubit2 }, controls, controlLen);
 }
 void QPager::AntiCSqrtSwap(
     const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& qubit1, const bitLenInt& qubit2)
 {
+    if (controlLen == 0) {
+        SqrtSwap(qubit1, qubit2);
+        return;
+    }
+
+    if (qubit1 == qubit2) {
+        return;
+    }
+
     CombineAndOpControlled([&](QEnginePtr engine) { engine->AntiCSqrtSwap(controls, controlLen, qubit1, qubit2); },
         { qubit1, qubit2 }, controls, controlLen);
 }
 void QPager::CISqrtSwap(
     const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& qubit1, const bitLenInt& qubit2)
 {
+    if (controlLen == 0) {
+        ISqrtSwap(qubit1, qubit2);
+        return;
+    }
+
+    if (qubit1 == qubit2) {
+        return;
+    }
+
     CombineAndOpControlled([&](QEnginePtr engine) { engine->CISqrtSwap(controls, controlLen, qubit1, qubit2); },
         { qubit1, qubit2 }, controls, controlLen);
 }
 void QPager::AntiCISqrtSwap(
     const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& qubit1, const bitLenInt& qubit2)
 {
+    if (controlLen == 0) {
+        ISqrtSwap(qubit1, qubit2);
+        return;
+    }
+
+    if (qubit1 == qubit2) {
+        return;
+    }
+
     CombineAndOpControlled([&](QEnginePtr engine) { engine->AntiCISqrtSwap(controls, controlLen, qubit1, qubit2); },
         { qubit1, qubit2 }, controls, controlLen);
 }
@@ -892,8 +908,7 @@ void QPager::Hash(bitLenInt start, bitLenInt length, unsigned char* values)
         { static_cast<bitLenInt>(start + length - 1U) });
 }
 
-void QPager::MetaControlledSwap(
-    bool anti, const bitLenInt* controls, bitLenInt controlLen, bitLenInt qubit1, bitLenInt qubit2, bool isIPhaseFac)
+void QPager::MetaSwap(bitLenInt qubit1, bitLenInt qubit2, bool isIPhaseFac)
 {
     bitLenInt qpp = qubitsPerPage();
     qubit1 -= qpp;
@@ -901,36 +916,18 @@ void QPager::MetaControlledSwap(
     bitLenInt sqi = qpp - 1U;
 
     std::vector<bitCapInt> sortedMasks(2U);
-    bitCapInt qubit1Mask = pow2(qubit1);
-    sortedMasks[0] = qubit1Mask - ONE_BCI;
-    bitCapInt qubit2Mask = pow2(qubit2);
-    sortedMasks[1] = qubit2Mask - ONE_BCI;
-
-    std::vector<bitLenInt> subcontrols;
-    bitCapInt controlMask = 0;
-    bool isSqiSubcontrol = false;
-    for (bitLenInt i = 0; i < controlLen; i++) {
-        if (controls[i] > sqi) {
-            sortedMasks.push_back(pow2(controls[i] - qpp));
-            if (!anti) {
-                controlMask |= sortedMasks.back();
-            }
-            sortedMasks.back()--;
-        } else if (controls[i] == sqi) {
-            isSqiSubcontrol = true;
-        } else {
-            subcontrols.push_back(controls[i]);
-        }
-    }
+    bitCapInt qubit1Pow = pow2(qubit1);
+    sortedMasks[0] = qubit1Pow - ONE_BCI;
+    bitCapInt qubit2Pow = pow2(qubit2);
+    sortedMasks[1] = qubit2Pow - ONE_BCI;
     std::sort(sortedMasks.begin(), sortedMasks.end());
 
     bitCapInt maxLCV = qPages.size() >> sortedMasks.size();
     std::vector<std::future<void>> futures(maxLCV);
     bitCapInt i;
     for (i = 0; i < maxLCV; i++) {
-        futures[i] = std::async(std::launch::async,
-            [this, i, &qubit1Mask, &qubit2Mask, &sortedMasks, &subcontrols, &isIPhaseFac, &sqi, &controlMask,
-                &isSqiSubcontrol, &anti]() {
+        futures[i] =
+            std::async(std::launch::async, [this, i, &qubit1Pow, &qubit2Pow, &sortedMasks, &isIPhaseFac, &sqi]() {
                 bitCapInt j, k, jLo, jHi;
                 jHi = i;
                 j = 0;
@@ -941,168 +938,24 @@ void QPager::MetaControlledSwap(
                 }
                 j |= jHi;
 
-                QEnginePtr engine1 = qPages[j + qubit1Mask];
-                QEnginePtr engine2 = qPages[j + qubit2Mask];
+                std::swap(qPages[j + qubit1Pow], qPages[j + qubit2Pow]);
+
+                if (!isIPhaseFac) {
+                    return;
+                }
+
+                QEnginePtr engine1 = qPages[j + qubit1Pow];
+                QEnginePtr engine2 = qPages[j + qubit2Pow];
 
                 std::future<void> future1, future2;
 
-                if (subcontrols.size()) {
-                    engine1->ShuffleBuffers(engine2);
+                future1 =
+                    std::async(std::launch::async, [engine1]() { engine1->ApplySinglePhase(I_CMPLX, I_CMPLX, 0); });
+                future2 =
+                    std::async(std::launch::async, [engine2]() { engine2->ApplySinglePhase(I_CMPLX, I_CMPLX, 0); });
 
-                    if (isIPhaseFac) {
-                        if (!isSqiSubcontrol || anti) {
-                            future1 = std::async(std::launch::async, [engine1, &sqi, &subcontrols]() {
-                                engine1->ApplyControlledSingleInvert(
-                                    &(subcontrols[0]), subcontrols.size(), sqi, I_CMPLX, I_CMPLX);
-                            });
-                        }
-                        if (!isSqiSubcontrol || !anti) {
-                            future2 = std::async(std::launch::async, [engine2, &sqi, &subcontrols]() {
-                                engine2->ApplyControlledSingleInvert(
-                                    &(subcontrols[0]), subcontrols.size(), sqi, I_CMPLX, I_CMPLX);
-                            });
-                        }
-                    } else {
-                        if (!isSqiSubcontrol || anti) {
-                            future1 = std::async(std::launch::async, [engine1, &sqi, &subcontrols]() {
-                                engine1->ApplyControlledSingleInvert(
-                                    &(subcontrols[0]), subcontrols.size(), sqi, ONE_CMPLX, ONE_CMPLX);
-                            });
-                        }
-                        if (!isSqiSubcontrol || !anti) {
-                            future2 = std::async(std::launch::async, [engine2, &sqi, &subcontrols]() {
-                                engine2->ApplyControlledSingleInvert(
-                                    &(subcontrols[0]), subcontrols.size(), sqi, ONE_CMPLX, ONE_CMPLX);
-                            });
-                        }
-                    }
-
-                    if (!isSqiSubcontrol || anti) {
-                        future1.get();
-                    }
-                    if (!isSqiSubcontrol || !anti) {
-                        future2.get();
-                    }
-
-                    engine1->ShuffleBuffers(engine2);
-                } else {
-                    std::swap(qPages[j + qubit1Mask], qPages[j + qubit2Mask]);
-
-                    if (isIPhaseFac) {
-                        future1 = std::async(
-                            std::launch::async, [engine1]() { engine1->ApplySinglePhase(I_CMPLX, I_CMPLX, 0); });
-                        future2 = std::async(
-                            std::launch::async, [engine2]() { engine2->ApplySinglePhase(I_CMPLX, I_CMPLX, 0); });
-
-                        future1.get();
-                        future2.get();
-                    }
-                }
-            });
-    }
-
-    for (i = 0; i < maxLCV; i++) {
-        futures[i].get();
-    }
-}
-
-void QPager::SemiMetaControlledSwap(
-    bool anti, const bitLenInt* controls, bitLenInt controlLen, bitLenInt qubit1, bitLenInt qubit2, bool isIPhaseFac)
-{
-    if (qubit1 > qubit2) {
-        std::swap(qubit1, qubit2);
-    }
-
-    bitLenInt qpp = qubitsPerPage();
-    qubit2 -= qpp;
-    bitLenInt sqi = qpp - 1U;
-
-    std::vector<bitCapInt> sortedMasks(1U);
-    bitCapInt qubit2Mask = pow2(qubit2);
-    sortedMasks[0] = qubit2Mask - ONE_BCI;
-
-    std::vector<bitLenInt> subcontrols;
-    bitCapInt controlMask = 0;
-    bool isSqiSubcontrol = false;
-    for (bitLenInt i = 0; i < controlLen; i++) {
-        if (controls[i] > sqi) {
-            sortedMasks.push_back(pow2(controls[i] - qpp));
-            if (!anti) {
-                controlMask |= sortedMasks.back();
-            }
-            sortedMasks.back()--;
-        } else if (controls[i] == sqi) {
-            isSqiSubcontrol = true;
-        } else {
-            subcontrols.push_back(controls[i]);
-        }
-    }
-    std::sort(sortedMasks.begin(), sortedMasks.end());
-
-    bitCapInt maxLCV = qPages.size() >> sortedMasks.size();
-    std::vector<std::future<void>> futures(maxLCV);
-    bitCapInt i;
-    for (i = 0; i < maxLCV; i++) {
-        futures[i] = std::async(std::launch::async,
-            [this, i, &qubit1, &qubit2Mask, &sortedMasks, &subcontrols, &isIPhaseFac, &sqi, &controlMask,
-                &isSqiSubcontrol, &anti]() {
-                bitCapInt j, k, jLo, jHi;
-                jHi = i;
-                j = 0;
-                for (k = 0; k < (sortedMasks.size()); k++) {
-                    jLo = jHi & sortedMasks[k];
-                    jHi = (jHi ^ jLo) << ONE_BCI;
-                    j |= jLo;
-                }
-                j |= jHi | controlMask;
-
-                QEnginePtr engine1 = qPages[j];
-                QEnginePtr engine2 = qPages[j + qubit2Mask];
-
-                engine1->ShuffleBuffers(engine2);
-
-                std::future<void> future1, future2;
-
-                bitLenInt* subControlsPtr = subcontrols.size() ? &(subcontrols[0]) : NULL;
-
-                if (isIPhaseFac) {
-                    if (!isSqiSubcontrol || anti) {
-                        future1 =
-                            std::async(std::launch::async, [engine1, &qubit1, &sqi, &subcontrols, subControlsPtr]() {
-                                engine1->CSwap(subControlsPtr, subcontrols.size(), qubit1, sqi);
-                                engine1->ApplySinglePhase(I_CMPLX, I_CMPLX, 0);
-                            });
-                    }
-                    if (!isSqiSubcontrol || !anti) {
-                        future2 =
-                            std::async(std::launch::async, [engine2, &qubit1, &sqi, &subcontrols, subControlsPtr]() {
-                                engine2->CSwap(subControlsPtr, subcontrols.size(), qubit1, sqi);
-                                engine2->ApplySinglePhase(I_CMPLX, I_CMPLX, 0);
-                            });
-                    }
-                } else {
-                    if (!isSqiSubcontrol || anti) {
-                        future1 =
-                            std::async(std::launch::async, [engine1, &qubit1, &sqi, &subcontrols, subControlsPtr]() {
-                                engine1->CSwap(subControlsPtr, subcontrols.size(), qubit1, sqi);
-                            });
-                    }
-                    if (!isSqiSubcontrol || !anti) {
-                        future2 =
-                            std::async(std::launch::async, [engine2, &qubit1, &sqi, &subcontrols, subControlsPtr]() {
-                                engine2->CSwap(subControlsPtr, subcontrols.size(), qubit1, sqi);
-                            });
-                    }
-                }
-
-                if (!isSqiSubcontrol || anti) {
-                    future1.get();
-                }
-                if (!isSqiSubcontrol || !anti) {
-                    future2.get();
-                }
-
-                engine1->ShuffleBuffers(engine2);
+                future1.get();
+                future2.get();
             });
     }
 
@@ -1121,16 +974,13 @@ void QPager::Swap(bitLenInt qubit1, bitLenInt qubit2)
     bitLenInt baseQubits = (highestBit < baseQubitsPerPage) ? baseQubitsPerPage : (highestBit + 1U);
     SeparateEngines(baseQubits);
 
-    bool isQubit1Meta = qubit1 >= qubitsPerPage();
-    bool isQubit2Meta = qubit2 >= qubitsPerPage();
+    bitLenInt qpp = qubitsPerPage();
+    bool isQubit1Meta = qubit1 >= qpp;
+    bool isQubit2Meta = qubit2 >= qpp;
     if (isQubit1Meta && isQubit2Meta) {
-        MetaControlledSwap(false, NULL, 0, qubit1, qubit2, false);
+        MetaSwap(qubit1, qubit2, false);
         return;
     }
-    // if (isQubit1Meta || isQubit2Meta) {
-    //    SemiMetaControlledSwap(false, NULL, 0, qubit1, qubit2, false);
-    //    return;
-    //}
 
     CombineAndOp([&](QEnginePtr engine) { engine->Swap(qubit1, qubit2); }, { qubit1, qubit2 });
 }
@@ -1144,29 +994,38 @@ void QPager::ISwap(bitLenInt qubit1, bitLenInt qubit2)
     bitLenInt baseQubits = (highestBit < baseQubitsPerPage) ? baseQubitsPerPage : (highestBit + 1U);
     SeparateEngines(baseQubits);
 
-    bool isQubit1Meta = qubit1 >= qubitsPerPage();
-    bool isQubit2Meta = qubit2 >= qubitsPerPage();
+    bitLenInt qpp = qubitsPerPage();
+    bool isQubit1Meta = qubit1 >= qpp;
+    bool isQubit2Meta = qubit2 >= qpp;
     if (isQubit1Meta && isQubit2Meta) {
-        MetaControlledSwap(false, NULL, 0, qubit1, qubit2, true);
+        MetaSwap(qubit1, qubit2, true);
         return;
     }
-    // if (isQubit1Meta || isQubit2Meta) {
-    //    SemiMetaControlledSwap(false, NULL, 0, qubit1, qubit2, true);
-    //    return;
-    //}
 
     CombineAndOp([&](QEnginePtr engine) { engine->ISwap(qubit1, qubit2); }, { qubit1, qubit2 });
 }
 void QPager::SqrtSwap(bitLenInt qubit1, bitLenInt qubit2)
 {
+    if (qubit1 == qubit2) {
+        return;
+    }
+
     CombineAndOp([&](QEnginePtr engine) { engine->SqrtSwap(qubit1, qubit2); }, { qubit1, qubit2 });
 }
 void QPager::ISqrtSwap(bitLenInt qubit1, bitLenInt qubit2)
 {
+    if (qubit1 == qubit2) {
+        return;
+    }
+
     CombineAndOp([&](QEnginePtr engine) { engine->ISqrtSwap(qubit1, qubit2); }, { qubit1, qubit2 });
 }
 void QPager::FSim(real1 theta, real1 phi, bitLenInt qubit1, bitLenInt qubit2)
 {
+    if (qubit1 == qubit2) {
+        return;
+    }
+
     CombineAndOp([&](QEnginePtr engine) { engine->FSim(theta, phi, qubit1, qubit2); }, { qubit1, qubit2 });
 }
 

--- a/src/qpager.cpp
+++ b/src/qpager.cpp
@@ -567,6 +567,9 @@ void QPager::UniformlyControlledSingleBit(const bitLenInt* controls, const bitLe
 void QPager::CSwap(
     const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& qubit1, const bitLenInt& qubit2)
 {
+    if (qubit1 == qubit2) {
+        return;
+    }
 
     bitLenInt highestBit = qubit1 > qubit2 ? qubit1 : qubit2;
     bitLenInt baseQubits = (highestBit < baseQubitsPerPage) ? baseQubitsPerPage : (highestBit + 1U);
@@ -589,6 +592,9 @@ void QPager::CSwap(
 void QPager::AntiCSwap(
     const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& qubit1, const bitLenInt& qubit2)
 {
+    if (qubit1 == qubit2) {
+        return;
+    }
 
     bitLenInt highestBit = qubit1 > qubit2 ? qubit1 : qubit2;
     bitLenInt baseQubits = (highestBit < baseQubitsPerPage) ? baseQubitsPerPage : (highestBit + 1U);
@@ -904,7 +910,7 @@ void QPager::MetaControlledSwap(
     bitCapInt controlMask = 0;
     bool isSqiSubcontrol = false;
     for (bitLenInt i = 0; i < controlLen; i++) {
-        if (controls[i] < sqi) {
+        if (controls[i] > sqi) {
             sortedMasks.push_back(pow2(controls[i] - qpp));
             if (!anti) {
                 controlMask |= sortedMasks.back();
@@ -1018,7 +1024,7 @@ void QPager::SemiMetaControlledSwap(
     bitCapInt controlMask = 0;
     bool isSqiSubcontrol = false;
     for (bitLenInt i = 0; i < controlLen; i++) {
-        if (controls[i] < sqi) {
+        if (controls[i] > sqi) {
             sortedMasks.push_back(pow2(controls[i] - qpp));
             if (!anti) {
                 controlMask |= sortedMasks.back();
@@ -1102,6 +1108,9 @@ void QPager::SemiMetaControlledSwap(
 
 void QPager::Swap(bitLenInt qubit1, bitLenInt qubit2)
 {
+    if (qubit1 == qubit2) {
+        return;
+    }
 
     bitLenInt highestBit = qubit1 > qubit2 ? qubit1 : qubit2;
     bitLenInt baseQubits = (highestBit < baseQubitsPerPage) ? baseQubitsPerPage : (highestBit + 1U);
@@ -1122,6 +1131,9 @@ void QPager::Swap(bitLenInt qubit1, bitLenInt qubit2)
 }
 void QPager::ISwap(bitLenInt qubit1, bitLenInt qubit2)
 {
+    if (qubit1 == qubit2) {
+        return;
+    }
 
     bitLenInt highestBit = qubit1 > qubit2 ? qubit1 : qubit2;
     bitLenInt baseQubits = (highestBit < baseQubitsPerPage) ? baseQubitsPerPage : (highestBit + 1U);


### PR DESCRIPTION
Most "meta-" variants of `Swap` in `QPager` were half-baked, but this only became apparent once full unit tests were feasible. Temporarily, most of these variants have been removed. (This doesn't affect the public API, just the implementation "under-the-hood.")

Two different models of NVIDIA graphics cards seem to give peak `QPager` performance for their "preferred concurrency" qubits, +12 qubits. I only have two points to plot my line, but users can test for themselves in the benchmarks, particularly `test_x_all`, in this case.

More "lazy separation" optimizations have been followed-through on.