### PR TITLE
QUnitMulti debug

### DIFF
--- a/include/common/oclengine.hpp
+++ b/include/common/oclengine.hpp
@@ -155,6 +155,7 @@ public:
     cl::Device device;
     cl::Context context;
     int context_id;
+    int device_id;
     cl::CommandQueue queue;
     EventVecPtr wait_events;
 
@@ -164,11 +165,12 @@ protected:
     std::map<OCLAPI, std::unique_ptr<std::mutex>> mutexes;
 
 public:
-    OCLDeviceContext(cl::Platform& p, cl::Device& d, cl::Context& c, int cntxt_id)
+    OCLDeviceContext(cl::Platform& p, cl::Device& d, cl::Context& c, int cntxt_id, int dev_id)
         : platform(p)
         , device(d)
         , context(c)
         , context_id(cntxt_id)
+        , device_id(dev_id)
     {
         cl_int error;
         queue = cl::CommandQueue(context, d, CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE, &error);
@@ -237,7 +239,7 @@ public:
     /// Get the count of devices in the current list.
     int GetDeviceCount() { return all_device_contexts.size(); }
     /// Get default device ID.
-    int GetDefaultDeviceID() { return default_device_context->context_id; }
+    int GetDefaultDeviceID() { return default_device_context->device_id; }
     /// Pick a default device, for QEngineOCL instances that don't specify a preferred device.
     void SetDefaultDeviceContext(DeviceContextPtr dcp);
     /// Initialize the OCL environment, with the option to save the generated binaries. Binaries will be saved/loaded

--- a/include/qengine_opencl.hpp
+++ b/include/qengine_opencl.hpp
@@ -109,7 +109,6 @@ protected:
     BufferPtr stateBuffer;
     BufferPtr nrmBuffer;
     BufferPtr powersBuffer;
-    BufferPtr lockSyncStateBuffer;
     std::vector<PoolItemPtr> poolItems;
     real1* nrmArray;
     size_t nrmGroupCount;
@@ -319,6 +318,29 @@ protected:
     PoolItemPtr GetFreePoolItem();
 
     real1 ParSum(real1* toSum, bitCapIntOcl maxI);
+
+    /**
+     * Locks synchronization between the state vector buffer and general RAM, so the state vector can be directly read
+     * and/or written to.
+     *
+     * OpenCL buffers, even when allocated on "host" general RAM, are not safe to read from or write to unless "mapped."
+     * When mapped, a buffer cannot be used by OpenCL kernels. If the state vector needs to be directly manipulated, it
+     * needs to be temporarily mapped, and this can be accomplished with LockSync(). When direct reading from or writing
+     * to the state vector is done, before performing other OpenCL operations on it, it must be unmapped with
+     * UnlockSync().
+     */
+    void LockSync(cl_int flags = (CL_MAP_READ | CL_MAP_WRITE));
+    /**
+     * Unlocks synchronization between the state vector buffer and general RAM, so the state vector can be operated on
+     * with OpenCL kernels and operations.
+     *
+     * OpenCL buffers, even when allocated on "host" general RAM, are not safe to read from or write to unless "mapped."
+     * When mapped, a buffer cannot be used by OpenCL kernels. If the state vector needs to be directly manipulated, it
+     * needs to be temporarily mapped, and this can be accomplished with LockSync(). When direct reading from or writing
+     * to the state vector is done, before performing other OpenCL operations on it, it must be unmapped with
+     * UnlockSync().
+     */
+    void UnlockSync();
 
     /**
      * Finishes the asynchronous wait event list or queue of OpenCL events.

--- a/include/qfactory.hpp
+++ b/include/qfactory.hpp
@@ -42,7 +42,7 @@ QInterfacePtr CreateQuantumInterface(
         return std::make_shared<QUnit>(subengine1, subengine2, args...);
 #if ENABLE_OPENCL
     case QINTERFACE_QUNIT_MULTI:
-        return std::make_shared<QUnit>(subengine1, args...);
+        return std::make_shared<QUnitMulti>(subengine1, args...);
 #endif
     default:
         return NULL;
@@ -65,7 +65,7 @@ QInterfacePtr CreateQuantumInterface(QInterfaceEngine engine, QInterfaceEngine s
         return std::make_shared<QUnit>(subengine, args...);
 #if ENABLE_OPENCL
     case QINTERFACE_QUNIT_MULTI:
-        return std::make_shared<QUnit>(subengine, args...);
+        return std::make_shared<QUnitMulti>(subengine, args...);
 #endif
     default:
         return NULL;

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -2020,6 +2020,21 @@ public:
      */
     virtual QInterfacePtr Clone() = 0;
 
+    /**
+     *  Set the device index, if more than one device is available.
+     */
+    virtual void SetDevice(const int& dID, const bool& forceReInit = false) {}
+
+    /**
+     *  Get the device index. ("-1" is default).
+     */
+    virtual int GetDeviceID() { return -1; }
+
+    /**
+     *  Get maximum number of amplitudes that can be allocated on current device.
+     */
+    bitCapIntOcl GetMaxSize() { return pow2(sizeof(bitCapInt) * 8); };
+
     /** @} */
 };
 } // namespace Qrack

--- a/include/qpager.hpp
+++ b/include/qpager.hpp
@@ -231,5 +231,22 @@ public:
     virtual bool TrySeparate(bitLenInt start, bitLenInt length = 1) { return false; }
 
     virtual QInterfacePtr Clone();
+
+    virtual void SetDevice(const int& dID, const bool& forceReInit = false)
+    {
+        deviceIDs.clear();
+        deviceIDs.push_back(dID);
+
+        for (bitCapInt i = 0; i < qPages.size(); i++) {
+            qPages[i]->SetDevice(dID, forceReInit);
+        }
+    }
+
+    virtual int GetDeviceID() { return qPages[0]->GetDeviceID(); }
+
+    /**
+     *  Get maximum number of amplitudes that can be allocated on current device.
+     */
+    bitCapIntOcl GetMaxSize() { return qPages[0]->GetMaxSize(); };
 };
 } // namespace Qrack

--- a/include/qunitmulti.hpp
+++ b/include/qunitmulti.hpp
@@ -23,7 +23,7 @@
 namespace Qrack {
 
 struct QEngineInfo {
-    QEngineOCLPtr unit;
+    QInterfacePtr unit;
     bitLenInt deviceIndex;
 
     QEngineInfo()
@@ -32,7 +32,7 @@ struct QEngineInfo {
     {
     }
 
-    QEngineInfo(QEngineOCLPtr u, bitLenInt devIndex)
+    QEngineInfo(QInterfacePtr u, bitLenInt devIndex)
         : unit(u)
         , deviceIndex(devIndex)
     {
@@ -68,16 +68,15 @@ protected:
     std::vector<DeviceInfo> deviceList;
 
 public:
-    QUnitMulti(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState = 0, qrack_rand_gen_ptr rgp = nullptr,
-        complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = true, bool randomGlobalPhase = true,
-        bool useHostMem = false, int deviceID = -1, bool useHardwareRNG = true, bool useSparseStateVec = false,
-        real1 norm_thresh = REAL1_DEFAULT_ARG, std::vector<int> devList = {}, bitLenInt qubitThreshold = 0)
-        : QUnitMulti(qBitCount, initState, rgp, phaseFac, doNorm, randomGlobalPhase, useHostMem, -1, useHardwareRNG,
-              qubitThreshold)
+    QUnitMulti(bitLenInt qBitCount, bitCapInt initState, qrack_rand_gen_ptr rgp, complex phaseFac, bool doNorm,
+        bool randomGlobalPhase, bool useHostMem, int deviceID, bool useHardwareRNG, bool useSparseStateVec,
+        real1 norm_thresh, std::vector<int> devList, bitLenInt qubitThreshold)
+        : QUnitMulti(QINTERFACE_OPENCL, qBitCount, initState, rgp, phaseFac, doNorm, randomGlobalPhase, useHostMem, -1,
+              useHardwareRNG, qubitThreshold)
     {
     }
 
-    QUnitMulti(bitLenInt qBitCount, bitCapInt initState = 0, qrack_rand_gen_ptr rgp = nullptr,
+    QUnitMulti(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState = 0, qrack_rand_gen_ptr rgp = nullptr,
         complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = true, bool randomGlobalPhase = true,
         bool useHostMem = false, int deviceID = -1, bool useHardwareRNG = true, bool useSparseStateVec = false,
         real1 norm_thresh = REAL1_DEFAULT_ARG, std::vector<int> devList = {}, bitLenInt qubitThreshold = 0);

--- a/src/common/oclengine.cpp
+++ b/src/common/oclengine.cpp
@@ -298,7 +298,7 @@ void OCLEngine::InitOCL(bool buildFromSource, bool saveBinaries, std::string hom
             all_contexts.push_back(cl::Context(all_platforms_devices[plat_id]));
         }
         std::shared_ptr<OCLDeviceContext> devCntxt = std::make_shared<OCLDeviceContext>(
-            devPlatVec[i], all_devices[i], all_contexts[all_contexts.size() - 1], plat_id);
+            devPlatVec[i], all_devices[i], all_contexts[all_contexts.size() - 1], i, plat_id);
 
         std::string fileName = binary_file_prefix + std::to_string(i) + binary_file_ext;
         std::string clBinName = home + fileName;

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -375,7 +375,7 @@ void QEngineOCL::SetDevice(const int& dID, const bool& forceReInit)
         }
 
         // We're about to switch to a new device, so finish the queue, first.
-        clFinish(true);
+        clFinish();
     }
 
     cl::Context oldContext = context;
@@ -386,7 +386,6 @@ void QEngineOCL::SetDevice(const int& dID, const bool& forceReInit)
     queue = device_context->queue;
 
     OCLDeviceCall ocl = device_context->Reserve(OCL_API_APPLY2X2_NORM_SINGLE);
-    clFinish(true);
 
     bitCapIntOcl oldNrmGroupCount = nrmGroupCount;
     nrmGroupSize = ocl.call.getWorkGroupInfo<CL_KERNEL_PREFERRED_WORK_GROUP_SIZE_MULTIPLE>(device_context->device);

--- a/src/qpager.cpp
+++ b/src/qpager.cpp
@@ -163,8 +163,8 @@ void QPager::MetaControlled(
     bitLenInt sqi = qpp - 1U;
 
     std::vector<bitCapInt> sortedMasks(1U + controls.size());
-    bitCapInt targetMask = pow2(target);
-    sortedMasks[controls.size()] = targetMask - ONE_BCI;
+    bitCapInt targetPow = pow2(target);
+    sortedMasks[controls.size()] = targetPow - ONE_BCI;
 
     bitCapInt controlMask = 0;
     for (bitLenInt i = 0; i < controls.size(); i++) {
@@ -205,7 +205,7 @@ void QPager::MetaControlled(
     bitCapInt i;
     for (i = 0; i < maxLCV; i++) {
         futures[i] = std::async(std::launch::async,
-            [this, i, fn, &sqi, &controlMask, &targetMask, &sortedMasks, &isSpecial, &isInvert, &top, &bottom]() {
+            [this, i, fn, &sqi, &controlMask, &targetPow, &sortedMasks, &isSpecial, &isInvert, &top, &bottom]() {
                 bitCapInt j, k, jLo, jHi;
                 jHi = i;
                 j = 0;
@@ -217,11 +217,11 @@ void QPager::MetaControlled(
                 j |= jHi | controlMask;
 
                 if (isSpecial && isInvert) {
-                    std::swap(qPages[j], qPages[j + targetMask]);
+                    std::swap(qPages[j], qPages[j + targetPow]);
                 }
 
                 QEnginePtr engine1 = qPages[j];
-                QEnginePtr engine2 = qPages[j + targetMask];
+                QEnginePtr engine2 = qPages[j + targetPow];
 
                 std::future<void> future1, future2;
                 if (isSpecial) {
@@ -459,8 +459,8 @@ void QPager::ApplySingleEither(const bool& isInvert, complex top, complex bottom
     bitLenInt qpp = qubitsPerPage();
 
     target -= qpp;
-    bitCapInt targetMask = pow2(target);
-    bitCapInt qMask = targetMask - 1U;
+    bitCapInt targetPow = pow2(target);
+    bitCapInt qMask = targetPow - 1U;
 
     if (randGlobalPhase) {
         bottom /= top;
@@ -471,16 +471,16 @@ void QPager::ApplySingleEither(const bool& isInvert, complex top, complex bottom
     std::vector<std::future<void>> futures(maxLCV);
     bitCapInt i;
     for (i = 0; i < maxLCV; i++) {
-        futures[i] = std::async(std::launch::async, [this, i, &isInvert, &top, &bottom, &targetMask, &qMask]() {
+        futures[i] = std::async(std::launch::async, [this, i, &isInvert, &top, &bottom, &targetPow, &qMask]() {
             bitCapInt j = i & qMask;
             j |= (i ^ j) << ONE_BCI;
 
             if (isInvert) {
-                std::swap(qPages[j], qPages[j + targetMask]);
+                std::swap(qPages[j], qPages[j + targetPow]);
             }
 
             QEnginePtr engine1 = qPages[j];
-            QEnginePtr engine2 = qPages[j + targetMask];
+            QEnginePtr engine2 = qPages[j + targetPow];
 
             std::future<void> future1, future2;
             if (top != ONE_CMPLX) {

--- a/src/qunitmulti.cpp
+++ b/src/qunitmulti.cpp
@@ -167,30 +167,38 @@ QInterfacePtr QUnitMulti::EntangleInCurrentBasis(
         }
     }
 
-    // This does nothing if the first unit is the default device:
-    if (!isAlreadyEntangled && deviceList[0].id != unit1->GetDeviceID()) {
-        // Check if size exceeds single device capacity:
-        bitLenInt qubitCount = 0;
-        std::map<QInterfacePtr, bool> found;
+    QInterfacePtr toRet;
 
+    if (isAlreadyEntangled) {
         for (auto bit = first; bit < last; bit++) {
-            QInterfacePtr unit = shards[**bit].unit;
-            if (found.find(unit) == found.end()) {
-                found[unit] = true;
-                qubitCount += unit->GetQubitCount();
+            EndEmulation(shards[**bit]);
+        }
+        toRet = unit1;
+    } else {
+        // This does nothing if the first unit is the default device:
+        if (deviceList[0].id != unit1->GetDeviceID()) {
+            // Check if size exceeds single device capacity:
+            bitLenInt qubitCount = 0;
+            std::map<QInterfacePtr, bool> found;
+
+            for (auto bit = first; bit < last; bit++) {
+                QInterfacePtr unit = shards[**bit].unit;
+                if (found.find(unit) == found.end()) {
+                    found[unit] = true;
+                    qubitCount += unit->GetQubitCount();
+                }
+            }
+
+            // If device capacity is exceeded, put on default device:
+            if (pow2(qubitCount) > unit1->GetMaxSize()) {
+                unit1->SetDevice(deviceList[0].id);
             }
         }
 
-        // If device capacity is exceeded, put on default device:
-        if (pow2(qubitCount) > unit1->GetMaxSize()) {
-            unit1->SetDevice(deviceList[0].id);
-        }
-    }
-
-    QInterfacePtr toRet = QUnit::EntangleInCurrentBasis(first, last);
-    if (!isAlreadyEntangled) {
+        toRet = QUnit::EntangleInCurrentBasis(first, last);
         RedistributeQEngines();
     }
+
     return toRet;
 }
 

--- a/src/qunitmulti.cpp
+++ b/src/qunitmulti.cpp
@@ -17,16 +17,15 @@
 
 namespace Qrack {
 
-QUnitMulti::QUnitMulti(bitLenInt qBitCount, bitCapInt initState, qrack_rand_gen_ptr rgp, complex phaseFac, bool doNorm,
-    bool randomGlobalPhase, bool useHostMem, int deviceID, bool useHardwareRNG, bool useSparseStateVec,
-    real1 norm_thresh, std::vector<int> devList, bitLenInt qubitThreshold)
-    : QUnit(QINTERFACE_OPENCL, qBitCount, initState, rgp, phaseFac, doNorm, randomGlobalPhase, useHostMem, -1,
+QUnitMulti::QUnitMulti(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState, qrack_rand_gen_ptr rgp,
+    complex phaseFac, bool doNorm, bool randomGlobalPhase, bool useHostMem, int deviceID, bool useHardwareRNG,
+    bool useSparseStateVec, real1 norm_thresh, std::vector<int> devList, bitLenInt qubitThreshold)
+    : QUnit(eng, QINTERFACE_OPENCL, qBitCount, initState, rgp, phaseFac, doNorm, randomGlobalPhase, useHostMem, -1,
           useHardwareRNG, useSparseStateVec, norm_thresh, devList, qubitThreshold)
 {
-    // Notice that this constructor does not take an engine type parameter, and it always passes QINTERFACE_OPENCL to
-    // the QUnit constructor. For QUnitMulti, the "shard" engines are therefore guaranteed to always be QEngineOCL
-    // types, and it's safe to assume that they can be cast from QInterfacePtr types to QEngineOCLPtr types in this
-    // class.
+    // Notice that this constructor always passes QINTERFACE_OPENCL to the QUnit constructor. For QUnitMulti, the
+    // "shard" engines are therefore guaranteed to always be QEngineOCL or QPager types, and it's safe to assume that
+    // they can be cast from QInterfacePtr types to QEngineOCLPtr types in this class.
 
     std::vector<DeviceContextPtr> deviceContext = OCLEngine::Instance()->GetDeviceContextPtrVector();
 
@@ -64,8 +63,7 @@ QUnitMulti::QUnitMulti(bitLenInt qBitCount, bitCapInt initState, qrack_rand_gen_
 void QUnitMulti::RedistributeSingleQubits()
 {
     for (bitLenInt i = 0; i < qubitCount; i++) {
-        std::dynamic_pointer_cast<QEngineOCL>(shards[i].unit)
-            ->SetDevice(deviceList[(int)((real1)(i * deviceList.size()) / qubitCount)].id);
+        shards[i].unit->SetDevice(deviceList[(int)((real1)(i * deviceList.size()) / qubitCount)].id);
     }
 }
 
@@ -73,18 +71,16 @@ std::vector<QEngineInfo> QUnitMulti::GetQInfos()
 {
     // Get shard sizes and devices
     std::vector<QInterfacePtr> qips;
-    QEngineOCLPtr qOCL;
     std::vector<QEngineInfo> qinfos;
     int deviceIndex;
 
     for (auto&& shard : shards) {
         if (std::find(qips.begin(), qips.end(), shard.unit) == qips.end()) {
             qips.push_back(shard.unit);
-            qOCL = std::dynamic_pointer_cast<QEngineOCL>(shard.unit);
             deviceIndex = std::distance(deviceList.begin(),
-                std::find_if(
-                    deviceList.begin(), deviceList.end(), [&](DeviceInfo di) { return di.id == qOCL->GetDeviceID(); }));
-            qinfos.push_back(QEngineInfo(qOCL, deviceIndex));
+                std::find_if(deviceList.begin(), deviceList.end(),
+                    [&](DeviceInfo di) { return di.id == shard.unit->GetDeviceID(); }));
+            qinfos.push_back(QEngineInfo(shard.unit, deviceIndex));
         }
     }
 
@@ -159,7 +155,7 @@ void QUnitMulti::Detach(bitLenInt start, bitLenInt length, QUnitMultiPtr dest)
 QInterfacePtr QUnitMulti::EntangleInCurrentBasis(
     std::vector<bitLenInt*>::iterator first, std::vector<bitLenInt*>::iterator last)
 {
-    QEngineOCLPtr unit1 = std::dynamic_pointer_cast<QEngineOCL>(shards[**first].unit);
+    QInterfacePtr unit1 = shards[**first].unit;
 
     // If already fully entangled, just return unit1.
     bool isAlreadyEntangled = true;
@@ -186,7 +182,7 @@ QInterfacePtr QUnitMulti::EntangleInCurrentBasis(
         }
 
         // If device capacity is exceeded, put on default device:
-        if (pow2(qubitCount) > std::dynamic_pointer_cast<QEngineOCL>(unit1)->GetMaxSize()) {
+        if (pow2(qubitCount) > unit1->GetMaxSize()) {
             unit1->SetDevice(deviceList[0].id);
         }
     }
@@ -227,7 +223,7 @@ QInterfacePtr QUnitMulti::Clone()
     EndAllEmulation();
 
     QUnitMultiPtr copyPtr = std::make_shared<QUnitMulti>(
-        qubitCount, 0, rand_generator, complex(ONE_R1, ZERO_R1), doNormalize, randGlobalPhase, useHostRam);
+        engine, qubitCount, 0, rand_generator, complex(ONE_R1, ZERO_R1), doNormalize, randGlobalPhase, useHostRam);
 
     return CloneBody(copyPtr);
 }

--- a/test/benchmarks_main.cpp
+++ b/test/benchmarks_main.cpp
@@ -235,7 +235,7 @@ int main(int argc, char* argv[])
         if (num_failed == 0 && cpu) {
             testSubSubEngineType = QINTERFACE_CPU;
             session.config().stream() << "############ QUnit -> QPager -> CPU ############" << std::endl;
-            testSubEngineType = QINTERFACE_CPU;
+            testSubSubEngineType = QINTERFACE_CPU;
             num_failed = session.run();
         }
 
@@ -243,7 +243,15 @@ int main(int argc, char* argv[])
         if (num_failed == 0 && opencl_single) {
             testSubSubEngineType = QINTERFACE_OPENCL;
             session.config().stream() << "############ QUnit -> QPager -> OpenCL ############" << std::endl;
-            testSubEngineType = QINTERFACE_OPENCL;
+            testSubSubEngineType = QINTERFACE_OPENCL;
+            CreateQuantumInterface(QINTERFACE_OPENCL, 1, 0).reset(); /* Get the OpenCL banner out of the way. */
+            num_failed = session.run();
+        }
+
+        if (num_failed == 0 && opencl_multi) {
+            session.config().stream() << "############ QUnitMulti -> QPager (OpenCL) ############" << std::endl;
+            testEngineType = QINTERFACE_QUNIT_MULTI;
+            testSubSubEngineType = QINTERFACE_OPENCL;
             CreateQuantumInterface(QINTERFACE_OPENCL, 1, 0).reset(); /* Get the OpenCL banner out of the way. */
             num_failed = session.run();
         }

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -208,7 +208,15 @@ int main(int argc, char* argv[])
         if (num_failed == 0 && opencl_single) {
             testSubSubEngineType = QINTERFACE_OPENCL;
             session.config().stream() << "############ QUnit -> QPager -> OpenCL ############" << std::endl;
-            testSubEngineType = QINTERFACE_OPENCL;
+            testSubSubEngineType = QINTERFACE_OPENCL;
+            CreateQuantumInterface(QINTERFACE_OPENCL, 1, 0).reset(); /* Get the OpenCL banner out of the way. */
+            num_failed = session.run();
+        }
+
+        if (num_failed == 0 && opencl_multi) {
+            session.config().stream() << "############ QUnitMulti -> QPager (OpenCL) ############" << std::endl;
+            testEngineType = QINTERFACE_QUNIT_MULTI;
+            testSubSubEngineType = QINTERFACE_OPENCL;
             CreateQuantumInterface(QINTERFACE_OPENCL, 1, 0).reset(); /* Get the OpenCL banner out of the way. */
             num_failed = session.run();
         }


### PR DESCRIPTION
I apologize for this, but, weirdly enough, `QUnitMulti` wasn't engaged at all in `qfactory.cpp` and therefore also not in unit tests or benchmarks. (Some unspecified configuration of `QUnit` was being used, instead.) When I re-engaged `QUnitMulti` in the factory, I also debugged it. This should be fully compatible with OpenCL v1.1 and SnuCL, (and non-trivially so, now).