### PR TITLE
Fix QUnit->QPager benchmarks

### DIFF
--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -277,7 +277,7 @@ PoolItemPtr QEngineOCL::GetFreePoolItem()
 
 EventVecPtr QEngineOCL::ResetWaitEvents(bool waitQueue)
 {
-    if (waitQueue) {
+    if ((runningNorm != ZERO_CMPLX) && waitQueue) {
         while (wait_queue_items.size() > 1) {
             device_context->WaitOnAllEvents();
             PopQueue(NULL, CL_COMPLETE);

--- a/src/qpager.cpp
+++ b/src/qpager.cpp
@@ -1020,16 +1020,18 @@ void QPager::FSim(real1 theta, real1 phi, bitLenInt qubit1, bitLenInt qubit2)
 
 real1 QPager::Prob(bitLenInt qubitIndex)
 {
+    if (qubitIndex >= qubitsPerPage()) {
+        CombineEngines(qubitIndex + 1U);
+    } else {
+        SeparateEngines(qubitIndex + 1U);
+    }
+
     if (qPages.size() == 1U) {
         return qPages[0]->Prob(qubitIndex);
     }
 
     real1 oneChance = ZERO_R1;
     bitCapInt i;
-
-    if (qubitIndex >= qubitsPerPage()) {
-        CombineEngines(qubitIndex + 1U);
-    }
 
     std::vector<std::future<real1>> futures(qPages.size());
     for (i = 0; i < qPages.size(); i++) {
@@ -1039,9 +1041,6 @@ real1 QPager::Prob(bitLenInt qubitIndex)
     for (i = 0; i < qPages.size(); i++) {
         oneChance += futures[i].get();
     }
-
-    // Prob() tends to be called during M(), at end of algorithms.
-    SeparateEngines();
 
     return oneChance;
 }


### PR DESCRIPTION
When amplitudes are zeroed throughout an entire `QEngine` because it is a part of a `QPager`, `ResetWaitEvents()` also fails. Skip it, if the `QEngine` is zeroed.