### PR TITLE
Lock wait events queue on dispatch for all QEngineOCL instances

### DIFF
--- a/include/common/oclengine.hpp
+++ b/include/common/oclengine.hpp
@@ -199,6 +199,10 @@ public:
         return waitVec;
     }
 
+    void LockWaitEvents() { waitEventsMutex.lock(); }
+
+    void UnlockWaitEvents() { waitEventsMutex.unlock(); }
+
     void WaitOnAllEvents()
     {
         std::lock_guard<std::mutex> guard(waitEventsMutex);

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -39,18 +39,24 @@ namespace Qrack {
     queue.flush();
 
 #define DISPATCH_WRITE(waitVec, buff, size, array)                                                                     \
+    device_context->LockWaitEvents();                                                                                  \
     device_context->wait_events->emplace_back();                                                                       \
     queue.enqueueWriteBuffer(buff, CL_FALSE, 0, size, array, waitVec.get(), &(device_context->wait_events->back()));   \
+    device_context->UnlockWaitEvents();                                                                                \
     queue.flush()
 
 #define DISPATCH_READ(waitVec, buff, size, array)                                                                      \
+    device_context->LockWaitEvents();                                                                                  \
     device_context->wait_events->emplace_back();                                                                       \
     queue.enqueueReadBuffer(buff, CL_FALSE, 0, size, array, waitVec.get(), &(device_context->wait_events->back()));    \
+    device_context->UnlockWaitEvents();                                                                                \
     queue.flush()
 
 #define DISPATCH_COPY(waitVec, buff1, buff2, size)                                                                     \
+    device_context->LockWaitEvents();                                                                                  \
     device_context->wait_events->emplace_back();                                                                       \
     queue.enqueueCopyBuffer(buff1, buff2, 0, 0, size, waitVec.get(), &(device_context->wait_events->back()));          \
+    device_context->UnlockWaitEvents();                                                                                \
     queue.flush();
 
 #define WAIT_REAL1_SUM(buff, size, array, sumPtr)                                                                      \
@@ -557,9 +563,11 @@ void QEngineOCL::SetPermutation(bitCapInt perm, complex phaseFac)
     }
 
     EventVecPtr waitVec = ResetWaitEvents();
+    device_context->LockWaitEvents();
     device_context->wait_events->emplace_back();
     queue.enqueueWriteBuffer(*stateBuffer, CL_FALSE, sizeof(complex) * (bitCapIntOcl)perm, sizeof(complex),
         &permutationAmp, waitVec.get(), &(device_context->wait_events->back()));
+    device_context->UnlockWaitEvents();
     queue.flush();
 
     runningNorm = ONE_R1;
@@ -590,9 +598,11 @@ void QEngineOCL::CArithmeticCall(OCLAPI api_call, bitCapIntOcl (&bciArgs)[BCI_AR
     nStateBuffer = MakeStateVecBuffer(nStateVec);
 
     if (controlLen > 0) {
+        device_context->LockWaitEvents();
         device_context->wait_events->emplace_back();
         queue.enqueueCopyBuffer(*stateBuffer, *nStateBuffer, 0, 0, sizeof(complex) * maxQPowerOcl, waitVec.get(),
             &(device_context->wait_events->back()));
+        device_context->UnlockWaitEvents();
         queue.flush();
     } else {
         ClearBuffer(nStateBuffer, 0, maxQPowerOcl, waitVec);
@@ -2284,9 +2294,11 @@ void QEngineOCL::SetAmplitude(bitCapInt perm, complex amp)
     permutationAmp = amp;
 
     EventVecPtr waitVec = ResetWaitEvents();
+    device_context->LockWaitEvents();
     device_context->wait_events->emplace_back();
     queue.enqueueWriteBuffer(*stateBuffer, CL_FALSE, sizeof(complex) * (bitCapIntOcl)perm, sizeof(complex),
         &permutationAmp, waitVec.get(), &(device_context->wait_events->back()));
+    device_context->UnlockWaitEvents();
     queue.flush();
 }
 


### PR DESCRIPTION
I hadn't appreciated that `QPager` layered over `QEngineOCL` makes for a situation where multiple `QEngineOCL` instances share a device/platform context. It was always part of the design intention that `QEngineOCL` should work in at least certain multi-threaded situations, but we didn't have a great opportunity to test this until `QPager`. It seems that some of the most immediate bugs are due to `DispatchQueue()` without a mutex on wait event lists, but this is hopefully fixed, now.