### PR TITLE
QPager device ID default

### DIFF
--- a/src/qpager.cpp
+++ b/src/qpager.cpp
@@ -46,7 +46,7 @@ QPager::QPager(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState, q
     }
 
     if (deviceIDs.size() == 0) {
-        deviceIDs.push_back(-1);
+        deviceIDs.push_back(deviceId);
     }
 
     SetQubitCount(qubitCount);

--- a/src/qpager.cpp
+++ b/src/qpager.cpp
@@ -46,7 +46,7 @@ QPager::QPager(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState, q
     }
 
     if (deviceIDs.size() == 0) {
-        deviceIDs.push_back(deviceId);
+        deviceIDs.push_back(devID);
     }
 
     SetQubitCount(qubitCount);


### PR DESCRIPTION
The "deviceID" parameter in QPager now selects the default device.