### PR TITLE
QPager::SemiMetaSwap()

### DIFF
--- a/include/qengine_cpu.hpp
+++ b/include/qengine_cpu.hpp
@@ -110,6 +110,9 @@ public:
         }
 
         stateVec->shuffle(engineCpu->stateVec);
+
+        runningNorm = ONE_R1;
+        engineCpu->runningNorm = ONE_R1;
     }
 
     virtual void SetQuantumState(const complex* inputState);

--- a/include/qpager.hpp
+++ b/include/qpager.hpp
@@ -65,6 +65,7 @@ protected:
     template <typename Qubit1Fn>
     void SemiMetaControlled(bool anti, std::vector<bitLenInt> controls, bitLenInt target, Qubit1Fn fn);
     void MetaSwap(bitLenInt qubit1, bitLenInt qubit2, bool isIPhaseFac);
+    void SemiMetaSwap(bitLenInt qubit1, bitLenInt qubit2, bool isIPhaseFac);
 
     template <typename F> void CombineAndOp(F fn, std::vector<bitLenInt> bits);
     template <typename F>

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -404,6 +404,22 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_swap")
     qftReg->SetPermutation(0xb2000);
     qftReg->Swap(12, 16, 4);
     REQUIRE_THAT(qftReg, HasProbability(0x2b000));
+
+    qftReg->SetPermutation(0x80000);
+    qftReg->Swap(18, 19);
+    REQUIRE_THAT(qftReg, HasProbability(0x40000));
+
+    qftReg->SetPermutation(0xc0000);
+    qftReg->Swap(18, 19);
+    REQUIRE_THAT(qftReg, HasProbability(0xc0000));
+
+    qftReg->SetPermutation(0x80000);
+    qftReg->Swap(17, 19);
+    REQUIRE_THAT(qftReg, HasProbability(0x20000));
+
+    qftReg->SetPermutation(0xa0000);
+    qftReg->Swap(17, 19);
+    REQUIRE_THAT(qftReg, HasProbability(0xa0000));
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_iswap")


### PR DESCRIPTION
This optimizes `QPager::Swap()` with one bit "meta-" and one bit within "pages."