### PR TITLE
QEngineCPU optimization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ include ("cmake/Format.cmake")
 
 include_directories ("include" "include/common")
 
-set(PSTRIDE "64" CACHE STRING "Stride of parallel for loops (must be power of 2)")
+set(PSTRIDEPOW "9" CACHE STRING "Stride of parallel for loops (as a power of 2)")
 
 set(QBCAPPOW "6" CACHE STRING "Log2 of maximum qubit capacity of a single QInterface (must be at least 5, equivalent to >= 32 qubits)")
 if (QBCAPPOW LESS 5)

--- a/include/common/config.h.in
+++ b/include/common/config.h.in
@@ -1,4 +1,4 @@
 #cmakedefine ENABLE_OPENCL 1
 #cmakedefine ENABLE_COMPLEX_X2 1
 #cmakedefine ENABLE_COMPLEX8 1
-#cmakedefine PSTRIDE @PSTRIDE@
+#cmakedefine PSTRIDEPOW @PSTRIDEPOW@

--- a/include/common/parallel_for.hpp
+++ b/include/common/parallel_for.hpp
@@ -72,8 +72,11 @@ public:
     void par_for_sparse_compose(const std::vector<bitCapInt>& lowSet, const std::vector<bitCapInt>& highSet,
         const bitLenInt& highStart, ParallelFunc fn);
 
-    /** Calculate the normal for the array. */
-    real1 par_norm(const bitCapInt maxQPower, const StateVectorPtr stateArray, real1 norm_thresh = REAL1_DEFAULT_ARG);
+    /** Calculate the normal for the array, (with flooring). */
+    real1 par_norm(const bitCapInt maxQPower, const StateVectorPtr stateArray, real1 norm_thresh = ZERO_R1);
+
+    /** Calculate the normal for the array, (without flooring. */
+    real1 par_norm_exact(const bitCapInt maxQPower, const StateVectorPtr stateArray);
 };
 
 } // namespace Qrack

--- a/src/common/parallel_for.cpp
+++ b/src/common/parallel_for.cpp
@@ -61,7 +61,8 @@ void ParallelFor::par_for_inc(const bitCapInt begin, const bitCapInt itemCount, 
         for (int cpu = 0; cpu < numCores; cpu++) {
             futures[cpu] = ATOMIC_ASYNC(cpu, &idx, begin, itemCount, Stride, inc, fn)
             {
-                bitCapInt i, j, k, l;
+                bitCapInt i, j, l;
+                bitCapInt k = 0;
                 for (;;) {
                     ATOMIC_INC();
                     l = i * Stride;


### PR DESCRIPTION
I find that I am using `QEngineCPU` in important cases, so it's due for a round of optimization. We never considered performance on this engine type to be particularly important, in expectation of OpenCL being available even for CPU-only systems, but I'm very glad we maintained a pure C++11 implementation, in retrospect. The `QEngineCPU::Apply2x2()` code becomes slightly unwieldy, but it's important to branch outside of its lambda expression kernel, so the complexity is acceptable, with a payoff.