### PR TITLE
QInterface::SetConcurrency()

### DIFF
--- a/include/pinvoke_api.hpp
+++ b/include/pinvoke_api.hpp
@@ -32,6 +32,7 @@ MICROSOFT_QUANTUM_DECL unsigned init();
 MICROSOFT_QUANTUM_DECL unsigned init_count(_In_ unsigned q);
 MICROSOFT_QUANTUM_DECL void destroy(_In_ unsigned sid);
 MICROSOFT_QUANTUM_DECL void seed(_In_ unsigned sid, _In_ unsigned s);
+MICROSOFT_QUANTUM_DECL void set_concurrency(_In_ unsigned sid, _In_ unsigned p);
 MICROSOFT_QUANTUM_DECL void Dump(_In_ unsigned sid, _In_ ProbAmpCallback callback);
 
 // pseudo-quantum

--- a/include/qengine_cpu.hpp
+++ b/include/qengine_cpu.hpp
@@ -51,6 +51,8 @@ public:
         // Intentionally left blank
     }
 
+    virtual void SetConcurrency(uint32_t threadsPerEngine) { SetConcurrencyLevel(threadsPerEngine); }
+
     virtual void ZeroAmplitudes()
     {
         runningNorm = ZERO_R1;

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -225,6 +225,9 @@ public:
         }
     }
 
+    /** Set the number of threads in parallel for loops, per component QEngine */
+    virtual void SetConcurrency(uint32_t threadsPerEngine) {}
+
     /** Get the count of bits in this register */
     bitLenInt GetQubitCount() { return qubitCount; }
 

--- a/include/qpager.hpp
+++ b/include/qpager.hpp
@@ -82,6 +82,13 @@ public:
         int deviceId = -1, bool useHardwareRNG = true, bool useSparseStateVec = false,
         real1 ignored3 = REAL1_DEFAULT_ARG, std::vector<int> devList = {}, bitLenInt qubitThreshold = 0);
 
+    virtual void SetConcurrency(uint32_t threadsPerEngine)
+    {
+        for (bitCapInt i = 0; i < qPages.size(); i++) {
+            qPages[i]->SetConcurrency(threadsPerEngine);
+        }
+    }
+
     virtual void SetQuantumState(const complex* inputState);
     virtual void GetQuantumState(complex* outputState);
     virtual void GetProbs(real1* outputProbs);

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -686,6 +686,16 @@ public:
 
     virtual ~QUnit() { Dump(); }
 
+    virtual void SetConcurrency(uint32_t threadsPerEngine)
+    {
+        ParallelUnitApply(
+            [](QInterfacePtr unit, real1 unused1, real1 unused2, int32_t threadsPerEngine) {
+                unit->SetConcurrency(threadsPerEngine);
+                return true;
+            },
+            ZERO_R1, ZERO_R1, threadsPerEngine);
+    }
+
     virtual void SetQuantumState(const complex* inputState);
     virtual void GetQuantumState(complex* outputState);
     virtual void GetProbs(real1* outputProbs);
@@ -921,8 +931,8 @@ protected:
     virtual QInterfacePtr EntangleInCurrentBasis(
         std::vector<bitLenInt*>::iterator first, std::vector<bitLenInt*>::iterator last);
 
-    typedef bool (*ParallelUnitFn)(QInterfacePtr unit, real1 param1, real1 param2);
-    bool ParallelUnitApply(ParallelUnitFn fn, real1 param1 = ZERO_R1, real1 param2 = ZERO_R1);
+    typedef bool (*ParallelUnitFn)(QInterfacePtr unit, real1 param1, real1 param2, int32_t param3);
+    bool ParallelUnitApply(ParallelUnitFn fn, real1 param1 = ZERO_R1, real1 param2 = ZERO_R1, int32_t param3 = 0);
 
     virtual void SeparateBit(bool value, bitLenInt qubit, bool doDispose = true);
 

--- a/src/pinvoke_api.cpp
+++ b/src/pinvoke_api.cpp
@@ -318,6 +318,18 @@ MICROSOFT_QUANTUM_DECL void seed(_In_ unsigned sid, _In_ unsigned s)
 }
 
 /**
+ * (External API) Set concurrency level per QEngine shard
+ */
+MICROSOFT_QUANTUM_DECL void set_concurrency(_In_ unsigned sid, _In_ unsigned p)
+{
+    SIMULATOR_LOCK_GUARD(sid)
+
+    if (simulators[sid] != NULL) {
+        simulators[sid]->SetConcurrency(p);
+    }
+}
+
+/**
  * (External API) "Dump" all IDs from the selected simulator ID into the callback
  */
 MICROSOFT_QUANTUM_DECL void DumpIds(_In_ unsigned sid, _In_ IdCallback callback)

--- a/src/qengine/state.cpp
+++ b/src/qengine/state.cpp
@@ -48,7 +48,7 @@ QEngineCPU::QEngineCPU(bitLenInt qBitCount, bitCapInt initState, qrack_rand_gen_
     , isSparse(useSparseStateVec)
     , dispatchQueue(1)
 {
-    SetConcurrencyLevel(std::thread::hardware_concurrency());
+    SetConcurrency(std::thread::hardware_concurrency());
 
     stateVec = AllocStateVec(maxQPower);
     stateVec->clear();

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -3056,14 +3056,14 @@ void QUnit::Hash(bitLenInt start, bitLenInt length, unsigned char* values)
     DirtyShardRangePhase(start, length);
 }
 
-bool QUnit::ParallelUnitApply(ParallelUnitFn fn, real1 param1, real1 param2)
+bool QUnit::ParallelUnitApply(ParallelUnitFn fn, real1 param1, real1 param2, int32_t param3)
 {
     std::vector<QInterfacePtr> units;
     for (bitLenInt i = 0; i < shards.size(); i++) {
         QInterfacePtr toFind = shards[i].unit;
         if (find(units.begin(), units.end(), toFind) == units.end()) {
             units.push_back(toFind);
-            if (!fn(toFind, param1, param2)) {
+            if (!fn(toFind, param1, param2, param3)) {
                 return false;
             }
         }
@@ -3076,7 +3076,7 @@ void QUnit::UpdateRunningNorm(real1 norm_thresh)
 {
     EndAllEmulation();
     ParallelUnitApply(
-        [](QInterfacePtr unit, real1 norm_thresh, real1 unused2) {
+        [](QInterfacePtr unit, real1 norm_thresh, real1 unused2, int32_t unused3) {
             unit->UpdateRunningNorm(norm_thresh);
             return true;
         },
@@ -3087,7 +3087,7 @@ void QUnit::NormalizeState(real1 nrm, real1 norm_thresh)
 {
     EndAllEmulation();
     ParallelUnitApply(
-        [](QInterfacePtr unit, real1 nrm, real1 norm_thresh) {
+        [](QInterfacePtr unit, real1 nrm, real1 norm_thresh, int32_t unused) {
             unit->NormalizeState(nrm, norm_thresh);
             return true;
         },
@@ -3096,7 +3096,7 @@ void QUnit::NormalizeState(real1 nrm, real1 norm_thresh)
 
 void QUnit::Finish()
 {
-    ParallelUnitApply([](QInterfacePtr unit, real1 unused1, real1 unused2) {
+    ParallelUnitApply([](QInterfacePtr unit, real1 unused1, real1 unused2, int32_t unused3) {
         unit->Finish();
         return true;
     });
@@ -3104,7 +3104,7 @@ void QUnit::Finish()
 
 void QUnit::Dump()
 {
-    ParallelUnitApply([](QInterfacePtr unit, real1 unused1, real1 unused2) {
+    ParallelUnitApply([](QInterfacePtr unit, real1 unused1, real1 unused2, int32_t unused3) {
         unit.reset();
         return true;
     });
@@ -3112,7 +3112,8 @@ void QUnit::Dump()
 
 bool QUnit::isFinished()
 {
-    return ParallelUnitApply([](QInterfacePtr unit, real1 unused1, real1 unused2) { return unit->isFinished(); });
+    return ParallelUnitApply(
+        [](QInterfacePtr unit, real1 unused1, real1 unused2, int32_t unused3) { return unit->isFinished(); });
 }
 
 bool QUnit::ApproxCompare(QUnitPtr toCompare)

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -301,6 +301,12 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_qengine_getmaxqpower")
     REQUIRE((qftReg->GetMaxQPower() == 1048576U));
 }
 
+TEST_CASE_METHOD(QInterfaceTestFixture, "test_setconcurrency")
+{
+    // Make sure it doesn't throw:
+    qftReg->SetConcurrency(1);
+}
+
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_cnot")
 {
     qftReg->SetPermutation(0x55F00);


### PR DESCRIPTION
In this branch, user code has a method to set QEngineCPU thread concurrency, (and QUnit shard concurrency, layered on top of QEngineCPU,) including in the PInvoke API.