### PR TITLE
Lazy QEngine initialization in QUnit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,6 +105,7 @@ include ("cmake/Complex8.cmake")
 include ("cmake/Complex_x2.cmake")
 include ("cmake/Pure32.cmake")
 include ("cmake/Boost.cmake")
+include ("cmake/QUnit_CPU_Parallel.cmake")
 include ("cmake/VM6502Q.cmake")
 
 target_compile_definitions (qrack PUBLIC QBCAPPOW=${QBCAPPOW})

--- a/include/common/dispatchqueue.hpp
+++ b/include/common/dispatchqueue.hpp
@@ -56,6 +56,7 @@ private:
     std::condition_variable cvFinished_;
     bool quit_;
     bool isFinished_;
+    bool isStarted_;
 
     void dispatch_thread_handler(void);
 };

--- a/include/common/dispatchqueue.hpp
+++ b/include/common/dispatchqueue.hpp
@@ -17,9 +17,9 @@
 #include <condition_variable>
 #include <cstdint>
 #include <functional>
+#include <future>
 #include <mutex>
 #include <queue>
-#include <thread>
 #include <vector>
 
 namespace Qrack {
@@ -50,7 +50,7 @@ public:
 
 private:
     std::mutex lock_;
-    std::thread thread_;
+    std::future<void> thread_;
     std::queue<fp_t> q_;
     std::condition_variable cv_;
     std::condition_variable cvFinished_;

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -641,8 +641,11 @@ public:
 
     bool IsInvert() { return IsInvertTarget() || IsInvertControl(); }
 
-    bool operator==(const QEngineShard& rhs) { return (mapped == rhs.mapped) && (unit == rhs.unit); }
-    bool operator!=(const QEngineShard& rhs) { return (mapped != rhs.mapped) || (unit != rhs.unit); }
+    bitLenInt GetQubitCount() { return (unit == NULL) ? 1U : unit->GetQubitCount(); };
+    real1 Prob() { return unit->Prob(mapped); };
+
+    bool operator==(const QEngineShard& rhs) { return unit && (mapped == rhs.mapped) && (unit == rhs.unit); }
+    bool operator!=(const QEngineShard& rhs) { return !unit || (mapped != rhs.mapped) || (unit != rhs.unit); }
 };
 
 class QUnit;
@@ -1122,9 +1125,6 @@ protected:
     }
 
     void CommuteH(const bitLenInt& bitIndex);
-
-    /* Debugging and diagnostic routines. */
-    void DumpShards();
 };
 
 } // namespace Qrack

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -110,8 +110,8 @@ public:
     {
     }
 
-    QEngineShard(QInterfacePtr u, const bool& set, const real1 amp_thresh = min_norm)
-        : unit(u)
+    QEngineShard(const bool& set, const real1 amp_thresh = min_norm)
+        : unit(NULL)
         , mapped(0)
         , amplitudeThreshold(amp_thresh)
         , isProbDirty(false)
@@ -875,7 +875,7 @@ public:
 protected:
     virtual void XBase(const bitLenInt& target);
     virtual void ZBase(const bitLenInt& target);
-    virtual real1 ProbBase(const bitLenInt& qubit, const bool& trySeparate = true);
+    virtual real1 ProbBase(const bitLenInt& qubit);
 
     virtual void UniformlyControlledSingleBit(const bitLenInt* controls, const bitLenInt& controlLen,
         bitLenInt qubitIndex, const complex* mtrxs, const bitCapInt* mtrxSkipPowers, const bitLenInt mtrxSkipLen,
@@ -1053,8 +1053,6 @@ protected:
         }
     }
 
-    void CheckShardSeparable(const bitLenInt& target);
-
     void DirtyShardRange(bitLenInt start, bitLenInt length)
     {
         for (bitLenInt i = 0; i < length; i++) {
@@ -1066,13 +1064,6 @@ protected:
     {
         for (bitLenInt i = 0; i < length; i++) {
             shards[start + i].isPhaseDirty = true;
-        }
-    }
-
-    void DirtyShardIndexArray(bitLenInt* bitIndices, bitLenInt length)
-    {
-        for (bitLenInt i = 0; i < length; i++) {
-            shards[bitIndices[i]].MakeDirty();
         }
     }
 

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -116,8 +116,6 @@ public:
         , amplitudeThreshold(amp_thresh)
         , isProbDirty(false)
         , isPhaseDirty(false)
-        , amp0(ONE_CMPLX)
-        , amp1(ZERO_CMPLX)
         , isPlusMinus(false)
         , controlsShards()
         , antiControlsShards()
@@ -642,7 +640,7 @@ public:
 
     bool IsInvert() { return IsInvertTarget() || IsInvertControl(); }
 
-    bitLenInt GetQubitCount() { return (unit == NULL) ? 1U : unit->GetQubitCount(); };
+    bitLenInt GetQubitCount() { return unit ? unit->GetQubitCount() : 1U; };
     real1 Prob() { return unit->Prob(mapped); };
 };
 
@@ -1114,7 +1112,7 @@ protected:
     {
         shard->found = true;
         for (bitLenInt i = 0; i < shards.size(); i++) {
-            if (shard->found) {
+            if (shards[i].found) {
                 shard->found = false;
                 return i;
             }

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -1057,8 +1057,7 @@ protected:
     void DirtyShardRange(bitLenInt start, bitLenInt length)
     {
         for (bitLenInt i = 0; i < length; i++) {
-            shards[start + i].isProbDirty = true;
-            shards[start + i].isPhaseDirty = true;
+            shards[start + i].MakeDirty();
         }
     }
 
@@ -1072,16 +1071,14 @@ protected:
     void DirtyShardIndexArray(bitLenInt* bitIndices, bitLenInt length)
     {
         for (bitLenInt i = 0; i < length; i++) {
-            shards[bitIndices[i]].isProbDirty = true;
-            shards[bitIndices[i]].isPhaseDirty = true;
+            shards[bitIndices[i]].MakeDirty();
         }
     }
 
     void DirtyShardIndexVector(std::vector<bitLenInt> bitIndices)
     {
         for (bitLenInt i = 0; i < bitIndices.size(); i++) {
-            shards[bitIndices[i]].isProbDirty = true;
-            shards[bitIndices[i]].isPhaseDirty = true;
+            shards[bitIndices[i]].MakeDirty();
         }
     }
 
@@ -1114,15 +1111,6 @@ protected:
         }
     }
 
-    template <typename F> void ApplyOrEmulate(QEngineShard& shard, F payload)
-    {
-        if ((shard.unit->GetQubitCount() == 1) && !shard.isProbDirty && !shard.isPhaseDirty) {
-            shard.isEmulated = true;
-        } else {
-            payload(shard);
-        }
-    }
-
     bitLenInt FindShardIndex(const QEngineShard& shard)
     {
         for (bitLenInt i = 0; i < shards.size(); i++) {
@@ -1137,7 +1125,6 @@ protected:
 
     /* Debugging and diagnostic routines. */
     void DumpShards();
-    QInterfacePtr GetUnit(bitLenInt bit) { return shards[bit].unit; }
 };
 
 } // namespace Qrack

--- a/include/qunitmulti.hpp
+++ b/include/qunitmulti.hpp
@@ -81,7 +81,6 @@ public:
         bool useHostMem = false, int deviceID = -1, bool useHardwareRNG = true, bool useSparseStateVec = false,
         real1 norm_thresh = REAL1_DEFAULT_ARG, std::vector<int> devList = {}, bitLenInt qubitThreshold = 0);
 
-    virtual void SetPermutation(bitCapInt perm, complex phaseFac = complex(-999.0, -999.0));
     virtual bool TrySeparate(bitLenInt start, bitLenInt length = 1);
 
     virtual QInterfacePtr Clone();
@@ -100,8 +99,6 @@ protected:
     virtual void Detach(bitLenInt start, bitLenInt length, QUnitMultiPtr dest);
 
     virtual void RedistributeQEngines();
-
-    virtual void RedistributeSingleQubits();
 
     virtual QInterfacePtr EntangleInCurrentBasis(
         std::vector<bitLenInt*>::iterator first, std::vector<bitLenInt*>::iterator last);

--- a/src/qengine/state.cpp
+++ b/src/qengine/state.cpp
@@ -212,7 +212,7 @@ void QEngineCPU::Apply2x2(bitCapInt offset1, bitCapInt offset2, const complex* m
         runningNorm = ONE_R1;
     }
 
-    Dispatch([this, mtrx, qPowersSorted, offset1, offset2, bitCount, doCalcNorm, nrm_thresh]() {
+    Dispatch([this, mtrx, qPowersSorted, offset1, offset2, bitCount, doCalcNorm, nrm_thresh] {
         real1 nrm = doNormalize ? (ONE_R1 / std::sqrt(runningNorm)) : ONE_R1;
         real1 norm_thresh = (nrm_thresh < ZERO_R1) ? amplitudeFloor : nrm_thresh;
         int numCores = GetConcurrencyLevel();
@@ -370,7 +370,7 @@ void QEngineCPU::Apply2x2(bitCapInt offset1, bitCapInt offset2, const complex* m
         runningNorm = ONE_R1;
     }
 
-    Dispatch([this, mtrx, qPowersSorted, offset1, offset2, bitCount, doCalcNorm, nrm_thresh]() {
+    Dispatch([this, mtrx, qPowersSorted, offset1, offset2, bitCount, doCalcNorm, nrm_thresh] {
         real1 nrm = doNormalize ? (ONE_R1 / std::sqrt(runningNorm)) : ONE_R1;
         real1 norm_thresh = (nrm_thresh < ZERO_R1) ? amplitudeFloor : nrm_thresh;
         int numCores = GetConcurrencyLevel();
@@ -1105,7 +1105,7 @@ void QEngineCPU::PhaseFlip()
         return;
     }
 
-    Dispatch([this]() {
+    Dispatch([this] {
         ParallelFunc fn = [&](const bitCapInt lcv, const int cpu) { stateVec->write(lcv, -stateVec->read(lcv)); };
 
         if (stateVec->is_sparse()) {
@@ -1121,7 +1121,7 @@ void QEngineCPU::ZeroPhaseFlip(bitLenInt start, bitLenInt length)
 {
     CHECK_ZERO_SKIP();
 
-    Dispatch([this, start, length]() {
+    Dispatch([this, start, length] {
         par_for_skip(0, maxQPower, pow2(start), length,
             [&](const bitCapInt lcv, const int cpu) { stateVec->write(lcv, -stateVec->read(lcv)); });
     });
@@ -1132,7 +1132,7 @@ void QEngineCPU::CPhaseFlipIfLess(bitCapInt greaterPerm, bitLenInt start, bitLen
 {
     CHECK_ZERO_SKIP();
 
-    Dispatch([this, greaterPerm, start, length, flagIndex]() {
+    Dispatch([this, greaterPerm, start, length, flagIndex] {
         bitCapInt regMask = bitRegMask(start, length);
         bitCapInt flagMask = pow2(flagIndex);
 
@@ -1148,7 +1148,7 @@ void QEngineCPU::PhaseFlipIfLess(bitCapInt greaterPerm, bitLenInt start, bitLenI
 {
     CHECK_ZERO_SKIP();
 
-    Dispatch([this, greaterPerm, start, length]() {
+    Dispatch([this, greaterPerm, start, length] {
         bitCapInt regMask = bitRegMask(start, length);
 
         par_for(0, maxQPower, [&](const bitCapInt lcv, const int cpu) {
@@ -1162,7 +1162,7 @@ void QEngineCPU::ApplyM(bitCapInt regMask, bitCapInt result, complex nrm)
 {
     CHECK_ZERO_SKIP();
 
-    Dispatch([this, regMask, result, nrm]() {
+    Dispatch([this, regMask, result, nrm] {
         ParallelFunc fn = [&](const bitCapInt i, const int cpu) {
             if ((i & regMask) == result) {
                 stateVec->write(i, nrm * stateVec->read(i));

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -2230,12 +2230,6 @@ void QUnit::INT(bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt ca
         return;
     }
 
-    EndEmulation(start + length);
-    if (hasCarry) {
-        EndEmulation(carryIndex);
-    }
-    EndEmulation(controls, controlLen);
-
     std::vector<bitLenInt> allBits(controlLen + 1U);
     std::copy(controls, controls + controlLen, allBits.begin());
     std::sort(allBits.begin(), allBits.begin() + controlLen);

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1813,7 +1813,7 @@ void QUnit::ApplyAntiControlledSinglePhase(const bitLenInt* cControls, const bit
 
         tShard.AddAntiPhaseAngles(&cShard, bottomRight, topLeft);
 
-        ShardToPhaseMap::iterator phaseShard = tShard.antiTargetOfShards.find(&cShard);
+        /*ShardToPhaseMap::iterator phaseShard = tShard.antiTargetOfShards.find(&cShard);
 
         if ((phaseShard == tShard.antiTargetOfShards.end()) || phaseShard->second->isInvert) {
             return;
@@ -1825,7 +1825,7 @@ void QUnit::ApplyAntiControlledSinglePhase(const bitLenInt* cControls, const bit
         if (IS_SAME(buffer->cmplxDiff, buffer->cmplxSame)) {
             ApplyBuffer(buffer, control, target, true);
             tShard.RemovePhaseAntiControl(&cShard);
-        }
+        }*/
 
         return;
     }


### PR DESCRIPTION
In this branch, QUnit now waits to initialize QEngine instances until they cannot be "emulated" via single bits. In many cases, this reduces and defers threading and OpenCL buffer costs.