### PR TITLE
Default -DENABLE_QUNIT_CPU_PARALLEL=ON

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,11 @@ install:
   - python -m pip install --upgrade pip numpy setuptools wheel
   - python -m pip install cvxpy cython stestr qiskit pennylane
 script:
-  - mkdir _build && cd _build && cmake -DENABLE_OPENCL=OFF -DENABLE_COMPLEX8=OFF -DENABLE_QUNIT_CPU_PARALLEL=OFF .. && make -j 8 all
+  - mkdir _build && cd _build && cmake -DENABLE_OPENCL=OFF -DENABLE_COMPLEX8=OFF .. && make -j 8 all
   - sudo make install
   - ./unittest --proc-cpu
   - cd .. && sudo rm -r _build
-  - mkdir _build && cd _build && cmake -DENABLE_OPENCL=OFF -DENABLE_COMPLEX8=ON -DENABLE_QUNIT_CPU_PARALLEL=ON .. && make -j 8 all && cd ../..
+  - mkdir _build && cd _build && cmake -DENABLE_OPENCL=OFF -DENABLE_COMPLEX8=ON .. && make -j 8 all && cd ../..
 #  - cd ../.. && git clone -b qrack_unit_tests https://github.com/vm6502q/ProjectQ.git && cd ProjectQ
 #  - python -m pip install -r requirements.txt
 #  - python setup.py install

--- a/cmake/QUnit_CPU_Parallel.cmake
+++ b/cmake/QUnit_CPU_Parallel.cmake
@@ -1,1 +1,1 @@
-option (ENABLE_QUNIT_CPU_PARALLEL "Make QEngineCPU partially async, so QUnit can parallelize over it (may exceed shell threading limits)" OFF)
+option (ENABLE_QUNIT_CPU_PARALLEL "Make QEngineCPU partially async, so QUnit can parallelize over it (may exceed shell threading limits)" ON)


### PR DESCRIPTION
Feature #456, implemented by #457, makes it so that asynchronous CPU dispatch simply "just works" as far as stack integration is concerned. We can (and should) leave the option in CMake to turn it off, but the default can be "ON," and unit tests should run with the default "ON" option.