### PR TITLE
Restore disabled QUnit optimization code

### DIFF
--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1813,7 +1813,7 @@ void QUnit::ApplyAntiControlledSinglePhase(const bitLenInt* cControls, const bit
 
         tShard.AddAntiPhaseAngles(&cShard, bottomRight, topLeft);
 
-        /*ShardToPhaseMap::iterator phaseShard = tShard.antiTargetOfShards.find(&cShard);
+        ShardToPhaseMap::iterator phaseShard = tShard.antiTargetOfShards.find(&cShard);
 
         if ((phaseShard == tShard.antiTargetOfShards.end()) || phaseShard->second->isInvert) {
             return;
@@ -1825,7 +1825,7 @@ void QUnit::ApplyAntiControlledSinglePhase(const bitLenInt* cControls, const bit
         if (IS_SAME(buffer->cmplxDiff, buffer->cmplxSame)) {
             ApplyBuffer(buffer, control, target, true);
             tShard.RemovePhaseAntiControl(&cShard);
-        }*/
+        }
 
         return;
     }


### PR DESCRIPTION
I missed restoring section of optimization code that I disabled in QUnit, in the last few PRs. (This is not particularly important, but it's nice to have.)