### PR TITLE
Avoid redundant std::find

### DIFF
--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1179,20 +1179,23 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
 
     if (!freezeBasis) {
         RevertBasis1Qb(control);
-
         RevertBasis2Qb(control, ONLY_INVERT, ONLY_TARGETS);
 
-        if (cShard.IsInvertControlOf(&tShard)) {
+        bool isInvert = cShard.IsInvertControlOf(&tShard);
+        if (isInvert) {
             RevertBasis1Qb(target);
         }
-
         RevertBasis2Qb(target, INVERT_AND_PHASE, CONTROLS_AND_TARGETS, CTRL_AND_ANTI, {}, { control });
 
         tShard.AddInversionAngles(&cShard, ONE_CMPLX, ONE_CMPLX);
 
+        if (!isInvert) {
+            return;
+        }
+
         ShardToPhaseMap::iterator phaseShard = tShard.targetOfShards.find(&cShard);
 
-        if ((phaseShard == tShard.targetOfShards.end()) || phaseShard->second->isInvert) {
+        if (phaseShard == tShard.targetOfShards.end()) {
             return;
         }
 
@@ -1390,8 +1393,7 @@ void QUnit::CZ(bitLenInt control, bitLenInt target)
 
     if (!freezeBasis) {
         RevertBasis1Qb(control);
-
-        RevertBasis2Qb(control, ONLY_INVERT, ONLY_TARGETS, CTRL_AND_ANTI);
+        RevertBasis2Qb(control, ONLY_INVERT, ONLY_TARGETS);
 
         bool isInvert = cShard.IsInvertControlOf(&tShard);
         if (isInvert) {


### PR DESCRIPTION
This mirrors another (tiny) optimization in a similar method in QUnit.