### PR TITLE
Enable QUnitMulti layering over QHybrid

### DIFF
--- a/include/qfactory.hpp
+++ b/include/qfactory.hpp
@@ -45,7 +45,7 @@ QInterfacePtr CreateQuantumInterface(
     case QINTERFACE_HYBRID:
         return std::make_shared<QHybrid>(args...);
     case QINTERFACE_QUNIT_MULTI:
-        return std::make_shared<QUnitMulti>(args...);
+        return std::make_shared<QUnitMulti>(subengine1, args...);
 #endif
     default:
         return NULL;
@@ -70,7 +70,7 @@ QInterfacePtr CreateQuantumInterface(QInterfaceEngine engine, QInterfaceEngine s
     case QINTERFACE_HYBRID:
         return std::make_shared<QHybrid>(args...);
     case QINTERFACE_QUNIT_MULTI:
-        return std::make_shared<QUnitMulti>(args...);
+        return std::make_shared<QUnitMulti>(subengine, args...);
 #endif
     default:
         return NULL;

--- a/include/qfactory.hpp
+++ b/include/qfactory.hpp
@@ -45,7 +45,7 @@ QInterfacePtr CreateQuantumInterface(
     case QINTERFACE_HYBRID:
         return std::make_shared<QHybrid>(args...);
     case QINTERFACE_QUNIT_MULTI:
-        return std::make_shared<QUnitMulti>(subengine1, args...);
+        return std::make_shared<QUnitMulti>(subengine1, subengine2, args...);
 #endif
     default:
         return NULL;

--- a/include/qunitmulti.hpp
+++ b/include/qunitmulti.hpp
@@ -71,6 +71,15 @@ public:
     QUnitMulti(bitLenInt qBitCount, bitCapInt initState = 0, qrack_rand_gen_ptr rgp = nullptr,
         complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = true, bool randomGlobalPhase = true,
         bool useHostMem = false, int deviceID = -1, bool useHardwareRNG = true, bool useSparseStateVec = false,
+        real1 norm_thresh = REAL1_DEFAULT_ARG, std::vector<int> devList = {}, bitLenInt qubitThreshold = 0)
+        : QUnitMulti(QINTERFACE_OPTIMAL, qBitCount, initState, rgp, phaseFac, doNorm, randomGlobalPhase, useHostMem,
+              deviceID, useHardwareRNG, useSparseStateVec, norm_thresh, devList, qubitThreshold)
+    {
+    }
+
+    QUnitMulti(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState = 0, qrack_rand_gen_ptr rgp = nullptr,
+        complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = true, bool randomGlobalPhase = true,
+        bool useHostMem = false, int deviceID = -1, bool useHardwareRNG = true, bool useSparseStateVec = false,
         real1 norm_thresh = REAL1_DEFAULT_ARG, std::vector<int> devList = {}, bitLenInt qubitThreshold = 0);
 
     virtual bool TrySeparate(bitLenInt start, bitLenInt length = 1);

--- a/include/qunitmulti.hpp
+++ b/include/qunitmulti.hpp
@@ -72,15 +72,26 @@ public:
         complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = true, bool randomGlobalPhase = true,
         bool useHostMem = false, int deviceID = -1, bool useHardwareRNG = true, bool useSparseStateVec = false,
         real1 norm_thresh = REAL1_DEFAULT_ARG, std::vector<int> devList = {}, bitLenInt qubitThreshold = 0)
-        : QUnitMulti(QINTERFACE_OPTIMAL, qBitCount, initState, rgp, phaseFac, doNorm, randomGlobalPhase, useHostMem,
-              deviceID, useHardwareRNG, useSparseStateVec, norm_thresh, devList, qubitThreshold)
+        : QUnitMulti(QINTERFACE_OPTIMAL, QINTERFACE_OPTIMAL, qBitCount, initState, rgp, phaseFac, doNorm,
+              randomGlobalPhase, useHostMem, deviceID, useHardwareRNG, useSparseStateVec, norm_thresh, devList,
+              qubitThreshold)
     {
     }
 
     QUnitMulti(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState = 0, qrack_rand_gen_ptr rgp = nullptr,
         complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = true, bool randomGlobalPhase = true,
         bool useHostMem = false, int deviceID = -1, bool useHardwareRNG = true, bool useSparseStateVec = false,
-        real1 norm_thresh = REAL1_DEFAULT_ARG, std::vector<int> devList = {}, bitLenInt qubitThreshold = 0);
+        real1 norm_thresh = REAL1_DEFAULT_ARG, std::vector<int> devList = {}, bitLenInt qubitThreshold = 0)
+        : QUnitMulti(eng, eng, qBitCount, initState, rgp, phaseFac, doNorm, randomGlobalPhase, useHostMem, deviceID,
+              useHardwareRNG, useSparseStateVec, norm_thresh, devList, qubitThreshold)
+    {
+    }
+
+    QUnitMulti(QInterfaceEngine eng, QInterfaceEngine subEng, bitLenInt qBitCount, bitCapInt initState = 0,
+        qrack_rand_gen_ptr rgp = nullptr, complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = true,
+        bool randomGlobalPhase = true, bool useHostMem = false, int deviceID = -1, bool useHardwareRNG = true,
+        bool useSparseStateVec = false, real1 norm_thresh = REAL1_DEFAULT_ARG, std::vector<int> devList = {},
+        bitLenInt qubitThreshold = 0);
 
     virtual bool TrySeparate(bitLenInt start, bitLenInt length = 1);
 

--- a/src/qunitmulti.cpp
+++ b/src/qunitmulti.cpp
@@ -17,15 +17,16 @@
 
 namespace Qrack {
 
-QUnitMulti::QUnitMulti(bitLenInt qBitCount, bitCapInt initState, qrack_rand_gen_ptr rgp, complex phaseFac, bool doNorm,
-    bool randomGlobalPhase, bool useHostMem, int deviceID, bool useHardwareRNG, bool useSparseStateVec,
-    real1 norm_thresh, std::vector<int> devList, bitLenInt qubitThreshold)
-    : QUnit(QINTERFACE_OPENCL, qBitCount, initState, rgp, phaseFac, doNorm, randomGlobalPhase, useHostMem, -1,
-          useHardwareRNG, useSparseStateVec, norm_thresh, devList, qubitThreshold)
+QUnitMulti::QUnitMulti(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState, qrack_rand_gen_ptr rgp,
+    complex phaseFac, bool doNorm, bool randomGlobalPhase, bool useHostMem, int deviceID, bool useHardwareRNG,
+    bool useSparseStateVec, real1 norm_thresh, std::vector<int> devList, bitLenInt qubitThreshold)
+    : QUnit(eng, qBitCount, initState, rgp, phaseFac, doNorm, randomGlobalPhase, useHostMem, -1, useHardwareRNG,
+          useSparseStateVec, norm_thresh, devList, qubitThreshold)
 {
-    // Notice that this constructor always passes QINTERFACE_OPENCL to the QUnit constructor. For QUnitMulti, the
-    // "shard" engines are therefore guaranteed to always be QEngineOCL or QPager types, and it's safe to assume that
-    // they can be cast from QInterfacePtr types to QEngineOCLPtr types in this class.
+    // The "shard" engine type must be QINTERFACE_OPENCL or QINTERFACE_HYBRID.
+    if ((engine != QINTERFACE_HYBRID) && (engine != QINTERFACE_OPENCL)) {
+        throw "Invalid sub-engine type: QUnitMulti must layer over only QEngineOCL or QHybrid.";
+    }
 
     std::vector<DeviceContextPtr> deviceContext = OCLEngine::Instance()->GetDeviceContextPtrVector();
 
@@ -101,7 +102,9 @@ void QUnitMulti::RedistributeQEngines()
         // If the engine adds negligible load, we can let any given unit keep its
         // residency on this device.
         // In fact, single qubit units will be handled entirely by the CPU, anyway.
-        if (!(qinfos[i].unit) || (qinfos[i].unit->GetMaxQPower() <= 2U)) {
+        // So will QHybrid "shards" that are below the GPU transition threshold.
+        if (!(qinfos[i].unit) || (qinfos[i].unit->GetMaxQPower() <= 2U) ||
+            ((engine == QINTERFACE_HYBRID) && (qinfos[i].unit->GetQubitCount() < thresholdQubits))) {
             continue;
         }
 

--- a/test/benchmarks_main.cpp
+++ b/test/benchmarks_main.cpp
@@ -275,6 +275,14 @@ int main(int argc, char* argv[])
             CreateQuantumInterface(QINTERFACE_OPENCL, 1, 0).reset(); /* Get the OpenCL banner out of the way. */
             num_failed = session.run();
         }
+
+        if (num_failed == 0 && opencl_multi) {
+            session.config().stream() << "############ QUnitMulti -> QPager (OpenCL) ############" << std::endl;
+            testEngineType = QINTERFACE_QUNIT_MULTI;
+            testSubSubEngineType = QINTERFACE_OPENCL;
+            CreateQuantumInterface(QINTERFACE_OPENCL, 1, 0).reset(); /* Get the OpenCL banner out of the way. */
+            num_failed = session.run();
+        }
 #endif
     }
 

--- a/test/benchmarks_main.cpp
+++ b/test/benchmarks_main.cpp
@@ -49,6 +49,7 @@ int main(int argc, char* argv[])
     bool opencl_single = false;
     bool opencl_multi = false;
     bool hybrid = false;
+    bool hybrid_multi = false;
 
     int mxQbts = 24;
 
@@ -65,6 +66,7 @@ int main(int argc, char* argv[])
         Opt(opencl_single)["--proc-opencl-single"]("Single (parallel) processor OpenCL tests") |
         Opt(opencl_multi)["--proc-opencl-multi"]("Multiple processor OpenCL tests") |
         Opt(hybrid)["--proc-hybrid"]("Enable CPU/OpenCL hybrid implementation tests") |
+        Opt(hybrid_multi)["--proc-hybrid-multi"]("Multiple processor hybrid CPU/OpenCL tests") |
         Opt(async_time)["--async-time"]("Time based on asynchronous return") |
         Opt(enable_normalization)["--enable-normalization"](
             "Enable state vector normalization. (Usually not "
@@ -230,18 +232,26 @@ int main(int argc, char* argv[])
             num_failed = session.run();
         }
 
+        if (num_failed == 0 && hybrid) {
+            session.config().stream() << "############ QUnit -> QHybrid ############" << std::endl;
+            testSubEngineType = QINTERFACE_HYBRID;
+            CreateQuantumInterface(QINTERFACE_OPENCL, 1, 0).reset(); /* Get the OpenCL banner out of the way. */
+            num_failed = session.run();
+        }
+
         if (num_failed == 0 && opencl_multi) {
-            session.config().stream() << "############ QUnitMulti (OpenCL) ############" << std::endl;
+            session.config().stream() << "############ QUnitMulti -> QEngineOCL ############" << std::endl;
             testEngineType = QINTERFACE_QUNIT_MULTI;
             testSubEngineType = QINTERFACE_OPENCL;
             CreateQuantumInterface(QINTERFACE_OPENCL, 1, 0).reset(); /* Get the OpenCL banner out of the way. */
             num_failed = session.run();
         }
 
-        if (num_failed == 0 && hybrid) {
-            session.config().stream() << "############ QUnit -> QHybrid ############" << std::endl;
+        if (num_failed == 0 && hybrid_multi) {
+            session.config().stream() << "############ QUnitMulti -> QHybrid ############" << std::endl;
+            testEngineType = QINTERFACE_QUNIT_MULTI;
             testSubEngineType = QINTERFACE_HYBRID;
-            CreateQuantumInterface(QINTERFACE_OPENCL, 1, 0).reset(); /* Get the OpenCL banner out of the way. */
+            CreateQuantumInterface(QINTERFACE_HYBRID, 1, 0).reset(); /* Get the OpenCL banner out of the way. */
             num_failed = session.run();
         }
 #endif
@@ -261,14 +271,6 @@ int main(int argc, char* argv[])
         if (num_failed == 0 && opencl_single) {
             testSubSubEngineType = QINTERFACE_OPENCL;
             session.config().stream() << "############ QUnit -> QPager -> OpenCL ############" << std::endl;
-            testSubSubEngineType = QINTERFACE_OPENCL;
-            CreateQuantumInterface(QINTERFACE_OPENCL, 1, 0).reset(); /* Get the OpenCL banner out of the way. */
-            num_failed = session.run();
-        }
-
-        if (num_failed == 0 && opencl_multi) {
-            session.config().stream() << "############ QUnitMulti -> QPager (OpenCL) ############" << std::endl;
-            testEngineType = QINTERFACE_QUNIT_MULTI;
             testSubSubEngineType = QINTERFACE_OPENCL;
             CreateQuantumInterface(QINTERFACE_OPENCL, 1, 0).reset(); /* Get the OpenCL banner out of the way. */
             num_failed = session.run();


### PR DESCRIPTION
If QHybrid is used for the "shard" type under QUnitMulti, not only does this allow faster operation for small counts of "shard" qubits, but the QUnitMulti switching threshold can benefit from not being taxed under the QHybrid threshold for GPU mode.