### PR TITLE
QUnit CNOT: control bits commute

### DIFF
--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1224,7 +1224,7 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
     // alone, by way of the last optional "true" argument in the call.
     if (cShard.isPlusMinus && tShard.isPlusMinus) {
         RevertBasis2Qb(control);
-        RevertBasis2Qb(target);
+        RevertBasis2Qb(target, ONLY_INVERT, ONLY_TARGETS);
 
         std::swap(controls[0], target);
         ApplyEitherControlled(

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1224,7 +1224,7 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
     // alone, by way of the last optional "true" argument in the call.
     if (cShard.isPlusMinus && tShard.isPlusMinus) {
         RevertBasis2Qb(control);
-        RevertBasis2Qb(target, ONLY_INVERT, ONLY_TARGETS);
+        RevertBasis2Qb(target, INVERT_AND_PHASE, ONLY_TARGETS);
 
         std::swap(controls[0], target);
         ApplyEitherControlled(


### PR DESCRIPTION
Even in the |+>/|-> basis case, buffer control bits commute, such that the buffer flushing restrictions can be slightly relaxed.