### PR TITLE
CNOT debug and optimize

### DIFF
--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -658,7 +658,8 @@ protected:
     bool useHostRam;
     bool useRDRAND;
     bool isSparse;
-    bool freezeBasis;
+    bool freezeBasisH;
+    bool freezeBasis2Qb;
     bitLenInt thresholdQubits;
 
     QInterfacePtr MakeEngine(bitLenInt length, bitCapInt perm);
@@ -956,16 +957,16 @@ protected:
 
     void RevertBasis1Qb(const bitLenInt& i)
     {
-        if (freezeBasis || !shards[i].isPlusMinus) {
+        if (freezeBasisH || !shards[i].isPlusMinus) {
             // Recursive call that should be blocked,
             // or already in target basis.
             return;
         }
 
-        freezeBasis = true;
+        freezeBasisH = true;
         H(i);
         shards[i].isPlusMinus = false;
-        freezeBasis = false;
+        freezeBasisH = false;
     }
 
     enum RevertExclusivity { INVERT_AND_PHASE = 0, ONLY_INVERT = 1, ONLY_PHASE = 2 };

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -328,7 +328,9 @@ protected:
             buffer = phaseShard->second;
             partner = phaseShard->first;
 
-            if (buffer->isInvert || !IS_ARG_0(buffer->cmplxDiff)) {
+            if (!IS_ARG_0(buffer->cmplxDiff) ||
+                (buffer->isInvert &&
+                    !((!makeThisControl && isPlusMinus) || (makeThisControl && partner->isPlusMinus)))) {
                 continue;
             }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1178,7 +1178,9 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
         }
     }
 
-    if (!freezeBasis2Qb && !(cShard.isPlusMinus && tShard.isPlusMinus)) {
+    bool pmBasis = (cShard.isPlusMinus && tShard.isPlusMinus && !QUEUED_PHASE(cShard) && !QUEUED_PHASE(tShard));
+
+    if (!freezeBasis2Qb && !pmBasis) {
         RevertBasis2Qb(control, ONLY_INVERT, ONLY_TARGETS);
 
         bool isInvert = cShard.IsInvertControlOf(&tShard);
@@ -1222,7 +1224,7 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
     // Under the Jacobian transformation between these two bases for defining the truth table, the matrix representation
     // is equivalent to the gate with bits flipped. We just let ApplyEitherControlled() know to leave the current basis
     // alone, by way of the last optional "true" argument in the call.
-    if (cShard.isPlusMinus && tShard.isPlusMinus && !QUEUED_PHASE(cShard) && !QUEUED_PHASE(tShard)) {
+    if (pmBasis) {
         std::swap(controls[0], target);
         ApplyEitherControlled(
             controls, controlLen, { target }, false,

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -63,7 +63,8 @@ QUnit::QUnit(QInterfaceEngine eng, QInterfaceEngine subEng, bitLenInt qBitCount,
     , useHostRam(useHostMem)
     , useRDRAND(useHardwareRNG)
     , isSparse(useSparseStateVec)
-    , freezeBasis(false)
+    , freezeBasisH(false)
+    , freezeBasis2Qb(false)
     , thresholdQubits(qubitThreshold)
 {
     if ((engine == QINTERFACE_CPU) || (engine == QINTERFACE_OPENCL)) {
@@ -996,7 +997,7 @@ void QUnit::H(bitLenInt target)
 {
     QEngineShard& shard = shards[target];
 
-    if (!freezeBasis) {
+    if (!freezeBasisH) {
         CommuteH(target);
         shard.isPlusMinus = !shard.isPlusMinus;
         return;
@@ -1177,8 +1178,7 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
         }
     }
 
-    if (!freezeBasis && !(cShard.isPlusMinus && tShard.isPlusMinus)) {
-        RevertBasis1Qb(control);
+    if (!freezeBasis2Qb && !(cShard.isPlusMinus && tShard.isPlusMinus)) {
         RevertBasis2Qb(control, ONLY_INVERT, ONLY_TARGETS);
 
         bool isInvert = cShard.IsInvertControlOf(&tShard);
@@ -1222,10 +1222,7 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
     // Under the Jacobian transformation between these two bases for defining the truth table, the matrix representation
     // is equivalent to the gate with bits flipped. We just let ApplyEitherControlled() know to leave the current basis
     // alone, by way of the last optional "true" argument in the call.
-    if (cShard.isPlusMinus && tShard.isPlusMinus) {
-        RevertBasis2Qb(control);
-        RevertBasis2Qb(target);
-
+    if (cShard.isPlusMinus && tShard.isPlusMinus && !QUEUED_PHASE(cShard) && !QUEUED_PHASE(tShard)) {
         std::swap(controls[0], target);
         ApplyEitherControlled(
             controls, controlLen, { target }, false,
@@ -1261,7 +1258,7 @@ void QUnit::AntiCNOT(bitLenInt control, bitLenInt target)
     bitLenInt controls[1] = { control };
     bitLenInt controlLen = 1;
 
-    if (!freezeBasis) {
+    if (!freezeBasis2Qb) {
         RevertBasis1Qb(control);
 
         RevertBasis2Qb(control, ONLY_INVERT, ONLY_TARGETS);
@@ -1391,8 +1388,7 @@ void QUnit::CZ(bitLenInt control, bitLenInt target)
         return;
     }
 
-    if (!freezeBasis) {
-        RevertBasis1Qb(control);
+    if (!freezeBasis2Qb) {
         RevertBasis2Qb(control, ONLY_INVERT, ONLY_TARGETS);
 
         bool isInvert = cShard.IsInvertControlOf(&tShard);
@@ -1690,7 +1686,7 @@ void QUnit::ApplyControlledSinglePhase(const bitLenInt* cControls, const bitLenI
         }
     }
 
-    if (!freezeBasis && (controlLen == 1U)) {
+    if (!freezeBasis2Qb && (controlLen == 1U)) {
         bitLenInt control = controls[0];
         delete[] controls;
         QEngineShard& cShard = shards[control];
@@ -1706,9 +1702,8 @@ void QUnit::ApplyControlledSinglePhase(const bitLenInt* cControls, const bitLenI
             return;
         }
 
-        RevertBasis1Qb(control);
+        RevertBasis2Qb(control, ONLY_INVERT, ONLY_TARGETS);
 
-        RevertBasis2Qb(control, ONLY_INVERT, ONLY_TARGETS, CTRL_AND_ANTI);
         RevertBasis2Qb(target, ONLY_INVERT, IS_ONE_CMPLX(topLeft) ? ONLY_TARGETS : CONTROLS_AND_TARGETS, CTRL_AND_ANTI);
 
         tShard.AddPhaseAngles(&cShard, topLeft, bottomRight);
@@ -1793,7 +1788,7 @@ void QUnit::ApplyAntiControlledSinglePhase(const bitLenInt* cControls, const bit
         }
     }
 
-    if (!freezeBasis && (controlLen == 1U)) {
+    if (!freezeBasis2Qb && (controlLen == 1U)) {
         bitLenInt control = controls[0];
         delete[] controls;
         QEngineShard& cShard = shards[control];
@@ -1808,9 +1803,8 @@ void QUnit::ApplyAntiControlledSinglePhase(const bitLenInt* cControls, const bit
             return;
         }
 
-        RevertBasis1Qb(control);
+        RevertBasis2Qb(control, ONLY_INVERT, ONLY_TARGETS);
 
-        RevertBasis2Qb(control, ONLY_INVERT, ONLY_TARGETS, CTRL_AND_ANTI);
         RevertBasis2Qb(
             target, ONLY_INVERT, IS_ONE_CMPLX(bottomRight) ? ONLY_TARGETS : CONTROLS_AND_TARGETS, CTRL_AND_ANTI);
 
@@ -3204,7 +3198,7 @@ void QUnit::ApplyBuffer(PhaseShardPtr phaseShard, const bitLenInt& control, cons
     complex polarDiff = phaseShard->cmplxDiff;
     complex polarSame = phaseShard->cmplxSame;
 
-    freezeBasis = true;
+    freezeBasis2Qb = true;
     if (phaseShard->isInvert) {
         if (isAnti) {
             ApplyAntiControlledSingleInvert(controls, 1U, target, polarSame, polarDiff);
@@ -3218,7 +3212,7 @@ void QUnit::ApplyBuffer(PhaseShardPtr phaseShard, const bitLenInt& control, cons
             ApplyControlledSinglePhase(controls, 1U, target, polarDiff, polarSame);
         }
     }
-    freezeBasis = false;
+    freezeBasis2Qb = false;
 }
 
 void QUnit::ApplyBufferMap(const bitLenInt& bitIndex, ShardToPhaseMap bufferMap, const RevertExclusivity& exclusivity,
@@ -3264,26 +3258,22 @@ void QUnit::ApplyBufferMap(const bitLenInt& bitIndex, ShardToPhaseMap bufferMap,
         }
 
         if (isControl) {
-            ApplyBuffer(phaseShard->second, bitIndex, partnerIndex, isAnti);
-        } else {
-            ApplyBuffer(phaseShard->second, partnerIndex, bitIndex, isAnti);
-        }
-
-        bufferMap.erase(phaseShard);
-
-        if (isControl) {
             if (isAnti) {
                 shard.RemovePhaseAntiTarget(partner);
             } else {
                 shard.RemovePhaseTarget(partner);
             }
+            ApplyBuffer(phaseShard->second, bitIndex, partnerIndex, isAnti);
         } else {
             if (isAnti) {
                 shard.RemovePhaseAntiControl(partner);
             } else {
                 shard.RemovePhaseControl(partner);
             }
+            ApplyBuffer(phaseShard->second, partnerIndex, bitIndex, isAnti);
         }
+
+        bufferMap.erase(phaseShard);
     }
 }
 
@@ -3293,7 +3283,7 @@ void QUnit::RevertBasis2Qb(const bitLenInt& i, const RevertExclusivity& exclusiv
 {
     QEngineShard& shard = shards[i];
 
-    if (freezeBasis || !QUEUED_PHASE(shard)) {
+    if (freezeBasis2Qb || !QUEUED_PHASE(shard)) {
         // Recursive call that should be blocked,
         // or already in target basis.
         return;


### PR DESCRIPTION
While the |+>/|-> basis CNOT case is great to have, I wasn't considering that reverting 2-qubit buffers could change the |+>/|-> basis in the middle of the optimized case. Also, with this fixed, we can continue to buffer H gates on "wires" that buffer phase and inversion gates at the same time. This should help with #367.