### PR TITLE
Clifford set optimization

### DIFF
--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -110,8 +110,7 @@ public:
         , antiTargetOfShards()
         , found(false)
     {
-        isClifford = std::make_shared<bool>();
-        *isClifford = true;
+        isClifford = std::make_shared<bool>(true);
     }
 
     QEngineShard(const bool& set, const real1 amp_thresh = min_norm)
@@ -127,8 +126,7 @@ public:
         , antiTargetOfShards()
         , found(false)
     {
-        isClifford = std::make_shared<bool>();
-        *isClifford = true;
+        isClifford = std::make_shared<bool>(true);
         amp0 = set ? ZERO_CMPLX : ONE_CMPLX;
         amp1 = set ? ONE_CMPLX : ZERO_CMPLX;
     }
@@ -154,7 +152,7 @@ public:
 
     void MakeDirty()
     {
-        if (isPhaseDirty || !(*isClifford)) {
+        if (isProbDirty || isPhaseDirty || !(*isClifford)) {
             isProbDirty = true;
         } else {
             amp0 = M_SQRT1_2;

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -475,17 +475,12 @@ bool QUnit::TrySeparate(bitLenInt start, bitLenInt length)
     bool didSeparate = false;
     for (bitLenInt i = 0; i < length; i++) {
         if (shards[start + i].GetQubitCount() == 1) {
-            return true;
+            didSeparate = true;
+            continue;
         }
 
         // This is usually all that's worth trying:
-        QEngineShard& shard = shards[start + i];
-        real1 prob;
-        if (shard.isPlusMinus || QUEUED_PHASE(shard)) {
-            prob = ProbBase(start);
-        } else {
-            prob = Prob(start);
-        }
+        real1 prob = ProbBase(start + i);
         didSeparate |= (IS_ZERO_R1(prob) || IS_ONE_R1(prob));
     }
 
@@ -2130,7 +2125,7 @@ void QUnit::ApplyEitherControlled(const bitLenInt* controls, const bitLenInt& co
     // TODO: Find a better way to leverage Clifford set separability potential.
     if (*(shards[targets[0]].isClifford)) {
         for (i = 0; i < allBits.size(); i++) {
-            ProbBase(allBits[i]);
+            TrySeparate(allBits[i]);
         }
     }
 }

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -871,7 +871,6 @@ void QUnit::ISwap(bitLenInt qubit1, bitLenInt qubit2)
 
     QInterfacePtr unit = Entangle({ qubit1, qubit2 });
     unit->ISwap(shards[qubit1].mapped, shards[qubit2].mapped);
-    *(shards[qubit1].isClifford) = false;
 
     // TODO: If we multiply out cached amplitudes, we can optimize this.
 
@@ -1576,11 +1575,6 @@ void QUnit::ApplySinglePhase(const complex topLeft, const complex bottomRight, b
         return;
     }
 
-    complex sTest = bottomRight / topLeft;
-    if (!IS_I_CMPLX(sTest) && !IS_I_CMPLX(-sTest)) {
-        *(shards[target].isClifford) = false;
-    }
-
     QEngineShard& shard = shards[target];
 
     if (shard.IsInvertTarget()) {
@@ -1596,6 +1590,11 @@ void QUnit::ApplySinglePhase(const complex topLeft, const complex bottomRight, b
             Flush1Eigenstate(target);
             return;
         }
+    }
+
+    complex sTest = bottomRight / topLeft;
+    if (!IS_I_CMPLX(sTest) && !IS_I_CMPLX(-sTest)) {
+        *(shards[target].isClifford) = false;
     }
 
     if (!shard.isPlusMinus) {
@@ -1927,6 +1926,8 @@ void QUnit::ApplySingleBit(const complex* mtrx, bitLenInt target)
 
     RevertBasis2Qb(target);
 
+    *(shard.isClifford) = false;
+
     complex trnsMtrx[4];
 
     if (!shard.isPlusMinus) {
@@ -2126,6 +2127,7 @@ void QUnit::ApplyEitherControlled(const bitLenInt* controls, const bitLenInt& co
         shards[targets[i]].MakeDirty();
     }
 
+    // TODO: Find a better way to leverage Clifford set separability potential.
     if (*(shards[targets[0]].isClifford)) {
         for (i = 0; i < allBits.size(); i++) {
             ProbBase(allBits[i]);

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -2165,6 +2165,8 @@ void QUnit::INCx(INCxFn fn, bitCapInt toMod, bitLenInt start, bitLenInt length, 
     QInterfacePtr unit = Entangle({ start, flagIndex });
 
     *(shards[start].isClifford) = false;
+    DirtyShardRangePhase(start, length);
+    shards[flagIndex].isPhaseDirty = true;
 
     ((*unit).*fn)(toMod, shards[start].mapped, length, shards[flagIndex].mapped);
 
@@ -2178,7 +2180,11 @@ void QUnit::INCxx(
     /* Make sure the flag bits are entangled in the same QU. */
     EntangleRange(start, length);
     QInterfacePtr unit = Entangle({ start, flag1Index, flag2Index });
+
     *(shards[start].isClifford) = false;
+    DirtyShardRangePhase(start, length);
+    shards[flag1Index].isPhaseDirty = true;
+    shards[flag2Index].isPhaseDirty = true;
 
     ((*unit).*fn)(toMod, shards[start].mapped, length, shards[flag1Index].mapped, shards[flag2Index].mapped);
 
@@ -2744,8 +2750,13 @@ void QUnit::POWModNOut(bitCapInt toMod, bitCapInt modN, bitLenInt inStart, bitLe
 QInterfacePtr QUnit::CMULEntangle(std::vector<bitLenInt> controlVec, bitLenInt start, bitLenInt carryStart,
     bitLenInt length, std::vector<bitLenInt>* controlsMapped)
 {
+    // TODO: Can we conceptualize arithmetic as Clifford?
     EntangleRange(start, length);
+    *(shards[start].isClifford) = false;
+    DirtyShardRangePhase(start, length);
     EntangleRange(carryStart, length);
+    *(shards[carryStart].isClifford) = false;
+    DirtyShardRangePhase(carryStart, length);
     DirtyShardRange(carryStart, length);
 
     std::vector<bitLenInt> bits(controlVec.size() + 2);
@@ -2789,8 +2800,6 @@ void QUnit::CMULx(CMULFn fn, bitCapInt toMod, bitLenInt start, bitLenInt carrySt
     ((*unit).*fn)(
         toMod, shards[start].mapped, shards[carryStart].mapped, length, &(controlsMapped[0]), controlVec.size());
 
-    // TODO: Can we conceptualize arithmetic as Clifford?
-    *(shards[start].isClifford) = false;
     DirtyShardRange(start, length);
 }
 

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -564,8 +564,8 @@ TEST_CASE("test_quantum_triviality", "[supreme]")
 
 TEST_CASE("test_stabilizer", "[supreme]")
 {
-    const int GateCount1Qb = 5;
-    const int GateCountMultiQb = 3;
+    const int GateCount1Qb = 4;
+    const int GateCountMultiQb = 2;
     const int Depth = 20;
 
     benchmarkLoop(
@@ -585,10 +585,8 @@ TEST_CASE("test_stabilizer", "[supreme]")
                         qReg->X(i);
                     } else if (gateRand < (3 * ONE_R1 / GateCount1Qb)) {
                         qReg->Y(i);
-                    } else if (gateRand < (3 * ONE_R1 / GateCount1Qb)) {
-                        qReg->S(i);
                     } else {
-                        // Identity
+                        qReg->S(i);
                     }
                 }
 
@@ -607,10 +605,8 @@ TEST_CASE("test_stabilizer", "[supreme]")
 
                     if (gateRand < ONE_R1) {
                         qReg->CNOT(b1, b2);
-                    } else if (gateRand < (2 * ONE_R1)) {
-                        qReg->CZ(b1, b2);
                     } else {
-                        // Identity
+                        qReg->CZ(b1, b2);
                     }
                 }
             }


### PR DESCRIPTION
We're not yet at full parity with stabilizer simulators, but I have added a flag to each QUnit sub-engine that keeps track of whether all flushed gates have been Clifford. This allows optimizations to calculating bit probability and separating qubit representations. The payoff is typically small-to-nil, but this forms the basis for further work toward parity with stabilizer simulators