### PR TITLE
QUnit::ProbBase() debug

### DIFF
--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -665,16 +665,6 @@ real1 QUnit::ProbBase(const bitLenInt& qubit)
     partnerShard.unit->GetQuantumState(amps);
     if (IS_NORM_ZERO(amps[0]) || IS_NORM_ZERO(amps[1])) {
         partnerShard.isClifford = std::make_shared<bool>(true);
-    } else if (norm(amps[0] - amps[1]) < REAL1_EPSILON) {
-        partnerShard.isPlusMinus = !partnerShard.isPlusMinus;
-        amps[0] = amps[0] / abs(amps[0]);
-        amps[1] = ZERO_R1;
-        partnerShard.isClifford = std::make_shared<bool>(true);
-    } else if (norm(amps[0] + amps[1]) < REAL1_EPSILON) {
-        partnerShard.isPlusMinus = !partnerShard.isPlusMinus;
-        amps[1] = amps[0] / abs(amps[0]);
-        amps[0] = ZERO_R1;
-        partnerShard.isClifford = std::make_shared<bool>(true);
     } else {
         partnerShard.isClifford = std::make_shared<bool>(false);
     }

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -4989,10 +4989,10 @@ TEST_CASE("test_universal_circuit_digital_cross_entropy", "[supreme]")
 
     const int GateCount1Qb = 5;
     const int GateCountMultiQb = 4;
-    const int Depth = 3;
+    const int Depth = 4;
 
-    const int TRIALS = 200;
-    const int ITERATIONS = 60000;
+    const int TRIALS = 2000;
+    const int ITERATIONS = 100000;
     const int n = 8;
     bitCapInt permCount = pow2(n);
     bitCapInt perm;

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -4989,10 +4989,10 @@ TEST_CASE("test_universal_circuit_digital_cross_entropy", "[supreme]")
 
     const int GateCount1Qb = 5;
     const int GateCountMultiQb = 4;
-    const int Depth = 4;
+    const int Depth = 3;
 
-    const int TRIALS = 2000;
-    const int ITERATIONS = 100000;
+    const int TRIALS = 200;
+    const int ITERATIONS = 60000;
     const int n = 8;
     bitCapInt permCount = pow2(n);
     bitCapInt perm;


### PR DESCRIPTION
Based on cross entropy integration tests, it seems that QUnit::ProbBase() leads to logical errors on decomposing an X-basis eigenstate. We simply drop that decomposition, here.