### PR TITLE
Simplify Z to Y basis transformation to 1 gate (and inverse)

### DIFF
--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -605,6 +605,20 @@ public:
     virtual void SqrtH(bitLenInt qubitIndex);
 
     /**
+     * Y-basis transformation gate
+     *
+     * Converts from Pauli Z basis to Y, (via H then S gates).
+     */
+    virtual void SH(bitLenInt qubitIndex);
+
+    /**
+     * Y-basis (inverse) transformation gate
+     *
+     * Converts from Pauli Y basis to Z, (via IS then H gates).
+     */
+    virtual void HIS(bitLenInt qubitIndex);
+
+    /**
      * Measurement gate
      *
      * Measures the qubit at "qubitIndex" and returns either "true" or "false."
@@ -1188,6 +1202,12 @@ public:
 
     /** Bitwise Hadamard */
     virtual void H(bitLenInt start, bitLenInt length);
+
+    /** Bitwise Y-basis transformation gate */
+    virtual void SH(bitLenInt start, bitLenInt length);
+
+    /** Bitwise inverse Y-basis transformation gate */
+    virtual void HIS(bitLenInt start, bitLenInt length);
 
     /** Bitwise square root of Hadamard */
     virtual void SqrtH(bitLenInt start, bitLenInt length);

--- a/src/qinterface/gates.cpp
+++ b/src/qinterface/gates.cpp
@@ -147,6 +147,12 @@ GATE_1_PHASE(Z, ONE_CMPLX, -ONE_CMPLX);
 /// Hadamard gate
 GATE_1_BIT(H, C_SQRT1_2, C_SQRT1_2, C_SQRT1_2, -C_SQRT1_2);
 
+/// Y-basis transformation gate
+GATE_1_BIT(SH, C_SQRT1_2, C_SQRT1_2, C_I_SQRT1_2, -C_I_SQRT1_2);
+
+/// Inverse Y-basis transformation gate
+GATE_1_BIT(HIS, C_SQRT1_2, -C_I_SQRT1_2, C_SQRT1_2, C_I_SQRT1_2);
+
 /// Square root of Hadamard gate
 GATE_1_BIT(SqrtH, complex((ONE_R1 + M_SQRT2) / (2 * M_SQRT2), (-ONE_R1 + M_SQRT2) / (2 * M_SQRT2)),
     complex(M_SQRT1_2 / 2, -M_SQRT1_2 / 2), complex(M_SQRT1_2 / 2, -M_SQRT1_2 / 2),

--- a/src/qinterface/qinterface.cpp
+++ b/src/qinterface/qinterface.cpp
@@ -167,6 +167,12 @@ REG_GATE_1(ISqrtXConjT);
 /// Apply Hadamard gate to each bit in "length," starting from bit index "start"
 REG_GATE_1(H);
 
+/// Apply Y-basis transformation gate to each bit in "length," starting from bit index "start"
+REG_GATE_1(SH);
+
+/// Apply inverse Y-basis transformation gate to each bit in "length," starting from bit index "start"
+REG_GATE_1(HIS);
+
 /// Apply square root of Hadamard gate to each bit in "length," starting from bit index "start"
 REG_GATE_1(SqrtH);
 

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -387,6 +387,15 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_ccnot")
     REQUIRE_THAT(qftReg, HasProbability(0x03));
 }
 
+TEST_CASE_METHOD(QInterfaceTestFixture, "test_sh")
+{
+    qftReg->SH(0);
+    REQUIRE_FLOAT(qftReg->Prob(0), 0.5);
+    qftReg->HIS(0, 2);
+    REQUIRE_FLOAT(qftReg->Prob(0), 0);
+    REQUIRE_FLOAT(qftReg->Prob(1), 0.5);
+}
+
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_anticcnot")
 {
     qftReg->SetPermutation(0xCAC00);


### PR DESCRIPTION
Since QUnit fluently switches between Z and X basis, and given some experimentation with stabilizer formalism, I'm curious about Y basis optimizations, in coordination with (computational) Z and X