### PR TITLE
Remove redundant 'length' param from Decompose() signature

### DIFF
--- a/include/qengine_cpu.hpp
+++ b/include/qengine_cpu.hpp
@@ -196,7 +196,7 @@ public:
         return Compose(std::dynamic_pointer_cast<QEngineCPU>(toCopy), start);
     }
 
-    virtual void Decompose(bitLenInt start, bitLenInt length, QInterfacePtr dest);
+    virtual void Decompose(bitLenInt start, QInterfacePtr dest);
 
     virtual void Dispose(bitLenInt start, bitLenInt length);
     virtual void Dispose(bitLenInt start, bitLenInt length, bitCapInt disposedPerm);

--- a/include/qengine_opencl.hpp
+++ b/include/qengine_opencl.hpp
@@ -230,7 +230,7 @@ public:
     {
         return Compose(std::dynamic_pointer_cast<QEngineOCL>(toCopy), start);
     }
-    virtual void Decompose(bitLenInt start, bitLenInt length, QInterfacePtr dest);
+    virtual void Decompose(bitLenInt start, QInterfacePtr dest);
     virtual void Dispose(bitLenInt start, bitLenInt length);
     virtual void Dispose(bitLenInt start, bitLenInt length, bitCapInt disposedPerm);
 

--- a/include/qhybrid.hpp
+++ b/include/qhybrid.hpp
@@ -93,17 +93,17 @@ public:
     {
         return Compose(std::dynamic_pointer_cast<QHybrid>(toCopy), start);
     }
-    virtual void Decompose(bitLenInt start, bitLenInt length, QInterfacePtr dest)
+    virtual void Decompose(bitLenInt start, QInterfacePtr dest)
     {
-        Decompose(start, length, std::dynamic_pointer_cast<QHybrid>(dest));
+        Decompose(start, std::dynamic_pointer_cast<QHybrid>(dest));
     }
-    virtual void Decompose(bitLenInt start, bitLenInt length, QHybridPtr dest)
+    virtual void Decompose(bitLenInt start, QHybridPtr dest)
     {
-        bitLenInt nQubitCount = qubitCount - length;
+        bitLenInt nQubitCount = qubitCount - dest->GetQubitCount();
         SwitchModes(nQubitCount >= thresholdQubits);
         dest->SwitchModes(isGpu);
         SetQubitCount(nQubitCount);
-        return engine->Decompose(start, length, dest->engine);
+        return engine->Decompose(start, dest->engine);
     }
     virtual void Dispose(bitLenInt start, bitLenInt length)
     {

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -359,7 +359,7 @@ public:
      * QInterface, it can be measured with M(), or else all qubits <i>other
      * than</i> the subsystem can be measured.
      */
-    virtual void Decompose(bitLenInt start, bitLenInt length, QInterfacePtr dest) = 0;
+    virtual void Decompose(bitLenInt start, QInterfacePtr dest) = 0;
 
     /**
      * Minimally decompose a set of contiguous bits from the separably composed unit,

--- a/include/qpager.hpp
+++ b/include/qpager.hpp
@@ -112,11 +112,11 @@ public:
     {
         return Compose(std::dynamic_pointer_cast<QPager>(toCopy), start);
     }
-    virtual void Decompose(bitLenInt start, bitLenInt length, QInterfacePtr dest)
+    virtual void Decompose(bitLenInt start, QInterfacePtr dest)
     {
-        Decompose(start, length, std::dynamic_pointer_cast<QPager>(dest));
+        Decompose(start, std::dynamic_pointer_cast<QPager>(dest));
     }
-    virtual void Decompose(bitLenInt start, bitLenInt length, QPagerPtr dest);
+    virtual void Decompose(bitLenInt start, QPagerPtr dest);
     virtual void Dispose(bitLenInt start, bitLenInt length);
     virtual void Dispose(bitLenInt start, bitLenInt length, bitCapInt disposedPerm);
 

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -722,11 +722,11 @@ public:
     {
         return Compose(std::dynamic_pointer_cast<QUnit>(toCopy), start);
     }
-    virtual void Decompose(bitLenInt start, bitLenInt length, QInterfacePtr dest)
+    virtual void Decompose(bitLenInt start, QInterfacePtr dest)
     {
-        Decompose(start, length, std::dynamic_pointer_cast<QUnit>(dest));
+        Decompose(start, std::dynamic_pointer_cast<QUnit>(dest));
     }
-    virtual void Decompose(bitLenInt start, bitLenInt length, QUnitPtr dest);
+    virtual void Decompose(bitLenInt start, QUnitPtr dest);
     virtual void Dispose(bitLenInt start, bitLenInt length);
     virtual void Dispose(bitLenInt start, bitLenInt length, bitCapInt disposedPerm);
 

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -1229,9 +1229,9 @@ void QEngineOCL::DecomposeDispose(bitLenInt start, bitLenInt length, QEngineOCLP
     QueueCall(OCL_API_DECOMPOSEAMP, ngc, ngs, { probBuffer1, angleBuffer1, poolItem->ulongBuffer, stateBuffer });
 }
 
-void QEngineOCL::Decompose(bitLenInt start, bitLenInt length, QInterfacePtr destination)
+void QEngineOCL::Decompose(bitLenInt start, QInterfacePtr destination)
 {
-    DecomposeDispose(start, length, std::dynamic_pointer_cast<QEngineOCL>(destination));
+    DecomposeDispose(start, destination->GetQubitCount(), std::dynamic_pointer_cast<QEngineOCL>(destination));
 }
 
 void QEngineOCL::Dispose(bitLenInt start, bitLenInt length) { DecomposeDispose(start, length, (QEngineOCLPtr)NULL); }

--- a/src/qengine/state.cpp
+++ b/src/qengine/state.cpp
@@ -841,9 +841,9 @@ void QEngineCPU::DecomposeDispose(bitLenInt start, bitLenInt length, QEngineCPUP
     delete[] partStateAngle;
 }
 
-void QEngineCPU::Decompose(bitLenInt start, bitLenInt length, QInterfacePtr destination)
+void QEngineCPU::Decompose(bitLenInt start, QInterfacePtr destination)
 {
-    DecomposeDispose(start, length, std::dynamic_pointer_cast<QEngineCPU>(destination));
+    DecomposeDispose(start, destination->GetQubitCount(), std::dynamic_pointer_cast<QEngineCPU>(destination));
 }
 
 void QEngineCPU::Dispose(bitLenInt start, bitLenInt length) { DecomposeDispose(start, length, (QEngineCPUPtr)NULL); }

--- a/src/qpager.cpp
+++ b/src/qpager.cpp
@@ -392,11 +392,11 @@ bitLenInt QPager::Compose(QPagerPtr toCopy, bitLenInt start)
     return toRet;
 }
 
-void QPager::Decompose(bitLenInt start, bitLenInt length, QPagerPtr dest)
+void QPager::Decompose(bitLenInt start, QPagerPtr dest)
 {
     CombineEngines();
     dest->CombineEngines();
-    qPages[0]->Decompose(start, length, dest->qPages[0]);
+    qPages[0]->Decompose(start, dest->qPages[0]);
     SetQubitCount(qPages[0]->GetQubitCount());
 }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -254,7 +254,7 @@ void QUnit::Detach(bitLenInt start, bitLenInt length, QUnitPtr dest)
             dest->shards[start + i].unit = tempUnit;
         }
 
-        unit->Decompose(mapped, length, destEngine);
+        unit->Decompose(mapped, destEngine);
     } else {
         unit->Dispose(mapped, length);
     }
@@ -275,7 +275,7 @@ void QUnit::Detach(bitLenInt start, bitLenInt length, QUnitPtr dest)
     }
 }
 
-void QUnit::Decompose(bitLenInt start, bitLenInt length, QUnitPtr dest) { Detach(start, length, dest); }
+void QUnit::Decompose(bitLenInt start, QUnitPtr dest) { Detach(start, dest->GetQubitCount(), dest); }
 
 void QUnit::Dispose(bitLenInt start, bitLenInt length) { Detach(start, length, nullptr); }
 

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -3551,7 +3551,7 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_decompose")
         ONE_CMPLX, enable_normalization, true, false, device_id, !disable_hardware_rng, sparse);
 
     qftReg->SetPermutation(0x2b);
-    qftReg->Decompose(0, 4, qftReg2);
+    qftReg->Decompose(0, qftReg2);
 
     REQUIRE_THAT(qftReg, HasProbability(0, 4, 0x2));
     REQUIRE_THAT(qftReg2, HasProbability(0, 4, 0xb));
@@ -3563,7 +3563,7 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_decompose")
         complex(ONE_R1, ZERO_R1), enable_normalization, true, true, device_id, !disable_hardware_rng, sparse);
 
     qftReg->SetPermutation(0x2b);
-    qftReg->Decompose(0, 4, qftReg2);
+    qftReg->Decompose(0, qftReg2);
 
     REQUIRE_THAT(qftReg, HasProbability(0, 4, 0x2));
     REQUIRE_THAT(qftReg2, HasProbability(0, 4, 0xb));


### PR DESCRIPTION
Decompose() must take a destination QInterfacePtr with qubit width equal to the "length" parameter of Decompose. Since Decompose() can't accept an argument different from the size of the destination pointer, we might as well remove the length parameter and specify the "length" explicitly via the size of the passed-in QInterfacePtr.