### PR TITLE
Update isClifford before 'bit'

### DIFF
--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -351,8 +351,8 @@ QInterfacePtr QUnit::EntangleInCurrentBasis(
     /* Change the source parameters to the correct newly mapped bit indexes. */
     /* Also update isClifford metadata. */
     for (auto bit = first; bit < last; bit++) {
-        **bit = shards[**bit].mapped;
         shards[**bit].isClifford = isClifford;
+        **bit = shards[**bit].mapped;
     }
 
     return unit1;


### PR DESCRIPTION
The update order of "isClifford" and "bit" in QUnit::EntangleInCurrentBasis() was wrong, leading to the wrong bits having their "isClifford" pointer updated