### PR TITLE
Sweep all shards for isClifford update after QUnit entangle

### DIFF
--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -349,10 +349,15 @@ QInterfacePtr QUnit::EntangleInCurrentBasis(
     }
 
     /* Change the source parameters to the correct newly mapped bit indexes. */
-    /* Also update isClifford metadata. */
     for (auto bit = first; bit < last; bit++) {
-        shards[**bit].isClifford = isClifford;
         **bit = shards[**bit].mapped;
+    }
+
+    /* Also update isClifford metadata. */
+    for (auto&& shard : shards) {
+        if (shard.unit == shards[**first].unit) {
+            shard.isClifford = isClifford;
+        }
     }
 
     return unit1;


### PR DESCRIPTION
We might be able to get more aggressive about preserving the `isClifford = true` flag in QUnit shards, but this was not the intended algorithm, and I can't guarantee general accuracy without this fix.