### PR TITLE
ProbBase: Separate remaining single shard in Z or X basis

### DIFF
--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -2125,11 +2125,11 @@ void QUnit::ApplyEitherControlled(const bitLenInt* controls, const bitLenInt& co
     }
 
     // TODO: Find a better way to leverage Clifford set separability potential.
-    // if (*(shards[targets[0]].isClifford)) {
-    //     for (i = 0; i < allBits.size(); i++) {
-    //         TrySeparate(allBits[i]);
-    //     }
-    // }
+    if (*(shards[targets[0]].isClifford)) {
+        for (i = 0; i < allBits.size(); i++) {
+            TrySeparate(allBits[i]);
+        }
+    }
 }
 
 bool QUnit::CArithmeticOptimize(bitLenInt* controls, bitLenInt controlLen, std::vector<bitLenInt>* controlVec)

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -238,6 +238,7 @@ void QUnit::Detach(bitLenInt start, bitLenInt length, QUnitPtr dest)
         if (dest) {
             dest->EntangleRange(0, length);
             dest->OrderContiguous(dest->shards[0].unit);
+
             destEngine = dest->shards[0].unit;
             isClifford = dest->shards[0].isClifford;
             *isClifford = *(shards[start].isClifford);

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -238,7 +238,6 @@ void QUnit::Detach(bitLenInt start, bitLenInt length, QUnitPtr dest)
         if (dest) {
             dest->EntangleRange(0, length);
             dest->OrderContiguous(dest->shards[0].unit);
-
             destEngine = dest->shards[0].unit;
             isClifford = dest->shards[0].isClifford;
             *isClifford = *(shards[start].isClifford);
@@ -652,11 +651,11 @@ real1 QUnit::ProbBase(const bitLenInt& qubit)
     }
 
     if (!didSeparate) {
-        return norm(shard.amp1);
+        return prob;
     }
 
     if (shardQbCount != 2) {
-        return norm(shard.amp1);
+        return prob;
     }
 
     bitLenInt partnerIndex;
@@ -667,11 +666,25 @@ real1 QUnit::ProbBase(const bitLenInt& qubit)
         }
     }
 
+    RevertBasis1Qb(partnerIndex);
+
     QEngineShard& partnerShard = shards[partnerIndex];
+
     complex amps[2];
     partnerShard.unit->GetQuantumState(amps);
-    if (IS_NORM_ZERO(amps[0]) || IS_NORM_ZERO(amps[1])) {
+    if (IS_NORM_ZERO(amps[0]) || IS_NORM_ZERO(amps[1]) || IS_NORM_ZERO((I_CMPLX * amps[0]) - amps[1]) ||
+        IS_NORM_ZERO((I_CMPLX * amps[0]) + amps[1])) {
         partnerShard.isClifford = std::make_shared<bool>(true);
+    } else if (IS_NORM_ZERO(amps[0] - amps[1])) {
+        partnerShard.isClifford = std::make_shared<bool>(true);
+        partnerShard.isPlusMinus = true;
+        amps[0] = ONE_CMPLX;
+        amps[1] = ZERO_CMPLX;
+    } else if (IS_NORM_ZERO(amps[0] + amps[1])) {
+        partnerShard.isClifford = std::make_shared<bool>(true);
+        partnerShard.isPlusMinus = true;
+        amps[0] = ZERO_CMPLX;
+        amps[1] = ONE_CMPLX;
     } else {
         partnerShard.isClifford = std::make_shared<bool>(false);
     }
@@ -679,13 +692,12 @@ real1 QUnit::ProbBase(const bitLenInt& qubit)
     partnerShard.amp1 = amps[1];
     partnerShard.isProbDirty = false;
     partnerShard.isPhaseDirty = false;
-    partnerShard.mapped = 0;
     partnerShard.unit = NULL;
     if (doNormalize) {
         partnerShard.ClampAmps(amplitudeFloor);
     }
 
-    return norm(shard.amp1);
+    return prob;
 }
 
 real1 QUnit::Prob(bitLenInt qubit)
@@ -873,9 +885,9 @@ void QUnit::SqrtSwap(bitLenInt qubit1, bitLenInt qubit2)
         return;
     }
 
+    *(shard1.isClifford) = false;
     QInterfacePtr unit = Entangle({ qubit1, qubit2 });
     unit->SqrtSwap(shards[qubit1].mapped, shards[qubit2].mapped);
-    *(shards[qubit1].isClifford) = false;
 
     // TODO: If we multiply out cached amplitudes, we can optimize this.
 
@@ -901,9 +913,9 @@ void QUnit::ISqrtSwap(bitLenInt qubit1, bitLenInt qubit2)
         return;
     }
 
+    *(shard1.isClifford) = false;
     QInterfacePtr unit = Entangle({ qubit1, qubit2 });
     unit->ISqrtSwap(shards[qubit1].mapped, shards[qubit2].mapped);
-    *(shards[qubit1].isClifford) = false;
 
     // TODO: If we multiply out cached amplitudes, we can optimize this.
 
@@ -944,9 +956,9 @@ void QUnit::FSim(real1 theta, real1 phi, bitLenInt qubit1, bitLenInt qubit2)
         return;
     }
 
+    *(shard1.isClifford) = false;
     QInterfacePtr unit = Entangle({ qubit1, qubit2 });
     unit->FSim(theta, phi, shards[qubit1].mapped, shards[qubit2].mapped);
-    *(shards[qubit1].isClifford) = false;
 
     // TODO: If we multiply out cached amplitudes, we can optimize this.
 
@@ -959,7 +971,7 @@ void QUnit::UniformlyControlledSingleBit(const bitLenInt* controls, const bitLen
     const bitCapInt& mtrxSkipValueMask)
 {
     // If there are no controls, this is equivalent to the single bit gate.
-    if (controlLen == 0) {
+    if (!controlLen) {
         ApplySingleBit(mtrxs, qubitIndex);
         return;
     }
@@ -979,7 +991,7 @@ void QUnit::UniformlyControlledSingleBit(const bitLenInt* controls, const bitLen
     }
 
     // If all controls are in eigenstates, we can avoid entangling them.
-    if (trimmedControls.size() == 0) {
+    if (!trimmedControls.size()) {
         bitCapInt controlPerm = GetCachedPermutation(controls, controlLen);
         complex mtrx[4];
         std::copy(
@@ -1666,7 +1678,7 @@ void QUnit::ApplyControlledSinglePhase(const bitLenInt* cControls, const bitLenI
     const bitLenInt& cTarget, const complex topLeft, const complex bottomRight)
 {
     // Commutes with controlled phase optimizations
-    if (controlLen == 0) {
+    if (!controlLen) {
         ApplySinglePhase(topLeft, bottomRight, cTarget);
         return;
     }
@@ -1788,7 +1800,7 @@ void QUnit::ApplyAntiControlledSinglePhase(const bitLenInt* cControls, const bit
     const bitLenInt& cTarget, const complex topLeft, const complex bottomRight)
 {
     // Commutes with controlled phase optimizations
-    if (controlLen == 0) {
+    if (!controlLen) {
         ApplySinglePhase(topLeft, bottomRight, cTarget);
         return;
     }
@@ -1892,11 +1904,11 @@ void QUnit::ApplySingleBit(const complex* mtrx, bitLenInt target)
         return;
     }
 
-    if ((norm(mtrx[1]) == 0) && (norm(mtrx[2]) == 0)) {
+    if (!norm(mtrx[1]) && !norm(mtrx[2])) {
         ApplySinglePhase(mtrx[0], mtrx[3], target);
         return;
     }
-    if ((norm(mtrx[0]) == 0) && (norm(mtrx[3]) == 0)) {
+    if (!norm(mtrx[0]) && !norm(mtrx[3])) {
         ApplySingleInvert(mtrx[1], mtrx[2], target);
         return;
     }
@@ -1941,12 +1953,12 @@ void QUnit::ApplyControlledSingleBit(
         return;
     }
 
-    if ((norm(mtrx[1]) == 0) && (norm(mtrx[2]) == 0)) {
+    if (!norm(mtrx[1]) && !norm(mtrx[2])) {
         ApplyControlledSinglePhase(controls, controlLen, target, mtrx[0], mtrx[3]);
         return;
     }
 
-    if ((norm(mtrx[0]) == 0) && (norm(mtrx[3]) == 0)) {
+    if (!norm(mtrx[0]) && !norm(mtrx[3])) {
         ApplyControlledSingleInvert(controls, controlLen, target, mtrx[1], mtrx[2]);
         return;
     }
@@ -1961,12 +1973,12 @@ void QUnit::ApplyAntiControlledSingleBit(
         return;
     }
 
-    if ((norm(mtrx[1]) == 0) && (norm(mtrx[2]) == 0)) {
+    if (!norm(mtrx[1]) && !norm(mtrx[2])) {
         ApplyAntiControlledSinglePhase(controls, controlLen, target, mtrx[0], mtrx[3]);
         return;
     }
 
-    if ((norm(mtrx[0]) == 0) && (norm(mtrx[3]) == 0)) {
+    if (!norm(mtrx[0]) && !norm(mtrx[3])) {
         ApplyAntiControlledSingleInvert(controls, controlLen, target, mtrx[1], mtrx[2]);
         return;
     }
@@ -2062,7 +2074,7 @@ void QUnit::ApplyEitherControlled(const bitLenInt* controls, const bitLenInt& co
         }
     }
 
-    if (controlVec.size() == 0) {
+    if (!controlVec.size()) {
         // Here, the gate is guaranteed to act as if it wasn't controlled, so we apply the gate without controls,
         // avoiding an entangled representation.
         fn();
@@ -2112,16 +2124,16 @@ void QUnit::ApplyEitherControlled(const bitLenInt* controls, const bitLenInt& co
     }
 
     // TODO: Find a better way to leverage Clifford set separability potential.
-    if (*(shards[targets[0]].isClifford)) {
-        for (i = 0; i < allBits.size(); i++) {
-            TrySeparate(allBits[i]);
-        }
-    }
+    // if (*(shards[targets[0]].isClifford)) {
+    //     for (i = 0; i < allBits.size(); i++) {
+    //         TrySeparate(allBits[i]);
+    //     }
+    // }
 }
 
 bool QUnit::CArithmeticOptimize(bitLenInt* controls, bitLenInt controlLen, std::vector<bitLenInt>* controlVec)
 {
-    if (controlLen == 0) {
+    if (!controlLen) {
         return false;
     }
 
@@ -2268,7 +2280,7 @@ void QUnit::INT(bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt ca
 {
     // Keep the bits separate, if cheap to do so:
     toMod &= pow2Mask(length);
-    if (toMod == 0) {
+    if (!toMod) {
         return;
     }
 
@@ -2400,7 +2412,7 @@ void QUnit::INT(bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt ca
         }
     }
 
-    if ((toMod == 0) && (length == 0)) {
+    if (!toMod && !length) {
         // We were able to avoid entangling the carry.
         if (hasCarry && carry) {
             if (controlLen == 1U) {
@@ -2481,7 +2493,7 @@ void QUnit::INTS(
     bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt overflowIndex, bitLenInt carryIndex, bool hasCarry)
 {
     toMod &= pow2Mask(length);
-    if (toMod == 0) {
+    if (!toMod) {
         return;
     }
 
@@ -2607,7 +2619,7 @@ void QUnit::DECBCDC(bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenIn
 void QUnit::MUL(bitCapInt toMul, bitLenInt inOutStart, bitLenInt carryStart, bitLenInt length)
 {
     // Keep the bits separate, if cheap to do so:
-    if (toMul == 0U) {
+    if (!toMul) {
         SetReg(inOutStart, length, 0U);
         SetReg(carryStart, length, 0U);
         return;
@@ -2665,7 +2677,7 @@ void QUnit::xMULModNOut(
     bitCapInt toMod, bitCapInt modN, bitLenInt inStart, bitLenInt outStart, bitLenInt length, bool inverse)
 {
     // Inexpensive edge case
-    if (toMod == 0U) {
+    if (!toMod) {
         SetReg(outStart, length, 0U);
         return;
     }
@@ -2786,7 +2798,7 @@ QInterfacePtr QUnit::CMULEntangle(std::vector<bitLenInt> controlVec, bitLenInt s
 
     QInterfacePtr unit = Entangle(ebits);
 
-    controlsMapped->resize(controlVec.size() == 0 ? 1 : controlVec.size());
+    controlsMapped->resize(!controlVec.size() ? 1 : controlVec.size());
     for (bitLenInt i = 0; i < controlVec.size(); i++) {
         (*controlsMapped)[i] = shards[controlVec[i]].mapped;
         shards[controlVec[i]].isPhaseDirty = true;
@@ -2832,7 +2844,7 @@ void QUnit::CMULModx(CMULModFn fn, bitCapInt toMod, bitCapInt modN, bitLenInt st
 void QUnit::CMUL(
     bitCapInt toMod, bitLenInt start, bitLenInt carryStart, bitLenInt length, bitLenInt* controls, bitLenInt controlLen)
 {
-    if (controlLen == 0U) {
+    if (!controlLen) {
         MUL(toMod, start, carryStart, length);
         return;
     }
@@ -2843,7 +2855,7 @@ void QUnit::CMUL(
 void QUnit::CDIV(
     bitCapInt toMod, bitLenInt start, bitLenInt carryStart, bitLenInt length, bitLenInt* controls, bitLenInt controlLen)
 {
-    if (controlLen == 0U) {
+    if (!controlLen) {
         DIV(toMod, start, carryStart, length);
         return;
     }
@@ -2861,7 +2873,7 @@ void QUnit::CxMULModNOut(bitCapInt toMod, bitCapInt modN, bitLenInt inStart, bit
         return;
     }
 
-    if (controlVec.size() == 0U) {
+    if (!controlVec.size()) {
         if (inverse) {
             IMULModNOut(toMod, modN, inStart, outStart, length);
         } else {
@@ -2924,7 +2936,7 @@ void QUnit::CIMULModNOut(bitCapInt toMod, bitCapInt modN, bitLenInt inStart, bit
 void QUnit::CPOWModNOut(bitCapInt toMod, bitCapInt modN, bitLenInt inStart, bitLenInt outStart, bitLenInt length,
     bitLenInt* controls, bitLenInt controlLen)
 {
-    if (controlLen == 0U) {
+    if (!controlLen) {
         POWModNOut(toMod, modN, inStart, outStart, length);
         return;
     }


### PR DESCRIPTION
QUnit::ProbBase() also resets the remaining shard when pulling 1 qubit off a unit of 2, leaving a single remainder qubit, which can be cached. This branch optimizes that caching. (I'm pulling this work aside from `stabilizer` as independently useful.)