### PR TITLE
CCNOT/CCZ overrides for QStabilizerHybrid

### DIFF
--- a/include/qstabilizerhybrid.hpp
+++ b/include/qstabilizerhybrid.hpp
@@ -177,28 +177,34 @@ public:
         }
     }
 
-#if 0
     virtual void CCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target)
     {
+        real1 prob;
+
         if (stabilizer) {
-            if (stabilizer->IsSeparableZ(control1)) {
-                if (stabilizer->M(control1)) {
-                    CNOT(control2, target);
-                }
+            prob = Prob(control1);
+            if (prob == ZERO_R1) {
                 return;
-            } else if (stabilizer->IsSeparableZ(control2)) {
-                if (stabilizer->M(control2)) {
-                    CNOT(control1, target);
-                }
-                return;
-            } else {
-                SwitchToEngine();
             }
+            if (prob == ONE_R1) {
+                stabilizer->CNOT(control2, target);
+                return;
+            }
+
+            prob = Prob(control2);
+            if (prob == ZERO_R1) {
+                return;
+            }
+            if (prob == ONE_R1) {
+                stabilizer->CNOT(control1, target);
+                return;
+            }
+
+            SwitchToEngine();
         }
 
         engine->CCNOT(control1, control2, target);
     }
-#endif
 
     /// Apply a Hadamard gate to target
     virtual void H(bitLenInt target)
@@ -266,28 +272,34 @@ public:
         }
     }
 
-#if 0
     virtual void CCZ(bitLenInt control1, bitLenInt control2, bitLenInt target)
     {
+        real1 prob;
+
         if (stabilizer) {
-            if (stabilizer->IsSeparableZ(control1)) {
-                if (stabilizer->M(control1)) {
-                    CZ(control2, target);
-                }
+            prob = Prob(control1);
+            if (prob == ZERO_R1) {
                 return;
-            } else if (stabilizer->IsSeparableZ(control2)) {
-                if (stabilizer->M(control2)) {
-                    CZ(control1, target);
-                }
-                return;
-            } else {
-                SwitchToEngine();
             }
+            if (prob == ONE_R1) {
+                stabilizer->CZ(control2, target);
+                return;
+            }
+
+            prob = Prob(control2);
+            if (prob == ZERO_R1) {
+                return;
+            }
+            if (prob == ONE_R1) {
+                stabilizer->CZ(control1, target);
+                return;
+            }
+
+            SwitchToEngine();
         }
 
         engine->CCZ(control1, control2, target);
     }
-#endif
 
     virtual void Swap(bitLenInt qubit1, bitLenInt qubit2)
     {
@@ -669,10 +681,10 @@ public:
         }
 
         // TODO: Generalize to trim all possible controls, like in QUnit.
-        // if ((controlLen == 2U) && (topLeft == ONE_CMPLX) && (bottomRight == -ONE_CMPLX)) {
-        //     CCZ(controls[0], controls[1], target);
-        //     return;
-        // }
+        if ((controlLen == 2U) && (topLeft == ONE_CMPLX) && (bottomRight == -ONE_CMPLX)) {
+            CCZ(controls[0], controls[1], target);
+            return;
+        }
 
         if ((topLeft != ONE_CMPLX) || (controlLen > 1U)) {
             SwitchToEngine();
@@ -706,10 +718,10 @@ public:
         }
 
         // TODO: Generalize to trim all possible controls, like in QUnit.
-        // if ((controlLen == 2U) && (topRight == ONE_CMPLX) && (bottomLeft == ONE_CMPLX)) {
-        //     CCNOT(controls[0], controls[1], target);
-        //     return;
-        // }
+        if ((controlLen == 2U) && (topRight == ONE_CMPLX) && (bottomLeft == ONE_CMPLX)) {
+            CCNOT(controls[0], controls[1], target);
+            return;
+        }
 
         if (controlLen > 1U) {
             SwitchToEngine();

--- a/include/qstabilizerhybrid.hpp
+++ b/include/qstabilizerhybrid.hpp
@@ -179,10 +179,8 @@ public:
 
     virtual void CCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target)
     {
-        real1 prob;
-
         if (stabilizer) {
-            prob = Prob(control1);
+            real1 prob = Prob(control1);
             if (prob == ZERO_R1) {
                 return;
             }
@@ -216,6 +214,24 @@ public:
         }
     }
 
+    virtual void CH(bitLenInt control, bitLenInt target)
+    {
+        if (stabilizer) {
+            real1 prob = Prob(control);
+            if (prob == ZERO_R1) {
+                return;
+            }
+            if (prob == ONE_R1) {
+                stabilizer->H(target);
+                return;
+            }
+
+            SwitchToEngine();
+        }
+
+        engine->CH(control, target);
+    }
+
     /// Apply a phase gate (|0>->|0>, |1>->i|1>, or "S") to qubit b
     virtual void S(bitLenInt target)
     {
@@ -224,6 +240,24 @@ public:
         } else {
             engine->S(target);
         }
+    }
+
+    virtual void CS(bitLenInt control, bitLenInt target)
+    {
+        if (stabilizer) {
+            real1 prob = Prob(control);
+            if (prob == ZERO_R1) {
+                return;
+            }
+            if (prob == ONE_R1) {
+                stabilizer->S(target);
+                return;
+            }
+
+            SwitchToEngine();
+        }
+
+        engine->CS(control, target);
     }
 
     // TODO: Custom implementations for decompositions:
@@ -243,6 +277,24 @@ public:
         } else {
             engine->IS(target);
         }
+    }
+
+    virtual void CIS(bitLenInt control, bitLenInt target)
+    {
+        if (stabilizer) {
+            real1 prob = Prob(control);
+            if (prob == ZERO_R1) {
+                return;
+            }
+            if (prob == ONE_R1) {
+                stabilizer->IS(target);
+                return;
+            }
+
+            SwitchToEngine();
+        }
+
+        engine->CIS(control, target);
     }
 
     virtual void X(bitLenInt target)
@@ -274,10 +326,8 @@ public:
 
     virtual void CCZ(bitLenInt control1, bitLenInt control2, bitLenInt target)
     {
-        real1 prob;
-
         if (stabilizer) {
-            prob = Prob(control1);
+            real1 prob = Prob(control1);
             if (prob == ZERO_R1) {
                 return;
             }
@@ -668,6 +718,12 @@ public:
             return;
         }
 
+        if ((controlLen == 1U) && (mtrx[0] == complex(M_SQRT1_2, ZERO_R1)) && (mtrx[0] == mtrx[1]) &&
+            (mtrx[0] == mtrx[2]) && (mtrx[2] == -mtrx[3])) {
+            CH(controls[0], target);
+            return;
+        }
+
         SwitchToEngine();
         engine->ApplyControlledSingleBit(controls, controlLen, target, mtrx);
     }
@@ -692,6 +748,16 @@ public:
 
         if (engine) {
             engine->ApplyControlledSinglePhase(controls, controlLen, target, topLeft, bottomRight);
+            return;
+        }
+
+        if (bottomRight == I_CMPLX) {
+            CS(controls[0], target);
+            return;
+        }
+
+        if (bottomRight == -I_CMPLX) {
+            CIS(controls[0], target);
             return;
         }
 
@@ -815,6 +881,20 @@ public:
 
         if (engine) {
             engine->ApplyAntiControlledSinglePhase(controls, controlLen, target, topLeft, bottomRight);
+            return;
+        }
+
+        if (bottomRight == I_CMPLX) {
+            X(controls[0]);
+            CS(controls[0], target);
+            X(controls[0]);
+            return;
+        }
+
+        if (bottomRight == -I_CMPLX) {
+            X(controls[0]);
+            CIS(controls[0], target);
+            X(controls[0]);
             return;
         }
 


### PR DESCRIPTION
When a QStabilizerHybrid encounters a CCNOT or CCZ gate, it can sometimes handle it as a Clifford gate, borrowing an optimization method from QUnit.