### PR TITLE
Skip QUnit buffering, if QUnit -> QStabilizerHybrid stack

### DIFF
--- a/include/qstabilizerhybrid.hpp
+++ b/include/qstabilizerhybrid.hpp
@@ -958,7 +958,7 @@ public:
     {
         // TODO: QStabilizer appears not to be decomposable after measurement, and in many cases where a bit is in an
         // eigenstate.
-        if (stabilizer) {
+        if (stabilizer && ((engineType == QINTERFACE_QUNIT) || (engineType == QINTERFACE_QUNIT_MULTI))) {
             return stabilizer->M(qubit, result, doForce, doApply);
         }
 

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -668,6 +668,7 @@ protected:
     bool freezeBasisH;
     bool freezeBasis2Qb;
     bitLenInt thresholdQubits;
+    bool doNotBuffer;
 
     QInterfacePtr MakeEngine(bitLenInt length, bitCapInt perm);
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -66,6 +66,7 @@ QUnit::QUnit(QInterfaceEngine eng, QInterfaceEngine subEng, bitLenInt qBitCount,
     , freezeBasisH(false)
     , freezeBasis2Qb(false)
     , thresholdQubits(qubitThreshold)
+    , doNotBuffer(eng == QINTERFACE_STABILIZER_HYBRID)
 {
     if ((engine == QINTERFACE_CPU) || (engine == QINTERFACE_OPENCL)) {
         subEngine = engine;
@@ -1193,7 +1194,7 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
 
     bool pmBasis = (cShard.isPlusMinus && tShard.isPlusMinus && !QUEUED_PHASE(cShard) && !QUEUED_PHASE(tShard));
 
-    if (!freezeBasis2Qb && !pmBasis) {
+    if (!doNotBuffer && !freezeBasis2Qb && !pmBasis) {
         RevertBasis2Qb(control, ONLY_INVERT, ONLY_TARGETS);
 
         bool isInvert = cShard.IsInvertControlOf(&tShard);
@@ -1273,7 +1274,7 @@ void QUnit::AntiCNOT(bitLenInt control, bitLenInt target)
     bitLenInt controls[1] = { control };
     bitLenInt controlLen = 1;
 
-    if (!freezeBasis2Qb) {
+    if (!doNotBuffer && !freezeBasis2Qb) {
         RevertBasis2Qb(control, ONLY_INVERT, ONLY_TARGETS);
         RevertBasis2Qb(target, ONLY_PHASE, CONTROLS_AND_TARGETS);
         RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI, {}, { control });
@@ -1401,7 +1402,7 @@ void QUnit::CZ(bitLenInt control, bitLenInt target)
         return;
     }
 
-    if (!freezeBasis2Qb) {
+    if (!doNotBuffer && !freezeBasis2Qb) {
         RevertBasis2Qb(control, ONLY_INVERT, ONLY_TARGETS);
 
         bool isInvert = cShard.IsInvertControlOf(&tShard);
@@ -1699,7 +1700,7 @@ void QUnit::ApplyControlledSinglePhase(const bitLenInt* cControls, const bitLenI
         }
     }
 
-    if (!freezeBasis2Qb && (controlLen == 1U)) {
+    if (!doNotBuffer && !freezeBasis2Qb && (controlLen == 1U)) {
         bitLenInt control = controls[0];
         delete[] controls;
         QEngineShard& cShard = shards[control];
@@ -1801,7 +1802,7 @@ void QUnit::ApplyAntiControlledSinglePhase(const bitLenInt* cControls, const bit
         }
     }
 
-    if (!freezeBasis2Qb && (controlLen == 1U)) {
+    if (!doNotBuffer && !freezeBasis2Qb && (controlLen == 1U)) {
         bitLenInt control = controls[0];
         delete[] controls;
         QEngineShard& cShard = shards[control];


### PR DESCRIPTION
QUnit's buffering system doesn't seem to give an obvious performance advantage, at least when layered over QStabilizerHybrid. If QUnit detects that it is layered over a QStabilizerHybrid, it can skip buffering exclusively in this case.