### PR TITLE
Skip QUnit buffering if two shards are in same unit

### DIFF
--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -48,6 +48,7 @@
     (!shard.isProbDirty && !shard.isPlusMinus && (IS_NORM_ZERO(shard.amp0) || IS_NORM_ZERO(shard.amp1)))
 #define UNSAFE_CACHED_ONE(shard) (!shard.isProbDirty && !shard.isPlusMinus && IS_NORM_ZERO(shard.amp0))
 #define UNSAFE_CACHED_ZERO(shard) (!shard.isProbDirty && !shard.isPlusMinus && IS_NORM_ZERO(shard.amp1))
+#define IS_SAME_UNIT(shard1, shard2) ((shard1.unit || shard2.unit) && (shard1.unit == shard2.unit))
 
 namespace Qrack {
 
@@ -1202,27 +1203,29 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
         }
         RevertBasis2Qb(target, INVERT_AND_PHASE, CONTROLS_AND_TARGETS, CTRL_AND_ANTI, {}, { control });
 
-        tShard.AddInversionAngles(&cShard, ONE_CMPLX, ONE_CMPLX);
+        if (!IS_SAME_UNIT(cShard, tShard)) {
+            tShard.AddInversionAngles(&cShard, ONE_CMPLX, ONE_CMPLX);
 
-        if (!isInvert) {
+            if (!isInvert) {
+                return;
+            }
+
+            ShardToPhaseMap::iterator phaseShard = tShard.targetOfShards.find(&cShard);
+
+            if (phaseShard == tShard.targetOfShards.end()) {
+                return;
+            }
+
+            real1 amplitudeThreshold = doNormalize ? amplitudeFloor : ZERO_R1;
+            PhaseShardPtr buffer = phaseShard->second;
+
+            if (IS_SAME(buffer->cmplxDiff, buffer->cmplxSame)) {
+                ApplyBuffer(buffer, control, target, false);
+                shards[target].RemovePhaseControl(&cShard);
+            }
+
             return;
         }
-
-        ShardToPhaseMap::iterator phaseShard = tShard.targetOfShards.find(&cShard);
-
-        if (phaseShard == tShard.targetOfShards.end()) {
-            return;
-        }
-
-        real1 amplitudeThreshold = doNormalize ? amplitudeFloor : ZERO_R1;
-        PhaseShardPtr buffer = phaseShard->second;
-
-        if (IS_SAME(buffer->cmplxDiff, buffer->cmplxSame)) {
-            ApplyBuffer(buffer, control, target, false);
-            shards[target].RemovePhaseControl(&cShard);
-        }
-
-        return;
     }
 
     bitLenInt controls[1] = { control };
@@ -1278,8 +1281,10 @@ void QUnit::AntiCNOT(bitLenInt control, bitLenInt target)
         RevertBasis2Qb(target, ONLY_PHASE, CONTROLS_AND_TARGETS);
         RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI, {}, { control });
 
-        shards[target].AddAntiInversionAngles(&(shards[control]), ONE_CMPLX, ONE_CMPLX);
-        return;
+        if (!IS_SAME_UNIT(cShard, tShard)) {
+            shards[target].AddAntiInversionAngles(&(shards[control]), ONE_CMPLX, ONE_CMPLX);
+            return;
+        }
     }
 
     CTRLED_PHASE_INVERT_WRAP(AntiCNOT(CTRL_1_ARGS), ApplyAntiControlledSingleBit(CTRL_GEN_ARGS), X(target), true, true,
@@ -1411,27 +1416,29 @@ void QUnit::CZ(bitLenInt control, bitLenInt target)
 
         RevertBasis2Qb(target, ONLY_INVERT, ONLY_TARGETS, CTRL_AND_ANTI, {}, { control });
 
-        tShard.AddPhaseAngles(&cShard, ONE_CMPLX, -ONE_CMPLX);
+        if (!IS_SAME_UNIT(cShard, tShard)) {
+            tShard.AddPhaseAngles(&cShard, ONE_CMPLX, -ONE_CMPLX);
 
-        if (isInvert) {
+            if (isInvert) {
+                return;
+            }
+
+            ShardToPhaseMap::iterator phaseShard = tShard.targetOfShards.find(&cShard);
+
+            if (phaseShard == tShard.targetOfShards.end()) {
+                return;
+            }
+
+            real1 amplitudeThreshold = doNormalize ? amplitudeFloor : ZERO_R1;
+            PhaseShardPtr buffer = phaseShard->second;
+
+            if (IS_SAME(buffer->cmplxDiff, buffer->cmplxSame)) {
+                ApplyBuffer(buffer, control, target, false);
+                tShard.RemovePhaseControl(&cShard);
+            }
+
             return;
         }
-
-        ShardToPhaseMap::iterator phaseShard = tShard.targetOfShards.find(&cShard);
-
-        if (phaseShard == tShard.targetOfShards.end()) {
-            return;
-        }
-
-        real1 amplitudeThreshold = doNormalize ? amplitudeFloor : ZERO_R1;
-        PhaseShardPtr buffer = phaseShard->second;
-
-        if (IS_SAME(buffer->cmplxDiff, buffer->cmplxSame)) {
-            ApplyBuffer(buffer, control, target, false);
-            tShard.RemovePhaseControl(&cShard);
-        }
-
-        return;
     }
 
     bitLenInt controls[1] = { control };
@@ -1701,7 +1708,6 @@ void QUnit::ApplyControlledSinglePhase(const bitLenInt* cControls, const bitLenI
 
     if (!freezeBasis2Qb && (controlLen == 1U)) {
         bitLenInt control = controls[0];
-        delete[] controls;
         QEngineShard& cShard = shards[control];
         QEngineShard& tShard = shards[target];
         if (!cShard.IsInvertTarget() && UNSAFE_CACHED_CLASSICAL(cShard)) {
@@ -1712,6 +1718,7 @@ void QUnit::ApplyControlledSinglePhase(const bitLenInt* cControls, const bitLenI
                 Flush0Eigenstate(control);
             }
 
+            delete[] controls;
             return;
         }
 
@@ -1719,23 +1726,26 @@ void QUnit::ApplyControlledSinglePhase(const bitLenInt* cControls, const bitLenI
 
         RevertBasis2Qb(target, ONLY_INVERT, IS_ONE_CMPLX(topLeft) ? ONLY_TARGETS : CONTROLS_AND_TARGETS, CTRL_AND_ANTI);
 
-        tShard.AddPhaseAngles(&cShard, topLeft, bottomRight);
+        if (!IS_SAME_UNIT(cShard, tShard)) {
+            delete[] controls;
+            tShard.AddPhaseAngles(&cShard, topLeft, bottomRight);
 
-        ShardToPhaseMap::iterator phaseShard = tShard.targetOfShards.find(&cShard);
+            ShardToPhaseMap::iterator phaseShard = tShard.targetOfShards.find(&cShard);
 
-        if ((phaseShard == tShard.targetOfShards.end()) || phaseShard->second->isInvert) {
+            if ((phaseShard == tShard.targetOfShards.end()) || phaseShard->second->isInvert) {
+                return;
+            }
+
+            real1 amplitudeThreshold = doNormalize ? amplitudeFloor : ZERO_R1;
+            PhaseShardPtr buffer = phaseShard->second;
+
+            if (IS_SAME(buffer->cmplxDiff, buffer->cmplxSame)) {
+                ApplyBuffer(buffer, control, target, false);
+                tShard.RemovePhaseControl(&cShard);
+            }
+
             return;
         }
-
-        real1 amplitudeThreshold = doNormalize ? amplitudeFloor : ZERO_R1;
-        PhaseShardPtr buffer = phaseShard->second;
-
-        if (IS_SAME(buffer->cmplxDiff, buffer->cmplxSame)) {
-            ApplyBuffer(buffer, control, target, false);
-            tShard.RemovePhaseControl(&cShard);
-        }
-
-        return;
     }
 
     CTRLED_PHASE_INVERT_WRAP(ApplyControlledSinglePhase(CTRL_P_ARGS), ApplyControlledSingleBit(CTRL_GEN_ARGS),
@@ -1803,7 +1813,6 @@ void QUnit::ApplyAntiControlledSinglePhase(const bitLenInt* cControls, const bit
 
     if (!freezeBasis2Qb && (controlLen == 1U)) {
         bitLenInt control = controls[0];
-        delete[] controls;
         QEngineShard& cShard = shards[control];
         QEngineShard& tShard = shards[target];
         if (!cShard.IsInvertTarget() && UNSAFE_CACHED_CLASSICAL(cShard)) {
@@ -1813,6 +1822,7 @@ void QUnit::ApplyAntiControlledSinglePhase(const bitLenInt* cControls, const bit
                 Flush0Eigenstate(control);
                 ApplySinglePhase(topLeft, bottomRight, target);
             }
+            delete[] controls;
             return;
         }
 
@@ -1821,23 +1831,26 @@ void QUnit::ApplyAntiControlledSinglePhase(const bitLenInt* cControls, const bit
         RevertBasis2Qb(
             target, ONLY_INVERT, IS_ONE_CMPLX(bottomRight) ? ONLY_TARGETS : CONTROLS_AND_TARGETS, CTRL_AND_ANTI);
 
-        tShard.AddAntiPhaseAngles(&cShard, bottomRight, topLeft);
+        if (!IS_SAME_UNIT(cShard, tShard)) {
+            delete[] controls;
+            tShard.AddAntiPhaseAngles(&cShard, bottomRight, topLeft);
 
-        ShardToPhaseMap::iterator phaseShard = tShard.antiTargetOfShards.find(&cShard);
+            ShardToPhaseMap::iterator phaseShard = tShard.antiTargetOfShards.find(&cShard);
 
-        if ((phaseShard == tShard.antiTargetOfShards.end()) || phaseShard->second->isInvert) {
+            if ((phaseShard == tShard.antiTargetOfShards.end()) || phaseShard->second->isInvert) {
+                return;
+            }
+
+            real1 amplitudeThreshold = doNormalize ? amplitudeFloor : ZERO_R1;
+            PhaseShardPtr buffer = phaseShard->second;
+
+            if (IS_SAME(buffer->cmplxDiff, buffer->cmplxSame)) {
+                ApplyBuffer(buffer, control, target, true);
+                tShard.RemovePhaseAntiControl(&cShard);
+            }
+
             return;
         }
-
-        real1 amplitudeThreshold = doNormalize ? amplitudeFloor : ZERO_R1;
-        PhaseShardPtr buffer = phaseShard->second;
-
-        if (IS_SAME(buffer->cmplxDiff, buffer->cmplxSame)) {
-            ApplyBuffer(buffer, control, target, true);
-            tShard.RemovePhaseAntiControl(&cShard);
-        }
-
-        return;
     }
 
     CTRLED_PHASE_INVERT_WRAP(ApplyAntiControlledSinglePhase(CTRL_P_ARGS), ApplyAntiControlledSingleBit(CTRL_GEN_ARGS),

--- a/test/benchmarks_main.cpp
+++ b/test/benchmarks_main.cpp
@@ -246,7 +246,7 @@ int main(int argc, char* argv[])
         if (num_failed == 0 && hybrid) {
             session.config().stream() << "############ QUnit -> QHybrid ############" << std::endl;
             testSubEngineType = QINTERFACE_HYBRID;
-            CreateQuantumInterface(QINTERFACE_HYBRID, 1, 0).reset(); /* Get the OpenCL banner out of the way. */
+            CreateQuantumInterface(QINTERFACE_OPENCL, 1, 0).reset(); /* Get the OpenCL banner out of the way. */
             num_failed = session.run();
         }
 

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -218,7 +218,7 @@ int main(int argc, char* argv[])
         if (num_failed == 0 && hybrid) {
             session.config().stream() << "############ QUnit -> QHybrid ############" << std::endl;
             testSubEngineType = QINTERFACE_HYBRID;
-            CreateQuantumInterface(QINTERFACE_HYBRID, 1, 0).reset(); /* Get the OpenCL banner out of the way. */
+            CreateQuantumInterface(QINTERFACE_OPENCL, 1, 0).reset(); /* Get the OpenCL banner out of the way. */
             num_failed = session.run();
         }
 


### PR DESCRIPTION
There's no obvious advantage to buffering a controlled gate in QUnit, if both control and target qubits are already entangled in the same "unit."