### PR TITLE
Skip end of QStabilizer::M() if redundant

### DIFF
--- a/src/qstabilizer.cpp
+++ b/src/qstabilizer.cpp
@@ -546,6 +546,12 @@ bool QStabilizer::M(const bitLenInt& t, bool result, const bool& doForce, const 
         }
     }
 
+    if (m >= n) {
+        // TODO: Repeating deterministic measurement to the exhaustion of this check might fix Decompose()/Dispose()
+        // separability issues.
+        return r[elemCount];
+    }
+
     rowcopy(elemCount, m + n);
     for (bitLenInt i = m + 1U; i < n; i++) {
         if (x[i][t]) {

--- a/src/qstabilizer.cpp
+++ b/src/qstabilizer.cpp
@@ -491,9 +491,6 @@ bool QStabilizer::M(const bitLenInt& t, bool result, const bool& doForce, const 
 
     bitLenInt elemCount = qubitCount << 1U;
 
-    // Is the outcome random?
-    bool ran = false;
-
     // pivot row in stabilizer
     bitLenInt p;
     // pivot row in destabilizer
@@ -505,14 +502,14 @@ bool QStabilizer::M(const bitLenInt& t, bool result, const bool& doForce, const 
     // loop over stabilizer generators
     for (p = 0; p < n; p++) {
         // if a Zbar does NOT commute with Z_b (the operator being measured), then outcome is random
-        ran = x[p + n][t];
-        if (ran) {
+        if (x[p + n][t]) {
+            // The outcome is random
             break;
         }
     }
 
     // If outcome is indeterminate
-    if (ran) {
+    if (p < n) {
         if (!doApply) {
             result = (doForce ? result : Rand());
             return result;


### PR DESCRIPTION
There are cases where QStabilizer::M() works in the "scratch" row of Aaronson's tableau, to no meaningful end. We skip these cases, and we note that preparing form for `Decompose()` and `Dispose()` could depend on repeating the deterministic measurement routine to recursive exhaustion at this case.