### PR TITLE
Cover X basis buffer stabilizer edge case

### DIFF
--- a/src/qstabilizerhybrid.cpp
+++ b/src/qstabilizerhybrid.cpp
@@ -378,6 +378,16 @@ void QStabilizerHybrid::ApplySingleBit(const complex* mtrx, bitLenInt target)
         return;
     }
 
+    complex sTest = mtrx[0] / mtrx[1];
+
+    if (!engine && (norm(sTest - I_CMPLX) < REAL1_EPSILON) && (norm(mtrx[0] - mtrx[3]) < REAL1_EPSILON) &&
+        (norm(mtrx[1] - mtrx[2]) < REAL1_EPSILON)) {
+        S(target);
+        H(target);
+        S(target);
+        return;
+    }
+
     SwitchToEngine();
     engine->ApplySingleBit(mtrx, target);
 }

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -772,6 +772,10 @@ bitCapInt QUnit::ForceMReg(bitLenInt start, bitLenInt length, bitCapInt result, 
 
 bitCapInt QUnit::MAll()
 {
+    if (engine != QINTERFACE_STABILIZER_HYBRID) {
+        return MReg(0, qubitCount);
+    }
+
     ToPermBasisAllMeasure();
 
     std::vector<bitCapInt> partResults;
@@ -1050,7 +1054,7 @@ void QUnit::H(bitLenInt target)
 {
     QEngineShard& shard = shards[target];
 
-    if (!doSkipBuffer && !freezeBasisH) {
+    if (!freezeBasisH) {
         CommuteH(target);
         shard.isPlusMinus = !shard.isPlusMinus;
         return;
@@ -2074,6 +2078,9 @@ void QUnit::ApplyEitherControlled(const bitLenInt* controls, const bitLenInt& co
         }
         // If the shard's probability is cached, then it's free to check it, so we advance the loop.
         bool isEigenstate = false;
+        // if (shards[controls[i]].unit && shards[controls[i]].unit->isClifford()) {
+        //     ProbBase(controls[i]);
+        // }
         if (!shards[controls[i]].isProbDirty) {
             // This might determine that we can just skip out of the whole gate, in which case it returns this
             // method:


### PR DESCRIPTION
With this edge case covered, X basis buffering can be restored for QUnit -> QStabilizerHybrid. 2 bit buffering is still in development. Also, skip a more costly `MAll()` if not for QStabilizerHybrid shards. 