### PR TITLE
Skip buffering for QUnit -> QStabilizerHybrid

### DIFF
--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -665,14 +665,16 @@ real1 QUnit::ProbBase(const bitLenInt& qubit)
 
     complex amps[2];
     partnerShard.unit->GetQuantumState(amps);
-    if (IS_NORM_ZERO(amps[0] - amps[1])) {
-        partnerShard.isPlusMinus = true;
-        amps[0] = ONE_CMPLX;
-        amps[1] = ZERO_CMPLX;
-    } else if (IS_NORM_ZERO(amps[0] + amps[1])) {
-        partnerShard.isPlusMinus = true;
-        amps[0] = ZERO_CMPLX;
-        amps[1] = ONE_CMPLX;
+    if (!doSkipBuffer) {
+        if (IS_NORM_ZERO(amps[0] - amps[1])) {
+            partnerShard.isPlusMinus = true;
+            amps[0] = ONE_CMPLX;
+            amps[1] = ZERO_CMPLX;
+        } else if (IS_NORM_ZERO(amps[0] + amps[1])) {
+            partnerShard.isPlusMinus = true;
+            amps[0] = ZERO_CMPLX;
+            amps[1] = ONE_CMPLX;
+        }
     }
     partnerShard.amp0 = amps[0];
     partnerShard.amp1 = amps[1];
@@ -1058,7 +1060,7 @@ void QUnit::H(bitLenInt target)
 {
     QEngineShard& shard = shards[target];
 
-    if (!freezeBasisH) {
+    if (!doSkipBuffer && !freezeBasisH) {
         CommuteH(target);
         shard.isPlusMinus = !shard.isPlusMinus;
         return;


### PR DESCRIPTION
I thought I had X basis buffering compatible between the two pieces, but that felt out of the last PR in debugging. This restores QUnit -> QStabilizerHybrid effciency on `test_stabilizer`.