### PR TITLE
QStabilizerHybrid::ApplySingleBit() fix

### DIFF
--- a/src/qstabilizerhybrid.cpp
+++ b/src/qstabilizerhybrid.cpp
@@ -381,13 +381,22 @@ void QStabilizerHybrid::ApplySingleBit(const complex* mtrx, bitLenInt target)
         return;
     }
 
-    complex sTest = mtrx[0] / mtrx[1];
+    if (!engine && IS_SAME(mtrx[0], mtrx[3]) && IS_SAME(mtrx[1], mtrx[2])) {
+        complex sTest = mtrx[0] / mtrx[1];
 
-    if (!engine && IS_SAME(sTest, -I_CMPLX) && IS_SAME(mtrx[0], mtrx[3]) && IS_SAME(mtrx[1], mtrx[2])) {
-        S(target);
-        H(target);
-        S(target);
-        return;
+        if (IS_SAME(sTest, I_CMPLX)) {
+            S(target);
+            H(target);
+            S(target);
+            return;
+        }
+
+        if (IS_SAME(sTest, -I_CMPLX)) {
+            IS(target);
+            H(target);
+            IS(target);
+            return;
+        }
     }
 
     SwitchToEngine();

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1060,7 +1060,7 @@ void QUnit::H(bitLenInt target)
 {
     QEngineShard& shard = shards[target];
 
-    if (!doSkipBuffer && !freezeBasisH) {
+    if (!freezeBasisH) {
         CommuteH(target);
         shard.isPlusMinus = !shard.isPlusMinus;
         return;

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -665,14 +665,16 @@ real1 QUnit::ProbBase(const bitLenInt& qubit)
 
     complex amps[2];
     partnerShard.unit->GetQuantumState(amps);
-    if (IS_NORM_ZERO(amps[0] - amps[1])) {
-        partnerShard.isPlusMinus = true;
-        amps[0] = ONE_CMPLX;
-        amps[1] = ZERO_CMPLX;
-    } else if (IS_NORM_ZERO(amps[0] + amps[1])) {
-        partnerShard.isPlusMinus = true;
-        amps[0] = ZERO_CMPLX;
-        amps[1] = ONE_CMPLX;
+    if (!doSkipBuffer) {
+        if (IS_NORM_ZERO(amps[0] - amps[1])) {
+            partnerShard.isPlusMinus = true;
+            amps[0] = ONE_CMPLX;
+            amps[1] = ZERO_CMPLX;
+        } else if (IS_NORM_ZERO(amps[0] + amps[1])) {
+            partnerShard.isPlusMinus = true;
+            amps[0] = ZERO_CMPLX;
+            amps[1] = ONE_CMPLX;
+        }
     }
     partnerShard.amp0 = amps[0];
     partnerShard.amp1 = amps[1];
@@ -1058,7 +1060,7 @@ void QUnit::H(bitLenInt target)
 {
     QEngineShard& shard = shards[target];
 
-    if (!freezeBasisH) {
+    if (!doSkipBuffer && !freezeBasisH) {
         CommuteH(target);
         shard.isPlusMinus = !shard.isPlusMinus;
         return;


### PR DESCRIPTION
QStabilizerHybrid needs non-obvious Clifford cases diverted to function optimally with QUnit. This corrects and expands the case handling on one such compilation.