### PR TITLE
REAL1_EPSILON is likely to be common limit of systematic error

### DIFF
--- a/include/qengine.hpp
+++ b/include/qengine.hpp
@@ -43,7 +43,7 @@ protected:
 
 public:
     QEngine(bitLenInt qBitCount, qrack_rand_gen_ptr rgp = nullptr, bool doNorm = false, bool randomGlobalPhase = true,
-        bool useHostMem = false, bool useHardwareRNG = true, real1 norm_thresh = min_norm)
+        bool useHostMem = false, bool useHardwareRNG = true, real1 norm_thresh = REAL1_EPSILON)
         : QInterface(qBitCount, rgp, doNorm, useHardwareRNG, randomGlobalPhase, norm_thresh)
         , useHostRam(useHostMem)
         , runningNorm(ONE_R1)

--- a/include/qengine_cpu.hpp
+++ b/include/qengine_cpu.hpp
@@ -48,8 +48,8 @@ protected:
 public:
     QEngineCPU(bitLenInt qBitCount, bitCapInt initState, qrack_rand_gen_ptr rgp = nullptr,
         complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = false, bool randomGlobalPhase = true, bool ignored = false,
-        int ignored2 = -1, bool useHardwareRNG = true, bool useSparseStateVec = false, real1 norm_thresh = min_norm,
-        std::vector<int> ignored3 = {}, bitLenInt ignored4 = 0);
+        int ignored2 = -1, bool useHardwareRNG = true, bool useSparseStateVec = false,
+        real1 norm_thresh = REAL1_EPSILON, std::vector<int> ignored3 = {}, bitLenInt ignored4 = 0);
 
     virtual ~QEngineCPU() { Dump(); }
 

--- a/include/qengine_opencl.hpp
+++ b/include/qengine_opencl.hpp
@@ -148,7 +148,7 @@ public:
     QEngineOCL(bitLenInt qBitCount, bitCapInt initState, qrack_rand_gen_ptr rgp = nullptr,
         complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = false, bool randomGlobalPhase = true,
         bool useHostMem = false, int devID = -1, bool useHardwareRNG = true, bool ignored = false,
-        real1 norm_thresh = min_norm, std::vector<int> ignored2 = {}, bitLenInt ignored3 = 0);
+        real1 norm_thresh = REAL1_EPSILON, std::vector<int> ignored2 = {}, bitLenInt ignored3 = 0);
 
     virtual ~QEngineOCL() { ZeroAmplitudes(); }
 

--- a/include/qhybrid.hpp
+++ b/include/qhybrid.hpp
@@ -39,7 +39,7 @@ public:
     QHybrid(bitLenInt qBitCount, bitCapInt initState = 0, qrack_rand_gen_ptr rgp = nullptr,
         complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = true, bool randomGlobalPhase = true,
         bool useHostMem = false, int deviceId = -1, bool useHardwareRNG = true, bool useSparseStateVec = false,
-        real1 norm_thresh = min_norm, std::vector<int> ignored = {}, bitLenInt qubitThreshold = 0);
+        real1 norm_thresh = REAL1_EPSILON, std::vector<int> ignored = {}, bitLenInt qubitThreshold = 0);
 
     QEnginePtr MakeEngine(bool isOpenCL, bitCapInt initState = 0);
 

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -189,7 +189,7 @@ protected:
 
 public:
     QInterface(bitLenInt n, qrack_rand_gen_ptr rgp = nullptr, bool doNorm = false, bool useHardwareRNG = true,
-        bool randomGlobalPhase = true, real1 norm_thresh = min_norm)
+        bool randomGlobalPhase = true, real1 norm_thresh = REAL1_EPSILON)
         : rand_distribution(0.0, 1.0)
         , hardware_rand_generator(NULL)
         , doNormalize(doNorm)

--- a/include/qpager.hpp
+++ b/include/qpager.hpp
@@ -78,7 +78,7 @@ protected:
 public:
     QPager(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState = 0, qrack_rand_gen_ptr rgp = nullptr,
         complex phaseFac = CMPLX_DEFAULT_ARG, bool ignored = false, bool ignored2 = false, bool useHostMem = false,
-        int deviceId = -1, bool useHardwareRNG = true, bool useSparseStateVec = false, real1 ignored3 = min_norm,
+        int deviceId = -1, bool useHardwareRNG = true, bool useSparseStateVec = false, real1 ignored3 = REAL1_EPSILON,
         std::vector<int> devList = {}, bitLenInt qubitThreshold = 0);
 
     virtual void SetConcurrency(uint32_t threadsPerEngine)

--- a/include/qstabilizerhybrid.hpp
+++ b/include/qstabilizerhybrid.hpp
@@ -49,13 +49,13 @@ public:
     QStabilizerHybrid(QInterfaceEngine eng, QInterfaceEngine subEng, bitLenInt qBitCount, bitCapInt initState = 0,
         qrack_rand_gen_ptr rgp = nullptr, complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = true,
         bool randomGlobalPhase = true, bool useHostMem = false, int deviceId = -1, bool useHardwareRNG = true,
-        bool useSparseStateVec = false, real1 norm_thresh = min_norm, std::vector<int> ignored = {},
+        bool useSparseStateVec = false, real1 norm_thresh = REAL1_EPSILON, std::vector<int> ignored = {},
         bitLenInt qubitThreshold = 0);
 
     QStabilizerHybrid(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState = 0,
         qrack_rand_gen_ptr rgp = nullptr, complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = true,
         bool randomGlobalPhase = true, bool useHostMem = false, int deviceId = -1, bool useHardwareRNG = true,
-        bool useSparseStateVec = false, real1 norm_thresh = min_norm, std::vector<int> ignored = {},
+        bool useSparseStateVec = false, real1 norm_thresh = REAL1_EPSILON, std::vector<int> ignored = {},
         bitLenInt qubitThreshold = 0)
         : QStabilizerHybrid(eng, eng, qBitCount, initState, rgp, phaseFac, doNorm, randomGlobalPhase, useHostMem,
               deviceId, useHardwareRNG, useSparseStateVec, norm_thresh, ignored, qubitThreshold)

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -93,7 +93,7 @@ protected:
     ShardToPhaseMap& GetAntiTargetOfShards() { return antiTargetOfShards; }
 
 public:
-    QEngineShard(const real1 amp_thresh = min_norm)
+    QEngineShard(const real1 amp_thresh = REAL1_EPSILON)
         : unit(NULL)
         , mapped(0)
         , amplitudeFloor(amp_thresh)
@@ -110,7 +110,7 @@ public:
     {
     }
 
-    QEngineShard(const bool& set, const real1 amp_thresh = min_norm)
+    QEngineShard(const bool& set, const real1 amp_thresh = REAL1_EPSILON)
         : unit(NULL)
         , mapped(0)
         , amplitudeFloor(amp_thresh)
@@ -128,7 +128,7 @@ public:
     }
 
     // Dirty state constructor:
-    QEngineShard(QInterfacePtr u, const bitLenInt& mapping, const real1 amp_thresh = min_norm)
+    QEngineShard(QInterfacePtr u, const bitLenInt& mapping, const real1 amp_thresh = REAL1_EPSILON)
         : unit(u)
         , mapped(mapping)
         , amplitudeFloor(amp_thresh)
@@ -676,12 +676,12 @@ public:
     QUnit(QInterfaceEngine eng, QInterfaceEngine subEng, bitLenInt qBitCount, bitCapInt initState = 0,
         qrack_rand_gen_ptr rgp = nullptr, complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = true,
         bool randomGlobalPhase = true, bool useHostMem = false, int deviceId = -1, bool useHardwareRNG = true,
-        bool useSparseStateVec = false, real1 norm_thresh = min_norm, std::vector<int> ignored = {},
+        bool useSparseStateVec = false, real1 norm_thresh = REAL1_EPSILON, std::vector<int> ignored = {},
         bitLenInt qubitThreshold = 0);
     QUnit(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState = 0, qrack_rand_gen_ptr rgp = nullptr,
         complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = true, bool randomGlobalPhase = true,
         bool useHostMem = false, int deviceId = -1, bool useHardwareRNG = true, bool useSparseStateVec = false,
-        real1 norm_thresh = min_norm, std::vector<int> ignored = {}, bitLenInt qubitThreshold = 0)
+        real1 norm_thresh = REAL1_EPSILON, std::vector<int> ignored = {}, bitLenInt qubitThreshold = 0)
         : QUnit(eng, eng, qBitCount, initState, rgp, phaseFac, doNorm, randomGlobalPhase, useHostMem, deviceId,
               useHardwareRNG, useSparseStateVec, norm_thresh, ignored, qubitThreshold)
     {

--- a/include/qunitmulti.hpp
+++ b/include/qunitmulti.hpp
@@ -71,7 +71,7 @@ public:
     QUnitMulti(bitLenInt qBitCount, bitCapInt initState = 0, qrack_rand_gen_ptr rgp = nullptr,
         complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = true, bool randomGlobalPhase = true,
         bool useHostMem = false, int deviceID = -1, bool useHardwareRNG = true, bool useSparseStateVec = false,
-        real1 norm_thresh = min_norm, std::vector<int> devList = {}, bitLenInt qubitThreshold = 0)
+        real1 norm_thresh = REAL1_EPSILON, std::vector<int> devList = {}, bitLenInt qubitThreshold = 0)
         : QUnitMulti(QINTERFACE_OPTIMAL, QINTERFACE_OPTIMAL, qBitCount, initState, rgp, phaseFac, doNorm,
               randomGlobalPhase, useHostMem, deviceID, useHardwareRNG, useSparseStateVec, norm_thresh, devList,
               qubitThreshold)
@@ -81,7 +81,7 @@ public:
     QUnitMulti(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState = 0, qrack_rand_gen_ptr rgp = nullptr,
         complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = true, bool randomGlobalPhase = true,
         bool useHostMem = false, int deviceID = -1, bool useHardwareRNG = true, bool useSparseStateVec = false,
-        real1 norm_thresh = min_norm, std::vector<int> devList = {}, bitLenInt qubitThreshold = 0)
+        real1 norm_thresh = REAL1_EPSILON, std::vector<int> devList = {}, bitLenInt qubitThreshold = 0)
         : QUnitMulti(eng, eng, qBitCount, initState, rgp, phaseFac, doNorm, randomGlobalPhase, useHostMem, deviceID,
               useHardwareRNG, useSparseStateVec, norm_thresh, devList, qubitThreshold)
     {
@@ -90,7 +90,7 @@ public:
     QUnitMulti(QInterfaceEngine eng, QInterfaceEngine subEng, bitLenInt qBitCount, bitCapInt initState = 0,
         qrack_rand_gen_ptr rgp = nullptr, complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = true,
         bool randomGlobalPhase = true, bool useHostMem = false, int deviceID = -1, bool useHardwareRNG = true,
-        bool useSparseStateVec = false, real1 norm_thresh = min_norm, std::vector<int> devList = {},
+        bool useSparseStateVec = false, real1 norm_thresh = REAL1_EPSILON, std::vector<int> devList = {},
         bitLenInt qubitThreshold = 0);
 
     virtual bool TrySeparate(bitLenInt start, bitLenInt length = 1);

--- a/src/qstabilizerhybrid.cpp
+++ b/src/qstabilizerhybrid.cpp
@@ -381,8 +381,8 @@ void QStabilizerHybrid::ApplySingleBit(const complex* mtrx, bitLenInt target)
         return;
     }
 
-    if (IS_SAME(mtrx[0], complex(ONE_R1 / 2, ONE_R1 / 2)) && IS_SAME(mtrx[1], complex(ONE_R1 / 2, -ONE_R1 / 2)) &&
-        IS_SAME(mtrx[0], mtrx[3]) && IS_SAME(mtrx[1], mtrx[2])) {
+    if (stabilizer && IS_SAME(mtrx[0], complex(ONE_R1 / 2, ONE_R1 / 2)) &&
+        IS_SAME(mtrx[1], complex(ONE_R1 / 2, -ONE_R1 / 2)) && IS_SAME(mtrx[0], mtrx[3]) && IS_SAME(mtrx[1], mtrx[2])) {
         IS(target);
         H(target);
         IS(target);

--- a/src/qstabilizerhybrid.cpp
+++ b/src/qstabilizerhybrid.cpp
@@ -381,22 +381,12 @@ void QStabilizerHybrid::ApplySingleBit(const complex* mtrx, bitLenInt target)
         return;
     }
 
-    if (!engine && IS_SAME(mtrx[0], mtrx[3]) && IS_SAME(mtrx[1], mtrx[2])) {
-        complex sTest = mtrx[0] / mtrx[1];
-
-        if (IS_SAME(sTest, I_CMPLX)) {
-            S(target);
-            H(target);
-            S(target);
-            return;
-        }
-
-        if (IS_SAME(sTest, -I_CMPLX)) {
-            IS(target);
-            H(target);
-            IS(target);
-            return;
-        }
+    if (IS_SAME(mtrx[0], complex(ONE_R1 / 2, ONE_R1 / 2)) && IS_SAME(mtrx[1], complex(ONE_R1 / 2, -ONE_R1 / 2)) &&
+        IS_SAME(mtrx[0], mtrx[3]) && IS_SAME(mtrx[1], mtrx[2])) {
+        IS(target);
+        H(target);
+        IS(target);
+        return;
     }
 
     SwitchToEngine();

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -665,16 +665,14 @@ real1 QUnit::ProbBase(const bitLenInt& qubit)
 
     complex amps[2];
     partnerShard.unit->GetQuantumState(amps);
-    if (!doSkipBuffer) {
-        if (IS_NORM_ZERO(amps[0] - amps[1])) {
-            partnerShard.isPlusMinus = true;
-            amps[0] = ONE_CMPLX;
-            amps[1] = ZERO_CMPLX;
-        } else if (IS_NORM_ZERO(amps[0] + amps[1])) {
-            partnerShard.isPlusMinus = true;
-            amps[0] = ZERO_CMPLX;
-            amps[1] = ONE_CMPLX;
-        }
+    if (IS_NORM_ZERO(amps[0] - amps[1])) {
+        partnerShard.isPlusMinus = true;
+        amps[0] = ONE_CMPLX;
+        amps[1] = ZERO_CMPLX;
+    } else if (IS_NORM_ZERO(amps[0] + amps[1])) {
+        partnerShard.isPlusMinus = true;
+        amps[0] = ZERO_CMPLX;
+        amps[1] = ONE_CMPLX;
     }
     partnerShard.amp0 = amps[0];
     partnerShard.amp1 = amps[1];
@@ -1060,7 +1058,7 @@ void QUnit::H(bitLenInt target)
 {
     QEngineShard& shard = shards[target];
 
-    if (!doSkipBuffer && !freezeBasisH) {
+    if (!freezeBasisH) {
         CommuteH(target);
         shard.isPlusMinus = !shard.isPlusMinus;
         return;


### PR DESCRIPTION
QStabilizerHybrid performs better using C++ float or double "epsilon" macros. While we have set our tolerances lower than this, it is likely the limiting systematic error in multiplying gate matrices.