### PR TITLE
Skip QUnit::SeparateBit() if QStabilizerHybrid shards

### DIFF
--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -762,9 +762,7 @@ bool QUnit::ForceM(bitLenInt qubit, bool res, bool doForce, bool doApply)
             }
         }
 
-        if (!doSkipBuffer) {
-            SeparateBit(result, qubit);
-        }
+        SeparateBit(result, qubit);
     }
 
     return result;

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -634,6 +634,10 @@ real1 QUnit::ProbBase(const bitLenInt& qubit)
     shard.amp1 = complex(sqrt(prob), ZERO_R1);
     shard.amp0 = complex(sqrt(ONE_R1 - prob), ZERO_R1);
 
+    if (doSkipBuffer) {
+        return prob;
+    }
+
     bool didSeparate = false;
     if (IS_NORM_ZERO(shard.amp1)) {
         SeparateBit(false, qubit);
@@ -758,7 +762,9 @@ bool QUnit::ForceM(bitLenInt qubit, bool res, bool doForce, bool doApply)
             }
         }
 
-        SeparateBit(result, qubit);
+        if (!doSkipBuffer) {
+            SeparateBit(result, qubit);
+        }
     }
 
     return result;


### PR DESCRIPTION
Per #507, it has occurred to me that we can simply skip all cases of after-the-fact qubit separation in QUnit, only if the shard type is QStabilizerHybrid. This should stabilize the API generally, though it's still likely usually preferable to avoid `Prob()`-like methods with QStabilizerHybrid stack, from a performance standpoint.