### PR TITLE
No need to filter QUnitMulti sub-engine types

### DIFF
--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -2088,9 +2088,9 @@ void QUnit::ApplyEitherControlled(const bitLenInt* controls, const bitLenInt& co
         }
         // If the shard's probability is cached, then it's free to check it, so we advance the loop.
         bool isEigenstate = false;
-        // if (shards[controls[i]].unit && shards[controls[i]].unit->isClifford()) {
-        //     ProbBase(controls[i]);
-        // }
+        if (shards[controls[i]].unit && shards[controls[i]].unit->isClifford()) {
+            ProbBase(controls[i]);
+        }
         if (!shards[controls[i]].isProbDirty) {
             // This might determine that we can just skip out of the whole gate, in which case it returns this
             // method:

--- a/src/qunitmulti.cpp
+++ b/src/qunitmulti.cpp
@@ -26,16 +26,6 @@ QUnitMulti::QUnitMulti(QInterfaceEngine eng, QInterfaceEngine subEng, bitLenInt 
     // The "shard" engine type must be QINTERFACE_OPENCL or QINTERFACE_HYBRID, with or without an intermediate QPager
     // layer.
 
-    if ((engine != QINTERFACE_HYBRID) && (engine != QINTERFACE_OPENCL) && (engine != QINTERFACE_QPAGER)) {
-        throw "Invalid sub-engine type: QUnitMulti must layer over only QEngineOCL or QHybrid, with or without an "
-              "intermediate QPager layer.";
-    }
-
-    if ((subEngine != QINTERFACE_HYBRID) && (subEngine != QINTERFACE_OPENCL)) {
-        throw "Invalid sub-engine type: QUnitMulti must layer over only QEngineOCL or QHybrid, with or without an "
-              "intermediate QPager layer.";
-    }
-
     std::vector<DeviceContextPtr> deviceContext = OCLEngine::Instance()->GetDeviceContextPtrVector();
 
     if (devList.size() == 0) {

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -325,7 +325,7 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_setconcurrency")
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_base_case")
 {
     // TODO: Fix QUnit base cases
-    if (testEngineType == QINTERFACE_QUNIT) {
+    if ((testEngineType == QINTERFACE_QUNIT) || (testEngineType == QINTERFACE_QUNIT_MULTI)) {
         return;
     }
 


### PR DESCRIPTION
At one point, QUnitMulti needed to guarantee that sub-engine types conformed to the `QEngine` interface/sub-class. Since `QHybrid`, this is no longer the case. It doesn't make sense for QUnitMulti to use any sub-type that doesn't involve OpenCL, but it will likely break nothing, so we remove the check on sub-engine type.