### PR TITLE
Fix 128+ qubit builds

### DIFF
--- a/examples/qneuron_classification.cpp
+++ b/examples/qneuron_classification.cpp
@@ -92,9 +92,9 @@ struct dfObservation {
 void makeGeoPowerSetQnn(
     const bitLenInt& predictorCount, QInterfacePtr qReg, std::vector<QNeuronPtr>& outputLayer, std::vector<real1>& etas)
 {
-    bitCapInt neuronCount = pow2(predictorCount);
+    bitCapIntOcl neuronCount = pow2Ocl(predictorCount);
 
-    bitCapInt i, x, y, z;
+    bitCapIntOcl i, x, y, z;
 
     std::vector<bitLenInt> allInputIndices(predictorCount);
     for (bitLenInt i = 0; i < predictorCount; i++) {
@@ -119,7 +119,7 @@ void makeGeoPowerSetQnn(
         }
 
         outputLayer.push_back(std::make_shared<QNeuron>(qReg, &(inputIndices[0]), z, 0));
-        etas.push_back((ONE_R1 / nCr(predictorCount, x)) / pow2(x));
+        etas.push_back((ONE_R1 / nCr(predictorCount, x)) / pow2Ocl(x));
     }
 }
 
@@ -130,7 +130,7 @@ void train(std::vector<std::vector<BoolH>>& rawYX, std::vector<real1>& etas, QIn
     size_t i;
     size_t rowCount = rawYX.size();
     bitLenInt qRegSize = qReg->GetQubitCount();
-    bitCapInt perm;
+    bitCapIntOcl perm;
     std::vector<bitLenInt> permH;
 
     std::cout << "Learning..." << std::endl;
@@ -144,7 +144,7 @@ void train(std::vector<std::vector<BoolH>>& rawYX, std::vector<real1>& etas, QIn
         permH.clear();
         for (i = 0; i < qRegSize; i++) {
             if (row[i] == BOOLH_T) {
-                perm |= pow2(i);
+                perm |= pow2Ocl(i);
             } else if (row[i] == BOOLH_H) {
                 permH.push_back(i);
             }
@@ -161,7 +161,7 @@ void train(std::vector<std::vector<BoolH>>& rawYX, std::vector<real1>& etas, QIn
             }
         } else {
             for (i = 0; i < outputLayer.size(); i++) {
-                outputLayer[i]->Learn(row[0], etas[i] / (rowCount * pow2(permH.size())));
+                outputLayer[i]->Learn(row[0], etas[i] / (rowCount * pow2Ocl(permH.size())));
             }
         }
     }
@@ -175,7 +175,7 @@ std::vector<dfObservation> predict(
     size_t i, rowIndex;
     size_t rowCount = rawYX.size();
     bitLenInt qRegSize = qReg->GetQubitCount();
-    bitCapInt perm;
+    bitCapIntOcl perm;
     std::vector<bitLenInt> permH;
 
     std::vector<dfObservation> dfObs;
@@ -187,7 +187,7 @@ std::vector<dfObservation> predict(
         permH.clear();
         for (i = 0; i < qRegSize; i++) {
             if (row[i] == BOOLH_T) {
-                perm |= pow2(i);
+                perm |= pow2Ocl(i);
             } else if (row[i] == BOOLH_H) {
                 permH.push_back(i);
             }
@@ -198,7 +198,7 @@ std::vector<dfObservation> predict(
             qReg->H(permH[i]);
         }
 
-        for (bitCapInt i = 0; i < outputLayer.size(); i++) {
+        for (bitCapIntOcl i = 0; i < outputLayer.size(); i++) {
             outputLayer[i]->Predict();
         }
 

--- a/include/hamiltonian.hpp
+++ b/include/hamiltonian.hpp
@@ -109,10 +109,10 @@ struct UniformHamiltonianOp : HamiltonianOp {
 
         uniform = true;
 
-        bitCapInt mtrxTermCount = (ONE_BCI << (bitCapInt)controlLen) * 4U;
+        bitCapIntOcl mtrxTermCount = (ONE_BCI << (bitCapIntOcl)controlLen) * 4U;
         BitOp m(new complex[mtrxTermCount], std::default_delete<complex[]>());
         matrix = std::move(m);
-        for (bitCapInt i = 0; i < mtrxTermCount; i++) {
+        for (bitCapIntOcl i = 0; i < mtrxTermCount; i++) {
             matrix.get()[i] = complex((real1)mtrx[i * 2U], (real1)mtrx[(i * 2U) + 1U]);
         }
     }

--- a/include/qengine_cpu.hpp
+++ b/include/qengine_cpu.hpp
@@ -93,7 +93,7 @@ public:
         if (stateVec) {
             stateVec->copy_out(pagePtr, offset, length);
         } else {
-            std::fill(pagePtr, pagePtr + length, ZERO_CMPLX);
+            std::fill(pagePtr, pagePtr + (bitCapIntOcl)length, ZERO_CMPLX);
         }
     }
     virtual void SetAmplitudePage(const complex* pagePtr, const bitCapInt offset, const bitCapInt length)
@@ -165,7 +165,7 @@ public:
 
         complex* sv;
         if (isSparse) {
-            sv = new complex[maxQPower];
+            sv = new complex[(bitCapIntOcl)maxQPower];
         } else {
             sv = std::dynamic_pointer_cast<StateVectorArray>(stateVec)->amplitudes;
         }

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -2151,7 +2151,7 @@ public:
     /**
      *  Get maximum number of amplitudes that can be allocated on current device.
      */
-    bitCapIntOcl GetMaxSize() { return pow2(sizeof(bitCapInt) * 8); };
+    bitCapIntOcl GetMaxSize() { return pow2Ocl(sizeof(bitCapInt) * 8); };
 
     /** @} */
 };

--- a/include/qpager.hpp
+++ b/include/qpager.hpp
@@ -45,8 +45,8 @@ protected:
         QInterface::SetQubitCount(qb);
 
         baseQubitsPerPage = (qubitCount < thresholdQubitsPerPage) ? qubitCount : thresholdQubitsPerPage;
-        basePageCount = pow2(qubitCount - baseQubitsPerPage);
-        basePageMaxQPower = pow2(baseQubitsPerPage);
+        basePageCount = pow2Ocl(qubitCount - baseQubitsPerPage);
+        basePageMaxQPower = pow2Ocl(baseQubitsPerPage);
     }
 
     bitCapInt pageMaxQPower() { return maxQPower / qPages.size(); }
@@ -83,7 +83,7 @@ public:
 
     virtual void SetConcurrency(uint32_t threadsPerEngine)
     {
-        for (bitCapInt i = 0; i < qPages.size(); i++) {
+        for (bitCapIntOcl i = 0; i < qPages.size(); i++) {
             qPages[i]->SetConcurrency(threadsPerEngine);
         }
     }
@@ -93,12 +93,12 @@ public:
     virtual void GetProbs(real1* outputProbs);
     virtual complex GetAmplitude(bitCapInt perm)
     {
-        bitCapInt subIndex = perm / pageMaxQPower();
+        bitCapIntOcl subIndex = (bitCapIntOcl)(perm / pageMaxQPower());
         return qPages[subIndex]->GetAmplitude(perm - (subIndex * pageMaxQPower()));
     }
     virtual void SetAmplitude(bitCapInt perm, complex amp)
     {
-        bitCapInt subIndex = perm / pageMaxQPower();
+        bitCapIntOcl subIndex = (bitCapIntOcl)(perm / pageMaxQPower());
         return qPages[subIndex]->SetAmplitude(perm - (subIndex * pageMaxQPower()), amp);
     }
 
@@ -238,14 +238,14 @@ public:
 
     virtual void Finish()
     {
-        for (bitLenInt i = 0; i < qPages.size(); i++) {
+        for (bitCapIntOcl i = 0; i < qPages.size(); i++) {
             qPages[i]->Finish();
         }
     };
 
     virtual bool isFinished()
     {
-        for (bitCapInt i = 0; i < qPages.size(); i++) {
+        for (bitCapIntOcl i = 0; i < qPages.size(); i++) {
             if (!qPages[i]->isFinished()) {
                 return false;
             }
@@ -263,7 +263,7 @@ public:
         deviceIDs.clear();
         deviceIDs.push_back(dID);
 
-        for (bitCapInt i = 0; i < qPages.size(); i++) {
+        for (bitCapIntOcl i = 0; i < qPages.size(); i++) {
             qPages[i]->SetDevice(dID, forceReInit);
         }
     }

--- a/include/qstabilizer.hpp
+++ b/include/qstabilizer.hpp
@@ -75,7 +75,7 @@ protected:
 #endif
     }
 
-    bitCapInt pow2(const bitLenInt& qubit) { return ONE_BCI << (bitCapInt)qubit; }
+    bitCapIntOcl pow2Ocl(const bitLenInt& qubit) { return ONE_BCI << (bitCapIntOcl)qubit; }
 
 public:
     QStabilizer(
@@ -115,7 +115,7 @@ public:
 
     bitLenInt GetQubitCount() { return qubitCount; }
 
-    bitLenInt GetMaxQPower() { return pow2(qubitCount); }
+    bitCapIntOcl GetMaxQPower() { return pow2Ocl(qubitCount); }
 
     void SetPermutation(const bitCapInt& perm);
 

--- a/include/statevector.hpp
+++ b/include/statevector.hpp
@@ -126,7 +126,8 @@ public:
     void copy_in(StateVectorPtr copyInSv, const bitCapInt srcOffset, const bitCapInt dstOffset, const bitCapInt length)
     {
         if (copyInSv) {
-            const complex* copyIn = std::dynamic_pointer_cast<StateVectorArray>(copyInSv)->amplitudes + srcOffset;
+            const complex* copyIn =
+                std::dynamic_pointer_cast<StateVectorArray>(copyInSv)->amplitudes + (bitCapIntOcl)srcOffset;
             std::copy(copyIn, copyIn + (bitCapIntOcl)length, amplitudes + (bitCapIntOcl)dstOffset);
         } else {
             std::fill(amplitudes + (bitCapIntOcl)dstOffset, amplitudes + (bitCapIntOcl)dstOffset + (bitCapIntOcl)length,
@@ -345,7 +346,7 @@ public:
     void shuffle(StateVectorSparsePtr svp)
     {
         complex amp;
-        size_t halfCap = capacity >> ONE_BCI;
+        size_t halfCap = (size_t)(capacity >> ONE_BCI);
         mtx.lock();
         for (bitCapInt i = 0; i < halfCap; i++) {
             amp = svp->read(i);

--- a/src/common/parallel_for.cpp
+++ b/src/common/parallel_for.cpp
@@ -47,7 +47,7 @@ namespace Qrack {
  */
 void ParallelFor::par_for_inc(const bitCapInt begin, const bitCapInt itemCount, IncrementFunc inc, ParallelFunc fn)
 {
-    const bitCapInt Stride = (ONE_BCI << (bitCapInt)PSTRIDEPOW);
+    const bitCapIntOcl Stride = (ONE_BCI << (bitCapIntOcl)PSTRIDEPOW);
 
     if ((itemCount / Stride) < (bitCapInt)numCores) {
         bitCapInt maxLcv = begin + itemCount;
@@ -63,7 +63,7 @@ void ParallelFor::par_for_inc(const bitCapInt begin, const bitCapInt itemCount, 
     for (int cpu = 0; cpu < numCores; cpu++) {
         futures[cpu] = ATOMIC_ASYNC(cpu, &idx, begin, itemCount, inc, fn)
         {
-            const bitCapInt Stride = (ONE_BCI << (bitCapInt)PSTRIDEPOW);
+            const bitCapIntOcl Stride = (ONE_BCI << (bitCapIntOcl)PSTRIDEPOW);
 
             bitCapInt i, j, l;
             bitCapInt k = 0;
@@ -224,7 +224,7 @@ real1 ParallelFor::par_norm(const bitCapInt maxQPower, const StateVectorPtr stat
         return par_norm_exact(maxQPower, stateArray);
     }
 
-    const bitCapInt Stride = (ONE_BCI << (bitCapInt)PSTRIDEPOW);
+    const bitCapIntOcl Stride = (ONE_BCI << (bitCapIntOcl)PSTRIDEPOW);
 
     real1 nrmSqr = 0;
     if ((maxQPower / Stride) < (bitCapInt)numCores) {
@@ -242,7 +242,7 @@ real1 ParallelFor::par_norm(const bitCapInt maxQPower, const StateVectorPtr stat
         for (int cpu = 0; cpu != numCores; ++cpu) {
             futures[cpu] = ATOMIC_ASYNC(&idx, maxQPower, stateArray, &norm_thresh)
             {
-                const bitCapInt Stride = (ONE_BCI << (bitCapInt)PSTRIDEPOW);
+                const bitCapIntOcl Stride = (ONE_BCI << (bitCapIntOcl)PSTRIDEPOW);
 
                 real1 sqrNorm = ZERO_R1;
                 real1 nrm;
@@ -277,7 +277,7 @@ real1 ParallelFor::par_norm(const bitCapInt maxQPower, const StateVectorPtr stat
 
 real1 ParallelFor::par_norm_exact(const bitCapInt maxQPower, const StateVectorPtr stateArray)
 {
-    const bitCapInt Stride = (ONE_BCI << (bitCapInt)PSTRIDEPOW);
+    const bitCapIntOcl Stride = (ONE_BCI << (bitCapIntOcl)PSTRIDEPOW);
 
     real1 nrmSqr = 0;
     if ((maxQPower / Stride) < (bitCapInt)numCores) {
@@ -293,7 +293,7 @@ real1 ParallelFor::par_norm_exact(const bitCapInt maxQPower, const StateVectorPt
     for (int cpu = 0; cpu != numCores; ++cpu) {
         futures[cpu] = ATOMIC_ASYNC(&idx, maxQPower, stateArray)
         {
-            const bitCapInt Stride = (ONE_BCI << (bitCapInt)PSTRIDEPOW);
+            const bitCapIntOcl Stride = (ONE_BCI << (bitCapIntOcl)PSTRIDEPOW);
 
             real1 sqrNorm = ZERO_R1;
             bitCapInt i, j;

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -89,13 +89,13 @@ QEngineOCL::QEngineOCL(bitLenInt qBitCount, bitCapInt initState, qrack_rand_gen_
 void QEngineOCL::GetAmplitudePage(complex* pagePtr, const bitCapInt offset, const bitCapInt length)
 {
     if (!stateBuffer) {
-        std::fill(pagePtr, pagePtr + length, ZERO_CMPLX);
+        std::fill(pagePtr, pagePtr + (bitCapIntOcl)length, ZERO_CMPLX);
         return;
     }
 
     EventVecPtr waitVec = ResetWaitEvents();
-    queue.enqueueReadBuffer(
-        *stateBuffer, CL_TRUE, sizeof(complex) * offset, sizeof(complex) * length, pagePtr, waitVec.get());
+    queue.enqueueReadBuffer(*stateBuffer, CL_TRUE, sizeof(complex) * (bitCapIntOcl)offset,
+        sizeof(complex) * (bitCapIntOcl)length, pagePtr, waitVec.get());
 }
 
 void QEngineOCL::SetAmplitudePage(const complex* pagePtr, const bitCapInt offset, const bitCapInt length)
@@ -105,8 +105,8 @@ void QEngineOCL::SetAmplitudePage(const complex* pagePtr, const bitCapInt offset
     }
 
     EventVecPtr waitVec = ResetWaitEvents();
-    queue.enqueueWriteBuffer(
-        *stateBuffer, CL_TRUE, sizeof(complex) * offset, sizeof(complex) * length, pagePtr, waitVec.get());
+    queue.enqueueWriteBuffer(*stateBuffer, CL_TRUE, sizeof(complex) * (bitCapIntOcl)offset,
+        sizeof(complex) * (bitCapIntOcl)length, pagePtr, waitVec.get());
 
     runningNorm = ONE_R1;
 }
@@ -122,7 +122,7 @@ void QEngineOCL::SetAmplitudePage(
     }
 
     if (!oStateBuffer) {
-        ClearBuffer(stateBuffer, dstOffset, length, ResetWaitEvents());
+        ClearBuffer(stateBuffer, (bitCapIntOcl)dstOffset, (bitCapIntOcl)length, ResetWaitEvents());
         return;
     }
 
@@ -134,8 +134,8 @@ void QEngineOCL::SetAmplitudePage(
     clFinish();
     pageEngineOclPtr->clFinish();
 
-    queue.enqueueCopyBuffer(*oStateBuffer, *stateBuffer, sizeof(complex) * srcOffset, sizeof(complex) * dstOffset,
-        sizeof(complex) * length);
+    queue.enqueueCopyBuffer(*oStateBuffer, *stateBuffer, sizeof(complex) * (bitCapIntOcl)srcOffset,
+        sizeof(complex) * (bitCapIntOcl)dstOffset, sizeof(complex) * (bitCapIntOcl)length);
 
     queue.finish();
 
@@ -528,7 +528,7 @@ void QEngineOCL::SetDevice(const int& dID, const bool& forceReInit)
 
     poolItems.clear();
     poolItems.push_back(std::make_shared<PoolItem>(context));
-    powersBuffer = std::make_shared<cl::Buffer>(context, CL_MEM_READ_ONLY, sizeof(bitCapIntOcl) * pow2(QBCAPPOW));
+    powersBuffer = std::make_shared<cl::Buffer>(context, CL_MEM_READ_ONLY, sizeof(bitCapIntOcl) * pow2Ocl(QBCAPPOW));
 }
 
 real1 QEngineOCL::ParSum(real1* toSum, bitCapIntOcl maxI)
@@ -1514,7 +1514,7 @@ real1 QEngineOCL::ProbParity(const bitCapInt& mask)
         return Prob(log2(mask));
     }
 
-    bitCapIntOcl bciArgs[BCI_ARG_LEN] = { maxQPowerOcl, mask, 0, 0, 0, 0, 0, 0, 0, 0 };
+    bitCapIntOcl bciArgs[BCI_ARG_LEN] = { maxQPowerOcl, (bitCapIntOcl)mask, 0, 0, 0, 0, 0, 0, 0, 0 };
 
     return Probx(OCL_API_PROBPARITY, bciArgs);
 }
@@ -1535,7 +1535,7 @@ bool QEngineOCL::ForceMParity(const bitCapInt& mask, bool result, bool doForce)
         result = (Rand() <= ProbParity(mask));
     }
 
-    bitCapIntOcl bciArgs[BCI_ARG_LEN] = { maxQPowerOcl, mask, result ? ONE_BCI : 0, 0, 0, 0, 0, 0, 0, 0 };
+    bitCapIntOcl bciArgs[BCI_ARG_LEN] = { maxQPowerOcl, (bitCapIntOcl)mask, result ? ONE_BCI : 0, 0, 0, 0, 0, 0, 0, 0 };
 
     runningNorm = Probx(OCL_API_FORCEMPARITY, bciArgs);
 

--- a/src/qengine/state.cpp
+++ b/src/qengine/state.cpp
@@ -145,7 +145,7 @@ void QEngineCPU::SetQuantumState(const complex* inputState)
 void QEngineCPU::GetQuantumState(complex* outputState)
 {
     if (!stateVec) {
-        std::fill(outputState, outputState + maxQPower, ZERO_CMPLX);
+        std::fill(outputState, outputState + (bitCapIntOcl)maxQPower, ZERO_CMPLX);
         return;
     }
 
@@ -162,7 +162,7 @@ void QEngineCPU::GetQuantumState(complex* outputState)
 void QEngineCPU::GetProbs(real1* outputProbs)
 {
     if (!stateVec) {
-        std::fill(outputProbs, outputProbs + maxQPower, ZERO_R1);
+        std::fill(outputProbs, outputProbs + (bitCapIntOcl)maxQPower, ZERO_R1);
         return;
     }
 

--- a/src/qstabilizer.cpp
+++ b/src/qstabilizer.cpp
@@ -87,7 +87,7 @@ void QStabilizer::SetPermutation(const bitCapInt& perm)
     }
 
     for (j = 0; j < qubitCount; j++) {
-        if (perm & pow2(j)) {
+        if (perm & pow2Ocl(j)) {
             X(j);
         }
     }
@@ -302,10 +302,10 @@ void QStabilizer::setBasisState(const real1& nrm, complex* stateVec)
         amp *= -ONE_CMPLX;
     }
 
-    bitCapInt perm = 0;
+    bitCapIntOcl perm = 0;
     for (j = 0; j < qubitCount; j++) {
         if (x[elemCount][j]) {
-            perm |= pow2(j);
+            perm |= pow2Ocl(j);
         }
     }
 
@@ -320,27 +320,27 @@ void QStabilizer::GetQuantumState(complex* stateVec)
 {
     Finish();
 
-    bitCapInt t;
-    bitCapInt t2;
+    bitCapIntOcl t;
+    bitCapIntOcl t2;
     bitLenInt i;
 
     // log_2 of number of nonzero basis states
     bitLenInt g = gaussian();
-    bitCapInt permCount = pow2(g);
-    bitCapInt permCountMin1 = permCount - ONE_BCI;
+    bitCapIntOcl permCount = pow2Ocl(g);
+    bitCapIntOcl permCountMin1 = permCount - ONE_BCI;
     bitLenInt elemCount = qubitCount << 1U;
     real1 nrm = sqrt(ONE_R1 / permCount);
 
     seed(g);
 
     // init stateVec as all 0 values
-    std::fill(stateVec, stateVec + pow2(qubitCount), ZERO_CMPLX);
+    std::fill(stateVec, stateVec + pow2Ocl(qubitCount), ZERO_CMPLX);
 
     setBasisState(nrm, stateVec);
     for (t = 0; t < permCountMin1; t++) {
         t2 = t ^ (t + 1);
         for (i = 0; i < g; i++) {
-            if (t2 & pow2(i)) {
+            if (t2 & pow2Ocl(i)) {
                 rowmult(elemCount, qubitCount + i);
             }
         }

--- a/src/qstabilizerhybrid.cpp
+++ b/src/qstabilizerhybrid.cpp
@@ -80,7 +80,7 @@ QInterfacePtr QStabilizerHybrid::Clone()
     if (stabilizer) {
         c->stabilizer = std::make_shared<QStabilizer>(*stabilizer);
     } else {
-        complex* stateVec = new complex[maxQPower];
+        complex* stateVec = new complex[(bitCapIntOcl)maxQPower];
         engine->GetQuantumState(stateVec);
         c->SwitchToEngine();
         c->engine->SetQuantumState(stateVec);
@@ -96,7 +96,7 @@ void QStabilizerHybrid::SwitchToEngine()
         return;
     }
 
-    complex* stateVec = new complex[maxQPower];
+    complex* stateVec = new complex[(bitCapIntOcl)maxQPower];
     stabilizer->GetQuantumState(stateVec);
 
     engine = MakeEngine();
@@ -366,9 +366,9 @@ void QStabilizerHybrid::SetQuantumState(const complex* inputState)
 void QStabilizerHybrid::GetProbs(real1* outputProbs)
 {
     if (stabilizer) {
-        complex* stateVec = new complex[maxQPower];
+        complex* stateVec = new complex[(bitCapIntOcl)maxQPower];
         stabilizer->GetQuantumState(stateVec);
-        for (bitCapInt i = 0; i < maxQPower; i++) {
+        for (bitCapIntOcl i = 0; i < maxQPower; i++) {
             outputProbs[i] = norm(stateVec[i]);
         }
         delete[] stateVec;
@@ -781,11 +781,11 @@ void QStabilizerHybrid::ApplyAntiControlledSingleInvert(const bitLenInt* control
 bitCapInt QStabilizerHybrid::MAll()
 {
     if (stabilizer) {
-        bitCapInt toRet = 0;
+        bitCapIntOcl toRet = 0;
         for (bitLenInt i = 0; i < qubitCount; i++) {
             toRet |= ((stabilizer->M(i) ? 1 : 0) << i);
         }
-        return toRet;
+        return (bitCapInt)toRet;
     }
 
     SwitchToEngine();


### PR DESCRIPTION
It was brought to my attention that the build option for 128+ qubit QInterface types was broken. This PR fixes compilation. Please remember, underlying "Schrödinger method" simulation types cannot handle this many qubits, but QUnit potentially can, in limited cases.