### PR TITLE
QUnit::SetQuantumState() debug, and PInvoke DLL refactor

### DIFF
--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -924,7 +924,11 @@ protected:
     virtual QInterfacePtr EntangleRange(bitLenInt start, bitLenInt length, bitLenInt start2, bitLenInt length2);
     virtual QInterfacePtr EntangleRange(
         bitLenInt start, bitLenInt length, bitLenInt start2, bitLenInt length2, bitLenInt start3, bitLenInt length3);
-    virtual QInterfacePtr EntangleAll() { return EntangleRange(0, qubitCount); }
+    virtual QInterfacePtr EntangleAll() {
+        QInterfacePtr toRet = EntangleRange(0, qubitCount);
+        OrderContiguous(toRet);
+        return toRet;
+    }
 
     virtual QInterfacePtr CloneBody(QUnitPtr copyPtr);
 

--- a/src/pinvoke_api.cpp
+++ b/src/pinvoke_api.cpp
@@ -135,7 +135,7 @@ void MCRHelper(unsigned sid, unsigned b, double phi, unsigned n, unsigned* c, un
 
     switch (b) {
     case PauliI: {
-        complex phaseFac = std::exp(complex(ZERO_R1, phi / 2));
+        complex phaseFac = complex(cosine, sine);
         simulator->ApplyControlledSinglePhase(ctrlsArray, n, shards[simulator][q], phaseFac, phaseFac);
         break;
     }

--- a/src/pinvoke_api.cpp
+++ b/src/pinvoke_api.cpp
@@ -99,9 +99,14 @@ void RHelper(unsigned sid, unsigned b, double phi, unsigned q)
     QInterfacePtr simulator = simulators[sid];
 
     switch (b) {
-    case PauliI:
-        simulator->Exp(phi, shards[simulator][q]);
+    case PauliI: {
+        // This is a global phase factor, with no measurable physical effect.
+        // However, the underlying QInterface will not execute the gate
+        // UNLESS it is specifically "keeping book" for non-measurable phase effects.
+        complex phaseFac = std::exp(complex(ZERO_R1, phi / 2));
+        simulator->ApplySinglePhase(phaseFac, phaseFac, shards[simulator][q]);
         break;
+    }
     case PauliX:
         simulator->RX(phi, shards[simulator][q]);
         break;
@@ -124,15 +129,16 @@ void MCRHelper(unsigned sid, unsigned b, double phi, unsigned n, unsigned* c, un
         ctrlsArray[i] = shards[simulator][c[i]];
     }
 
-    real1 cosine = cos(phi / 2.0);
-    real1 sine = sin(phi / 2.0);
+    real1 cosine = cos(phi / 2);
+    real1 sine = sin(phi / 2);
     complex pauliR[4];
 
     switch (b) {
-    case PauliI:
-        simulator->ApplyControlledSinglePhase(
-            ctrlsArray, n, shards[simulator][q], complex(cosine, sine), complex(cosine, sine));
+    case PauliI: {
+        complex phaseFac = std::exp(complex(ZERO_R1, phi / 2));
+        simulator->ApplyControlledSinglePhase(ctrlsArray, n, shards[simulator][q], phaseFac, phaseFac);
         break;
+    }
     case PauliX:
         pauliR[0] = complex(cosine, ZERO_R1);
         pauliR[1] = complex(ZERO_R1, -sine);
@@ -200,7 +206,7 @@ inline complex iExp(int power)
     case 3:
         return -I_CMPLX;
     }
-    return 0;
+    return ZERO_CMPLX;
 }
 
 void apply_controlled_exp(std::vector<complex>& wfn, std::vector<int> const& b, double phi,
@@ -385,11 +391,8 @@ double _JointEnsembleProbabilityHelper(QInterfacePtr simulator, unsigned n, int*
         return 0.0;
     }
 
-    std::vector<int> bVec(n);
-    std::vector<unsigned> qVec(n);
-
-    std::copy(b, b + n, bVec.begin());
-    std::copy(q, q + n, qVec.begin());
+    std::vector<int> bVec(b, b + n);
+    std::vector<unsigned> qVec(q, q + n);
 
     removeIdentities(&bVec, &qVec);
     n = qVec.size();
@@ -783,11 +786,8 @@ MICROSOFT_QUANTUM_DECL void Exp(
 
     SIMULATOR_LOCK_GUARD(sid)
 
-    std::vector<int> bVec(n);
-    std::vector<unsigned> qVec(n);
-
-    std::copy(b, b + n, bVec.begin());
-    std::copy(q, q + n, qVec.begin());
+    std::vector<int> bVec(b, b + n);
+    std::vector<unsigned> qVec(q, q + n);
 
     unsigned someQubit = qVec.front();
 
@@ -802,13 +802,11 @@ MICROSOFT_QUANTUM_DECL void Exp(
         std::vector<complex> wfn((bitCapIntOcl)simulator->GetMaxQPower());
         simulator->GetQuantumState(&(wfn[0]));
 
-        std::vector<int> bVec(n);
-        std::copy(b, b + n, bVec.begin());
+        std::vector<int> bVec(b, b + n);
 
         std::vector<unsigned> csVec;
 
-        std::vector<unsigned> qVec(n);
-        std::copy(q, q + n, qVec.begin());
+        std::vector<unsigned> qVec(q, q + n);
 
         apply_controlled_exp(wfn, bVec, phi, csVec, qVec);
 
@@ -828,11 +826,8 @@ MICROSOFT_QUANTUM_DECL void MCExp(_In_ unsigned sid, _In_ unsigned n, _In_reads_
 
     SIMULATOR_LOCK_GUARD(sid)
 
-    std::vector<int> bVec(n);
-    std::vector<unsigned> qVec(n);
-
-    std::copy(b, b + n, bVec.begin());
-    std::copy(q, q + n, qVec.begin());
+    std::vector<int> bVec(b, b + n);
+    std::vector<unsigned> qVec(q, q + n);
 
     unsigned someQubit = qVec.front();
 
@@ -847,8 +842,7 @@ MICROSOFT_QUANTUM_DECL void MCExp(_In_ unsigned sid, _In_ unsigned n, _In_reads_
         std::vector<complex> wfn((bitCapIntOcl)simulator->GetMaxQPower());
         simulator->GetQuantumState(&(wfn[0]));
 
-        std::vector<unsigned> csVec(nc);
-        std::copy(cs, cs + nc, csVec.begin());
+        std::vector<unsigned> csVec(cs, cs + nc);
 
         apply_controlled_exp(wfn, bVec, phi, csVec, qVec);
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -114,13 +114,13 @@ void QUnit::SetQuantumState(const complex* inputState)
         shard.amp1 = inputState[1];
         shard.isPlusMinus = false;
         if (IS_NORM_ZERO(shard.amp0 - shard.amp1)) {
-            shard.isPlusMinus = !shard.isPlusMinus;
-            shard.amp0 = ZERO_R1;
-            shard.amp1 = shard.amp0 / norm(shard.amp0);
-        } else if (IS_NORM_ZERO(shard.amp0 + shard.amp1)) {
-            shard.isPlusMinus = !shard.isPlusMinus;
+            shard.isPlusMinus = true;
             shard.amp0 = shard.amp0 / norm(shard.amp0);
             shard.amp1 = ZERO_R1;
+        } else if (IS_NORM_ZERO(shard.amp0 + shard.amp1)) {
+            shard.isPlusMinus = true;
+            shard.amp1 = shard.amp0 / norm(shard.amp0);
+            shard.amp0 = ZERO_R1;
         }
         return;
     }
@@ -668,12 +668,12 @@ real1 QUnit::ProbBase(const bitLenInt& qubit)
     partnerShard.unit->GetQuantumState(amps);
     if (IS_NORM_ZERO(amps[0] - amps[1])) {
         partnerShard.isPlusMinus = true;
-        amps[0] = ONE_CMPLX;
+        amps[0] = amps[0] / norm(amps[0]);
         amps[1] = ZERO_CMPLX;
     } else if (IS_NORM_ZERO(amps[0] + amps[1])) {
         partnerShard.isPlusMinus = true;
+        amps[1] = amps[0] / norm(amps[0]);
         amps[0] = ZERO_CMPLX;
-        amps[1] = ONE_CMPLX;
     }
     partnerShard.amp0 = amps[0];
     partnerShard.amp1 = amps[1];
@@ -2493,7 +2493,7 @@ void QUnit::INT(bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt ca
         return;
     }
 
-    std::vector<bitLenInt> allBits(controlLen + 1U);
+    std::vector<bitLenInt> allBits(controlLen + 1);
     std::copy(controls, controls + controlLen, allBits.begin());
     std::sort(allBits.begin(), allBits.begin() + controlLen);
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -135,11 +135,10 @@ void QUnit::SetQuantumState(const complex* inputState)
 
 void QUnit::GetQuantumState(complex* outputState)
 {
-    ToPermBasisAll();
-    EndAllEmulation();
-
     QUnitPtr clone = std::dynamic_pointer_cast<QUnit>(Clone());
-    clone->OrderContiguous(clone->EntangleAll());
+    clone->ToPermBasisAll();
+    clone->EndAllEmulation();
+    clone->EntangleAll();
     clone->shards[0].unit->GetQuantumState(outputState);
 }
 
@@ -149,7 +148,7 @@ void QUnit::GetProbs(real1* outputProbs)
     EndAllEmulation();
 
     QUnitPtr clone = std::dynamic_pointer_cast<QUnit>(Clone());
-    clone->OrderContiguous(clone->EntangleAll());
+    clone->EntangleAll();
     clone->shards[0].unit->GetProbs(outputProbs);
 }
 
@@ -3428,11 +3427,9 @@ bool QUnit::ApproxCompare(QUnitPtr toCompare)
 
     QUnitPtr thisCopy = std::dynamic_pointer_cast<QUnit>(Clone());
     thisCopy->EntangleAll();
-    thisCopy->OrderContiguous(thisCopy->shards[0].unit);
 
     QUnitPtr thatCopy = std::dynamic_pointer_cast<QUnit>(toCompare->Clone());
     thatCopy->EntangleAll();
-    thatCopy->OrderContiguous(thatCopy->shards[0].unit);
 
     return thisCopy->shards[0].unit->ApproxCompare(thatCopy->shards[0].unit);
 }

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -115,11 +115,11 @@ void QUnit::SetQuantumState(const complex* inputState)
         shard.isPlusMinus = false;
         if (IS_NORM_ZERO(shard.amp0 - shard.amp1)) {
             shard.isPlusMinus = true;
-            shard.amp0 = shard.amp0 / norm(shard.amp0);
+            shard.amp0 = shard.amp0 / abs(shard.amp0);
             shard.amp1 = ZERO_R1;
         } else if (IS_NORM_ZERO(shard.amp0 + shard.amp1)) {
             shard.isPlusMinus = true;
-            shard.amp1 = shard.amp0 / norm(shard.amp0);
+            shard.amp1 = shard.amp0 / abs(shard.amp0);
             shard.amp0 = ZERO_R1;
         }
         return;
@@ -144,10 +144,9 @@ void QUnit::GetQuantumState(complex* outputState)
 
 void QUnit::GetProbs(real1* outputProbs)
 {
-    ToPermBasisAll();
-    EndAllEmulation();
-
     QUnitPtr clone = std::dynamic_pointer_cast<QUnit>(Clone());
+    clone->EntangleAll();
+    clone->EndAllEmulation();
     clone->EntangleAll();
     clone->shards[0].unit->GetProbs(outputProbs);
 }
@@ -667,11 +666,11 @@ real1 QUnit::ProbBase(const bitLenInt& qubit)
     partnerShard.unit->GetQuantumState(amps);
     if (IS_NORM_ZERO(amps[0] - amps[1])) {
         partnerShard.isPlusMinus = true;
-        amps[0] = amps[0] / norm(amps[0]);
+        amps[0] = amps[0] / abs(amps[0]);
         amps[1] = ZERO_CMPLX;
     } else if (IS_NORM_ZERO(amps[0] + amps[1])) {
         partnerShard.isPlusMinus = true;
-        amps[1] = amps[0] / norm(amps[0]);
+        amps[1] = amps[0] / abs(amps[0]);
         amps[0] = ZERO_CMPLX;
     }
     partnerShard.amp0 = amps[0];


### PR DESCRIPTION
There appears to have been an incorrectly handled single qubit edge case in QUnit::SetQuantumState(). (This does not yet fix the last two Q# simulator unit tests.)