### PR TITLE
Fix flipped terms in QUnit::TransformInvert()

### DIFF
--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -924,7 +924,8 @@ protected:
     virtual QInterfacePtr EntangleRange(bitLenInt start, bitLenInt length, bitLenInt start2, bitLenInt length2);
     virtual QInterfacePtr EntangleRange(
         bitLenInt start, bitLenInt length, bitLenInt start2, bitLenInt length2, bitLenInt start3, bitLenInt length3);
-    virtual QInterfacePtr EntangleAll() {
+    virtual QInterfacePtr EntangleAll()
+    {
         QInterfacePtr toRet = EntangleRange(0, qubitCount);
         OrderContiguous(toRet);
         return toRet;

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1318,8 +1318,8 @@ void QUnit::TransformPhase(const complex& topLeft, const complex& bottomRight, c
 
 void QUnit::TransformInvert(const complex& topRight, const complex& bottomLeft, complex* mtrxOut)
 {
-    mtrxOut[0] = (ONE_R1 / 2) * (bottomLeft + topRight);
-    mtrxOut[1] = (ONE_R1 / 2) * (-bottomLeft + topRight);
+    mtrxOut[0] = (ONE_R1 / 2) * (topRight + bottomLeft);
+    mtrxOut[1] = (ONE_R1 / 2) * (-topRight + bottomLeft);
     mtrxOut[2] = -mtrxOut[1];
     mtrxOut[3] = -mtrxOut[0];
 }


### PR DESCRIPTION
Terms were reversed in QUnit::TransformInvert(). (It's amazing how long a bug like this can go unnoticed, basically because it remains _almost_ equivalent for many observables.)