### PR TITLE
Multi-processor as test/benchmark "layer"

### DIFF
--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -605,10 +605,6 @@ void QEngineOCL::CArithmeticCall(OCLAPI api_call, bitCapIntOcl (&bciArgs)[BCI_AR
             context, CL_MEM_COPY_HOST_PTR | CL_MEM_READ_ONLY, sizeof(bitCapIntOcl) * controlLen, controlPowers);
     }
 
-    if (controlPowers != NULL) {
-        delete[] controlPowers;
-    }
-
     nStateBuffer = MakeStateVecBuffer(nStateVec);
 
     if (controlLen > 0) {

--- a/src/qstabilizer.cpp
+++ b/src/qstabilizer.cpp
@@ -560,7 +560,7 @@ bool QStabilizer::M(const bitLenInt& t, bool result, const bool& doForce, const 
         }
     }
 
-    return doForce ? result : r[elemCount];
+    return r[elemCount];
 }
 
 bitLenInt QStabilizer::Compose(QStabilizerPtr toCopy, const bitLenInt start)


### PR DESCRIPTION
Properly, `QUnitMulti` is a "layer" interface rather than akin to an underlying `QEngine`, but the test and benchmark selection options never properly managed that distinction, to date. This might require downstream reconfiguration, but it's simply easier to sub-select tests this way, and it's the conceptually better classification for our multi-accelerator tests.