### PR TITLE
"Tweaking" stabilizer measurement

### DIFF
--- a/include/qstabilizer.hpp
+++ b/include/qstabilizer.hpp
@@ -274,6 +274,7 @@ public:
     {
         DecomposeDispose(start, length, (QStabilizerPtr)NULL);
     }
+    bool CanDecomposeDispose(const bitLenInt start, const bitLenInt length);
 
     bool ApproxCompare(QStabilizerPtr o);
 };

--- a/include/qstabilizerhybrid.hpp
+++ b/include/qstabilizerhybrid.hpp
@@ -669,14 +669,8 @@ public:
 
     virtual bool TrySeparate(bitLenInt start, bitLenInt length = 1)
     {
-        // if (stabilizer) {
-        //     if (length == 1) {
-        //         return stabilizer->IsSeparable(start);
-        //     }
-        // }
-
         if (stabilizer) {
-            return false;
+            return stabilizer->CanDecomposeDispose(start, length);
         }
 
         return engine->TrySeparate(start, length);

--- a/include/qstabilizerhybrid.hpp
+++ b/include/qstabilizerhybrid.hpp
@@ -385,7 +385,7 @@ public:
 
     virtual bool ForceM(bitLenInt qubit, bool result, bool doForce = true, bool doApply = true)
     {
-        // TODO: QStabilizer appears not to be decomposable after measurement, and in many cases where a bit is in an
+        // TODO: QStabilizer appears not to be decomposable after measurement and in many cases where a bit is in an
         // eigenstate.
         if (stabilizer && ((engineType == QINTERFACE_QUNIT) || (engineType == QINTERFACE_QUNIT_MULTI))) {
             return stabilizer->M(qubit, result, doForce, doApply);

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -886,6 +886,7 @@ protected:
     virtual void XBase(const bitLenInt& target);
     virtual void ZBase(const bitLenInt& target);
     virtual real1 ProbBase(const bitLenInt& qubit);
+    virtual bool CheckCliffordSeparable(const bitLenInt& qubit);
 
     typedef void (QInterface::*INCxFn)(bitCapInt, bitLenInt, bitLenInt, bitLenInt);
     typedef void (QInterface::*INCxxFn)(bitCapInt, bitLenInt, bitLenInt, bitLenInt, bitLenInt);

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -886,7 +886,6 @@ protected:
     virtual void XBase(const bitLenInt& target);
     virtual void ZBase(const bitLenInt& target);
     virtual real1 ProbBase(const bitLenInt& qubit);
-    virtual bool CheckCliffordSeparable(const bitLenInt& qubit);
 
     typedef void (QInterface::*INCxFn)(bitCapInt, bitLenInt, bitLenInt, bitLenInt);
     typedef void (QInterface::*INCxxFn)(bitCapInt, bitLenInt, bitLenInt, bitLenInt, bitLenInt);

--- a/src/qstabilizer.cpp
+++ b/src/qstabilizer.cpp
@@ -616,6 +616,46 @@ bitLenInt QStabilizer::Compose(QStabilizerPtr toCopy, const bitLenInt start)
     return start;
 }
 
+bool QStabilizer::CanDecomposeDispose(const bitLenInt start, const bitLenInt length)
+{
+    bitLenInt i, j;
+    bitLenInt end = start + length;
+
+    for (i = 0; i < start; i++) {
+        for (j = 0; j < start; j++) {
+            if (x[i][j] || z[i][j]) {
+                return false;
+            }
+        }
+    }
+
+    for (i = 0; i < start; i++) {
+        for (j = end; j < qubitCount; j++) {
+            if (x[i][j] || z[i][j]) {
+                return false;
+            }
+        }
+    }
+
+    for (i = end; i < qubitCount; i++) {
+        for (j = 0; j < start; j++) {
+            if (x[i][j] || z[i][j]) {
+                return false;
+            }
+        }
+    }
+
+    for (i = end; i < qubitCount; i++) {
+        for (j = end; j < qubitCount; j++) {
+            if (x[i][j] || z[i][j]) {
+                return false;
+            }
+        }
+    }
+
+    return true;
+}
+
 void QStabilizer::DecomposeDispose(const bitLenInt start, const bitLenInt length, QStabilizerPtr dest)
 {
     if (length == 0) {

--- a/src/qstabilizer.cpp
+++ b/src/qstabilizer.cpp
@@ -515,7 +515,9 @@ bool QStabilizer::M(const bitLenInt& t, bool result, const bool& doForce, const 
     // If outcome is indeterminate
     if (p < n) {
         // moment of quantum randomness
-        result = (doForce ? result : Rand());
+        if (!doForce) {
+            result = Rand();
+        }
 
         if (!doApply) {
             return result;

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -902,13 +902,7 @@ bool QUnit::ForceM(bitLenInt qubit, bool res, bool doForce, bool doApply)
                 shards[i].MakeDirty();
             }
         }
-        if (shard.unit->isClifford()) {
-            for (bitLenInt i = 0; i < qubitCount; i++) {
-                if (shards[i].unit == shard.unit) {
-                    ProbBase(i);
-                }
-            }
-        } else {
+        if (!shard.unit->isClifford()) {
             SeparateBit(result, qubit);
         }
     }
@@ -924,7 +918,7 @@ bitCapInt QUnit::ForceMReg(bitLenInt start, bitLenInt length, bitCapInt result, 
 
     bitCapInt toRet = QInterface::ForceMReg(start, length, result, doForce, doApply);
 
-    if (!doForce && doApply && (length == qubitCount) && (engine == QINTERFACE_STABILIZER_HYBRID)) {
+    if (doApply && (length == qubitCount) && (engine == QINTERFACE_STABILIZER_HYBRID)) {
         SetPermutation(toRet);
     }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -878,6 +878,15 @@ bool QUnit::ForceM(bitLenInt qubit, bool res, bool doForce, bool doApply)
     bool result;
     if (!shard.isProbDirty && !shard.unit) {
         result = doForce ? res : (Rand() <= norm(shard.amp1));
+    } else if (shard.unit->isClifford()) {
+        real1 prob = shard.Prob();
+        if (prob == ZERO_R1) {
+            result = false;
+        } else if (prob == ONE_R1) {
+            result = true;
+        } else {
+            result = shard.unit->ForceM(shard.mapped, res, doForce, doApply);
+        }
     } else {
         result = shard.unit->ForceM(shard.mapped, res, doForce, doApply);
     }

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -632,7 +632,7 @@ real1 QUnit::ProbBase(const bitLenInt& qubit)
     shard.amp1 = complex(sqrt(prob), ZERO_R1);
     shard.amp0 = complex(sqrt(ONE_R1 - prob), ZERO_R1);
 
-    if (doSkipBuffer) {
+    if (shard.unit && shard.unit->isClifford() && !shard.unit->TrySeparate(qubit)) {
         if (IS_NORM_0(shard.amp1) || IS_NORM_0(shard.amp0)) {
             CheckCliffordSeparable(qubit);
         }
@@ -912,7 +912,7 @@ bool QUnit::ForceM(bitLenInt qubit, bool res, bool doForce, bool doApply)
                 shards[i].MakeDirty();
             }
         }
-        if (!shard.unit->isClifford()) {
+        if (!shard.unit->isClifford() || shard.unit->TrySeparate(qubit)) {
             SeparateBit(result, qubit);
         }
     }

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -632,6 +632,13 @@ real1 QUnit::ProbBase(const bitLenInt& qubit)
     shard.amp1 = complex(sqrt(prob), ZERO_R1);
     shard.amp0 = complex(sqrt(ONE_R1 - prob), ZERO_R1);
 
+    if (doSkipBuffer) {
+        if (IS_NORM_0(shard.amp1) || IS_NORM_0(shard.amp0)) {
+            CheckCliffordSeparable(qubit);
+        }
+        return prob;
+    }
+
     bool didSeparate = false;
     if (IS_NORM_0(shard.amp1)) {
         SeparateBit(false, qubit);
@@ -678,6 +685,43 @@ real1 QUnit::ProbBase(const bitLenInt& qubit)
     }
 
     return prob;
+}
+
+bool QUnit::CheckCliffordSeparable(const bitLenInt& qubit)
+{
+    QInterfacePtr unit = shards[qubit].unit;
+
+    std::vector<bitLenInt> partnerIndices;
+    std::vector<bool> partnerStates;
+
+    for (bitLenInt partnerIndex = 0; partnerIndex < qubitCount; partnerIndex++) {
+        QEngineShard& partnerShard = shards[partnerIndex];
+
+        if (unit != partnerShard.unit) {
+            continue;
+        }
+
+        if (partnerShard.isProbDirty) {
+            ProbBase(partnerIndex);
+        }
+
+        if (IS_NORM_0(partnerShard.amp0)) {
+            partnerStates.push_back(true);
+        } else if (IS_NORM_0(partnerShard.amp1)) {
+            partnerStates.push_back(false);
+        } else {
+            return false;
+        }
+
+        partnerIndices.push_back(partnerIndex);
+    }
+
+    // If we made it this far, the Clifford engine is entirely separable into single qubit Z and/or X eigenstates.
+    for (bitLenInt i = 0; i < partnerIndices.size(); i++) {
+        SeparateBit(partnerStates[i], partnerIndices[i]);
+    }
+
+    return true;
 }
 
 real1 QUnit::Prob(bitLenInt qubit)
@@ -859,7 +903,9 @@ bool QUnit::ForceM(bitLenInt qubit, bool res, bool doForce, bool doApply)
                 shards[i].MakeDirty();
             }
         }
-        SeparateBit(result, qubit);
+        if (!shard.unit->isClifford()) {
+            SeparateBit(result, qubit);
+        }
     }
 
     return result;

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -632,8 +632,10 @@ real1 QUnit::ProbBase(const bitLenInt& qubit)
     shard.amp1 = complex(sqrt(prob), ZERO_R1);
     shard.amp0 = complex(sqrt(ONE_R1 - prob), ZERO_R1);
 
-    if (doSkipBuffer && (IS_NORM_0(shard.amp1) || IS_NORM_0(shard.amp0))) {
-        CheckCliffordSeparable(qubit);
+    if (doSkipBuffer) {
+        if (IS_NORM_0(shard.amp1) || IS_NORM_0(shard.amp0)) {
+            CheckCliffordSeparable(qubit);
+        }
         return prob;
     }
 
@@ -884,21 +886,20 @@ bool QUnit::ForceM(bitLenInt qubit, bool res, bool doForce, bool doApply)
         return result;
     }
 
-    if (shard.GetQubitCount() == 1U) {
-        shard.isProbDirty = false;
-        shard.isPhaseDirty = false;
-        shard.unit = NULL;
-        shard.amp0 = result ? ZERO_CMPLX : ONE_CMPLX;
-        shard.amp1 = result ? ONE_CMPLX : ZERO_CMPLX;
+    shard.isProbDirty = false;
+    shard.isPhaseDirty = false;
+    shard.amp0 = result ? ZERO_CMPLX : ONE_CMPLX;
+    shard.amp1 = result ? ONE_CMPLX : ZERO_CMPLX;
 
-        // If we're keeping the bits, and they're already in their own unit, there's nothing to do.
+    if (shard.GetQubitCount() == 1U) {
+        shard.unit = NULL;
         return result;
     }
 
     // This is critical: it's the "nonlocal correlation" of "wave function collapse".
     if (shard.unit) {
         for (bitLenInt i = 0; i < qubitCount; i++) {
-            if (shards[i].unit == shard.unit) {
+            if ((i != qubit) && shards[i].unit == shard.unit) {
                 shards[i].MakeDirty();
             }
         }


### PR DESCRIPTION
I still haven't figured out a way to use QStabilizerHybrid under QUnit without converting to ket notation upon measurement, but I have found out that, once measurement of an entangled qubit happens this way, `IsSeparableZ()` no longer works correctly for collapsed qubits. The bug seems to involve an inability to distinguish Z basis eigenstates after "wave function collapse," and this might be a deeper limitation of my attempted use of the stabilizer formalism, rather than a simple bug. However, as we have used QStabilizerHybrid previously and here in this PR, the overall stack works, if not perfectly optimally.