### PR TITLE
Do not convert to ket on ForceM() if Z eigenstate

### DIFF
--- a/include/qstabilizerhybrid.hpp
+++ b/include/qstabilizerhybrid.hpp
@@ -387,7 +387,9 @@ public:
     {
         // TODO: QStabilizer appears not to be decomposable after measurement and in many cases where a bit is in an
         // eigenstate.
-        if (stabilizer && ((engineType == QINTERFACE_QUNIT) || (engineType == QINTERFACE_QUNIT_MULTI))) {
+        if (stabilizer &&
+            (stabilizer->IsSeparableZ(qubit) ||
+                ((engineType == QINTERFACE_QUNIT) || (engineType == QINTERFACE_QUNIT_MULTI)))) {
             return stabilizer->M(qubit, result, doForce, doApply);
         }
 


### PR DESCRIPTION
As like the earlier PR from today, we're continuing to chip away at easy "land-grabs," to avoid the conversion from stabilizer to ket wherever we can under QUnit.