### PR TITLE
Optimize MAll() for stabilizer shards

### DIFF
--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -922,17 +922,15 @@ bool QUnit::ForceM(bitLenInt qubit, bool res, bool doForce, bool doApply)
 
 bitCapInt QUnit::ForceMReg(bitLenInt start, bitLenInt length, bitCapInt result, bool doForce, bool doApply)
 {
+    if (!doForce && doApply && (length == qubitCount) && (engine == QINTERFACE_STABILIZER_HYBRID)) {
+        return MAll();
+    }
+
     // This will discard all buffered gates that don't affect Z basis probability,
     // so it's safe to call ToPermBasis() without performance penalty, afterward.
     ToPermBasisMeasure(start, length);
 
-    bitCapInt toRet = QInterface::ForceMReg(start, length, result, doForce, doApply);
-
-    if (doApply && (length == qubitCount) && (engine == QINTERFACE_STABILIZER_HYBRID)) {
-        SetPermutation(toRet);
-    }
-
-    return toRet;
+    return QInterface::ForceMReg(start, length, result, doForce, doApply);
 }
 
 bitCapInt QUnit::MAll()

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -938,7 +938,9 @@ bitCapInt QUnit::ForceMReg(bitLenInt start, bitLenInt length, bitCapInt result, 
 bitCapInt QUnit::MAll()
 {
     bitCapInt toRet = MReg(0, qubitCount);
-    SetPermutation(toRet);
+    if (engine == QINTERFACE_STABILIZER_HYBRID) {
+        SetPermutation(toRet);
+    }
     return toRet;
 }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -937,10 +937,47 @@ bitCapInt QUnit::ForceMReg(bitLenInt start, bitLenInt length, bitCapInt result, 
 
 bitCapInt QUnit::MAll()
 {
-    bitCapInt toRet = MReg(0, qubitCount);
-    if (engine == QINTERFACE_STABILIZER_HYBRID) {
-        SetPermutation(toRet);
+    if (engine != QINTERFACE_STABILIZER_HYBRID) {
+        return MReg(0, qubitCount);
     }
+
+    ToPermBasisAllMeasure();
+
+    std::vector<bitCapInt> partResults;
+    bitCapInt toRet = 0;
+
+    std::vector<QInterfacePtr> units;
+    for (bitLenInt i = 0; i < qubitCount; i++) {
+        QInterfacePtr toFind = shards[i].unit;
+        if (!toFind) {
+            if (Rand() <= norm(shards[i].amp1)) {
+                shards[i].amp0 = ZERO_CMPLX;
+                shards[i].amp1 = ONE_CMPLX;
+                toRet |= pow2(i);
+            } else {
+                shards[i].amp0 = ONE_CMPLX;
+                shards[i].amp1 = ZERO_CMPLX;
+            }
+        } else if (!(toFind->isClifford())) {
+            if (M(i)) {
+                toRet |= pow2(i);
+            }
+        } else if (find(units.begin(), units.end(), toFind) == units.end()) {
+            units.push_back(toFind);
+            partResults.push_back(toFind->MAll());
+        }
+    }
+
+    for (bitLenInt i = 0; i < qubitCount; i++) {
+        if (!shards[i].unit) {
+            continue;
+        }
+        bitLenInt offset = find(units.begin(), units.end(), shards[i].unit) - units.begin();
+        toRet |= ((partResults[offset] >> shards[i].mapped) & 1U) << i;
+    }
+
+    SetPermutation(toRet);
+
     return toRet;
 }
 


### PR DESCRIPTION
This optimization was intended for just the stabilizer shard case, hence we condition it upon that.