### PR TITLE
Move CNOT RevertBasisY() to more opportune place

### DIFF
--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1599,11 +1599,11 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
         }
     }
 
+    RevertBasisY(target);
+
     bool pmBasis = (cShard.isPauliX && tShard.isPauliX && !QUEUED_PHASE(cShard) && !QUEUED_PHASE(tShard));
 
     if (!freezeBasis2Qb && !pmBasis) {
-        RevertBasisY(target);
-
         bool isSameUnit = IS_SAME_UNIT(cShard, tShard);
 
         RevertBasis2Qb(control, ONLY_INVERT, ONLY_TARGETS);


### PR DESCRIPTION
This is just a tiny "tweak" on the last PR, to move a basis reversion into a more opportune place, for optimization.