### PR TITLE
SVD improvements

### DIFF
--- a/include/common/qrack_types.hpp
+++ b/include/common/qrack_types.hpp
@@ -102,12 +102,6 @@ typedef double real1;
 #define I_CMPLX complex(ZERO_R1, ONE_R1)
 #define CMPLX_DEFAULT_ARG complex(REAL1_DEFAULT_ARG, REAL1_DEFAULT_ARG)
 
-// approxcompare_error is the maximum acceptable sum of probability amplitude difference for ApproxCompare to return
-// "true." When TrySeparate or TryDecohere is applied after the QFT followed by its inverse on a permutation, the sum of
-// square errors of probability is generally less than 10^-11, for float accuracy. (A small number of trials return many
-// orders larger error, but these cases should not be separated, as the code stands.)
-#define approxcompare_error 1e-7f
-
 namespace Qrack {
 typedef std::shared_ptr<complex> BitOp;
 

--- a/include/qengine_cpu.hpp
+++ b/include/qengine_cpu.hpp
@@ -272,11 +272,11 @@ public:
     virtual real1 ProbParity(const bitCapInt& mask);
     virtual bool ForceMParity(const bitCapInt& mask, bool result, bool doForce = true);
     virtual void NormalizeState(real1 nrm = REAL1_DEFAULT_ARG, real1 norm_thresh = REAL1_DEFAULT_ARG);
-    virtual bool ApproxCompare(QInterfacePtr toCompare, real1 error_tol = REAL1_EPSILON)
+    virtual real1 SumSqrDiff(QInterfacePtr toCompare)
     {
-        return ApproxCompare(std::dynamic_pointer_cast<QEngineCPU>(toCompare), error_tol);
+        return SumSqrDiff(std::dynamic_pointer_cast<QEngineCPU>(toCompare));
     }
-    virtual bool ApproxCompare(QEngineCPUPtr toCompare, real1 error_tol = REAL1_EPSILON);
+    virtual real1 SumSqrDiff(QEngineCPUPtr toCompare);
     virtual QInterfacePtr Clone();
 
     /** @} */

--- a/include/qengine_cpu.hpp
+++ b/include/qengine_cpu.hpp
@@ -272,11 +272,11 @@ public:
     virtual real1 ProbParity(const bitCapInt& mask);
     virtual bool ForceMParity(const bitCapInt& mask, bool result, bool doForce = true);
     virtual void NormalizeState(real1 nrm = REAL1_DEFAULT_ARG, real1 norm_thresh = REAL1_DEFAULT_ARG);
-    virtual bool ApproxCompare(QInterfacePtr toCompare)
+    virtual bool ApproxCompare(QInterfacePtr toCompare, real1 error_tol = REAL1_EPSILON)
     {
-        return ApproxCompare(std::dynamic_pointer_cast<QEngineCPU>(toCompare));
+        return ApproxCompare(std::dynamic_pointer_cast<QEngineCPU>(toCompare), error_tol);
     }
-    virtual bool ApproxCompare(QEngineCPUPtr toCompare);
+    virtual bool ApproxCompare(QEngineCPUPtr toCompare, real1 error_tol = REAL1_EPSILON);
     virtual QInterfacePtr Clone();
 
     /** @} */

--- a/include/qengine_opencl.hpp
+++ b/include/qengine_opencl.hpp
@@ -292,11 +292,11 @@ public:
     virtual complex GetAmplitude(bitCapInt perm);
     virtual void SetAmplitude(bitCapInt perm, complex amp);
 
-    virtual bool ApproxCompare(QInterfacePtr toCompare, real1 error_tol = REAL1_EPSILON)
+    virtual real1 SumSqrDiff(QInterfacePtr toCompare)
     {
-        return ApproxCompare(std::dynamic_pointer_cast<QEngineOCL>(toCompare), error_tol);
+        return SumSqrDiff(std::dynamic_pointer_cast<QEngineOCL>(toCompare));
     }
-    virtual bool ApproxCompare(QEngineOCLPtr toCompare, real1 error_tol = REAL1_EPSILON);
+    virtual real1 SumSqrDiff(QEngineOCLPtr toCompare);
 
     virtual void NormalizeState(real1 nrm = REAL1_DEFAULT_ARG, real1 norm_thresh = REAL1_DEFAULT_ARG);
     virtual void UpdateRunningNorm(real1 norm_thresh = REAL1_DEFAULT_ARG);

--- a/include/qengine_opencl.hpp
+++ b/include/qengine_opencl.hpp
@@ -292,11 +292,11 @@ public:
     virtual complex GetAmplitude(bitCapInt perm);
     virtual void SetAmplitude(bitCapInt perm, complex amp);
 
-    virtual bool ApproxCompare(QInterfacePtr toCompare)
+    virtual bool ApproxCompare(QInterfacePtr toCompare, real1 error_tol = REAL1_EPSILON)
     {
-        return ApproxCompare(std::dynamic_pointer_cast<QEngineOCL>(toCompare));
+        return ApproxCompare(std::dynamic_pointer_cast<QEngineOCL>(toCompare), error_tol);
     }
-    virtual bool ApproxCompare(QEngineOCLPtr toCompare);
+    virtual bool ApproxCompare(QEngineOCLPtr toCompare, real1 error_tol = REAL1_EPSILON);
 
     virtual void NormalizeState(real1 nrm = REAL1_DEFAULT_ARG, real1 norm_thresh = REAL1_DEFAULT_ARG);
     virtual void UpdateRunningNorm(real1 norm_thresh = REAL1_DEFAULT_ARG);

--- a/include/qhybrid.hpp
+++ b/include/qhybrid.hpp
@@ -342,10 +342,7 @@ public:
         return engine->ForceMParity(mask, result, doForce);
     }
 
-    virtual bool ApproxCompare(QInterfacePtr toCompare, real1 error_tol = REAL1_EPSILON)
-    {
-        return engine->ApproxCompare(toCompare, error_tol);
-    }
+    virtual real1 SumSqrDiff(QInterfacePtr toCompare) { return engine->SumSqrDiff(toCompare); }
     virtual void UpdateRunningNorm(real1 norm_thresh = REAL1_DEFAULT_ARG) { engine->UpdateRunningNorm(norm_thresh); }
     virtual void NormalizeState(real1 nrm = REAL1_DEFAULT_ARG, real1 norm_thresh = REAL1_DEFAULT_ARG)
     {

--- a/include/qhybrid.hpp
+++ b/include/qhybrid.hpp
@@ -342,7 +342,10 @@ public:
         return engine->ForceMParity(mask, result, doForce);
     }
 
-    virtual bool ApproxCompare(QInterfacePtr toCompare) { return engine->ApproxCompare(toCompare); }
+    virtual bool ApproxCompare(QInterfacePtr toCompare, real1 error_tol = REAL1_EPSILON)
+    {
+        return engine->ApproxCompare(toCompare, error_tol);
+    }
     virtual void UpdateRunningNorm(real1 norm_thresh = REAL1_DEFAULT_ARG) { engine->UpdateRunningNorm(norm_thresh); }
     virtual void NormalizeState(real1 nrm = REAL1_DEFAULT_ARG, real1 norm_thresh = REAL1_DEFAULT_ARG)
     {

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -2090,7 +2090,12 @@ public:
      *
      * \warning PSEUDO-QUANTUM
      */
-    virtual bool ApproxCompare(QInterfacePtr toCompare, real1 error_tol = REAL1_EPSILON) = 0;
+    virtual bool ApproxCompare(QInterfacePtr toCompare, real1 error_tol = REAL1_EPSILON)
+    {
+        return SumSqrDiff(toCompare) <= error_tol;
+    }
+
+    virtual real1 SumSqrDiff(QInterfacePtr toCompare) = 0;
 
     /**
      * Force a calculation of the norm of the state vector, in order to make it unit length before the next probability

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -2090,7 +2090,7 @@ public:
      *
      * \warning PSEUDO-QUANTUM
      */
-    virtual bool ApproxCompare(QInterfacePtr toCompare) = 0;
+    virtual bool ApproxCompare(QInterfacePtr toCompare, real1 error_tol = REAL1_EPSILON) = 0;
 
     /**
      * Force a calculation of the norm of the state vector, in order to make it unit length before the next probability

--- a/include/qstabilizerhybrid.hpp
+++ b/include/qstabilizerhybrid.hpp
@@ -639,12 +639,12 @@ public:
         return engine->ForceMParity(mask, result, doForce);
     }
 
-    virtual bool ApproxCompare(QInterfacePtr toCompare)
+    virtual bool ApproxCompare(QInterfacePtr toCompare, real1 error_tol = REAL1_EPSILON)
     {
-        return ApproxCompare(std::dynamic_pointer_cast<QStabilizerHybrid>(toCompare));
+        return ApproxCompare(std::dynamic_pointer_cast<QStabilizerHybrid>(toCompare), error_tol);
     }
 
-    virtual bool ApproxCompare(QStabilizerHybridPtr toCompare)
+    virtual bool ApproxCompare(QStabilizerHybridPtr toCompare, real1 error_tol = REAL1_EPSILON)
     {
         if (!stabilizer == !(toCompare->engine)) {
             return false;
@@ -654,7 +654,7 @@ public:
             return stabilizer->ApproxCompare(toCompare->stabilizer);
         }
 
-        return engine->ApproxCompare(toCompare->engine);
+        return engine->ApproxCompare(toCompare->engine, error_tol);
     }
     virtual void UpdateRunningNorm(real1 norm_thresh = REAL1_DEFAULT_ARG)
     {

--- a/include/qstabilizerhybrid.hpp
+++ b/include/qstabilizerhybrid.hpp
@@ -639,6 +639,17 @@ public:
         return engine->ForceMParity(mask, result, doForce);
     }
 
+    virtual real1 SumSqrDiff(QInterfacePtr toCompare)
+    {
+        return SumSqrDiff(std::dynamic_pointer_cast<QStabilizerHybrid>(toCompare));
+    }
+
+    virtual real1 SumSqrDiff(QStabilizerHybridPtr toCompare)
+    {
+        SwitchToEngine();
+
+        return engine->SumSqrDiff(toCompare->engine);
+    }
     virtual bool ApproxCompare(QInterfacePtr toCompare, real1 error_tol = REAL1_EPSILON)
     {
         return ApproxCompare(std::dynamic_pointer_cast<QStabilizerHybrid>(toCompare), error_tol);

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -893,11 +893,11 @@ public:
     virtual real1 ProbAll(bitCapInt fullRegister);
     virtual real1 ProbParity(const bitCapInt& mask);
     virtual bool ForceMParity(const bitCapInt& mask, bool result, bool doForce = true);
-    virtual bool ApproxCompare(QInterfacePtr toCompare, real1 error_tol = REAL1_EPSILON)
+    virtual real1 SumSqrDiff(QInterfacePtr toCompare)
     {
-        return ApproxCompare(std::dynamic_pointer_cast<QUnit>(toCompare), error_tol);
+        return SumSqrDiff(std::dynamic_pointer_cast<QUnit>(toCompare));
     }
-    virtual bool ApproxCompare(QUnitPtr toCompare, real1 error_tol = REAL1_EPSILON);
+    virtual real1 SumSqrDiff(QUnitPtr toCompare);
     virtual void UpdateRunningNorm(real1 norm_thresh = REAL1_DEFAULT_ARG);
     virtual void NormalizeState(real1 nrm = REAL1_DEFAULT_ARG, real1 norm_threshold = REAL1_DEFAULT_ARG);
     virtual void Finish();

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -893,11 +893,11 @@ public:
     virtual real1 ProbAll(bitCapInt fullRegister);
     virtual real1 ProbParity(const bitCapInt& mask);
     virtual bool ForceMParity(const bitCapInt& mask, bool result, bool doForce = true);
-    virtual bool ApproxCompare(QInterfacePtr toCompare)
+    virtual bool ApproxCompare(QInterfacePtr toCompare, real1 error_tol = REAL1_EPSILON)
     {
-        return ApproxCompare(std::dynamic_pointer_cast<QUnit>(toCompare));
+        return ApproxCompare(std::dynamic_pointer_cast<QUnit>(toCompare), error_tol);
     }
-    virtual bool ApproxCompare(QUnitPtr toCompare);
+    virtual bool ApproxCompare(QUnitPtr toCompare, real1 error_tol = REAL1_EPSILON);
     virtual void UpdateRunningNorm(real1 norm_thresh = REAL1_DEFAULT_ARG);
     virtual void NormalizeState(real1 nrm = REAL1_DEFAULT_ARG, real1 norm_threshold = REAL1_DEFAULT_ARG);
     virtual void Finish();

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -2454,7 +2454,7 @@ void QEngineOCL::GetQuantumState(complex* outputState)
 /// Get all probabilities, in unsigned int permutation basis
 void QEngineOCL::GetProbs(real1* outputProbs) { ProbRegAll(0, qubitCount, outputProbs); }
 
-bool QEngineOCL::ApproxCompare(QEngineOCLPtr toCompare, real1 error_tol)
+real1 QEngineOCL::SumSqrDiff(QEngineOCLPtr toCompare)
 {
     // If the qubit counts are unequal, these can't be approximately equal objects.
     if (qubitCount != toCompare->qubitCount) {
@@ -2484,7 +2484,7 @@ bool QEngineOCL::ApproxCompare(QEngineOCLPtr toCompare, real1 error_tol)
     real1 sumSqrErr = 0;
     WAIT_REAL1_SUM(*nrmBuffer, nrmGroupCount / nrmGroupSize, nrmArray, &sumSqrErr);
 
-    return sumSqrErr <= error_tol;
+    return sumSqrErr;
 }
 
 QInterfacePtr QEngineOCL::Clone()

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -2454,7 +2454,7 @@ void QEngineOCL::GetQuantumState(complex* outputState)
 /// Get all probabilities, in unsigned int permutation basis
 void QEngineOCL::GetProbs(real1* outputProbs) { ProbRegAll(0, qubitCount, outputProbs); }
 
-bool QEngineOCL::ApproxCompare(QEngineOCLPtr toCompare)
+bool QEngineOCL::ApproxCompare(QEngineOCLPtr toCompare, real1 error_tol)
 {
     // If the qubit counts are unequal, these can't be approximately equal objects.
     if (qubitCount != toCompare->qubitCount) {
@@ -2484,7 +2484,7 @@ bool QEngineOCL::ApproxCompare(QEngineOCLPtr toCompare)
     real1 sumSqrErr = 0;
     WAIT_REAL1_SUM(*nrmBuffer, nrmGroupCount / nrmGroupSize, nrmArray, &sumSqrErr);
 
-    return sumSqrErr < approxcompare_error;
+    return sumSqrErr <= error_tol;
 }
 
 QInterfacePtr QEngineOCL::Clone()

--- a/src/qengine/state.cpp
+++ b/src/qengine/state.cpp
@@ -1208,7 +1208,7 @@ bool QEngineCPU::ForceMParity(const bitCapInt& mask, bool result, bool doForce)
     return result;
 }
 
-bool QEngineCPU::ApproxCompare(QEngineCPUPtr toCompare, real1 error_tol)
+real1 QEngineCPU::SumSqrDiff(QEngineCPUPtr toCompare)
 {
     // If the qubit counts are unequal, these can't be approximately equal objects.
     if (qubitCount != toCompare->qubitCount) {
@@ -1242,12 +1242,7 @@ bool QEngineCPU::ApproxCompare(QEngineCPUPtr toCompare, real1 error_tol)
         }
     }
 
-    real1 nrmCompare = nrm;
     nrm = norm(toCompare->stateVec->read(basePerm));
-    if (abs(nrm - nrmCompare) > error_tol) {
-        // If the amplitude we sample for global phase offset correction doesn't match, we're done.
-        return false;
-    }
 
     complex basePhaseFac2 = (ONE_R1 / (real1)sqrt(nrm)) * toCompare->stateVec->read(basePerm);
 
@@ -1263,7 +1258,7 @@ bool QEngineCPU::ApproxCompare(QEngineCPUPtr toCompare, real1 error_tol)
 
     delete[] partError;
 
-    return totError <= error_tol;
+    return totError;
 }
 
 /// Phase flip always - equivalent to Z X Z X on any bit in the QEngineCPU

--- a/src/qengine/state.cpp
+++ b/src/qengine/state.cpp
@@ -1208,7 +1208,7 @@ bool QEngineCPU::ForceMParity(const bitCapInt& mask, bool result, bool doForce)
     return result;
 }
 
-bool QEngineCPU::ApproxCompare(QEngineCPUPtr toCompare)
+bool QEngineCPU::ApproxCompare(QEngineCPUPtr toCompare, real1 error_tol)
 {
     // If the qubit counts are unequal, these can't be approximately equal objects.
     if (qubitCount != toCompare->qubitCount) {
@@ -1244,7 +1244,7 @@ bool QEngineCPU::ApproxCompare(QEngineCPUPtr toCompare)
 
     real1 nrmCompare = nrm;
     nrm = norm(toCompare->stateVec->read(basePerm));
-    if (abs(nrm - nrmCompare) >= approxcompare_error) {
+    if (abs(nrm - nrmCompare) > error_tol) {
         // If the amplitude we sample for global phase offset correction doesn't match, we're done.
         return false;
     }
@@ -1263,7 +1263,7 @@ bool QEngineCPU::ApproxCompare(QEngineCPUPtr toCompare)
 
     delete[] partError;
 
-    return totError < approxcompare_error;
+    return totError <= error_tol;
 }
 
 /// Phase flip always - equivalent to Z X Z X on any bit in the QEngineCPU

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -3685,7 +3685,7 @@ bool QUnit::isFinished()
         [](QInterfacePtr unit, real1 unused1, real1 unused2, int32_t unused3) { return unit->isFinished(); });
 }
 
-bool QUnit::ApproxCompare(QUnitPtr toCompare, real1 error_tol)
+real1 QUnit::SumSqrDiff(QUnitPtr toCompare)
 {
     // If the qubit counts are unequal, these can't be approximately equal objects.
     if (qubitCount != toCompare->qubitCount) {
@@ -3698,7 +3698,7 @@ bool QUnit::ApproxCompare(QUnitPtr toCompare, real1 error_tol)
     QUnitPtr thatCopy = std::dynamic_pointer_cast<QUnit>(toCompare->Clone());
     thatCopy->EntangleAll();
 
-    return thisCopy->shards[0].unit->ApproxCompare(thatCopy->shards[0].unit, error_tol);
+    return thisCopy->shards[0].unit->SumSqrDiff(thatCopy->shards[0].unit);
 }
 
 QInterfacePtr QUnit::Clone()

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -3685,7 +3685,7 @@ bool QUnit::isFinished()
         [](QInterfacePtr unit, real1 unused1, real1 unused2, int32_t unused3) { return unit->isFinished(); });
 }
 
-bool QUnit::ApproxCompare(QUnitPtr toCompare)
+bool QUnit::ApproxCompare(QUnitPtr toCompare, real1 error_tol)
 {
     // If the qubit counts are unequal, these can't be approximately equal objects.
     if (qubitCount != toCompare->qubitCount) {
@@ -3698,7 +3698,7 @@ bool QUnit::ApproxCompare(QUnitPtr toCompare)
     QUnitPtr thatCopy = std::dynamic_pointer_cast<QUnit>(toCompare->Clone());
     thatCopy->EntangleAll();
 
-    return thisCopy->shards[0].unit->ApproxCompare(thatCopy->shards[0].unit);
+    return thisCopy->shards[0].unit->ApproxCompare(thatCopy->shards[0].unit, error_tol);
 }
 
 QInterfacePtr QUnit::Clone()


### PR DESCRIPTION
Per "What Limits the Simulation of Quantum Computers?", (https://journals.aps.org/prx/abstract/10.1103/PhysRevX.10.041038), we were also asked a question during our Unitary Fund talk, about whether we had a quantifiable notion of a "approximate entanglement," with regard to QUnit's Schmidt decomposition. This paper somewhat answers that question, by proposing a simulation technique that treats entanglement as the principle components of SVD in order to throw away small principle components, introducing a proportional error in fidelity, but greatly reducing the computational complexity of calculation the circuit.

The simulation method that the paper develops is similar in principle to using our `Decompose()` method, which is basically parallelized Schmidt decomposition, but for cases of imperfect decomposition. That method assumes that Schmidt decomposition can occur exactly on sub-spaces implied by the method parameters, which is a very special case in general ideal quantum computer simulation. However, if `Decompose()` were to be tested with `Compose()` called on the resulting separated subsystems, then with `ApproxCompare()` on the round-trip result vs. the original, then the imperfect `Decompose()` could prove tolerable to a quantifiably small loss of fidelity.

The existing `ApproxCompare()` method should first of all take a variable sum-of-square-differences threshold, to help this methodology. Further, rather than going to the trouble of only being able to calculate the sum-of-square-differences to hit-or-miss and throw it away, we add the `SumofSqrDiff()` method to expose that calculated value directly for the user.