### PR TITLE
Return max square difference from SumSqrDiff() if qubit lengths don't match

### DIFF
--- a/include/qstabilizerhybrid.hpp
+++ b/include/qstabilizerhybrid.hpp
@@ -658,7 +658,8 @@ public:
     virtual bool ApproxCompare(QStabilizerHybridPtr toCompare, real1 error_tol = REAL1_EPSILON)
     {
         if (!stabilizer == !(toCompare->engine)) {
-            return false;
+            // Max square difference:
+            return 4.0f;
         }
 
         if (stabilizer) {

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -2458,7 +2458,8 @@ real1 QEngineOCL::SumSqrDiff(QEngineOCLPtr toCompare)
 {
     // If the qubit counts are unequal, these can't be approximately equal objects.
     if (qubitCount != toCompare->qubitCount) {
-        return false;
+        // Max square difference:
+        return 4.0f;
     }
 
     // Make sure both engines are normalized

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -3689,7 +3689,8 @@ real1 QUnit::SumSqrDiff(QUnitPtr toCompare)
 {
     // If the qubit counts are unequal, these can't be approximately equal objects.
     if (qubitCount != toCompare->qubitCount) {
-        return false;
+        // Max square difference:
+        return 4.0f;
     }
 
     QUnitPtr thisCopy = std::dynamic_pointer_cast<QUnit>(Clone());


### PR DESCRIPTION
In converting `ApproxCompare()` to `SumSqrDiff()`, I forgot to handle the case where qubit lengths of the QInterface instances being compared don't match. 4.0 is the theoretical maximum error, so we return this as the result.