### PR TITLE
SumSqrDiff() QEngineCPU bug and QUnit optimization

### DIFF
--- a/src/qengine/state.cpp
+++ b/src/qengine/state.cpp
@@ -1212,7 +1212,8 @@ real1 QEngineCPU::SumSqrDiff(QEngineCPUPtr toCompare)
 {
     // If the qubit counts are unequal, these can't be approximately equal objects.
     if (qubitCount != toCompare->qubitCount) {
-        return false;
+        // Max square
+        return 4.0f;
     }
 
     // Make sure both engines are normalized

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -3693,11 +3693,25 @@ real1 QUnit::SumSqrDiff(QUnitPtr toCompare)
         return 4.0f;
     }
 
-    QUnitPtr thisCopy = std::dynamic_pointer_cast<QUnit>(Clone());
-    thisCopy->EntangleAll();
+    QUnitPtr thisCopyShared, thatCopyShared;
+    QUnit* thisCopy;
+    QUnit* thatCopy;
 
-    QUnitPtr thatCopy = std::dynamic_pointer_cast<QUnit>(toCompare->Clone());
-    thatCopy->EntangleAll();
+    if (shards[0].unit->GetQubitCount() == qubitCount) {
+        thisCopy = this;
+    } else {
+        thisCopyShared = std::dynamic_pointer_cast<QUnit>(Clone());
+        thisCopyShared->EntangleAll();
+        thisCopy = thisCopyShared.get();
+    }
+
+    if (toCompare->shards[0].unit->GetQubitCount() == qubitCount) {
+        thatCopy = toCompare.get();
+    } else {
+        thatCopyShared = std::dynamic_pointer_cast<QUnit>(toCompare->Clone());
+        thatCopyShared->EntangleAll();
+        thatCopy = thatCopyShared.get();
+    }
 
     return thisCopy->shards[0].unit->SumSqrDiff(thatCopy->shards[0].unit);
 }


### PR DESCRIPTION
I missed one of the length mismatch cases for SumSqrDiff(), in QEngineCPU. Also, QUnit::SumSqrDiff() has been optimized.