### PR TITLE
TryDecompose(), and SumSqrDiff() debugging

### DIFF
--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -2097,6 +2097,8 @@ public:
 
     virtual real1 SumSqrDiff(QInterfacePtr toCompare) = 0;
 
+    virtual bool TryDecompose(bitLenInt start, QInterfacePtr dest, real1 error_tol = REAL1_EPSILON);
+
     /**
      * Force a calculation of the norm of the state vector, in order to make it unit length before the next probability
      * or measurement operation. (On an actual quantum computer, the state should never require manual normalization.)

--- a/include/qstabilizerhybrid.hpp
+++ b/include/qstabilizerhybrid.hpp
@@ -646,7 +646,14 @@ public:
 
     virtual real1 SumSqrDiff(QStabilizerHybridPtr toCompare)
     {
+        // If the qubit counts are unequal, these can't be approximately equal objects.
+        if (qubitCount != toCompare->qubitCount) {
+            // Max square difference:
+            return 4.0f;
+        }
+
         SwitchToEngine();
+        toCompare->SwitchToEngine();
 
         return engine->SumSqrDiff(toCompare->engine);
     }
@@ -658,8 +665,8 @@ public:
     virtual bool ApproxCompare(QStabilizerHybridPtr toCompare, real1 error_tol = REAL1_EPSILON)
     {
         if (!stabilizer == !(toCompare->engine)) {
-            // Max square difference:
-            return 4.0f;
+            SwitchToEngine();
+            toCompare->SwitchToEngine();
         }
 
         if (stabilizer) {

--- a/src/qengine/state.cpp
+++ b/src/qengine/state.cpp
@@ -1212,7 +1212,7 @@ real1 QEngineCPU::SumSqrDiff(QEngineCPUPtr toCompare)
 {
     // If the qubit counts are unequal, these can't be approximately equal objects.
     if (qubitCount != toCompare->qubitCount) {
-        // Max square
+        // Max square difference:
         return 4.0f;
     }
 

--- a/src/qinterface/qinterface.cpp
+++ b/src/qinterface/qinterface.cpp
@@ -750,4 +750,30 @@ std::map<bitCapInt, int> QInterface::MultiShotMeasureMask(
     return results;
 }
 
+bool QInterface::TryDecompose(bitLenInt start, QInterfacePtr dest, real1 error_tol)
+{
+    Finish();
+
+    bool tempDoNorm = doNormalize;
+    doNormalize = false;
+
+    QInterfacePtr unitCopy = Clone();
+
+    unitCopy->Decompose(start, dest);
+    unitCopy->Compose(dest, start);
+
+    Finish();
+
+    doNormalize = tempDoNorm;
+
+    bool didSeparate = ApproxCompare(unitCopy, error_tol);
+
+    if (didSeparate) {
+        // The subsystem is separable.
+        Dispose(start, dest->GetQubitCount());
+    }
+
+    return didSeparate;
+}
+
 } // namespace Qrack

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -3642,6 +3642,25 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_compose")
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x2b));
 }
 
+TEST_CASE_METHOD(QInterfaceTestFixture, "test_trydecompose")
+{
+
+    qftReg = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 8, 0, rng, ONE_CMPLX);
+    QInterfacePtr qftReg2 =
+        CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 4, 0, rng, ONE_CMPLX);
+
+    qftReg->SetPermutation(0xb);
+    qftReg->H(0, 4);
+    qftReg->CNOT(0, 4, 4);
+    REQUIRE(qftReg->TryDecompose(0, qftReg2) == false);
+
+    qftReg->SetPermutation(0x2b);
+    REQUIRE(qftReg->TryDecompose(0, qftReg2) == true);
+
+    REQUIRE_THAT(qftReg, HasProbability(0, 4, 0x2));
+    REQUIRE_THAT(qftReg2, HasProbability(0, 4, 0xb));
+}
+
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_setbit")
 {
     qftReg->SetPermutation(0x02);


### PR DESCRIPTION
We used to have a "TryDecompose()" method, which we stopped supporting. Per #551, we could use it, again, for new development. The approach used here is not particularly efficient, but the QInterface definition is at least immediately supported for all sub-classes.