### PR TITLE
Optimized QUnit Decompose() and Dispose()

### DIFF
--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -2147,7 +2147,7 @@ public:
      * for simulation optimization purposes. This is not a truly quantum computational operation, but it also does not
      * lead to nonphysical effects.
      */
-    virtual bool TrySeparate(bitLenInt start, bitLenInt length = 1) { return false; }
+    virtual bool TrySeparate(bitLenInt start, bitLenInt length = 1, real1 error_tol = REAL1_EPSILON) { return false; }
 
     /**
      *  Clone this QInterface

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -904,7 +904,7 @@ public:
     virtual bool isFinished();
     virtual void Dump();
 
-    virtual bool TrySeparate(bitLenInt start, bitLenInt length = 1);
+    virtual bool TrySeparate(bitLenInt start, bitLenInt length = 1, real1 error_tol = REAL1_EPSILON);
 
     virtual QInterfacePtr Clone();
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -483,13 +483,13 @@ QInterfacePtr QUnit::EntangleRange(
     return toRet;
 }
 
-bool QUnit::TrySeparate(bitLenInt start, bitLenInt length)
+bool QUnit::TrySeparate(bitLenInt start, bitLenInt length, real1 error_tol)
 {
     if (length > 1) {
         QInterfacePtr dest = std::make_shared<QUnit>(
             engine, subEngine, length, 0, rand_generator, ONE_CMPLX, doNormalize, randGlobalPhase, useHostRam);
 
-        if (TryDecompose(start, dest)) {
+        if (TryDecompose(start, dest, error_tol)) {
             Compose(dest, start);
             return true;
         }

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -3596,8 +3596,16 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_decompose")
     qftReg->SetPermutation(0x2b);
     qftReg->Decompose(0, qftReg2);
 
-    REQUIRE_THAT(qftReg, HasProbability(0, 4, 0x2));
-    REQUIRE_THAT(qftReg2, HasProbability(0, 4, 0xb));
+    qftReg = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 8, 0x33, rng);
+    qftReg2 = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 4, 0x02, rng);
+    qftReg->H(1, 2);
+    qftReg->CNOT(1, 3, 2);
+    qftReg->Decompose(1, qftReg2);
+    qftReg2->CNOT(0, 2, 2);
+    qftReg2->H(0, 2);
+
+    REQUIRE_THAT(qftReg, HasProbability(0, 4, 0x3));
+    REQUIRE_THAT(qftReg2, HasProbability(0, 4, 0x9));
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_dispose")


### PR DESCRIPTION
Per #551, this PR optimizes `QUnit::Detach()` so as not to `Compose()` across the target range before "detaching." This should benefit specific use of both `Decompose()` and `Dispose()` for QUnit.