### PR TITLE
Optimizing single bit Detach() cases

### DIFF
--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -277,9 +277,11 @@ void QUnit::Detach(bitLenInt start, bitLenInt length, QUnitPtr dest)
                     if (subLen == 1U) {
                         pShard = &shard;
                     } else {
+                        bitLenInt mappedBefore = shards[decomposedUnits[unit]].mapped - 1U;
+                        bitLenInt mappedAfter = shards[decomposedUnits[unit]].mapped + subLen;
                         for (bitLenInt i = 0; i < shards.size(); i++) {
                             if ((shards[i].unit == unit) &&
-                                (shards[i].mapped == (shards[decomposedUnits[unit]].mapped + subLen))) {
+                                ((shards[i].mapped == mappedBefore) || (shards[i].mapped == mappedAfter))) {
                                 pShard = &shards[i];
                                 break;
                             }

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -277,11 +277,14 @@ void QUnit::Detach(bitLenInt start, bitLenInt length, QUnitPtr dest)
                     if (subLen == 1U) {
                         pShard = &shard;
                     } else {
-                        bitLenInt mappedBefore = shards[decomposedUnits[unit]].mapped - 1U;
-                        bitLenInt mappedAfter = shards[decomposedUnits[unit]].mapped + subLen;
+                        bitLenInt mapped = shards[decomposedUnits[unit]].mapped;
+                        if (mapped == 0) {
+                            mapped += subLen;
+                        } else {
+                            mapped = 0;
+                        }
                         for (bitLenInt i = 0; i < shards.size(); i++) {
-                            if ((shards[i].unit == unit) &&
-                                ((shards[i].mapped == mappedBefore) || (shards[i].mapped == mappedAfter))) {
+                            if ((shards[i].unit == unit) && (shards[i].mapped == mapped)) {
                                 pShard = &shards[i];
                                 break;
                             }

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -3600,6 +3600,8 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_decompose")
     qftReg2 = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 4, 0x02, rng);
     qftReg->H(1, 2);
     qftReg->CNOT(1, 3, 2);
+    qftReg->CNOT(1, 6);
+    qftReg->CNOT(3, 6);
     qftReg->Decompose(1, qftReg2);
     qftReg2->CNOT(0, 2, 2);
     qftReg2->H(0, 2);


### PR DESCRIPTION
Single qubit sub-units are a special case, for QUnit. This PR optimizes to maintain those cases. I need to figure out additional tests, before merging this.