### PR TITLE
Use OrderContiguous() in ApproxCompare() if already fully entangled

### DIFF
--- a/src/qinterface/qinterface.cpp
+++ b/src/qinterface/qinterface.cpp
@@ -759,12 +759,10 @@ bool QInterface::TryDecompose(bitLenInt start, QInterfacePtr dest, real1 error_t
 
     QInterfacePtr unitCopy = Clone();
 
+    doNormalize = tempDoNorm;
+
     unitCopy->Decompose(start, dest);
     unitCopy->Compose(dest, start);
-
-    Finish();
-
-    doNormalize = tempDoNorm;
 
     bool didSeparate = ApproxCompare(unitCopy, error_tol);
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -3769,6 +3769,7 @@ real1 QUnit::SumSqrDiff(QUnitPtr toCompare)
     QUnit* thatCopy;
 
     if (shards[0].unit->GetQubitCount() == qubitCount) {
+        OrderContiguous(shards[0].unit);
         thisCopy = this;
     } else {
         thisCopyShared = std::dynamic_pointer_cast<QUnit>(Clone());
@@ -3777,6 +3778,7 @@ real1 QUnit::SumSqrDiff(QUnitPtr toCompare)
     }
 
     if (toCompare->shards[0].unit->GetQubitCount() == qubitCount) {
+        toCompare->OrderContiguous(toCompare->shards[0].unit);
         thatCopy = toCompare.get();
     } else {
         thatCopyShared = std::dynamic_pointer_cast<QUnit>(toCompare->Clone());


### PR DESCRIPTION
Debugging #553, if the raw QInterface is used rather than a clone, because it is already fully entangled, then all qubits should be ensured to be in top-level mapping order before checking for approximate equality.