### PR TITLE
ToPermBasisAll() in QUnit::SumSqrDiff()

### DIFF
--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -3769,6 +3769,7 @@ real1 QUnit::SumSqrDiff(QUnitPtr toCompare)
     QUnit* thatCopy;
 
     if (shards[0].unit->GetQubitCount() == qubitCount) {
+        ToPermBasisAll();
         OrderContiguous(shards[0].unit);
         thisCopy = this;
     } else {
@@ -3778,6 +3779,7 @@ real1 QUnit::SumSqrDiff(QUnitPtr toCompare)
     }
 
     if (toCompare->shards[0].unit->GetQubitCount() == qubitCount) {
+        toCompare->ToPermBasisAll();
         toCompare->OrderContiguous(toCompare->shards[0].unit);
         thatCopy = toCompare.get();
     } else {


### PR DESCRIPTION
If the QUnit is already fully entangled, a copy can be avoided by calling `ToPermBasisAll()` followed by `OrderContiguous()`.