### PR TITLE
TryDecompose()/TrySeparate() not yet supported for QUnitMulti

### DIFF
--- a/include/qunitmulti.hpp
+++ b/include/qunitmulti.hpp
@@ -94,6 +94,7 @@ public:
         bitLenInt qubitThreshold = 0);
 
     virtual bool TrySeparate(bitLenInt start, bitLenInt length = 1);
+    virtual bool TryDecompose(bitLenInt start, QInterfacePtr dest, real1 error_tol = REAL1_EPSILON) { return false; }
 
     virtual QInterfacePtr Clone();
     virtual void GetQuantumState(complex* outputState);

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -3654,6 +3654,10 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_compose")
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_trydecompose")
 {
+    if (testEngineType == QINTERFACE_QUNIT_MULTI) {
+        // Not yet supported.
+        return;
+    }
 
     qftReg = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 8, 0, rng, ONE_CMPLX);
     QInterfacePtr qftReg2 =


### PR DESCRIPTION
As the title, TryDecompose() and TrySeparate() are not yet supported for QUnitMulti. This PR fixes resulting unit tests failures.