### PR TITLE
Debug TrySeparate() overloads

### DIFF
--- a/include/qhybrid.hpp
+++ b/include/qhybrid.hpp
@@ -380,7 +380,7 @@ public:
 
     virtual bool isFinished() { return engine->isFinished(); }
 
-    virtual bool TrySeparate(bitLenInt start, bitLenInt length = 1) { return engine->TrySeparate(start, length); }
+    virtual bool TrySeparate(bitLenInt start, bitLenInt length = 1, real1 error_tol = REAL1_EPSILON)  { return engine->TrySeparate(start, length, error_tol); }
 
     virtual QInterfacePtr Clone();
 

--- a/include/qstabilizerhybrid.hpp
+++ b/include/qstabilizerhybrid.hpp
@@ -688,13 +688,13 @@ public:
         }
     }
 
-    virtual bool TrySeparate(bitLenInt start, bitLenInt length = 1)
+    virtual bool TrySeparate(bitLenInt start, bitLenInt length = 1, real1 error_tol = REAL1_EPSILON) 
     {
         if (stabilizer) {
             return stabilizer->CanDecomposeDispose(start, length);
         }
 
-        return engine->TrySeparate(start, length);
+        return engine->TrySeparate(start, length, error_tol);
     }
 
     virtual QInterfacePtr Clone();


### PR DESCRIPTION
In trying to build for Android, I ran into some warnings about unintentional TrySeparate() overloading.