### PR TITLE
Add cloning method to PInvoke API

### DIFF
--- a/include/pinvoke_api.hpp
+++ b/include/pinvoke_api.hpp
@@ -30,6 +30,7 @@ extern "C" {
 // non-quantum
 MICROSOFT_QUANTUM_DECL unsigned init();
 MICROSOFT_QUANTUM_DECL unsigned init_count(_In_ unsigned q);
+MICROSOFT_QUANTUM_DECL unsigned init_clone(_In_ unsigned sid);
 MICROSOFT_QUANTUM_DECL void destroy(_In_ unsigned sid);
 MICROSOFT_QUANTUM_DECL void seed(_In_ unsigned sid, _In_ unsigned s);
 MICROSOFT_QUANTUM_DECL void set_concurrency(_In_ unsigned sid, _In_ unsigned p);


### PR DESCRIPTION
For my exploratory work in the Unity3D video game engine, it is useful to have the ability to clone simulators. I have added a corresponding method to the PInvoke API.