### PR TITLE
Fix -DENABLE_VM6502Q_DEBUG=ON

### DIFF
--- a/include/qengine.hpp
+++ b/include/qengine.hpp
@@ -132,6 +132,8 @@ public:
     virtual void NormalizeState(real1 nrm = REAL1_DEFAULT_ARG, real1 norm_thresh = REAL1_DEFAULT_ARG) = 0;
 
 protected:
+    virtual real1 GetExpectation(bitLenInt valueStart, bitLenInt valueLength) = 0;
+
     virtual void Apply2x2(bitCapInt offset1, bitCapInt offset2, const complex* mtrx, const bitLenInt bitCount,
         const bitCapInt* qPowersSorted, bool doCalcNorm, real1 norm_thresh = REAL1_DEFAULT_ARG) = 0;
     virtual void ApplyControlled2x2(

--- a/include/qengine_cpu.hpp
+++ b/include/qengine_cpu.hpp
@@ -282,6 +282,8 @@ public:
     /** @} */
 
 protected:
+    virtual real1 GetExpectation(bitLenInt valueStart, bitLenInt valueLength);
+
     virtual StateVectorPtr AllocStateVec(bitCapInt elemCount);
     virtual void ResetStateVec(StateVectorPtr sv);
 

--- a/include/qengine_opencl.hpp
+++ b/include/qengine_opencl.hpp
@@ -309,6 +309,8 @@ public:
     void DispatchQueue(cl_event event, cl_int type);
 
 protected:
+    virtual real1 GetExpectation(bitLenInt valueStart, bitLenInt valueLength);
+
     virtual complex* AllocStateVec(bitCapInt elemCount, bool doForceAlloc = false);
     virtual void ResetStateVec(complex* sv);
     virtual void ResetStateBuffer(BufferPtr nStateBuffer);

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -2226,6 +2226,28 @@ void QEngineOCL::CMULModx(OCLAPI api_call, bitCapIntOcl toMod, bitCapIntOcl modN
     delete[] controlPowers;
 }
 
+real1 QEngineOCL::GetExpectation(bitLenInt valueStart, bitLenInt valueLength)
+{
+    real1 average = ZERO_R1;
+    real1 prob;
+    real1 totProb = ZERO_R1;
+    bitCapInt i, outputInt;
+    bitCapInt outputMask = bitRegMask(valueStart, valueLength);
+    LockSync(CL_MAP_READ);
+    for (i = 0; i < maxQPower; i++) {
+        outputInt = (i & outputMask) >> valueStart;
+        prob = norm(stateVec[i]);
+        totProb += prob;
+        average += prob * outputInt;
+    }
+    UnlockSync();
+    if (totProb > ZERO_R1) {
+        average /= totProb;
+    }
+
+    return average;
+}
+
 /** Set 8 bit register bits based on read from classical memory */
 bitCapInt QEngineOCL::IndexedLDA(bitLenInt indexStart, bitLenInt indexLength, bitLenInt valueStart,
     bitLenInt valueLength, unsigned char* values, bool resetValue)

--- a/src/qengine/utility.cpp
+++ b/src/qengine/utility.cpp
@@ -26,4 +26,24 @@ QInterfacePtr QEngineCPU::Clone()
     return clone;
 }
 
+real1 QEngineCPU::GetExpectation(bitLenInt valueStart, bitLenInt valueLength)
+{
+    real1 average = ZERO_R1;
+    real1 prob;
+    real1 totProb = ZERO_R1;
+    bitCapInt i, outputInt;
+    bitCapInt outputMask = bitRegMask(valueStart, valueLength);
+    for (i = 0; i < maxQPower; i++) {
+        outputInt = (i & outputMask) >> valueStart;
+        prob = norm(stateVec->read(i));
+        totProb += prob;
+        average += prob * outputInt;
+    }
+    if (totProb > ZERO_R1) {
+        average /= totProb;
+    }
+
+    return average;
+}
+
 } // namespace Qrack


### PR DESCRIPTION
This build option was broken, due to a protected method that was accidentally removed.