### PR TITLE
Check full X/Y/Z basis for Clifford separability

### DIFF
--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -1006,11 +1006,11 @@ protected:
     void TransformYInvert(const complex& topRight, const complex& bottomLeft, complex* mtrxOut);
     void TransformPhase(const complex& topLeft, const complex& bottomRight, complex* mtrxOut);
 
-    void RevertBasisX(const bitLenInt& i) { TransformBasisX(i, false); }
-
-    void TransformBasisX(const bitLenInt& i, const bool& toXBasis)
+    void RevertBasisX(const bitLenInt& i)
     {
-        if (freezeBasisH || (shards[i].isPauliX == toXBasis)) {
+        QEngineShard& shard = shards[i];
+
+        if (freezeBasisH || !shard.isPauliX) {
             // Recursive call that should be blocked,
             // or already in target basis.
             return;
@@ -1018,30 +1018,24 @@ protected:
 
         freezeBasisH = true;
         H(i);
-        shards[i].isPauliX = toXBasis;
+        shard.isPauliX = false;
         freezeBasisH = false;
     }
 
-    void RevertBasisY(const bitLenInt& i) { TransformBasisY(i, false); }
-
-    void TransformBasisY(const bitLenInt& i, const bool& toYBasis)
+    void RevertBasisY(const bitLenInt& i)
     {
         QEngineShard& shard = shards[i];
 
-        if (freezeBasisH || (shard.isPauliY == toYBasis)) {
+        if (freezeBasisH || !shard.isPauliY) {
             // Recursive call that should be blocked,
             // or already in target basis.
             return;
         }
 
-        shards[i].isPauliY = toYBasis;
-        shards[i].isPauliX = !toYBasis;
         freezeBasisH = true;
-        if (toYBasis) {
-            IS(i);
-        } else {
-            S(i);
-        }
+        S(i);
+        shard.isPauliY = false;
+        shard.isPauliX = true;
         freezeBasisH = false;
     }
 

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -1034,14 +1034,18 @@ protected:
             return;
         }
 
-        if (toYBasis && (!shard.isPauliX)) {
-            TransformBasisX(i, true);
+        if (shard.isPauliX != toYBasis) {
+            TransformBasisX(i, !shard.isPauliX);
         }
 
         shards[i].isPauliY = toYBasis;
         shards[i].isPauliX = !toYBasis;
         freezeBasisH = true;
-        S(i);
+        if (toYBasis) {
+            IS(i);
+        } else {
+            S(i);
+        }
         freezeBasisH = false;
     }
 

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -1006,9 +1006,11 @@ protected:
     void TransformYInvert(const complex& topRight, const complex& bottomLeft, complex* mtrxOut);
     void TransformPhase(const complex& topLeft, const complex& bottomRight, complex* mtrxOut);
 
-    void RevertBasisX(const bitLenInt& i)
+    void RevertBasisX(const bitLenInt& i) { TransformBasisX(i, false); }
+
+    void TransformBasisX(const bitLenInt& i, const bool& toXBasis)
     {
-        if (freezeBasisH || !shards[i].isPauliX) {
+        if (freezeBasisH || (shards[i].isPauliX == toXBasis)) {
             // Recursive call that should be blocked,
             // or already in target basis.
             return;
@@ -1016,20 +1018,28 @@ protected:
 
         freezeBasisH = true;
         H(i);
-        shards[i].isPauliX = false;
+        shards[i].isPauliX = toXBasis;
         freezeBasisH = false;
     }
 
-    void RevertBasisY(const bitLenInt& i)
+    void RevertBasisY(const bitLenInt& i) { TransformBasisY(i, false); }
+
+    void TransformBasisY(const bitLenInt& i, const bool& toYBasis)
     {
-        if (freezeBasisH || !shards[i].isPauliY) {
+        QEngineShard& shard = shards[i];
+
+        if (freezeBasisH || (shard.isPauliY == toYBasis)) {
             // Recursive call that should be blocked,
             // or already in target basis.
             return;
         }
 
-        shards[i].isPauliY = false;
-        shards[i].isPauliX = true;
+        if (toYBasis && (!shard.isPauliX)) {
+            TransformBasisX(i, true);
+        }
+
+        shards[i].isPauliY = toYBasis;
+        shards[i].isPauliX = !toYBasis;
         freezeBasisH = true;
         S(i);
         freezeBasisH = false;

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -1008,9 +1008,7 @@ protected:
 
     void RevertBasisX(const bitLenInt& i)
     {
-        QEngineShard& shard = shards[i];
-
-        if (freezeBasisH || !shard.isPauliX) {
+        if (freezeBasisH || !shards[i].isPauliX) {
             // Recursive call that should be blocked,
             // or already in target basis.
             return;
@@ -1018,24 +1016,22 @@ protected:
 
         freezeBasisH = true;
         H(i);
-        shard.isPauliX = false;
+        shards[i].isPauliX = false;
         freezeBasisH = false;
     }
 
     void RevertBasisY(const bitLenInt& i)
     {
-        QEngineShard& shard = shards[i];
-
-        if (freezeBasisH || !shard.isPauliY) {
+        if (freezeBasisH || !shards[i].isPauliY) {
             // Recursive call that should be blocked,
             // or already in target basis.
             return;
         }
 
+        shards[i].isPauliY = false;
+        shards[i].isPauliX = true;
         freezeBasisH = true;
         S(i);
-        shard.isPauliY = false;
-        shard.isPauliX = true;
         freezeBasisH = false;
     }
 

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -1034,10 +1034,6 @@ protected:
             return;
         }
 
-        if (shard.isPauliX != toYBasis) {
-            TransformBasisX(i, !shard.isPauliX);
-        }
-
         shards[i].isPauliY = toYBasis;
         shards[i].isPauliX = !toYBasis;
         freezeBasisH = true;

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -818,6 +818,8 @@ bool QUnit::CheckCliffordSeparable(const bitLenInt& qubit)
 
     freezeClifford = true;
 
+    real1 ampThresh = doNormalize ? amplitudeFloor : ZERO_R1;
+
     std::vector<bitLenInt> partnerIndices;
     std::vector<bool> partnerStates;
 
@@ -833,11 +835,11 @@ bool QUnit::CheckCliffordSeparable(const bitLenInt& qubit)
             ProbBase(partnerIndex);
         }
 
-        if (norm(partnerShard.amp1) <= amplitudeFloor) {
+        if (norm(partnerShard.amp1) <= ampThresh) {
             partnerStates.push_back(false);
-        } else if (norm(partnerShard.amp0) <= amplitudeFloor) {
+        } else if (norm(partnerShard.amp0) <= ampThresh) {
             partnerStates.push_back(true);
-        } else if ((amplitudeFloor == 0) || !unit->TrySeparate(partnerShard.mapped)) {
+        } else if ((ampThresh == ZERO_R1) || !unit->TrySeparate(partnerShard.mapped)) {
             freezeClifford = false;
             return false;
         } else if (partnerShard.isPauliY) {
@@ -848,9 +850,9 @@ bool QUnit::CheckCliffordSeparable(const bitLenInt& qubit)
             partnerShard.MakeDirty();
             ProbBase(partnerIndex);
 
-            if (norm(partnerShard.amp1) <= amplitudeFloor) {
+            if (norm(partnerShard.amp1) <= ampThresh) {
                 partnerStates.push_back(false);
-            } else if (norm(partnerShard.amp0) <= amplitudeFloor) {
+            } else if (norm(partnerShard.amp0) <= ampThresh) {
                 partnerStates.push_back(true);
             } else {
                 // Guaranteed to be a Z eigenstate.
@@ -860,9 +862,9 @@ bool QUnit::CheckCliffordSeparable(const bitLenInt& qubit)
                 partnerShard.MakeDirty();
                 ProbBase(partnerIndex);
 
-                if (norm(partnerShard.amp1) <= amplitudeFloor) {
+                if (norm(partnerShard.amp1) <= ampThresh) {
                     partnerStates.push_back(false);
-                } else if (norm(partnerShard.amp0) <= amplitudeFloor) {
+                } else if (norm(partnerShard.amp0) <= ampThresh) {
                     partnerStates.push_back(true);
                 } else {
                     // This branch should never be reached, but something might have went wrong with rounding or buffer
@@ -879,9 +881,9 @@ bool QUnit::CheckCliffordSeparable(const bitLenInt& qubit)
             partnerShard.MakeDirty();
             ProbBase(partnerIndex);
 
-            if (norm(partnerShard.amp1) <= amplitudeFloor) {
+            if (norm(partnerShard.amp1) <= ampThresh) {
                 partnerStates.push_back(false);
-            } else if (norm(partnerShard.amp0) <= amplitudeFloor) {
+            } else if (norm(partnerShard.amp0) <= ampThresh) {
                 partnerStates.push_back(true);
             } else {
                 // Guaranteed to be a Z eigenstate.
@@ -892,9 +894,9 @@ bool QUnit::CheckCliffordSeparable(const bitLenInt& qubit)
                 partnerShard.MakeDirty();
                 ProbBase(partnerIndex);
 
-                if (norm(partnerShard.amp1) <= amplitudeFloor) {
+                if (norm(partnerShard.amp1) <= ampThresh) {
                     partnerStates.push_back(false);
-                } else if (norm(partnerShard.amp0) <= amplitudeFloor) {
+                } else if (norm(partnerShard.amp0) <= ampThresh) {
                     partnerStates.push_back(true);
                 } else {
                     // This branch should never be reached, but something might have went wrong with rounding or
@@ -911,9 +913,9 @@ bool QUnit::CheckCliffordSeparable(const bitLenInt& qubit)
             partnerShard.MakeDirty();
             ProbBase(partnerIndex);
 
-            if (norm(partnerShard.amp1) <= amplitudeFloor) {
+            if (norm(partnerShard.amp1) <= ampThresh) {
                 partnerStates.push_back(false);
-            } else if (norm(partnerShard.amp0) <= amplitudeFloor) {
+            } else if (norm(partnerShard.amp0) <= ampThresh) {
                 partnerStates.push_back(true);
             } else {
                 // Guaranteed to be an Y eigenstate.
@@ -923,9 +925,9 @@ bool QUnit::CheckCliffordSeparable(const bitLenInt& qubit)
                 partnerShard.MakeDirty();
                 ProbBase(partnerIndex);
 
-                if (norm(partnerShard.amp1) <= amplitudeFloor) {
+                if (norm(partnerShard.amp1) <= ampThresh) {
                     partnerStates.push_back(false);
-                } else if (norm(partnerShard.amp0) <= amplitudeFloor) {
+                } else if (norm(partnerShard.amp0) <= ampThresh) {
                     partnerStates.push_back(true);
                 } else {
                     // This branch should never be reached, but something might have went wrong with rounding or buffer

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -833,30 +833,36 @@ bool QUnit::CheckCliffordSeparable(const bitLenInt& qubit)
             ProbBase(partnerIndex);
         }
 
-        if (IS_NORM_0(partnerShard.amp1)) {
+        if (norm(partnerShard.amp1) <= amplitudeFloor) {
             partnerStates.push_back(false);
-        } else if (IS_NORM_0(partnerShard.amp0)) {
+        } else if (norm(partnerShard.amp0) <= amplitudeFloor) {
             partnerStates.push_back(true);
-        } else if (!unit->TrySeparate(partnerShard.mapped)) {
+        } else if ((amplitudeFloor == 0) || !unit->TrySeparate(partnerShard.mapped)) {
             freezeClifford = false;
             return false;
         } else if (partnerShard.isPauliY) {
             // Guaranteed to be an X or Z eigenstate.
-            RevertBasisY(partnerIndex);
+            unit->S(partnerShard.mapped);
+            partnerShard.isPauliX = true;
+            partnerShard.isPauliY = false;
+            partnerShard.MakeDirty();
             ProbBase(partnerIndex);
 
-            if (IS_NORM_0(partnerShard.amp1)) {
+            if (norm(partnerShard.amp1) <= amplitudeFloor) {
                 partnerStates.push_back(false);
-            } else if (IS_NORM_0(partnerShard.amp0)) {
+            } else if (norm(partnerShard.amp0) <= amplitudeFloor) {
                 partnerStates.push_back(true);
             } else {
                 // Guaranteed to be a Z eigenstate.
-                RevertBasisX(partnerIndex);
+                unit->H(partnerShard.mapped);
+                partnerShard.isPauliX = false;
+                partnerShard.isPauliY = false;
+                partnerShard.MakeDirty();
                 ProbBase(partnerIndex);
 
-                if (IS_NORM_0(partnerShard.amp1)) {
+                if (norm(partnerShard.amp1) <= amplitudeFloor) {
                     partnerStates.push_back(false);
-                } else if (IS_NORM_0(partnerShard.amp0)) {
+                } else if (norm(partnerShard.amp0) <= amplitudeFloor) {
                     partnerStates.push_back(true);
                 } else {
                     // This branch should never be reached, but something might have went wrong with rounding or buffer
@@ -867,47 +873,59 @@ bool QUnit::CheckCliffordSeparable(const bitLenInt& qubit)
             }
         } else if (partnerShard.isPauliX) {
             // Guaranteed to be an Y or Z eigenstate.
-            TransformBasisY(partnerIndex, true);
+            unit->IS(partnerShard.mapped);
+            partnerShard.isPauliX = false;
+            partnerShard.isPauliY = true;
+            partnerShard.MakeDirty();
             ProbBase(partnerIndex);
 
-            if (IS_NORM_0(partnerShard.amp1)) {
+            if (norm(partnerShard.amp1) <= amplitudeFloor) {
                 partnerStates.push_back(false);
-            } else if (IS_NORM_0(partnerShard.amp0)) {
+            } else if (norm(partnerShard.amp0) <= amplitudeFloor) {
                 partnerStates.push_back(true);
             } else {
                 // Guaranteed to be a Z eigenstate.
-                RevertBasisY(partnerIndex);
-                RevertBasisX(partnerIndex);
+                unit->S(partnerShard.mapped);
+                unit->H(partnerShard.mapped);
+                partnerShard.isPauliX = false;
+                partnerShard.isPauliY = false;
+                partnerShard.MakeDirty();
                 ProbBase(partnerIndex);
 
-                if (IS_NORM_0(partnerShard.amp1)) {
+                if (norm(partnerShard.amp1) <= amplitudeFloor) {
                     partnerStates.push_back(false);
-                } else if (IS_NORM_0(partnerShard.amp0)) {
+                } else if (norm(partnerShard.amp0) <= amplitudeFloor) {
                     partnerStates.push_back(true);
                 } else {
-                    // This branch should never be reached, but something might have went wrong with rounding or buffer
-                    // flushes.
+                    // This branch should never be reached, but something might have went wrong with rounding or
+                    // buffer flushes.
                     freezeClifford = false;
                     return false;
                 }
             }
         } else {
             // Guaranteed to be an X or Y eigenstate.
-            TransformBasisX(partnerIndex, true);
+            unit->H(partnerShard.mapped);
+            partnerShard.isPauliX = true;
+            partnerShard.isPauliY = false;
+            partnerShard.MakeDirty();
             ProbBase(partnerIndex);
 
-            if (IS_NORM_0(partnerShard.amp1)) {
+            if (norm(partnerShard.amp1) <= amplitudeFloor) {
                 partnerStates.push_back(false);
-            } else if (IS_NORM_0(partnerShard.amp0)) {
+            } else if (norm(partnerShard.amp0) <= amplitudeFloor) {
                 partnerStates.push_back(true);
             } else {
                 // Guaranteed to be an Y eigenstate.
-                TransformBasisY(partnerIndex, true);
+                unit->IS(partnerShard.mapped);
+                partnerShard.isPauliX = false;
+                partnerShard.isPauliY = true;
+                partnerShard.MakeDirty();
                 ProbBase(partnerIndex);
 
-                if (IS_NORM_0(partnerShard.amp1)) {
+                if (norm(partnerShard.amp1) <= amplitudeFloor) {
                     partnerStates.push_back(false);
-                } else if (IS_NORM_0(partnerShard.amp0)) {
+                } else if (norm(partnerShard.amp0) <= amplitudeFloor) {
                     partnerStates.push_back(true);
                 } else {
                     // This branch should never be reached, but something might have went wrong with rounding or buffer

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -840,9 +840,9 @@ bool QUnit::CheckCliffordSeparable(const bitLenInt& qubit)
         } else if (!unit->TrySeparate(partnerShard.mapped)) {
             freezeClifford = false;
             return false;
-        } else if (partnerShard.isPauliX) {
-            // Guaranteed to be a Z or Y eigenstate.
-            RevertBasisX(partnerIndex);
+        } else if (partnerShard.isPauliY) {
+            // Guaranteed to be an X or Z eigenstate.
+            RevertBasisY(partnerIndex);
             ProbBase(partnerIndex);
 
             if (IS_NORM_0(partnerShard.amp1)) {
@@ -850,8 +850,8 @@ bool QUnit::CheckCliffordSeparable(const bitLenInt& qubit)
             } else if (IS_NORM_0(partnerShard.amp0)) {
                 partnerStates.push_back(true);
             } else {
-                // Guaranteed to be an Y eigenstate.
-                TransformBasisY(partnerIndex, true);
+                // Guaranteed to be a Z eigenstate.
+                RevertBasisX(partnerIndex);
                 ProbBase(partnerIndex);
 
                 if (IS_NORM_0(partnerShard.amp1)) {
@@ -865,9 +865,9 @@ bool QUnit::CheckCliffordSeparable(const bitLenInt& qubit)
                     return false;
                 }
             }
-        } else if (partnerShard.isPauliY) {
-            // Guaranteed to be an X or Z eigenstate.
-            RevertBasisY(partnerIndex);
+        } else if (partnerShard.isPauliX) {
+            // Guaranteed to be an Y or Z eigenstate.
+            TransformBasisY(partnerIndex, true);
             ProbBase(partnerIndex);
 
             if (IS_NORM_0(partnerShard.amp1)) {
@@ -876,6 +876,7 @@ bool QUnit::CheckCliffordSeparable(const bitLenInt& qubit)
                 partnerStates.push_back(true);
             } else {
                 // Guaranteed to be a Z eigenstate.
+                RevertBasisY(partnerIndex);
                 RevertBasisX(partnerIndex);
                 ProbBase(partnerIndex);
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -837,9 +837,97 @@ bool QUnit::CheckCliffordSeparable(const bitLenInt& qubit)
             partnerStates.push_back(false);
         } else if (IS_NORM_0(partnerShard.amp0)) {
             partnerStates.push_back(true);
-        } else {
+        } else if (!unit->TrySeparate(partnerShard.mapped)) {
             freezeClifford = false;
             return false;
+        } else if (partnerShard.isPauliX) {
+            // Guaranteed to be an Y or X eigenstate.
+            unit->S(partnerShard.mapped);
+            partnerShard.isPauliX = false;
+            partnerShard.isPauliY = true;
+            ProbBase(partnerIndex);
+
+            if (IS_NORM_0(partnerShard.amp1)) {
+                partnerStates.push_back(false);
+            } else if (IS_NORM_0(partnerShard.amp0)) {
+                partnerStates.push_back(true);
+            } else {
+                // Guaranteed to be an X eigenstate.
+                unit->IS(partnerShard.mapped);
+                unit->H(partnerShard.mapped);
+                partnerShard.isPauliX = false;
+                partnerShard.isPauliY = false;
+                ProbBase(partnerIndex);
+
+                if (IS_NORM_0(partnerShard.amp1)) {
+                    partnerStates.push_back(false);
+                } else if (IS_NORM_0(partnerShard.amp0)) {
+                    partnerStates.push_back(true);
+                } else {
+                    // This branch should never be reached, but something might have went wrong with rounding or buffer
+                    // flushes.
+                    freezeClifford = false;
+                    return false;
+                }
+            }
+        } else if (partnerShard.isPauliY) {
+            // Guaranteed to be an Y or X eigenstate.
+            unit->IS(partnerShard.mapped);
+            partnerShard.isPauliX = true;
+            partnerShard.isPauliY = false;
+            ProbBase(partnerIndex);
+
+            if (IS_NORM_0(partnerShard.amp1)) {
+                partnerStates.push_back(false);
+            } else if (IS_NORM_0(partnerShard.amp0)) {
+                partnerStates.push_back(true);
+            } else {
+                // Guaranteed to be an X eigenstate.
+                unit->H(partnerShard.mapped);
+                partnerShard.isPauliX = false;
+                partnerShard.isPauliY = false;
+                ProbBase(partnerIndex);
+
+                if (IS_NORM_0(partnerShard.amp1)) {
+                    partnerStates.push_back(false);
+                } else if (IS_NORM_0(partnerShard.amp0)) {
+                    partnerStates.push_back(true);
+                } else {
+                    // This branch should never be reached, but something might have went wrong with rounding or buffer
+                    // flushes.
+                    freezeClifford = false;
+                    return false;
+                }
+            }
+        } else {
+            // Guaranteed to be an X or Y eigenstate.
+            unit->H(partnerShard.mapped);
+            partnerShard.isPauliX = true;
+            partnerShard.isPauliY = false;
+            ProbBase(partnerIndex);
+
+            if (IS_NORM_0(partnerShard.amp1)) {
+                partnerStates.push_back(false);
+            } else if (IS_NORM_0(partnerShard.amp0)) {
+                partnerStates.push_back(true);
+            } else {
+                // Guaranteed to be an Y eigenstate.
+                unit->S(partnerShard.mapped);
+                partnerShard.isPauliX = false;
+                partnerShard.isPauliY = true;
+                ProbBase(partnerIndex);
+
+                if (IS_NORM_0(partnerShard.amp1)) {
+                    partnerStates.push_back(false);
+                } else if (IS_NORM_0(partnerShard.amp0)) {
+                    partnerStates.push_back(true);
+                } else {
+                    // This branch should never be reached, but something might have went wrong with rounding or buffer
+                    // flushes.
+                    freezeClifford = false;
+                    return false;
+                }
+            }
         }
 
         partnerIndices.push_back(partnerIndex);

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -842,10 +842,7 @@ bool QUnit::CheckCliffordSeparable(const bitLenInt& qubit)
             return false;
         } else if (partnerShard.isPauliX) {
             // Guaranteed to be a Z or Y eigenstate.
-            unit->H(partnerShard.mapped);
-            partnerShard.isPauliX = false;
-            partnerShard.isPauliY = false;
-            partnerShard.MakeDirty();
+            RevertBasisX(partnerIndex);
             ProbBase(partnerIndex);
 
             if (IS_NORM_0(partnerShard.amp1)) {
@@ -854,11 +851,7 @@ bool QUnit::CheckCliffordSeparable(const bitLenInt& qubit)
                 partnerStates.push_back(true);
             } else {
                 // Guaranteed to be an Y eigenstate.
-                unit->H(partnerShard.mapped);
-                unit->S(partnerShard.mapped);
-                partnerShard.isPauliX = false;
-                partnerShard.isPauliY = true;
-                partnerShard.MakeDirty();
+                TransformBasisY(partnerIndex, true);
                 ProbBase(partnerIndex);
 
                 if (IS_NORM_0(partnerShard.amp1)) {
@@ -874,10 +867,7 @@ bool QUnit::CheckCliffordSeparable(const bitLenInt& qubit)
             }
         } else if (partnerShard.isPauliY) {
             // Guaranteed to be an X or Z eigenstate.
-            unit->IS(partnerShard.mapped);
-            partnerShard.isPauliX = true;
-            partnerShard.isPauliY = false;
-            partnerShard.MakeDirty();
+            RevertBasisY(partnerIndex);
             ProbBase(partnerIndex);
 
             if (IS_NORM_0(partnerShard.amp1)) {
@@ -886,10 +876,7 @@ bool QUnit::CheckCliffordSeparable(const bitLenInt& qubit)
                 partnerStates.push_back(true);
             } else {
                 // Guaranteed to be a Z eigenstate.
-                unit->H(partnerShard.mapped);
-                partnerShard.isPauliX = false;
-                partnerShard.isPauliY = false;
-                partnerShard.MakeDirty();
+                RevertBasisX(partnerIndex);
                 ProbBase(partnerIndex);
 
                 if (IS_NORM_0(partnerShard.amp1)) {
@@ -905,10 +892,7 @@ bool QUnit::CheckCliffordSeparable(const bitLenInt& qubit)
             }
         } else {
             // Guaranteed to be an X or Y eigenstate.
-            unit->H(partnerShard.mapped);
-            partnerShard.isPauliX = true;
-            partnerShard.isPauliY = false;
-            partnerShard.MakeDirty();
+            TransformBasisX(partnerIndex, true);
             ProbBase(partnerIndex);
 
             if (IS_NORM_0(partnerShard.amp1)) {
@@ -917,10 +901,7 @@ bool QUnit::CheckCliffordSeparable(const bitLenInt& qubit)
                 partnerStates.push_back(true);
             } else {
                 // Guaranteed to be an Y eigenstate.
-                unit->S(partnerShard.mapped);
-                partnerShard.isPauliX = false;
-                partnerShard.isPauliY = true;
-                partnerShard.MakeDirty();
+                TransformBasisY(partnerIndex, true);
                 ProbBase(partnerIndex);
 
                 if (IS_NORM_0(partnerShard.amp1)) {

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -841,10 +841,11 @@ bool QUnit::CheckCliffordSeparable(const bitLenInt& qubit)
             freezeClifford = false;
             return false;
         } else if (partnerShard.isPauliX) {
-            // Guaranteed to be an Y or X eigenstate.
-            unit->S(partnerShard.mapped);
+            // Guaranteed to be a Z or Y eigenstate.
+            unit->H(partnerShard.mapped);
             partnerShard.isPauliX = false;
-            partnerShard.isPauliY = true;
+            partnerShard.isPauliY = false;
+            partnerShard.MakeDirty();
             ProbBase(partnerIndex);
 
             if (IS_NORM_0(partnerShard.amp1)) {
@@ -852,11 +853,12 @@ bool QUnit::CheckCliffordSeparable(const bitLenInt& qubit)
             } else if (IS_NORM_0(partnerShard.amp0)) {
                 partnerStates.push_back(true);
             } else {
-                // Guaranteed to be an X eigenstate.
-                unit->IS(partnerShard.mapped);
+                // Guaranteed to be an Y eigenstate.
                 unit->H(partnerShard.mapped);
+                unit->S(partnerShard.mapped);
                 partnerShard.isPauliX = false;
-                partnerShard.isPauliY = false;
+                partnerShard.isPauliY = true;
+                partnerShard.MakeDirty();
                 ProbBase(partnerIndex);
 
                 if (IS_NORM_0(partnerShard.amp1)) {
@@ -871,10 +873,11 @@ bool QUnit::CheckCliffordSeparable(const bitLenInt& qubit)
                 }
             }
         } else if (partnerShard.isPauliY) {
-            // Guaranteed to be an Y or X eigenstate.
+            // Guaranteed to be an X or Z eigenstate.
             unit->IS(partnerShard.mapped);
             partnerShard.isPauliX = true;
             partnerShard.isPauliY = false;
+            partnerShard.MakeDirty();
             ProbBase(partnerIndex);
 
             if (IS_NORM_0(partnerShard.amp1)) {
@@ -882,10 +885,11 @@ bool QUnit::CheckCliffordSeparable(const bitLenInt& qubit)
             } else if (IS_NORM_0(partnerShard.amp0)) {
                 partnerStates.push_back(true);
             } else {
-                // Guaranteed to be an X eigenstate.
+                // Guaranteed to be a Z eigenstate.
                 unit->H(partnerShard.mapped);
                 partnerShard.isPauliX = false;
                 partnerShard.isPauliY = false;
+                partnerShard.MakeDirty();
                 ProbBase(partnerIndex);
 
                 if (IS_NORM_0(partnerShard.amp1)) {
@@ -904,6 +908,7 @@ bool QUnit::CheckCliffordSeparable(const bitLenInt& qubit)
             unit->H(partnerShard.mapped);
             partnerShard.isPauliX = true;
             partnerShard.isPauliY = false;
+            partnerShard.MakeDirty();
             ProbBase(partnerIndex);
 
             if (IS_NORM_0(partnerShard.amp1)) {
@@ -915,6 +920,7 @@ bool QUnit::CheckCliffordSeparable(const bitLenInt& qubit)
                 unit->S(partnerShard.mapped);
                 partnerShard.isPauliX = false;
                 partnerShard.isPauliY = true;
+                partnerShard.MakeDirty();
                 ProbBase(partnerIndex);
 
                 if (IS_NORM_0(partnerShard.amp1)) {

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -2807,7 +2807,7 @@ void QUnit::ApplyEitherControlled(const bitLenInt* controls, const bitLenInt& co
     }
 
     // This is the original method with the maximum number of non-entangled controls excised, (potentially leaving a
-    // target bit in |+>/|-> basis and acting as if |0>/|1> basis by commutation).
+    // target bit in X or Y basis and acting as if Z basis by commutation).
     cfn(unit, controlsMapped);
 
     for (i = 0; i < targets.size(); i++) {


### PR DESCRIPTION
If a Clifford sub-unit qubit is detected to be separable in X, Y, or Z basis, permute through all 3 to find which basis it is in, when attempting to completely separate Clifford sub-units.