### PR TITLE
More Clifford separability optimizations

### DIFF
--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -918,6 +918,7 @@ protected:
     virtual void ZBase(const bitLenInt& target);
     virtual real1 ProbBase(const bitLenInt& qubit);
     virtual bool CheckCliffordSeparable(const bitLenInt& qubit);
+    virtual bool TrySeparateCliffordBit(const bitLenInt& qubit);
 
     typedef void (QInterface::*INCxFn)(bitCapInt, bitLenInt, bitLenInt, bitLenInt);
     typedef void (QInterface::*INCxxFn)(bitCapInt, bitLenInt, bitLenInt, bitLenInt, bitLenInt);

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -2814,7 +2814,20 @@ void QUnit::ApplyEitherControlled(const bitLenInt* controls, const bitLenInt& co
         shards[targets[i]].MakeDirty();
     }
 
-    CheckCliffordSeparable(allBits[0]);
+    bitLenInt n = allBits[0];
+
+    // Only continue if the sub-unit is still clifford.
+    if (!shards[n].unit || !shards[n].unit->isClifford()) {
+        return;
+    }
+
+    for (i = 0; i < allBits.size(); i++) {
+        n = allBits[i];
+        if (shards[n].unit && shards[n].unit->isClifford()) {
+            // ProbBase will separate as it can, but it's only cheap to check if the sub-unit is Clifford.
+            ProbBase(n);
+        }
+    }
 }
 
 bool QUnit::CArithmeticOptimize(bitLenInt* controls, bitLenInt controlLen, std::vector<bitLenInt>* controlVec)

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -2809,25 +2809,7 @@ void QUnit::ApplyEitherControlled(const bitLenInt* controls, const bitLenInt& co
         shards[targets[i]].MakeDirty();
     }
 
-    bitLenInt n = allBits[0];
-
-    // Only continue if the sub-unit is still clifford.
-    if (!shards[n].unit || !shards[n].unit->isClifford()) {
-        return;
-    }
-
-    if (!shards[n].unit->TrySeparate(shards[n].mapped)) {
-        CheckCliffordSeparable(n);
-        return;
-    }
-
-    for (i = 0; i < allBits.size(); i++) {
-        n = allBits[i];
-        if (shards[n].unit && shards[n].unit->isClifford()) {
-            // ProbBase will separate as it can, but it's only cheap to check if the sub-unit is Clifford.
-            ProbBase(n);
-        }
-    }
+    CheckCliffordSeparable(allBits[0]);
 }
 
 bool QUnit::CArithmeticOptimize(bitLenInt* controls, bitLenInt controlLen, std::vector<bitLenInt>* controlVec)

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -734,9 +734,6 @@ real1 QUnit::ProbBase(const bitLenInt& qubit)
     shard.amp0 = complex(sqrt(ONE_R1 - prob), ZERO_R1);
 
     if (unit && unit->isClifford() && !unit->TrySeparate(qubit)) {
-        if (IS_NORM_0(shard.amp1) || IS_NORM_0(shard.amp0)) {
-            CheckCliffordSeparable(qubit);
-        }
         return prob;
     }
 
@@ -2818,6 +2815,10 @@ void QUnit::ApplyEitherControlled(const bitLenInt* controls, const bitLenInt& co
 
     // Only continue if the sub-unit is still clifford.
     if (!shards[n].unit || !shards[n].unit->isClifford()) {
+        return;
+    }
+
+    if (CheckCliffordSeparable(n)) {
         return;
     }
 


### PR DESCRIPTION
`CheckCliffordSeparable()` was intended as a fall-back, if stabilizer sub-units were in a state where immediate representation precluded the applicability of the `Decompose()` method, which is limited to special cases. This standard usage has been re-established, and we use better algorithms to recover separability when we have the opportunity.