### PR TITLE
Fixing segfault in MAll()

### DIFF
--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1263,7 +1263,9 @@ bitCapInt QUnit::MAll()
             continue;
         }
         bitLenInt offset = find(units.begin(), units.end(), shards[i].unit) - units.begin();
-        toRet |= ((partResults[offset] >> shards[i].mapped) & 1U) << i;
+        if (offset < partResults.size()) {
+            toRet |= ((partResults[offset] >> shards[i].mapped) & 1U) << i;
+        }
     }
 
     SetPermutation(toRet);


### PR DESCRIPTION
In its final steps, the MAll() method did not allow for skipping non-Clifford sub-units, which are already measured and included in the result.