### PR TITLE
Follow GetNonunitaryPhase() convention with QUnit's QEngineShards

### DIFF
--- a/include/qengine.hpp
+++ b/include/qengine.hpp
@@ -31,16 +31,6 @@ protected:
     /// summed, at each update. To normalize, we should always multiply by 1/sqrt(runningNorm).
     real1 runningNorm;
 
-    complex GetNonunitaryPhase()
-    {
-        if (randGlobalPhase) {
-            real1 angle = Rand() * 2 * M_PI;
-            return complex(cos(angle), sin(angle));
-        } else {
-            return ONE_CMPLX;
-        }
-    }
-
 public:
     QEngine(bitLenInt qBitCount, qrack_rand_gen_ptr rgp = nullptr, bool doNorm = false, bool randomGlobalPhase = true,
         bool useHostMem = false, bool useHardwareRNG = true, real1 norm_thresh = REAL1_EPSILON)

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -179,6 +179,16 @@ protected:
 
     bool IsIdentity(const complex* mtrx, const bool isControlled = false);
 
+    complex GetNonunitaryPhase()
+    {
+        if (randGlobalPhase) {
+            real1 angle = Rand() * 2 * M_PI;
+            return complex(cos(angle), sin(angle));
+        } else {
+            return ONE_CMPLX;
+        }
+    }
+
 public:
     QInterface(bitLenInt n, qrack_rand_gen_ptr rgp = nullptr, bool doNorm = false, bool useHardwareRNG = true,
         bool randomGlobalPhase = true, real1 norm_thresh = REAL1_EPSILON)

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -112,7 +112,7 @@ public:
     {
     }
 
-    QEngineShard(const bool& set, const real1 amp_thresh = REAL1_EPSILON)
+    QEngineShard(const bool& set, const real1 amp_thresh = REAL1_EPSILON, const complex rand_phase = ONE_CMPLX)
         : unit(NULL)
         , mapped(0)
         , amplitudeFloor(amp_thresh)
@@ -126,8 +126,8 @@ public:
         , antiTargetOfShards()
         , found(false)
     {
-        amp0 = set ? ZERO_CMPLX : ONE_CMPLX;
-        amp1 = set ? ONE_CMPLX : ZERO_CMPLX;
+        amp0 = set ? ZERO_CMPLX : rand_phase;
+        amp1 = set ? rand_phase : ZERO_CMPLX;
     }
 
     // Dirty state constructor:

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -82,7 +82,7 @@ QUnit::QUnit(QInterfaceEngine eng, QInterfaceEngine subEng, bitLenInt qBitCount,
 
     for (bitLenInt i = 0; i < qubitCount; i++) {
         bitState = ((initState >> (bitCapIntOcl)i) & ONE_BCI) != 0;
-        shards[i] = QEngineShard(bitState, doNormalize ? amplitudeFloor : ZERO_R1);
+        shards[i] = QEngineShard(bitState, doNormalize ? amplitudeFloor : ZERO_R1, GetNonunitaryPhase());
     }
 }
 
@@ -100,7 +100,7 @@ void QUnit::SetPermutation(bitCapInt perm, complex phaseFac)
 
     for (bitLenInt i = 0; i < qubitCount; i++) {
         bitState = ((perm >> (bitCapIntOcl)i) & ONE_BCI) != 0;
-        shards[i] = QEngineShard(bitState, doNormalize ? amplitudeFloor : ZERO_R1);
+        shards[i] = QEngineShard(bitState, doNormalize ? amplitudeFloor : ZERO_R1, GetNonunitaryPhase());
     }
 }
 
@@ -1242,10 +1242,10 @@ bitCapInt QUnit::MAll()
         if (!toFind) {
             if (Rand() <= norm(shards[i].amp1)) {
                 shards[i].amp0 = ZERO_CMPLX;
-                shards[i].amp1 = ONE_CMPLX;
+                shards[i].amp1 = GetNonunitaryPhase();
                 toRet |= pow2(i);
             } else {
-                shards[i].amp0 = ONE_CMPLX;
+                shards[i].amp0 = GetNonunitaryPhase();
                 shards[i].amp1 = ZERO_CMPLX;
             }
         } else if (!(toFind->isClifford())) {
@@ -1281,7 +1281,7 @@ void QUnit::SetReg(bitLenInt start, bitLenInt length, bitCapInt value)
     bool bitState;
     for (bitLenInt i = 0; i < length; i++) {
         bitState = ((value >> (bitCapIntOcl)i) & ONE_BCI) != 0;
-        shards[i + start] = QEngineShard(bitState, doNormalize ? amplitudeFloor : ZERO_R1);
+        shards[i + start] = QEngineShard(bitState, doNormalize ? amplitudeFloor : ZERO_R1, GetNonunitaryPhase());
     }
 }
 

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -728,7 +728,7 @@ TEST_CASE("test_universal_circuit_digital", "[supreme]")
 {
     const int GateCount1Qb = 4;
     const int GateCountMultiQb = 4;
-    const int Depth = 20;
+    const int Depth = 6;
 
     benchmarkLoop(
         [&](QInterfacePtr qReg, bitLenInt n) {


### PR DESCRIPTION
When the `randGlobalPhase` constructor/factory argument is enabled, Qrack assumes that global (separable subsystem) overall phase factors are physically/computationally arbitrary, since they have no possible effect on Hermitian operator expectation values, and therefore they present a useful symmetry for optimization.

When this same option is turned on, Qrack also, partly as a matter of legacy behavior, randomizes global overall phase factors upon initialization and measurement. This can be totally turned off by `randGlobalPhase = false`, but specific initialization phase, with the optimization option on, can still be passed directly through to another constructor argument, typically. This convention was being missed, in QUnit. Assuming no other great difference, I think this original convention should be followed. (I reasoned, 3 years ago, that this encourages good practice and hardware-realistic, "amplitude agnostic" simulator design and usage.)