### PR TITLE
SetAmplitudePage() edge cases

### DIFF
--- a/include/qengine_cpu.hpp
+++ b/include/qengine_cpu.hpp
@@ -123,7 +123,6 @@ public:
         }
 
         if (!oStateVec && (length == maxQPower)) {
-            Dump();
             FreeStateVec();
             return;
         }

--- a/include/qengine_cpu.hpp
+++ b/include/qengine_cpu.hpp
@@ -122,6 +122,11 @@ public:
             return;
         }
 
+        if (!oStateVec) {
+            FreeStateVec();
+            return;
+        }
+
         if (!stateVec) {
             ResetStateVec(AllocStateVec(maxQPower));
             stateVec->clear();

--- a/include/qengine_cpu.hpp
+++ b/include/qengine_cpu.hpp
@@ -122,7 +122,8 @@ public:
             return;
         }
 
-        if (!oStateVec) {
+        if (!oStateVec && (length == maxQPower)) {
+            Dump();
             FreeStateVec();
             return;
         }

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -122,7 +122,12 @@ void QEngineOCL::SetAmplitudePage(
     }
 
     if (!oStateBuffer) {
-        ClearBuffer(stateBuffer, (bitCapIntOcl)dstOffset, (bitCapIntOcl)length, ResetWaitEvents());
+        if (length == maxQPower) {
+            clDump();
+            FreeStateVec();
+        } else {
+            ClearBuffer(stateBuffer, (bitCapIntOcl)dstOffset, (bitCapIntOcl)length, ResetWaitEvents());
+        }
         return;
     }
 

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -121,9 +121,11 @@ void QEngineOCL::SetAmplitudePage(
         return;
     }
 
+    clFinish();
+    pageEngineOclPtr->clFinish();
+
     if (!oStateBuffer) {
         if (length == maxQPower) {
-            clDump();
             FreeStateVec();
         } else {
             ClearBuffer(stateBuffer, (bitCapIntOcl)dstOffset, (bitCapIntOcl)length, ResetWaitEvents());
@@ -135,9 +137,6 @@ void QEngineOCL::SetAmplitudePage(
         ReinitBuffer();
         ClearBuffer(stateBuffer, 0, maxQPowerOcl, ResetWaitEvents());
     }
-
-    clFinish();
-    pageEngineOclPtr->clFinish();
 
     queue.enqueueCopyBuffer(*oStateBuffer, *stateBuffer, sizeof(complex) * (bitCapIntOcl)srcOffset,
         sizeof(complex) * (bitCapIntOcl)dstOffset, sizeof(complex) * (bitCapIntOcl)length);


### PR DESCRIPTION
While I do not think this functionality is in use at the moment, edge cases involving `SetAmplitudePage()` can be optimized. As in this PR, `clFinish()`, `clDump()` or equivalent should be called before checking these method's various edge cases, under the design assumption that `QPager` "pages" might need to queue OpenCL events not necessarily from their own methods, as might happen with `Compose()` and related methods.