### PR TITLE
Enable normalization options for QPager

### DIFF
--- a/include/qengine.hpp
+++ b/include/qengine.hpp
@@ -51,6 +51,8 @@ public:
 
     virtual ~QEngine() { Finish(); }
 
+    virtual real1 GetRunningNorm() { return runningNorm; }
+
     virtual void ZeroAmplitudes() = 0;
 
     virtual void CopyStateVec(QInterfacePtr src) = 0;
@@ -62,6 +64,9 @@ public:
     /** Swap the high half of this engine with the low half of another. This is necessary for gates which cross
      * sub-engine  boundaries. */
     virtual void ShuffleBuffers(QEnginePtr engine) = 0;
+
+    virtual void QueueSetDoNormalize(const bool& doNorm) = 0;
+    virtual void QueueSetRunningNorm(const real1& runningNrm) = 0;
 
     virtual bool ForceM(bitLenInt qubitIndex, bool result, bool doForce = true, bool doApply = true);
     virtual bitCapInt ForceM(const bitLenInt* bits, const bitLenInt& length, const bool* values, bool doApply = true);

--- a/include/qengine_cpu.hpp
+++ b/include/qengine_cpu.hpp
@@ -183,6 +183,15 @@ public:
         }
     }
 
+    virtual void QueueSetDoNormalize(const bool& doNorm)
+    {
+        Dispatch([this, doNorm] { doNormalize = doNorm; });
+    }
+    virtual void QueueSetRunningNorm(const real1& runningNrm)
+    {
+        Dispatch([this, runningNrm] { runningNorm = runningNrm; });
+    }
+
     virtual void SetQuantumState(const complex* inputState);
     virtual void GetQuantumState(complex* outputState);
     virtual void GetProbs(real1* outputProbs);

--- a/include/qengine_cpu.hpp
+++ b/include/qengine_cpu.hpp
@@ -123,7 +123,7 @@ public:
         }
 
         if (!oStateVec && (length == maxQPower)) {
-            FreeStateVec();
+            ZeroAmplitudes();
             return;
         }
 

--- a/include/qengine_cpu.hpp
+++ b/include/qengine_cpu.hpp
@@ -107,7 +107,7 @@ public:
 
         stateVec->copy_in(pagePtr, offset, length);
 
-        runningNorm = ONE_R1;
+        runningNorm = REAL1_DEFAULT_ARG;
     }
     virtual void SetAmplitudePage(
         QEnginePtr pageEnginePtr, const bitCapInt srcOffset, const bitCapInt dstOffset, const bitCapInt length)
@@ -134,7 +134,7 @@ public:
 
         stateVec->copy_in(oStateVec, srcOffset, dstOffset, length);
 
-        runningNorm = ONE_R1;
+        runningNorm = REAL1_DEFAULT_ARG;
     }
     virtual void ShuffleBuffers(QEnginePtr engine)
     {
@@ -159,8 +159,8 @@ public:
 
         stateVec->shuffle(engineCpu->stateVec);
 
-        runningNorm = ONE_R1;
-        engineCpu->runningNorm = ONE_R1;
+        runningNorm = REAL1_DEFAULT_ARG;
+        engineCpu->runningNorm = REAL1_DEFAULT_ARG;
     }
 
     virtual void CopyStateVec(QInterfacePtr src)

--- a/include/qhybrid.hpp
+++ b/include/qhybrid.hpp
@@ -98,6 +98,9 @@ public:
     }
     virtual void ShuffleBuffers(QEnginePtr oEngine) { ShuffleBuffers(std::dynamic_pointer_cast<QHybrid>(oEngine)); }
     virtual void ShuffleBuffers(QHybridPtr oEngine) { engine->ShuffleBuffers(oEngine->engine); }
+    virtual void QueueSetDoNormalize(const bool& doNorm) { engine->QueueSetDoNormalize(doNorm); }
+    virtual void QueueSetRunningNorm(const real1& runningNrm) { engine->QueueSetRunningNorm(runningNrm); }
+
     virtual void ApplyM(bitCapInt regMask, bitCapInt result, complex nrm) { engine->ApplyM(regMask, result, nrm); }
     virtual real1 ProbReg(const bitLenInt& start, const bitLenInt& length, const bitCapInt& permutation)
     {

--- a/include/qhybrid.hpp
+++ b/include/qhybrid.hpp
@@ -35,7 +35,7 @@ protected:
 
 public:
     QHybrid(bitLenInt qBitCount, bitCapInt initState = 0, qrack_rand_gen_ptr rgp = nullptr,
-        complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = true, bool randomGlobalPhase = true,
+        complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = false, bool randomGlobalPhase = true,
         bool useHostMem = false, int deviceId = -1, bool useHardwareRNG = true, bool useSparseStateVec = false,
         real1 norm_thresh = REAL1_EPSILON, std::vector<int> ignored = {}, bitLenInt qubitThreshold = 0);
 

--- a/include/qpager.hpp
+++ b/include/qpager.hpp
@@ -78,12 +78,12 @@ protected:
 
 public:
     QPager(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState = 0, qrack_rand_gen_ptr rgp = nullptr,
-        complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = true, bool ignored = false, bool useHostMem = false,
+        complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = false, bool ignored = false, bool useHostMem = false,
         int deviceId = -1, bool useHardwareRNG = true, bool useSparseStateVec = false,
         real1 norm_thresh = REAL1_EPSILON, std::vector<int> devList = {}, bitLenInt qubitThreshold = 0);
 
     QPager(bitLenInt qBitCount, bitCapInt initState = 0, qrack_rand_gen_ptr rgp = nullptr,
-        complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = true, bool ignored = false, bool useHostMem = false,
+        complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = false, bool ignored = false, bool useHostMem = false,
         int deviceId = -1, bool useHardwareRNG = true, bool useSparseStateVec = false,
         real1 norm_thresh = REAL1_EPSILON, std::vector<int> devList = {}, bitLenInt qubitThreshold = 0)
         : QPager(QINTERFACE_HYBRID, qBitCount, initState, rgp, phaseFac, doNorm, ignored, useHostMem, deviceId,

--- a/include/qpager.hpp
+++ b/include/qpager.hpp
@@ -30,6 +30,7 @@ protected:
     bool useHostRam;
     bool useRDRAND;
     bool isSparse;
+    real1 runningNorm;
     std::vector<QEnginePtr> qPages;
     std::vector<int> deviceIDs;
 
@@ -77,16 +78,16 @@ protected:
 
 public:
     QPager(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState = 0, qrack_rand_gen_ptr rgp = nullptr,
-        complex phaseFac = CMPLX_DEFAULT_ARG, bool ignored = false, bool ignored2 = false, bool useHostMem = false,
-        int deviceId = -1, bool useHardwareRNG = true, bool useSparseStateVec = false, real1 ignored3 = REAL1_EPSILON,
-        std::vector<int> devList = {}, bitLenInt qubitThreshold = 0);
+        complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = true, bool ignored = false, bool useHostMem = false,
+        int deviceId = -1, bool useHardwareRNG = true, bool useSparseStateVec = false,
+        real1 norm_thresh = REAL1_EPSILON, std::vector<int> devList = {}, bitLenInt qubitThreshold = 0);
 
     QPager(bitLenInt qBitCount, bitCapInt initState = 0, qrack_rand_gen_ptr rgp = nullptr,
-        complex phaseFac = CMPLX_DEFAULT_ARG, bool ignored = false, bool ignored2 = false, bool useHostMem = false,
-        int deviceId = -1, bool useHardwareRNG = true, bool useSparseStateVec = false, real1 ignored3 = REAL1_EPSILON,
-        std::vector<int> devList = {}, bitLenInt qubitThreshold = 0)
-        : QPager(QINTERFACE_HYBRID, qBitCount, initState, rgp, phaseFac, ignored, ignored2, useHostMem, deviceId,
-              useHardwareRNG, useSparseStateVec, ignored3, devList, qubitThreshold)
+        complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = true, bool ignored = false, bool useHostMem = false,
+        int deviceId = -1, bool useHardwareRNG = true, bool useSparseStateVec = false,
+        real1 norm_thresh = REAL1_EPSILON, std::vector<int> devList = {}, bitLenInt qubitThreshold = 0)
+        : QPager(QINTERFACE_HYBRID, qBitCount, initState, rgp, phaseFac, doNorm, ignored, useHostMem, deviceId,
+              useHardwareRNG, useSparseStateVec, norm_thresh, devList, qubitThreshold)
     {
     }
 

--- a/include/qstabilizerhybrid.hpp
+++ b/include/qstabilizerhybrid.hpp
@@ -47,13 +47,13 @@ protected:
 
 public:
     QStabilizerHybrid(QInterfaceEngine eng, QInterfaceEngine subEng, bitLenInt qBitCount, bitCapInt initState = 0,
-        qrack_rand_gen_ptr rgp = nullptr, complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = true,
+        qrack_rand_gen_ptr rgp = nullptr, complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = false,
         bool randomGlobalPhase = true, bool useHostMem = false, int deviceId = -1, bool useHardwareRNG = true,
         bool useSparseStateVec = false, real1 norm_thresh = REAL1_EPSILON, std::vector<int> ignored = {},
         bitLenInt qubitThreshold = 0);
 
     QStabilizerHybrid(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState = 0,
-        qrack_rand_gen_ptr rgp = nullptr, complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = true,
+        qrack_rand_gen_ptr rgp = nullptr, complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = false,
         bool randomGlobalPhase = true, bool useHostMem = false, int deviceId = -1, bool useHardwareRNG = true,
         bool useSparseStateVec = false, real1 norm_thresh = REAL1_EPSILON, std::vector<int> ignored = {},
         bitLenInt qubitThreshold = 0)

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -703,12 +703,12 @@ protected:
 
 public:
     QUnit(QInterfaceEngine eng, QInterfaceEngine subEng, bitLenInt qBitCount, bitCapInt initState = 0,
-        qrack_rand_gen_ptr rgp = nullptr, complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = true,
+        qrack_rand_gen_ptr rgp = nullptr, complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = false,
         bool randomGlobalPhase = true, bool useHostMem = false, int deviceId = -1, bool useHardwareRNG = true,
         bool useSparseStateVec = false, real1 norm_thresh = REAL1_EPSILON, std::vector<int> ignored = {},
         bitLenInt qubitThreshold = 0);
     QUnit(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState = 0, qrack_rand_gen_ptr rgp = nullptr,
-        complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = true, bool randomGlobalPhase = true,
+        complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = false, bool randomGlobalPhase = true,
         bool useHostMem = false, int deviceId = -1, bool useHardwareRNG = true, bool useSparseStateVec = false,
         real1 norm_thresh = REAL1_EPSILON, std::vector<int> ignored = {}, bitLenInt qubitThreshold = 0)
         : QUnit(eng, eng, qBitCount, initState, rgp, phaseFac, doNorm, randomGlobalPhase, useHostMem, deviceId,

--- a/include/qunitmulti.hpp
+++ b/include/qunitmulti.hpp
@@ -69,7 +69,7 @@ protected:
 
 public:
     QUnitMulti(bitLenInt qBitCount, bitCapInt initState = 0, qrack_rand_gen_ptr rgp = nullptr,
-        complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = true, bool randomGlobalPhase = true,
+        complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = false, bool randomGlobalPhase = true,
         bool useHostMem = false, int deviceID = -1, bool useHardwareRNG = true, bool useSparseStateVec = false,
         real1 norm_thresh = REAL1_EPSILON, std::vector<int> devList = {}, bitLenInt qubitThreshold = 0)
         : QUnitMulti(QINTERFACE_OPTIMAL, QINTERFACE_OPTIMAL, qBitCount, initState, rgp, phaseFac, doNorm,
@@ -79,7 +79,7 @@ public:
     }
 
     QUnitMulti(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState = 0, qrack_rand_gen_ptr rgp = nullptr,
-        complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = true, bool randomGlobalPhase = true,
+        complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = false, bool randomGlobalPhase = true,
         bool useHostMem = false, int deviceID = -1, bool useHardwareRNG = true, bool useSparseStateVec = false,
         real1 norm_thresh = REAL1_EPSILON, std::vector<int> devList = {}, bitLenInt qubitThreshold = 0)
         : QUnitMulti(eng, eng, qBitCount, initState, rgp, phaseFac, doNorm, randomGlobalPhase, useHostMem, deviceID,
@@ -88,7 +88,7 @@ public:
     }
 
     QUnitMulti(QInterfaceEngine eng, QInterfaceEngine subEng, bitLenInt qBitCount, bitCapInt initState = 0,
-        qrack_rand_gen_ptr rgp = nullptr, complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = true,
+        qrack_rand_gen_ptr rgp = nullptr, complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = false,
         bool randomGlobalPhase = true, bool useHostMem = false, int deviceID = -1, bool useHardwareRNG = true,
         bool useSparseStateVec = false, real1 norm_thresh = REAL1_EPSILON, std::vector<int> devList = {},
         bitLenInt qubitThreshold = 0);

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -910,6 +910,9 @@ void QEngineOCL::Apply2x2(bitCapInt offset1, bitCapInt offset2, const complex* m
         // If we have calculated the norm of the state vector in this call, we need to sum the buffer of partial norm
         // values into a single normalization constant.
         WAIT_REAL1_SUM(*nrmBuffer, ngc / ngs, nrmArray, &runningNorm);
+        if (runningNorm == ZERO_R1) {
+            FreeStateVec();
+        }
     } else if ((runningNorm == ZERO_R1) || ((bitCount == 1) && !isXGate && !isZGate && !isInvertGate && !isPhaseGate)) {
         runningNorm = ONE_R1;
     }

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -912,7 +912,7 @@ void QEngineOCL::Apply2x2(bitCapInt offset1, bitCapInt offset2, const complex* m
         // values into a single normalization constant.
         WAIT_REAL1_SUM(*nrmBuffer, ngc / ngs, nrmArray, &runningNorm);
         if (runningNorm == ZERO_R1) {
-            FreeStateVec();
+            ZeroAmplitudes();
         }
     } else if ((runningNorm == ZERO_R1) || ((bitCount == 1) && !isXGate && !isZGate && !isInvertGate && !isPhaseGate)) {
         runningNorm = ONE_R1;

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -126,7 +126,7 @@ void QEngineOCL::SetAmplitudePage(
 
     if (!oStateBuffer) {
         if (length == maxQPower) {
-            FreeStateVec();
+            ZeroAmplitudes();
         } else {
             ClearBuffer(stateBuffer, (bitCapIntOcl)dstOffset, (bitCapIntOcl)length, ResetWaitEvents());
         }

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -108,7 +108,7 @@ void QEngineOCL::SetAmplitudePage(const complex* pagePtr, const bitCapInt offset
     queue.enqueueWriteBuffer(*stateBuffer, CL_TRUE, sizeof(complex) * (bitCapIntOcl)offset,
         sizeof(complex) * (bitCapIntOcl)length, pagePtr, waitVec.get());
 
-    runningNorm = ONE_R1;
+    runningNorm = REAL1_DEFAULT_ARG;
 }
 
 void QEngineOCL::SetAmplitudePage(
@@ -143,7 +143,7 @@ void QEngineOCL::SetAmplitudePage(
 
     queue.finish();
 
-    runningNorm = ONE_R1;
+    runningNorm = REAL1_DEFAULT_ARG;
 }
 
 void QEngineOCL::ShuffleBuffers(QEnginePtr engine)
@@ -176,8 +176,8 @@ void QEngineOCL::ShuffleBuffers(QEnginePtr engine)
 
     queue.finish();
 
-    runningNorm = ONE_R1;
-    engineOcl->runningNorm = ONE_R1;
+    runningNorm = REAL1_DEFAULT_ARG;
+    engineOcl->runningNorm = REAL1_DEFAULT_ARG;
 }
 
 void QEngineOCL::LockSync(cl_int flags)
@@ -585,7 +585,7 @@ void QEngineOCL::SetPermutation(bitCapInt perm, complex phaseFac)
     device_context->UnlockWaitEvents();
     queue.flush();
 
-    runningNorm = ONE_R1;
+    runningNorm = REAL1_DEFAULT_ARG;
 }
 
 void QEngineOCL::ArithmeticCall(
@@ -763,7 +763,8 @@ void QEngineOCL::Apply2x2(bitCapInt offset1, bitCapInt offset2, const complex* m
 
     // Is the vector already normalized, or is this method not appropriate for on-the-fly normalization?
     bool isUnitLength = (runningNorm == ONE_R1) || !(doNormalize && (bitCount == 1));
-    cmplx[4] = complex(isUnitLength ? ONE_R1 : (ONE_R1 / std::sqrt(runningNorm)), ZERO_R1);
+    cmplx[4] = complex(
+        (isUnitLength || (runningNorm == REAL1_DEFAULT_ARG)) ? ONE_R1 : (ONE_R1 / std::sqrt(runningNorm)), ZERO_R1);
     cmplx[5] = norm_thresh;
 
     BufferPtr locCmplxBuffer;

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -585,7 +585,7 @@ void QEngineOCL::SetPermutation(bitCapInt perm, complex phaseFac)
     device_context->UnlockWaitEvents();
     queue.flush();
 
-    runningNorm = REAL1_DEFAULT_ARG;
+    runningNorm = ONE_R1;
 }
 
 void QEngineOCL::ArithmeticCall(

--- a/src/qengine/state.cpp
+++ b/src/qengine/state.cpp
@@ -346,6 +346,10 @@ void QEngineCPU::Apply2x2(bitCapInt offset1, bitCapInt offset2, const complex* m
             }
             runningNorm = rNrm;
             delete[] rngNrm;
+
+            if (runningNorm == ZERO_R1) {
+                FreeStateVec();
+            }
         }
     });
 }

--- a/src/qengine/state.cpp
+++ b/src/qengine/state.cpp
@@ -204,7 +204,7 @@ void QEngineCPU::Apply2x2(bitCapInt offset1, bitCapInt offset2, const complex* m
 
     doCalcNorm = (doCalcNorm || (runningNorm != ONE_R1)) && doNormalize && (bitCount == 1);
 
-    real1 nrm = doNormalize ? (ONE_R1 / std::sqrt(runningNorm)) : ONE_R1;
+    real1 nrm = doNormalize && (runningNorm != REAL1_DEFAULT_ARG) ? (ONE_R1 / std::sqrt(runningNorm)) : ONE_R1;
 
     if (doCalcNorm) {
         runningNorm = ONE_R1;

--- a/src/qengine/state.cpp
+++ b/src/qengine/state.cpp
@@ -348,7 +348,7 @@ void QEngineCPU::Apply2x2(bitCapInt offset1, bitCapInt offset2, const complex* m
             delete[] rngNrm;
 
             if (runningNorm == ZERO_R1) {
-                FreeStateVec();
+                ZeroAmplitudes();
             }
         }
     });

--- a/test/benchmarks_main.cpp
+++ b/test/benchmarks_main.cpp
@@ -238,7 +238,7 @@ int main(int argc, char* argv[])
     }
 
 #if ENABLE_OPENCL
-    if (num_failed == 0 && stabilizer_qpager) {
+    if (num_failed == 0 && qengine && stabilizer_qpager) {
         testEngineType = QINTERFACE_STABILIZER_HYBRID;
         testSubEngineType = QINTERFACE_QPAGER;
         testSubSubEngineType = QINTERFACE_HYBRID;

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -191,7 +191,7 @@ int main(int argc, char* argv[])
     }
 
 #if ENABLE_OPENCL
-    if (num_failed == 0 && stabilizer_qpager) {
+    if (num_failed == 0 && qengine && stabilizer_qpager) {
         testEngineType = QINTERFACE_STABILIZER_HYBRID;
         testSubEngineType = QINTERFACE_QPAGER;
         testSubSubEngineType = QINTERFACE_HYBRID;


### PR DESCRIPTION
QPager should ultimately fully support all QEngine type constructor options. Now, we support normalization options.