### PR TITLE
Use Gaussian elimination to attempt to increase separability opportunities in QStabilizerHybrid

### DIFF
--- a/src/qstabilizer.cpp
+++ b/src/qstabilizer.cpp
@@ -618,6 +618,9 @@ bitLenInt QStabilizer::Compose(QStabilizerPtr toCopy, const bitLenInt start)
 
 bool QStabilizer::CanDecomposeDispose(const bitLenInt start, const bitLenInt length)
 {
+    Finish();
+    gaussian();
+
     bitLenInt i, j;
     bitLenInt end = start + length;
 

--- a/src/qstabilizer.cpp
+++ b/src/qstabilizer.cpp
@@ -619,6 +619,9 @@ bitLenInt QStabilizer::Compose(QStabilizerPtr toCopy, const bitLenInt start)
 bool QStabilizer::CanDecomposeDispose(const bitLenInt start, const bitLenInt length)
 {
     Finish();
+
+    // We want to have the maximum number of 0 cross terms possible.
+    // TODO: Determine whether this is the fundamentally ideal form adjustment.
     gaussian();
 
     bitLenInt i, j;


### PR DESCRIPTION
See #582. This doesn't give immediately obvious benefits in standard benchmark tests, but my guess is that it's the conceptually correct approach,