### PR TITLE
Simplify QUnit::CommuteH same/opposite cases

### DIFF
--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -4196,8 +4196,6 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
         return;
     }
 
-    bool isSame, isOpposite;
-
     ShardToPhaseMap targetOfShards = shard.targetOfShards;
 
     for (phaseShard = targetOfShards.begin(); phaseShard != targetOfShards.end(); phaseShard++) {
@@ -4206,17 +4204,11 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
         polarDiff = buffer->cmplxDiff;
         polarSame = buffer->cmplxSame;
 
-        partner = phaseShard->first;
-
-        // If isSame and !isInvert, application of this buffer is already "efficient."
-        isSame = (buffer->isInvert || (!partner->isPauliX && !partner->isPauliY) || !partner->IsInvertTarget()) &&
-            IS_SAME(polarDiff, polarSame);
-        isOpposite = !buffer->isInvert && IS_OPPOSITE(polarDiff, polarSame);
-
-        if (isSame || isOpposite) {
+        if (IS_SAME(polarDiff, polarSame) || IS_OPPOSITE(polarDiff, polarSame)) {
             continue;
         }
 
+        partner = phaseShard->first;
         control = FindShardIndex(partner);
         ApplyBuffer(buffer, control, bitIndex, false);
         shard.RemovePhaseControl(partner);
@@ -4230,17 +4222,11 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
         polarDiff = buffer->cmplxDiff;
         polarSame = buffer->cmplxSame;
 
-        partner = phaseShard->first;
-
-        // If isSame and !isInvert, application of this buffer is already "efficient."
-        isSame = (buffer->isInvert || (!partner->isPauliX && !partner->isPauliY) || !partner->IsInvertTarget()) &&
-            IS_SAME(polarDiff, polarSame);
-        isOpposite = !buffer->isInvert && IS_OPPOSITE(polarDiff, polarSame);
-
-        if (isSame || isOpposite) {
+        if (IS_SAME(polarDiff, polarSame) || IS_OPPOSITE(polarDiff, polarSame)) {
             continue;
         }
 
+        partner = phaseShard->first;
         control = FindShardIndex(partner);
         ApplyBuffer(buffer, control, bitIndex, true);
         shard.RemovePhaseAntiControl(partner);


### PR DESCRIPTION
As this feature was implemented and debugged, over months, many edge cases were excepted from a buffer commutation principle that should work more simply. Most of these cases didn't seem strictly necessary by the intended buffer algebra, (the rules of which can be checked by hand,) but it seemed like other bugs or limitations in the developing implementation needed to "shunted." To vague recollection, I would have still expected one edge cases that needs to be struck, here, but it doesn't seem to cause any problems in random circuit cross entropy tests, to leave that consideration out. I'll check my notes and continue to test, before merging.