### PR TITLE
QPager decomposition optimization (and revert bugged 8d8ed54)

### DIFF
--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -4196,6 +4196,8 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
         return;
     }
 
+    bool isSame, isOpposite;
+
     ShardToPhaseMap targetOfShards = shard.targetOfShards;
 
     for (phaseShard = targetOfShards.begin(); phaseShard != targetOfShards.end(); phaseShard++) {
@@ -4204,11 +4206,17 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
         polarDiff = buffer->cmplxDiff;
         polarSame = buffer->cmplxSame;
 
-        if (IS_SAME(polarDiff, polarSame) || IS_OPPOSITE(polarDiff, polarSame)) {
+        partner = phaseShard->first;
+
+        // If isSame and !isInvert, application of this buffer is already "efficient."
+        isSame = (buffer->isInvert || (!partner->isPauliX && !partner->isPauliY) || !partner->IsInvertTarget()) &&
+            IS_SAME(polarDiff, polarSame);
+        isOpposite = !buffer->isInvert && IS_OPPOSITE(polarDiff, polarSame);
+
+        if (isSame || isOpposite) {
             continue;
         }
 
-        partner = phaseShard->first;
         control = FindShardIndex(partner);
         ApplyBuffer(buffer, control, bitIndex, false);
         shard.RemovePhaseControl(partner);
@@ -4222,11 +4230,17 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
         polarDiff = buffer->cmplxDiff;
         polarSame = buffer->cmplxSame;
 
-        if (IS_SAME(polarDiff, polarSame) || IS_OPPOSITE(polarDiff, polarSame)) {
+        partner = phaseShard->first;
+
+        // If isSame and !isInvert, application of this buffer is already "efficient."
+        isSame = (buffer->isInvert || (!partner->isPauliX && !partner->isPauliY) || !partner->IsInvertTarget()) &&
+            IS_SAME(polarDiff, polarSame);
+        isOpposite = !buffer->isInvert && IS_OPPOSITE(polarDiff, polarSame);
+
+        if (isSame || isOpposite) {
             continue;
         }
 
-        partner = phaseShard->first;
         control = FindShardIndex(partner);
         ApplyBuffer(buffer, control, bitIndex, true);
         shard.RemovePhaseAntiControl(partner);


### PR DESCRIPTION
This improves QPager decomposition. Also, it's become apparent through CI that 8d8ed54 was not actually generally correct, via further cross entropy testing in our suite.