### PR TITLE
Restoring QUnit commutation simplification

### DIFF
--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -4196,8 +4196,6 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
         return;
     }
 
-    bool isSame, isOpposite;
-
     ShardToPhaseMap targetOfShards = shard.targetOfShards;
 
     for (phaseShard = targetOfShards.begin(); phaseShard != targetOfShards.end(); phaseShard++) {
@@ -4206,17 +4204,11 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
         polarDiff = buffer->cmplxDiff;
         polarSame = buffer->cmplxSame;
 
-        partner = phaseShard->first;
-
-        // If isSame and !isInvert, application of this buffer is already "efficient."
-        isSame = (buffer->isInvert || (!partner->isPauliX && !partner->isPauliY) || !partner->IsInvertTarget()) &&
-            IS_SAME(polarDiff, polarSame);
-        isOpposite = !buffer->isInvert && IS_OPPOSITE(polarDiff, polarSame);
-
-        if (isSame || isOpposite) {
+        if (IS_SAME(polarDiff, polarSame) || IS_OPPOSITE(polarDiff, polarSame)) {
             continue;
         }
 
+        partner = phaseShard->first;
         control = FindShardIndex(partner);
         ApplyBuffer(buffer, control, bitIndex, false);
         shard.RemovePhaseControl(partner);
@@ -4230,17 +4222,11 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
         polarDiff = buffer->cmplxDiff;
         polarSame = buffer->cmplxSame;
 
-        partner = phaseShard->first;
-
-        // If isSame and !isInvert, application of this buffer is already "efficient."
-        isSame = (buffer->isInvert || (!partner->isPauliX && !partner->isPauliY) || !partner->IsInvertTarget()) &&
-            IS_SAME(polarDiff, polarSame);
-        isOpposite = !buffer->isInvert && IS_OPPOSITE(polarDiff, polarSame);
-
-        if (isSame || isOpposite) {
+        if (IS_SAME(polarDiff, polarSame) || IS_OPPOSITE(polarDiff, polarSame)) {
             continue;
         }
 
+        partner = phaseShard->first;
         control = FindShardIndex(partner);
         ApplyBuffer(buffer, control, bitIndex, true);
         shard.RemovePhaseAntiControl(partner);


### PR DESCRIPTION
We had a couple of CI failures in QUnit cross entropy unit tests, and b79a351 seems to have been the culprit. I reverted other work in the same commutation method, while attempting to debug that, from #588. By turning up the width, depth, and trials in the cross entropy unit tests, for around 4+ hours of testing across most QUnit and QUnitMulti types, it seems that the current head of main encountered 0 cross entropy test failures in this time, but I'm currently running these tests again, to a comparable level of stringency, for the work in this branch. There are no failures, yet, which indicates that the work restored in this PR was not the culprit, but I'm waiting for higher confidence from this round of testing before merging this.