### PR TITLE
Fix QPager overload warnings

### DIFF
--- a/include/qpager.hpp
+++ b/include/qpager.hpp
@@ -244,7 +244,7 @@ public:
         return qPages[0]->ForceMParity(mask, result, doForce);
     }
 
-    virtual bool ApproxCompare(QInterfacePtr toCompare);
+    virtual bool ApproxCompare(QInterfacePtr toCompare, real1 error_tol = REAL1_EPSILON);
     virtual void UpdateRunningNorm(real1 norm_thresh = REAL1_DEFAULT_ARG);
     virtual void NormalizeState(real1 nrm = REAL1_DEFAULT_ARG, real1 norm_thresh = REAL1_DEFAULT_ARG) {
     } // TODO: skip implementation for now
@@ -267,7 +267,7 @@ public:
         return true;
     };
 
-    virtual bool TrySeparate(bitLenInt start, bitLenInt length = 1) { return false; }
+    virtual bool TrySeparate(bitLenInt start, bitLenInt length = 1, real1 error_tol = REAL1_EPSILON) { return false; }
 
     virtual QInterfacePtr Clone();
 

--- a/src/qpager.cpp
+++ b/src/qpager.cpp
@@ -1246,12 +1246,12 @@ real1 QPager::ProbMask(const bitCapInt& mask, const bitCapInt& permutation)
     return maskChance;
 }
 
-bool QPager::ApproxCompare(QInterfacePtr toCompare)
+bool QPager::ApproxCompare(QInterfacePtr toCompare, real1 error_tol)
 {
     QPagerPtr toComparePager = std::dynamic_pointer_cast<QPager>(toCompare);
     CombineEngines();
     toComparePager->CombineEngines();
-    bool toRet = qPages[0]->ApproxCompare(toComparePager->qPages[0]);
+    bool toRet = qPages[0]->ApproxCompare(toComparePager->qPages[0], error_tol);
     return toRet;
 }
 void QPager::UpdateRunningNorm(real1 norm_thresh)


### PR DESCRIPTION
This fixes QPager method overload warnings, on all supported mobile platforms