### PR TITLE
Remove unneeded doSkipBuffer conditional

### DIFF
--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -2526,7 +2526,7 @@ void QUnit::ApplyAntiControlledSinglePhase(const bitLenInt* cControls, const bit
         }
     }
 
-    if (!doSkipBuffer && !freezeBasis2Qb && (controlLen == 1U)) {
+    if (!freezeBasis2Qb && (controlLen == 1U)) {
         bitLenInt control = controls[0];
         QEngineShard& cShard = shards[control];
         QEngineShard& tShard = shards[target];


### PR DESCRIPTION
This condition was already removed from `ApplyControlledSinglePhase` counterpart, and it causes no problem with hybrid stabilizer simulation.