### PR TITLE
Optimize QUnit Clifford handling

### DIFF
--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -697,7 +697,6 @@ protected:
     bool freezeBasis2Qb;
     bool freezeClifford;
     bitLenInt thresholdQubits;
-    bool doSkipBuffer;
 
     QInterfacePtr MakeEngine(bitLenInt length, bitCapInt perm);
 

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -917,7 +917,6 @@ protected:
     virtual void YBase(const bitLenInt& target);
     virtual void ZBase(const bitLenInt& target);
     virtual real1 ProbBase(const bitLenInt& qubit);
-    virtual bool CheckCliffordSeparable(const bitLenInt& qubit);
     virtual bool TrySeparateCliffordBit(const bitLenInt& qubit);
 
     typedef void (QInterface::*INCxFn)(bitCapInt, bitLenInt, bitLenInt, bitLenInt);

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1016,14 +1016,19 @@ bool QUnit::ForceMParity(const bitCapInt& mask, bool result, bool doForce)
 void QUnit::SeparateBit(bool value, bitLenInt qubit, bool doDispose)
 {
     QInterfacePtr unit = shards[qubit].unit;
+
+    if (unit == NULL) {
+        return;
+    }
+
     bitLenInt mapped = shards[qubit].mapped;
 
     shards[qubit].unit = NULL;
     shards[qubit].mapped = 0;
     shards[qubit].isProbDirty = false;
     shards[qubit].isPhaseDirty = false;
-    shards[qubit].amp0 = value ? ZERO_CMPLX : ONE_CMPLX;
-    shards[qubit].amp1 = value ? ONE_CMPLX : ZERO_CMPLX;
+    shards[qubit].amp0 = value ? ZERO_CMPLX : GetNonunitaryPhase();
+    shards[qubit].amp1 = value ? GetNonunitaryPhase() : ZERO_CMPLX;
 
     if (!doDispose || !unit || (unit->GetQubitCount() == 1)) {
         return;

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -70,7 +70,6 @@ QUnit::QUnit(QInterfaceEngine eng, QInterfaceEngine subEng, bitLenInt qBitCount,
     , freezeBasis2Qb(false)
     , freezeClifford(false)
     , thresholdQubits(qubitThreshold)
-    , doSkipBuffer(engine == QINTERFACE_STABILIZER_HYBRID)
 {
     if ((engine == QINTERFACE_CPU) || (engine == QINTERFACE_OPENCL)) {
         subEngine = engine;
@@ -1605,11 +1604,7 @@ void QUnit::Z(bitLenInt target)
 
     if (shard.IsInvertTarget()) {
         RevertBasis1Qb(target);
-        if (doSkipBuffer) {
-            RevertBasis2Qb(target, ONLY_INVERT, ONLY_TARGETS);
-        } else {
-            shard.CommutePhase(ONE_CMPLX, -ONE_CMPLX);
-        }
+        shard.CommutePhase(ONE_CMPLX, -ONE_CMPLX);
     } else {
         if (UNSAFE_CACHED_ZERO(shard)) {
             Flush0Eigenstate(target);
@@ -2146,11 +2141,7 @@ void QUnit::ApplySinglePhase(const complex topLeft, const complex bottomRight, b
 
     if (shard.IsInvertTarget()) {
         RevertBasis1Qb(target);
-        if (doSkipBuffer) {
-            RevertBasis2Qb(target, ONLY_INVERT, ONLY_TARGETS);
-        } else {
-            shard.CommutePhase(topLeft, bottomRight);
-        }
+        shard.CommutePhase(topLeft, bottomRight);
     } else {
         if (IS_1_R1(topLeft) && UNSAFE_CACHED_ZERO(shard)) {
             Flush0Eigenstate(target);
@@ -2255,11 +2246,7 @@ void QUnit::ApplySingleInvert(const complex topRight, const complex bottomLeft, 
 
     if (shard.IsInvertTarget()) {
         RevertBasis1Qb(target);
-        if (doSkipBuffer) {
-            RevertBasis2Qb(target, ONLY_INVERT, ONLY_TARGETS);
-        } else {
-            shard.CommutePhase(bottomLeft, topRight);
-        }
+        shard.CommutePhase(bottomLeft, topRight);
     }
 
     shard.FlipPhaseAnti();

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1072,8 +1072,8 @@ bool QUnit::ForceM(bitLenInt qubit, bool res, bool doForce, bool doApply)
 
     shard.isProbDirty = false;
     shard.isPhaseDirty = false;
-    shard.amp0 = result ? ZERO_CMPLX : ONE_CMPLX;
-    shard.amp1 = result ? ONE_CMPLX : ZERO_CMPLX;
+    shard.amp0 = result ? ZERO_CMPLX : GetNonunitaryPhase();
+    shard.amp1 = result ? GetNonunitaryPhase() : ZERO_CMPLX;
 
     if (shard.GetQubitCount() == 1U) {
         shard.unit = NULL;


### PR DESCRIPTION
Certain "shunts" or "work-arounds" for Clifford "shards" under QUnit can now be removed entirely, due to previous improvements in QUnit with Clifford handling since they were added.