### PR TITLE
Swap map

### DIFF
--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -715,17 +715,15 @@ public:
 
     iterator end() { return (iterator)(&shards[swapMap.back()] + 1U); }
 
-    void insert(iterator position, QEngineShardMap& toInsert)
+    void insert(bitLenInt start, QEngineShardMap& toInsert)
     {
-        bitLenInt oSize = swapMap.size();
-        bitLenInt length = toInsert.size();
-        bitLenInt start = position - shards.begin();
+        bitLenInt oSize = size();
 
-        shards.insert(position, toInsert.shards.begin(), toInsert.shards.end());
-        swapMap.insert(swapMap.begin() + start, toInsert.swapMap.begin(), toInsert.swapMap.end());
+        shards.insert(shards.end(), toInsert.shards.begin(), toInsert.shards.end());
+        swapMap.insert(swapMap.end(), toInsert.swapMap.begin(), toInsert.swapMap.end());
 
-        for (bitLenInt i = 0; i < length; i++) {
-            swapMap[start + i] += oSize;
+        for (bitLenInt lcv = oSize; lcv < size(); lcv++) {
+            swapMap[lcv] += oSize;
         }
     }
 

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -737,7 +737,6 @@ public:
         for (iterator shard = begin; shard < end; shard++) {
             swapMapShard = swapMap.begin() + (shard - shards.begin());
             index = *swapMapShard;
-            swapMap.erase(swapMapShard);
 
             for (lcv = 0; lcv < swapMap.size(); lcv++) {
                 if (swapMap[lcv] > index) {
@@ -747,6 +746,7 @@ public:
         }
 
         shards.erase(begin, end);
+        swapMap.erase(swapMap.begin() + (begin - shards.begin()), swapMap.begin() + (end - shards.begin()));
     }
 
     void swap(bitLenInt qubit1, bitLenInt qubit2) { std::swap(swapMap[qubit1], swapMap[qubit2]); }

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -680,7 +680,7 @@ public:
 };
 
 class QEngineShardMap {
-private:
+protected:
     std::vector<QEngineShard> shards;
     std::vector<bitLenInt> swapMap;
 
@@ -715,17 +715,17 @@ public:
 
     iterator end() { return (iterator)(&shards[swapMap.back()] + 1U); }
 
-    void insert(iterator position, iterator begin, iterator end)
+    void insert(iterator position, QEngineShardMap& toInsert)
     {
         bitLenInt oSize = swapMap.size();
-        bitLenInt length = end - begin;
+        bitLenInt length = toInsert.size();
         bitLenInt start = position - shards.begin();
 
-        shards.insert(position, begin, end);
-        swapMap.insert(swapMap.begin() + start, length, 0);
+        shards.insert(position, toInsert.shards.begin(), toInsert.shards.end());
+        swapMap.insert(swapMap.begin() + start, toInsert.swapMap.begin(), toInsert.swapMap.end());
 
         for (bitLenInt i = 0; i < length; i++) {
-            swapMap[start + i] = oSize + i;
+            swapMap[start + i] += oSize;
         }
     }
 

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -720,10 +720,10 @@ public:
         bitLenInt oSize = size();
 
         shards.insert(shards.end(), toInsert.shards.begin(), toInsert.shards.end());
-        swapMap.insert(swapMap.end(), toInsert.swapMap.begin(), toInsert.swapMap.end());
+        swapMap.insert(swapMap.begin() + start, toInsert.swapMap.begin(), toInsert.swapMap.end());
 
-        for (bitLenInt lcv = oSize; lcv < size(); lcv++) {
-            swapMap[lcv] += oSize;
+        for (bitLenInt lcv = 0; lcv < toInsert.size(); lcv++) {
+            swapMap[start + lcv] += oSize;
         }
     }
 
@@ -736,7 +736,7 @@ public:
             shards.erase(shards.begin() + offset);
 
             for (lcv = 0; lcv < swapMap.size(); lcv++) {
-                if (swapMap[lcv] > offset) {
+                if (swapMap[lcv] >= offset) {
                     swapMap[lcv]--;
                 }
             }

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -733,21 +733,23 @@ public:
     {
         bitLenInt index, lcv;
         std::vector<bitLenInt>::iterator swapMapShard;
-        
+
         for (iterator shard = begin; shard < end; shard++) {
             swapMapShard = swapMap.begin() + (shard - shards.begin());
             index = *swapMapShard;
             swapMap.erase(swapMapShard);
-            
+
             for (lcv = 0; lcv < swapMap.size(); lcv++) {
                 if (swapMap[lcv] > index) {
                     swapMap[lcv]--;
                 }
             }
         }
-        
+
         shards.erase(begin, end);
     }
+
+    void swap(bitLenInt qubit1, bitLenInt qubit2) { std::swap(swapMap[qubit1], swapMap[qubit2]); }
 };
 
 class QUnit;

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -703,6 +703,10 @@ public:
 
     QEngineShard& operator[](const bitLenInt& i) { return shards[swapMap[i]]; }
 
+    iterator begin() { return shards.begin(); }
+
+    iterator end() { return shards.end(); }
+
     bitLenInt size() { return shards.size(); }
 
     void push_back(const QEngineShard& shard)
@@ -710,10 +714,6 @@ public:
         shards.push_back(shard);
         swapMap.push_back(swapMap.size());
     }
-
-    iterator begin() { return (iterator)&shards[swapMap.front()]; }
-
-    iterator end() { return (iterator)(&shards[swapMap.back()] + 1U); }
 
     void insert(bitLenInt start, QEngineShardMap& toInsert)
     {
@@ -727,24 +727,22 @@ public:
         }
     }
 
-    void erase(iterator begin, iterator end)
+    void erase(bitLenInt begin, bitLenInt end)
     {
-        bitLenInt index, lcv;
-        std::vector<bitLenInt>::iterator swapMapShard;
+        bitLenInt offset, lcv;
 
-        for (iterator shard = begin; shard < end; shard++) {
-            swapMapShard = swapMap.begin() + (shard - shards.begin());
-            index = *swapMapShard;
+        for (bitLenInt index = begin; index < end; index++) {
+            offset = swapMap[index];
+            shards.erase(shards.begin() + offset);
 
             for (lcv = 0; lcv < swapMap.size(); lcv++) {
-                if (swapMap[lcv] > index) {
+                if (swapMap[lcv] > offset) {
                     swapMap[lcv]--;
                 }
             }
         }
 
-        shards.erase(begin, end);
-        swapMap.erase(swapMap.begin() + (begin - shards.begin()), swapMap.begin() + (end - shards.begin()));
+        swapMap.erase(swapMap.begin() + begin, swapMap.begin() + end);
     }
 
     void swap(bitLenInt qubit1, bitLenInt qubit2) { std::swap(swapMap[qubit1], swapMap[qubit2]); }

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -2487,6 +2487,10 @@ void QEngineOCL::GetProbs(real1* outputProbs) { ProbRegAll(0, qubitCount, output
 
 real1 QEngineOCL::SumSqrDiff(QEngineOCLPtr toCompare)
 {
+    if (this == toCompare.get()) {
+        return ZERO_R1;
+    }
+
     // If the qubit counts are unequal, these can't be approximately equal objects.
     if (qubitCount != toCompare->qubitCount) {
         // Max square difference:

--- a/src/qengine/state.cpp
+++ b/src/qengine/state.cpp
@@ -1199,6 +1199,10 @@ bool QEngineCPU::ForceMParity(const bitCapInt& mask, bool result, bool doForce)
 
 real1 QEngineCPU::SumSqrDiff(QEngineCPUPtr toCompare)
 {
+    if (this == toCompare.get()) {
+        return ZERO_R1;
+    }
+
     // If the qubit counts are unequal, these can't be approximately equal objects.
     if (qubitCount != toCompare->qubitCount) {
         // Max square difference:
@@ -1231,6 +1235,11 @@ real1 QEngineCPU::SumSqrDiff(QEngineCPUPtr toCompare)
             basePhaseFac1 = (ONE_R1 / (real1)sqrt(nrm)) * stateVec->read(basePerm);
             break;
         }
+    }
+
+    if (basePerm == maxQPower) {
+        // Max square difference:
+        return 4.0f;
     }
 
     nrm = norm(toCompare->stateVec->read(basePerm));

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -371,7 +371,7 @@ void QUnit::Detach(bitLenInt start, bitLenInt length, QUnitPtr dest)
         }
     }
 
-    shards.erase(shards.begin() + start, shards.begin() + start + length);
+    shards.erase(start, start + length);
     SetQubitCount(qubitCount - length);
 }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -75,7 +75,7 @@ QUnit::QUnit(QInterfaceEngine eng, QInterfaceEngine subEng, bitLenInt qBitCount,
         subEngine = engine;
     }
 
-    shards.resize(qBitCount);
+    shards = QEngineShardMap(qBitCount);
 
     bool bitState;
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -3853,6 +3853,17 @@ real1 QUnit::SumSqrDiff(QUnitPtr toCompare)
         return norm(mAmps[0] - oAmps[0]) + norm(mAmps[1] - oAmps[1]);
     }
 
+    if (CheckBitsPermutation(0, qubitCount)) {
+        if (toCompare->CheckBitsPermutation(0, qubitCount) &&
+            (GetCachedPermutation((bitLenInt)0, qubitCount) ==
+                toCompare->GetCachedPermutation((bitLenInt)0, qubitCount))) {
+            return ZERO_R1;
+        }
+
+        // Necessarily max difference:
+        return 4.0f;
+    }
+
     QUnitPtr thisCopyShared, thatCopyShared;
     QUnit* thisCopy;
     QUnit* thatCopy;

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -75,13 +75,13 @@ QUnit::QUnit(QInterfaceEngine eng, QInterfaceEngine subEng, bitLenInt qBitCount,
         subEngine = engine;
     }
 
-    shards = QEngineShardMap(qBitCount);
+    shards = QEngineShardMap();
 
     bool bitState;
 
     for (bitLenInt i = 0; i < qubitCount; i++) {
         bitState = ((initState >> (bitCapIntOcl)i) & ONE_BCI) != 0;
-        shards[i] = QEngineShard(bitState, doNormalize ? amplitudeFloor : ZERO_R1, GetNonunitaryPhase());
+        shards.push_back(QEngineShard(bitState, doNormalize ? amplitudeFloor : ZERO_R1, GetNonunitaryPhase()));
     }
 }
 
@@ -97,9 +97,11 @@ void QUnit::SetPermutation(bitCapInt perm, complex phaseFac)
 
     Dump();
 
+    shards = QEngineShardMap();
+
     for (bitLenInt i = 0; i < qubitCount; i++) {
         bitState = ((perm >> (bitCapIntOcl)i) & ONE_BCI) != 0;
-        shards[i] = QEngineShard(bitState, doNormalize ? amplitudeFloor : ZERO_R1, GetNonunitaryPhase());
+        shards.push_back(QEngineShard(bitState, doNormalize ? amplitudeFloor : ZERO_R1, GetNonunitaryPhase()));
     }
 }
 
@@ -3820,6 +3822,10 @@ bool QUnit::isFinished()
 
 real1 QUnit::SumSqrDiff(QUnitPtr toCompare)
 {
+    if (this == toCompare.get()) {
+        return ZERO_R1;
+    }
+
     // If the qubit counts are unequal, these can't be approximately equal objects.
     if (qubitCount != toCompare->qubitCount) {
         // Max square difference:

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -253,7 +253,7 @@ bitLenInt QUnit::Compose(QUnitPtr toCopy, bitLenInt start)
     QUnitPtr clone = std::dynamic_pointer_cast<QUnit>(toCopy->Clone());
 
     /* Insert the new shards in the middle */
-    shards.insert(shards.begin() + start, clone->shards.begin(), clone->shards.end());
+    shards.insert(shards.begin() + start, clone->shards);
 
     SetQubitCount(qubitCount + toCopy->GetQubitCount());
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1173,26 +1173,8 @@ void QUnit::Swap(bitLenInt qubit1, bitLenInt qubit2)
         return;
     }
 
-    RevertBasis2Qb(qubit1, ONLY_INVERT);
-    RevertBasis2Qb(qubit2, ONLY_INVERT);
-
-    QEngineShard& shard1 = shards[qubit1];
-    QEngineShard& shard2 = shards[qubit2];
-
-    if (UNSAFE_CACHED_CLASSICAL(shard1) && UNSAFE_CACHED_CLASSICAL(shard2)) {
-        // We can avoid dirtying the cache and entangling, since the bits are classical.
-        if (SHARD_STATE(shard1) != SHARD_STATE(shard2)) {
-            X(qubit1);
-            X(qubit2);
-        }
-        return;
-    }
-
-    RevertBasis2Qb(qubit1);
-    RevertBasis2Qb(qubit2);
-
     // Simply swap the bit mapping.
-    std::swap(shards[qubit1], shards[qubit2]);
+    shards.swap(qubit1, qubit2);
 
     QInterfacePtr unit = shards[qubit1].unit;
     if (unit && (unit == shards[qubit2].unit)) {

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -253,7 +253,7 @@ bitLenInt QUnit::Compose(QUnitPtr toCopy, bitLenInt start)
     QUnitPtr clone = std::dynamic_pointer_cast<QUnit>(toCopy->Clone());
 
     /* Insert the new shards in the middle */
-    shards.insert(shards.begin() + start, clone->shards);
+    shards.insert(start, clone->shards);
 
     SetQubitCount(qubitCount + toCopy->GetQubitCount());
 


### PR DESCRIPTION
We noticed a long time ago that the quantum `Swap` gate was equivalent to simply switching bit labels, in QUnit a long time ago. When I added controlled phase and inversion buffering to QUnit, I let this optimization partially drop, because it was difficult to make play nicely with those pointers, and the buffers made a bigger difference in speed. However, there's no reason not to use both, ultimately. All this requires, in this case, is a second layer of mapping, but it's exactly the same concept as it was originally, still back in the commit history.