### PR TITLE
QUnit buffer optimization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,8 @@ script:
 #  - cd build && python -m pytest . && cd ..
   - git clone https://github.com/vm6502q/qiskit-qrack-provider.git && cd qiskit-qrack-provider
   - python -m pip install .
-  - python -m stestr run && cd ..
+# Deprecation warnings exceed log length, so direct output to /dev/null
+  - python -m stestr run > /dev/null 2>&1 && cd ..
 #  - cd .. && git clone https://github.com/XanaduAI/pennylane-pq.git && cd pennylane-pq
 #  - python -m pip install .
 #  - python -m pytest .

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ install:
   - sudo apt-get update
   - sudo apt-get install linuxdoc-tools linuxdoc-tools-info binutils-mingw-w64-i686 gcc-mingw-w64-i686 sshpass cmake
   - python -m pip install --upgrade pip numpy setuptools wheel
-  - python -m pip install cvxpy cython ddt stestr qiskit pennylane
+  - python -m pip install cvxpy cython ddt stestr qiskit=0.23.3 pennylane
 script:
   - mkdir _build && cd _build && cmake -DENABLE_OPENCL=OFF -DENABLE_COMPLEX8=OFF .. && make -j 8 all
   - sudo make install
@@ -20,8 +20,7 @@ script:
 #  - cd build && python -m pytest . && cd ..
   - git clone https://github.com/vm6502q/qiskit-qrack-provider.git && cd qiskit-qrack-provider
   - python -m pip install .
-# Deprecation warnings exceed log length, so direct output to /dev/null
-  - python -m stestr run > /dev/null 2>&1 && cd ..
+  - python -m stestr run && cd ..
 #  - cd .. && git clone https://github.com/XanaduAI/pennylane-pq.git && cd pennylane-pq
 #  - python -m pip install .
 #  - python -m pytest .

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ install:
   - sudo apt-get update
   - sudo apt-get install linuxdoc-tools linuxdoc-tools-info binutils-mingw-w64-i686 gcc-mingw-w64-i686 sshpass cmake
   - python -m pip install --upgrade pip numpy setuptools wheel
-  - python -m pip install cvxpy cython ddt stestr qiskit=0.23.3 pennylane
+  - python -m pip install cvxpy cython ddt stestr qiskit==0.23.3 pennylane
 script:
   - mkdir _build && cd _build && cmake -DENABLE_OPENCL=OFF -DENABLE_COMPLEX8=OFF .. && make -j 8 all
   - sudo make install

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ script:
 #  - cd build && python -m pytest . && cd ..
   - git clone https://github.com/vm6502q/qiskit-qrack-provider.git && cd qiskit-qrack-provider
   - python -m pip install .
-# Warnings exceed max log length, so shunt to /dev/null for now
+# Warnings exceed max log length, so shunt to /dev/null for now.
   - python -m stestr run > /dev/null 2>&1 && cd ..
 #  - cd .. && git clone https://github.com/XanaduAI/pennylane-pq.git && cd pennylane-pq
 #  - python -m pip install .

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ install:
   - sudo apt-get update
   - sudo apt-get install linuxdoc-tools linuxdoc-tools-info binutils-mingw-w64-i686 gcc-mingw-w64-i686 sshpass cmake
   - python -m pip install --upgrade pip numpy setuptools wheel
-  - python -m pip install cvxpy cython ddt stestr qiskit==0.23.3 pennylane
+  - python -m pip install cvxpy cython ddt stestr qiskit==0.23.2 pennylane
 script:
   - mkdir _build && cd _build && cmake -DENABLE_OPENCL=OFF -DENABLE_COMPLEX8=OFF .. && make -j 8 all
   - sudo make install
@@ -20,7 +20,8 @@ script:
 #  - cd build && python -m pytest . && cd ..
   - git clone https://github.com/vm6502q/qiskit-qrack-provider.git && cd qiskit-qrack-provider
   - python -m pip install .
-  - python -m stestr run && cd ..
+# Warnings exceed max log length, so shunt to /dev/null for now
+  - python -m stestr run > /dev/null 2>&1 && cd ..
 #  - cd .. && git clone https://github.com/XanaduAI/pennylane-pq.git && cd pennylane-pq
 #  - python -m pip install .
 #  - python -m pytest .

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -541,6 +541,8 @@ protected:
     }
 
     void CommuteH(const bitLenInt& bitIndex);
+
+    void OptimizePairBuffers(const bitLenInt& control, const bitLenInt& target, const bool& anti);
 };
 
 } // namespace Qrack

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -4163,7 +4163,7 @@ void QUnit::OptimizePairBuffers(const bitLenInt& control, const bitLenInt& targe
 
     PhaseShardPtr aBuffer = antiShard->second;
 
-    if (IS_NORM_0(buffer->cmplxDiff - aBuffer->cmplxDiff) && IS_NORM_0(buffer->cmplxSame - aBuffer->cmplxSame)) {
+    if (IS_NORM_0(buffer->cmplxDiff - aBuffer->cmplxSame) && IS_NORM_0(buffer->cmplxSame - aBuffer->cmplxDiff)) {
         ApplySinglePhase(buffer->cmplxDiff, buffer->cmplxSame, target);
         tShard.RemovePhaseControl(&cShard);
         tShard.RemovePhaseAntiControl(&cShard);

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1755,7 +1755,9 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
         if (!isSameUnit) {
             tShard.AddInversionAngles(&cShard, ONE_CMPLX, ONE_CMPLX);
 
-            OptimizePairBuffers(control, target, false);
+            if (isInvert) {
+                OptimizePairBuffers(control, target, false);
+            }
 
             return;
         }
@@ -1979,7 +1981,9 @@ void QUnit::CZ(bitLenInt control, bitLenInt target)
         if (!isSameUnit) {
             tShard.AddPhaseAngles(&cShard, ONE_CMPLX, -ONE_CMPLX);
 
-            OptimizePairBuffers(control, target, false);
+            if (isInvert) {
+                OptimizePairBuffers(control, target, false);
+            }
 
             return;
         }

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1736,8 +1736,6 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
     bool pmBasis = (cShard.isPauliX && tShard.isPauliX && !QUEUED_PHASE(cShard) && !QUEUED_PHASE(tShard));
 
     if (!freezeBasis2Qb && !pmBasis) {
-        bool isSameUnit = IS_SAME_UNIT(cShard, tShard);
-
         RevertBasis2Qb(control, ONLY_INVERT, ONLY_TARGETS);
 
         bool isInvert = cShard.IsInvertControlOf(&tShard);
@@ -1745,6 +1743,7 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
             RevertBasis1Qb(target);
         }
 
+        bool isSameUnit = IS_SAME_UNIT(cShard, tShard);
         std::set<bitLenInt> except;
         if (!isSameUnit) {
             except.insert(control);
@@ -1812,16 +1811,16 @@ void QUnit::AntiCNOT(bitLenInt control, bitLenInt target)
     bitLenInt controlLen = 1;
 
     if (!freezeBasis2Qb) {
-        bool isSameUnit = IS_SAME_UNIT(cShard, tShard);
         RevertBasis2Qb(control, ONLY_INVERT, ONLY_TARGETS);
         RevertBasis2Qb(target, ONLY_PHASE, CONTROLS_AND_TARGETS);
 
+        bool isSameUnit = IS_SAME_UNIT(cShard, tShard);
         std::set<bitLenInt> except;
         if (!isSameUnit) {
             except.insert(control);
         }
 
-        RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI, {}, except);
+        RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI, except, except);
 
         if (!isSameUnit) {
             shards[target].AddAntiInversionAngles(&(shards[control]), ONE_CMPLX, ONE_CMPLX);
@@ -1962,8 +1961,6 @@ void QUnit::CZ(bitLenInt control, bitLenInt target)
     }
 
     if (!freezeBasis2Qb) {
-        bool isSameUnit = IS_SAME_UNIT(cShard, tShard);
-
         RevertBasis2Qb(control, ONLY_INVERT, ONLY_TARGETS);
 
         bool isInvert = cShard.IsInvertControlOf(&tShard);
@@ -1971,6 +1968,7 @@ void QUnit::CZ(bitLenInt control, bitLenInt target)
             RevertBasis1Qb(target);
         }
 
+        bool isSameUnit = IS_SAME_UNIT(cShard, tShard);
         std::set<bitLenInt> except;
         if (!isSameUnit) {
             except.insert(control);
@@ -2325,9 +2323,16 @@ void QUnit::ApplyControlledSinglePhase(const bitLenInt* cControls, const bitLenI
 
         RevertBasis2Qb(control, ONLY_INVERT, ONLY_TARGETS);
 
-        RevertBasis2Qb(target, ONLY_INVERT, IS_1_CMPLX(topLeft) ? ONLY_TARGETS : CONTROLS_AND_TARGETS, CTRL_AND_ANTI);
+        bool isSameUnit = IS_SAME_UNIT(cShard, tShard);
+        std::set<bitLenInt> except;
+        if (!isSameUnit) {
+            except.insert(control);
+        }
 
-        if (!IS_SAME_UNIT(cShard, tShard)) {
+        RevertBasis2Qb(target, ONLY_INVERT, IS_1_CMPLX(topLeft) ? ONLY_TARGETS : CONTROLS_AND_TARGETS, CTRL_AND_ANTI,
+            except, except);
+
+        if (!isSameUnit) {
             delete[] controls;
             tShard.AddPhaseAngles(&cShard, topLeft, bottomRight);
 
@@ -2421,10 +2426,16 @@ void QUnit::ApplyAntiControlledSinglePhase(const bitLenInt* cControls, const bit
 
         RevertBasis2Qb(control, ONLY_INVERT, ONLY_TARGETS);
 
-        RevertBasis2Qb(
-            target, ONLY_INVERT, IS_1_CMPLX(bottomRight) ? ONLY_TARGETS : CONTROLS_AND_TARGETS, CTRL_AND_ANTI);
+        bool isSameUnit = IS_SAME_UNIT(cShard, tShard);
+        std::set<bitLenInt> except;
+        if (!isSameUnit) {
+            except.insert(control);
+        }
 
-        if (!IS_SAME_UNIT(cShard, tShard)) {
+        RevertBasis2Qb(target, ONLY_INVERT, IS_1_CMPLX(bottomRight) ? ONLY_TARGETS : CONTROLS_AND_TARGETS,
+            CTRL_AND_ANTI, except, except);
+
+        if (!isSameUnit) {
             delete[] controls;
             tShard.AddAntiPhaseAngles(&cShard, bottomRight, topLeft);
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1755,10 +1755,6 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
         if (!isSameUnit) {
             tShard.AddInversionAngles(&cShard, ONE_CMPLX, ONE_CMPLX);
 
-            if (!isInvert) {
-                return;
-            }
-
             OptimizePairBuffers(control, target, false);
 
             return;
@@ -1982,10 +1978,6 @@ void QUnit::CZ(bitLenInt control, bitLenInt target)
 
         if (!isSameUnit) {
             tShard.AddPhaseAngles(&cShard, ONE_CMPLX, -ONE_CMPLX);
-
-            if (isInvert) {
-                return;
-            }
 
             OptimizePairBuffers(control, target, false);
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -37,15 +37,15 @@
 #define QUEUED_PHASE(shard)                                                                                            \
     ((shard.targetOfShards.size() != 0) || (shard.controlsShards.size() != 0) ||                                       \
         (shard.antiTargetOfShards.size() != 0) || (shard.antiControlsShards.size() != 0))
-#define CACHED_PROB(shard) (!shard.isProbDirty && !shard.isPauliX && !shard.isPauliY && !QUEUED_PHASE(shard))
-#define CACHED_Z(shard) (CACHED_PROB(shard) && (IS_NORM_0(shard.amp0) || IS_NORM_0(shard.amp1)))
-#define CACHED_ONE(shard) (CACHED_PROB(shard) && IS_NORM_0(shard.amp0))
-#define CACHED_ZERO(shard) (CACHED_PROB(shard) && IS_NORM_0(shard.amp1))
+#define CACHED_Z(shard) (!shard.isPauliX && !shard.isPauliY && !DIRTY(shard) && !QUEUED_PHASE(shard))
+#define CACHED_ZERO_OR_ONE(shard) (CACHED_Z(shard) && (IS_NORM_0(shard.amp0) || IS_NORM_0(shard.amp1)))
+#define CACHED_ZERO(shard) (CACHED_Z(shard) && IS_NORM_0(shard.amp1))
+#define CACHED_ONE(shard) (CACHED_Z(shard) && IS_NORM_0(shard.amp0))
 #define CACHED_X(shard) (shard.isPauliX && !DIRTY(shard) && !QUEUED_PHASE(shard))
+#define CACHED_PLUS_OR_MINUS(shard) (CACHED_X(shard) && (IS_NORM_0(shard.amp0) || IS_NORM_0(shard.amp1)))
 #define CACHED_PLUS(shard) (CACHED_X(shard) && IS_NORM_0(shard.amp1))
-#define CACHED_Y(shard) (shard.isPauliY && !DIRTY(shard) && !QUEUED_PHASE(shard))
 /* "UNSAFE" variants here do not check whether the bit is in |0>/|1> rather than |+>/|-> basis. */
-#define UNSAFE_CACHED_Z(shard)                                                                                         \
+#define UNSAFE_CACHED_ZERO_OR_ONE(shard)                                                                               \
     (!shard.isProbDirty && !shard.isPauliX && !shard.isPauliY && (IS_NORM_0(shard.amp0) || IS_NORM_0(shard.amp1)))
 #define UNSAFE_CACHED_X(shard)                                                                                         \
     (!shard.isProbDirty && shard.isPauliX && !shard.isPauliY && (IS_NORM_0(shard.amp0) || IS_NORM_0(shard.amp1)))
@@ -698,7 +698,7 @@ bool QUnit::CheckBitPermutation(const bitLenInt& qubitIndex, const bool& inCurre
         ToPermBasis(qubitIndex);
     }
     QEngineShard& shard = shards[qubitIndex];
-    if (UNSAFE_CACHED_Z(shard)) {
+    if (UNSAFE_CACHED_ZERO_OR_ONE(shard)) {
         return true;
     } else {
         return false;
@@ -929,15 +929,8 @@ real1 QUnit::ProbParity(const bitCapInt& mask)
     real1 oddChance = ZERO_R1;
     real1 nOddChance;
     for (bitLenInt i = 0; i < qIndices.size(); i++) {
-        QEngineShard& shard = shards[qIndices[i]];
-
-        if (CACHED_X(shard) || CACHED_Y(shard)) {
-            nOddChance = ONE_R1 / 2;
-            oddChance = (oddChance * (ONE_R1 - nOddChance)) + ((ONE_R1 - oddChance) * nOddChance);
-            continue;
-        }
-
         ToPermBasis(qIndices[i]);
+        QEngineShard& shard = shards[qIndices[i]];
         if (!(shard.unit)) {
             nOddChance = shard.Prob();
             oddChance = (oddChance * (ONE_R1 - nOddChance)) + ((ONE_R1 - oddChance) * nOddChance);
@@ -1204,7 +1197,7 @@ void QUnit::ISwap(bitLenInt qubit1, bitLenInt qubit2)
     QEngineShard& shard1 = shards[qubit1];
     QEngineShard& shard2 = shards[qubit2];
 
-    if (UNSAFE_CACHED_Z(shard1) && UNSAFE_CACHED_Z(shard2)) {
+    if (UNSAFE_CACHED_ZERO_OR_ONE(shard1) && UNSAFE_CACHED_ZERO_OR_ONE(shard2)) {
         // We can avoid dirtying the cache and entangling, since the bits are classical.
         if (SHARD_STATE(shard1) != SHARD_STATE(shard2)) {
             XBase(qubit1);
@@ -1239,7 +1232,8 @@ void QUnit::SqrtSwap(bitLenInt qubit1, bitLenInt qubit2)
     QEngineShard& shard1 = shards[qubit1];
     QEngineShard& shard2 = shards[qubit2];
 
-    if (UNSAFE_CACHED_Z(shard1) && UNSAFE_CACHED_Z(shard2) && (SHARD_STATE(shard1) == SHARD_STATE(shard2))) {
+    if (UNSAFE_CACHED_ZERO_OR_ONE(shard1) && UNSAFE_CACHED_ZERO_OR_ONE(shard2) &&
+        (SHARD_STATE(shard1) == SHARD_STATE(shard2))) {
         // We can avoid dirtying the cache and entangling, since this gate doesn't swap identical classical bits.
         return;
     }
@@ -1265,7 +1259,8 @@ void QUnit::ISqrtSwap(bitLenInt qubit1, bitLenInt qubit2)
     QEngineShard& shard1 = shards[qubit1];
     QEngineShard& shard2 = shards[qubit2];
 
-    if (UNSAFE_CACHED_Z(shard1) && UNSAFE_CACHED_Z(shard2) && (SHARD_STATE(shard1) == SHARD_STATE(shard2))) {
+    if (UNSAFE_CACHED_ZERO_OR_ONE(shard1) && UNSAFE_CACHED_ZERO_OR_ONE(shard2) &&
+        (SHARD_STATE(shard1) == SHARD_STATE(shard2))) {
         // We can avoid dirtying the cache and entangling, since this gate doesn't swap identical classical bits.
         return;
     }
@@ -1303,7 +1298,8 @@ void QUnit::FSim(real1 theta, real1 phi, bitLenInt qubit1, bitLenInt qubit2)
     QEngineShard& shard1 = shards[qubit1];
     QEngineShard& shard2 = shards[qubit2];
 
-    if (UNSAFE_CACHED_Z(shard1) && UNSAFE_CACHED_Z(shard2) && (SHARD_STATE(shard1) == SHARD_STATE(shard2))) {
+    if (UNSAFE_CACHED_ZERO_OR_ONE(shard1) && UNSAFE_CACHED_ZERO_OR_ONE(shard2) &&
+        (SHARD_STATE(shard1) == SHARD_STATE(shard2))) {
         // We can avoid dirtying the cache and entangling, since this gate doesn't swap identical classical bits.
         if (SHARD_STATE(shard1)) {
             ApplyControlledSinglePhase(controls, 1, qubit2, ONE_CMPLX, exp(complex(ZERO_R1, phi)));
@@ -1389,7 +1385,7 @@ void QUnit::CUniformParityRZ(
     for (bitLenInt i = 0; i < controlLen; i++) {
         QEngineShard& shard = shards[cControls[i]];
 
-        if (!CACHED_PROB(shard)) {
+        if (!CACHED_Z(shard)) {
             // Control becomes entangled
             controls.push_back(cControls[i]);
             continue;
@@ -1723,7 +1719,7 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
 
     QEngineShard& cShard = shards[control];
 
-    if (!cShard.IsInvertTarget() && UNSAFE_CACHED_Z(cShard)) {
+    if (!cShard.IsInvertTarget() && UNSAFE_CACHED_ZERO_OR_ONE(cShard)) {
         if (IS_NORM_0(cShard.amp1)) {
             Flush0Eigenstate(control);
             return;
@@ -1813,7 +1809,7 @@ void QUnit::AntiCNOT(bitLenInt control, bitLenInt target)
     }
 
     QEngineShard& cShard = shards[control];
-    if (!cShard.IsInvertTarget() && UNSAFE_CACHED_Z(cShard)) {
+    if (!cShard.IsInvertTarget() && UNSAFE_CACHED_ZERO_OR_ONE(cShard)) {
         if (IS_NORM_0(cShard.amp1)) {
             Flush0Eigenstate(control);
             X(target);
@@ -1861,7 +1857,7 @@ void QUnit::CCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target)
     QEngineShard& c2Shard = shards[control2];
 
     if (!c1Shard.IsInvertTarget()) {
-        if (UNSAFE_CACHED_Z(c1Shard)) {
+        if (UNSAFE_CACHED_ZERO_OR_ONE(c1Shard)) {
             if (IS_NORM_0(c1Shard.amp1)) {
                 Flush0Eigenstate(control1);
                 return;
@@ -1875,7 +1871,7 @@ void QUnit::CCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target)
     }
 
     if (!c2Shard.IsInvertTarget()) {
-        if (UNSAFE_CACHED_Z(c2Shard)) {
+        if (UNSAFE_CACHED_ZERO_OR_ONE(c2Shard)) {
             if (IS_NORM_0(c2Shard.amp1)) {
                 Flush0Eigenstate(control2);
                 return;
@@ -1958,7 +1954,7 @@ void QUnit::CZ(bitLenInt control, bitLenInt target)
     QEngineShard& tShard = shards[target];
     QEngineShard& cShard = shards[control];
 
-    if (!tShard.IsInvertTarget() && UNSAFE_CACHED_Z(tShard)) {
+    if (!tShard.IsInvertTarget() && UNSAFE_CACHED_ZERO_OR_ONE(tShard)) {
         if (SHARD_STATE(tShard)) {
             Flush1Eigenstate(target);
             Z(control);
@@ -1968,7 +1964,7 @@ void QUnit::CZ(bitLenInt control, bitLenInt target)
         return;
     }
 
-    if (!cShard.IsInvertTarget() && UNSAFE_CACHED_Z(cShard)) {
+    if (!cShard.IsInvertTarget() && UNSAFE_CACHED_ZERO_OR_ONE(cShard)) {
         if (SHARD_STATE(cShard)) {
             Flush1Eigenstate(control);
             Z(target);
@@ -2013,6 +2009,22 @@ void QUnit::CZ(bitLenInt control, bitLenInt target)
             if (IS_NORM_0(buffer->cmplxDiff - buffer->cmplxSame)) {
                 ApplyBuffer(buffer, control, target, false);
                 tShard.RemovePhaseControl(&cShard);
+                return;
+            }
+
+            ShardToPhaseMap::iterator antiShard = tShard.antiTargetOfShards.find(&cShard);
+
+            if (antiShard == tShard.antiTargetOfShards.end()) {
+                return;
+            }
+
+            PhaseShardPtr aBuffer = antiShard->second;
+
+            if (IS_NORM_0(buffer->cmplxDiff - aBuffer->cmplxDiff) &&
+                IS_NORM_0(buffer->cmplxSame - aBuffer->cmplxSame)) {
+                ApplySinglePhase(buffer->cmplxDiff, buffer->cmplxSame, target);
+                tShard.RemovePhaseControl(&cShard);
+                tShard.RemovePhaseAntiControl(&cShard);
             }
 
             return;
@@ -2052,7 +2064,7 @@ void QUnit::CCZ(bitLenInt control1, bitLenInt control2, bitLenInt target)
     QEngineShard& c2Shard = shards[control2];
 
     if (!c1Shard.IsInvertTarget()) {
-        if (UNSAFE_CACHED_Z(c1Shard)) {
+        if (UNSAFE_CACHED_ZERO_OR_ONE(c1Shard)) {
             if (IS_NORM_0(c1Shard.amp1)) {
                 Flush0Eigenstate(control1);
                 return;
@@ -2066,7 +2078,7 @@ void QUnit::CCZ(bitLenInt control1, bitLenInt control2, bitLenInt target)
     }
 
     if (!c2Shard.IsInvertTarget()) {
-        if (UNSAFE_CACHED_Z(c2Shard)) {
+        if (UNSAFE_CACHED_ZERO_OR_ONE(c2Shard)) {
             if (IS_NORM_0(c2Shard.amp1)) {
                 Flush0Eigenstate(control2);
                 return;
@@ -2080,7 +2092,7 @@ void QUnit::CCZ(bitLenInt control1, bitLenInt control2, bitLenInt target)
     }
 
     if (!tShard.IsInvertTarget()) {
-        if (UNSAFE_CACHED_Z(tShard)) {
+        if (UNSAFE_CACHED_ZERO_OR_ONE(tShard)) {
             if (IS_NORM_0(tShard.amp1)) {
                 Flush0Eigenstate(target);
                 return;
@@ -2341,7 +2353,7 @@ void QUnit::ApplyControlledSinglePhase(const bitLenInt* cControls, const bitLenI
         bitLenInt control = controls[0];
         QEngineShard& cShard = shards[control];
         QEngineShard& tShard = shards[target];
-        if (!cShard.IsInvertTarget() && UNSAFE_CACHED_Z(cShard)) {
+        if (!cShard.IsInvertTarget() && UNSAFE_CACHED_ZERO_OR_ONE(cShard)) {
             if (SHARD_STATE(cShard)) {
                 Flush1Eigenstate(control);
                 ApplySinglePhase(topLeft, bottomRight, target);
@@ -2449,7 +2461,7 @@ void QUnit::ApplyAntiControlledSinglePhase(const bitLenInt* cControls, const bit
         bitLenInt control = controls[0];
         QEngineShard& cShard = shards[control];
         QEngineShard& tShard = shards[target];
-        if (!cShard.IsInvertTarget() && UNSAFE_CACHED_Z(cShard)) {
+        if (!cShard.IsInvertTarget() && UNSAFE_CACHED_ZERO_OR_ONE(cShard)) {
             if (SHARD_STATE(cShard)) {
                 Flush1Eigenstate(control);
             } else {

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1750,7 +1750,7 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
             except.insert(control);
         }
 
-        RevertBasis2Qb(target, INVERT_AND_PHASE, CONTROLS_AND_TARGETS, CTRL_AND_ANTI, {}, except);
+        RevertBasis2Qb(target, INVERT_AND_PHASE, CONTROLS_AND_TARGETS, CTRL_AND_ANTI, except, except);
 
         if (!isSameUnit) {
             tShard.AddInversionAngles(&cShard, ONE_CMPLX, ONE_CMPLX);
@@ -1976,7 +1976,7 @@ void QUnit::CZ(bitLenInt control, bitLenInt target)
             except.insert(control);
         }
 
-        RevertBasis2Qb(target, ONLY_INVERT, ONLY_TARGETS, CTRL_AND_ANTI, {}, except);
+        RevertBasis2Qb(target, ONLY_INVERT, ONLY_TARGETS, CTRL_AND_ANTI, except, except);
 
         if (!isSameUnit) {
             tShard.AddPhaseAngles(&cShard, ONE_CMPLX, -ONE_CMPLX);


### PR DESCRIPTION
I've found a few more cases in which QUnit 2-qubit buffer flushes can be avoided, and another set of cases in which buffers can be combined to result in overall single bit gate application. This might give a little improvement on `test_ccz_ccx_h`, among other benchmarks.