### PR TITLE
More QUnit Buffer optimization

### DIFF
--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1736,27 +1736,19 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
     bool pmBasis = (cShard.isPauliX && tShard.isPauliX && !QUEUED_PHASE(cShard) && !QUEUED_PHASE(tShard));
 
     if (!freezeBasis2Qb && !pmBasis) {
-        RevertBasis2Qb(control, ONLY_INVERT, ONLY_TARGETS);
-
-        bool isInvert = cShard.IsInvertControlOf(&tShard);
-        if (isInvert) {
-            RevertBasis1Qb(target);
-        }
-
         bool isSameUnit = IS_SAME_UNIT(cShard, tShard);
         std::set<bitLenInt> except;
         if (!isSameUnit) {
             except.insert(control);
         }
 
+        RevertBasis2Qb(control, ONLY_INVERT, ONLY_TARGETS, CTRL_AND_ANTI, except, except);
         RevertBasis2Qb(target, INVERT_AND_PHASE, CONTROLS_AND_TARGETS, CTRL_AND_ANTI, except, except);
 
         if (!isSameUnit) {
             tShard.AddInversionAngles(&cShard, ONE_CMPLX, ONE_CMPLX);
 
-            if (isInvert) {
-                OptimizePairBuffers(control, target, false);
-            }
+            OptimizePairBuffers(control, target, false);
 
             return;
         }
@@ -1961,27 +1953,19 @@ void QUnit::CZ(bitLenInt control, bitLenInt target)
     }
 
     if (!freezeBasis2Qb) {
-        RevertBasis2Qb(control, ONLY_INVERT, ONLY_TARGETS);
-
-        bool isInvert = cShard.IsInvertControlOf(&tShard);
-        if (isInvert) {
-            RevertBasis1Qb(target);
-        }
-
         bool isSameUnit = IS_SAME_UNIT(cShard, tShard);
         std::set<bitLenInt> except;
         if (!isSameUnit) {
             except.insert(control);
         }
 
+        RevertBasis2Qb(control, ONLY_INVERT, ONLY_TARGETS, CTRL_AND_ANTI, except, except);
         RevertBasis2Qb(target, ONLY_INVERT, ONLY_TARGETS, CTRL_AND_ANTI, except, except);
 
         if (!isSameUnit) {
             tShard.AddPhaseAngles(&cShard, ONE_CMPLX, -ONE_CMPLX);
 
-            if (isInvert) {
-                OptimizePairBuffers(control, target, false);
-            }
+            OptimizePairBuffers(control, target, false);
 
             return;
         }
@@ -2321,14 +2305,13 @@ void QUnit::ApplyControlledSinglePhase(const bitLenInt* cControls, const bitLenI
             return;
         }
 
-        RevertBasis2Qb(control, ONLY_INVERT, ONLY_TARGETS);
-
         bool isSameUnit = IS_SAME_UNIT(cShard, tShard);
         std::set<bitLenInt> except;
         if (!isSameUnit) {
             except.insert(control);
         }
 
+        RevertBasis2Qb(control, ONLY_INVERT, ONLY_TARGETS, CTRL_AND_ANTI, except, except);
         RevertBasis2Qb(target, ONLY_INVERT, IS_1_CMPLX(topLeft) ? ONLY_TARGETS : CONTROLS_AND_TARGETS, CTRL_AND_ANTI,
             except, except);
 
@@ -2424,14 +2407,13 @@ void QUnit::ApplyAntiControlledSinglePhase(const bitLenInt* cControls, const bit
             return;
         }
 
-        RevertBasis2Qb(control, ONLY_INVERT, ONLY_TARGETS);
-
         bool isSameUnit = IS_SAME_UNIT(cShard, tShard);
         std::set<bitLenInt> except;
         if (!isSameUnit) {
             except.insert(control);
         }
 
+        RevertBasis2Qb(control, ONLY_INVERT, ONLY_TARGETS, CTRL_AND_ANTI, except, except);
         RevertBasis2Qb(target, ONLY_INVERT, IS_1_CMPLX(bottomRight) ? ONLY_TARGETS : CONTROLS_AND_TARGETS,
             CTRL_AND_ANTI, except, except);
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -4149,11 +4149,7 @@ void QUnit::OptimizePairBuffers(const bitLenInt& control, const bitLenInt& targe
     PhaseShardPtr aBuffer = antiShard->second;
 
     if (IS_NORM_0(buffer->cmplxDiff - aBuffer->cmplxSame) && IS_NORM_0(buffer->cmplxSame - aBuffer->cmplxDiff)) {
-        if (phaseShard->second->isInvert) {
-            ApplySingleInvert(buffer->cmplxDiff, buffer->cmplxSame, target);
-        } else {
-            ApplySinglePhase(buffer->cmplxDiff, buffer->cmplxSame, target);
-        }
+        ApplySinglePhase(buffer->cmplxDiff, buffer->cmplxSame, target);
         tShard.RemovePhaseControl(&cShard);
         tShard.RemovePhaseAntiControl(&cShard);
     }

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -4090,8 +4090,8 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
         }
 
         control = FindShardIndex(partner);
-        ApplyBuffer(buffer, control, bitIndex, false);
         shard.RemovePhaseControl(partner);
+        ApplyBuffer(buffer, control, bitIndex, false);
     }
 
     targetOfShards = shard.antiTargetOfShards;
@@ -4114,8 +4114,8 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
         }
 
         control = FindShardIndex(partner);
-        ApplyBuffer(buffer, control, bitIndex, true);
         shard.RemovePhaseAntiControl(partner);
+        ApplyBuffer(buffer, control, bitIndex, true);
     }
 
     shard.CommuteH();
@@ -4135,8 +4135,8 @@ void QUnit::OptimizePairBuffers(const bitLenInt& control, const bitLenInt& targe
     PhaseShardPtr buffer = phaseShard->second;
 
     if (IS_NORM_0(buffer->cmplxDiff - buffer->cmplxSame)) {
-        ApplyBuffer(buffer, control, target, anti);
         tShard.RemovePhaseControl(&cShard);
+        ApplyBuffer(buffer, control, target, anti);
         return;
     }
 
@@ -4149,9 +4149,9 @@ void QUnit::OptimizePairBuffers(const bitLenInt& control, const bitLenInt& targe
     PhaseShardPtr aBuffer = antiShard->second;
 
     if (IS_NORM_0(buffer->cmplxDiff - aBuffer->cmplxSame) && IS_NORM_0(buffer->cmplxSame - aBuffer->cmplxDiff)) {
-        ApplySinglePhase(buffer->cmplxDiff, buffer->cmplxSame, target);
         tShard.RemovePhaseControl(&cShard);
         tShard.RemovePhaseAntiControl(&cShard);
+        ApplySinglePhase(buffer->cmplxDiff, buffer->cmplxSame, target);
     }
 }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1747,7 +1747,6 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
 
         if (!isSameUnit) {
             tShard.AddInversionAngles(&cShard, ONE_CMPLX, ONE_CMPLX);
-
             OptimizePairBuffers(control, target, false);
 
             return;
@@ -1964,7 +1963,6 @@ void QUnit::CZ(bitLenInt control, bitLenInt target)
 
         if (!isSameUnit) {
             tShard.AddPhaseAngles(&cShard, ONE_CMPLX, -ONE_CMPLX);
-
             OptimizePairBuffers(control, target, false);
 
             return;
@@ -2318,7 +2316,6 @@ void QUnit::ApplyControlledSinglePhase(const bitLenInt* cControls, const bitLenI
         if (!isSameUnit) {
             delete[] controls;
             tShard.AddPhaseAngles(&cShard, topLeft, bottomRight);
-
             OptimizePairBuffers(control, target, false);
 
             return;
@@ -2420,7 +2417,6 @@ void QUnit::ApplyAntiControlledSinglePhase(const bitLenInt* cControls, const bit
         if (!isSameUnit) {
             delete[] controls;
             tShard.AddAntiPhaseAngles(&cShard, bottomRight, topLeft);
-
             OptimizePairBuffers(control, target, true);
 
             return;
@@ -4132,13 +4128,13 @@ void QUnit::OptimizePairBuffers(const bitLenInt& control, const bitLenInt& targe
 
     ShardToPhaseMap::iterator phaseShard = tShard.targetOfShards.find(&cShard);
 
-    if (phaseShard == tShard.targetOfShards.end()) {
+    if ((phaseShard == tShard.targetOfShards.end()) || phaseShard->second->isInvert) {
         return;
     }
 
     PhaseShardPtr buffer = phaseShard->second;
 
-    if ((!phaseShard->second->isInvert) || (IS_NORM_0(buffer->cmplxDiff - buffer->cmplxSame))) {
+    if (IS_NORM_0(buffer->cmplxDiff - buffer->cmplxSame)) {
         ApplyBuffer(buffer, control, target, anti);
         tShard.RemovePhaseControl(&cShard);
         return;
@@ -4146,8 +4142,7 @@ void QUnit::OptimizePairBuffers(const bitLenInt& control, const bitLenInt& targe
 
     ShardToPhaseMap::iterator antiShard = tShard.antiTargetOfShards.find(&cShard);
 
-    if ((antiShard == tShard.antiTargetOfShards.end()) ||
-        (phaseShard->second->isInvert != antiShard->second->isInvert)) {
+    if ((antiShard == tShard.antiTargetOfShards.end()) || antiShard->second->isInvert) {
         return;
     }
 


### PR DESCRIPTION
Here's more buffer refactoring and optimization.

It stands to reason that surviving inversion buffers, by the point we try to reduce pairs of 2 qubit buffers to single bit gates, could still avoid entanglement if we come across them and combine them. In practice, the `std::find` we do a second time in order to likely still _not_ find an opportunity to combine buffers might hurt our average overall time, though. I'm still running benchmarks, to be sure, but I think skipping the inversions, as this already is, is likely the way to go.