### PR TITLE
AntiCNOT buffering should match CNOT

### DIFF
--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1809,7 +1809,7 @@ void QUnit::AntiCNOT(bitLenInt control, bitLenInt target)
             except.insert(control);
         }
 
-        RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI, {}, except);
+        RevertBasis2Qb(target, INVERT_AND_PHASE, CONTROLS_AND_TARGETS, CTRL_AND_ANTI, {}, except);
 
         if (!IS_SAME_UNIT(cShard, tShard)) {
             shards[target].AddAntiInversionAngles(&(shards[control]), ONE_CMPLX, ONE_CMPLX);


### PR DESCRIPTION
AntiCNOT was unnecessarily complicated, before the last PR, but the recent abstraction of buffering in the last couple of days points to AntiCNOT having the same commutivity as CNOT, and this makes theoretical sense. I need to run more rounds of cross entropy tests, at least, but this PR is a conservative change that stands to reason against CNOT, before v5.5 tagging is considered.