### PR TITLE
AntiCNOT OptimizePairBuffers()

### DIFF
--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1783,6 +1783,8 @@ void QUnit::AntiCNOT(bitLenInt control, bitLenInt target)
 
         if (!IS_SAME_UNIT(cShard, tShard)) {
             shards[target].AddAntiInversionAngles(&(shards[control]), ONE_CMPLX, ONE_CMPLX);
+            OptimizePairBuffers(control, target, true);
+
             return;
         }
     }


### PR DESCRIPTION
By inspection of the other singly-controlled gates, this optimization check was missing from AntiCNOT.