### PR TITLE
Fix OpenCL REAL1_EPSILON

### DIFF
--- a/src/common/qengine.cl
+++ b/src/common/qengine.cl
@@ -606,7 +606,7 @@ void kernel decomposeprob(global cmplx* stateVec, constant bitCapIntOcl* bitCapI
             nrm = dot(amp, amp);
             partProb += nrm;
 
-            if (nrm > min_norm) {
+            if (nrm >= REAL1_EPSILON) {
                 currentAngle = arg(amp);
                 if (firstAngle < angleThresh) {
                     firstAngle = currentAngle;
@@ -633,7 +633,7 @@ void kernel decomposeprob(global cmplx* stateVec, constant bitCapIntOcl* bitCapI
             nrm = dot(amp, amp);
             partProb += nrm;
 
-            if (nrm > min_norm) {
+            if (nrm >= REAL1_EPSILON) {
                 currentAngle = arg(stateVec[l]);
                 if (firstAngle < angleThresh) {
                     firstAngle = currentAngle;
@@ -2091,14 +2091,14 @@ void kernel approxcompare(global cmplx* stateVec1, global cmplx* stateVec2, cons
         amp = stateVec1[basePerm];
         nrm = dot(amp, amp);
         basePerm++;
-    } while (nrm < min_norm);
+    } while (nrm < REAL1_EPSILON);
 
     basePerm--;
     amp = stateVec1[basePerm];
     nrm = dot(amp, amp);
 
     // If the amplitude we sample for global phase offset correction doesn't match, we're done.
-    if (nrm > min_norm) {
+    if (nrm >= REAL1_EPSILON) {
         basePhaseFac1 = (ONE_R1 / sqrt(nrm)) * amp;
 
         amp = stateVec2[basePerm];

--- a/src/common/qheader32.cl
+++ b/src/common/qheader32.cl
@@ -19,7 +19,7 @@
 #define ONE_BCI 1U
 #define SineShift M_PI_2_F
 #define PI_R1 M_PI_F
-#define min_norm 1e-13f
+#define REAL1_EPSILON FLT_EPSILON
 #define bitCapIntOcl uint
 #define bitCapIntOcl2 uint2
 #define bitCapIntOcl4 uint4

--- a/src/common/qheader_double.cl
+++ b/src/common/qheader_double.cl
@@ -20,7 +20,7 @@
 #define ONE_BCI 1UL
 #define SineShift M_PI_2
 #define PI_R1 M_PI
-#define min_norm 1e-30
+#define REAL1_EPSILON DBL_EPSILON
 #define bitCapIntOcl ulong
 #define bitCapIntOcl2 ulong2
 #define bitCapIntOcl4 ulong4

--- a/src/common/qheader_float.cl
+++ b/src/common/qheader_float.cl
@@ -19,7 +19,7 @@
 #define ONE_BCI 1UL
 #define SineShift M_PI_2_F
 #define PI_R1 M_PI_F
-#define min_norm 1e-14f
+#define REAL1_EPSILON FLT_EPSILON
 #define bitCapIntOcl ulong
 #define bitCapIntOcl2 ulong2
 #define bitCapIntOcl4 ulong4


### PR DESCRIPTION
The OpenCL kernels were using an outdated concept of REAL1_EPSILON ("min_norm"). Amplitude flooring thresholds are specified in kernel arguments; the epsilon of equality with 0 checks should be the native system epsilon value.