### PR TITLE
Better smart QPager sizing

### DIFF
--- a/include/common/oclengine.hpp
+++ b/include/common/oclengine.hpp
@@ -233,6 +233,8 @@ public:
         return nrmGroupCount;
     }
 
+    size_t GetMaxAlloc() { return device.getInfo<CL_DEVICE_MAX_MEM_ALLOC_SIZE>(); }
+
     friend class OCLEngine;
 };
 

--- a/src/qpager.cpp
+++ b/src/qpager.cpp
@@ -46,6 +46,13 @@ QPager::QPager(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState, q
         // concurrency.
         thresholdQubitsPerPage =
             log2(OCLEngine::Instance()->GetDeviceContextPtr(devID)->GetPreferredConcurrency()) + 12U;
+
+        bitLenInt maxAllocQubits =
+            log2(OCLEngine::Instance()->GetDeviceContextPtr(devID)->GetMaxAlloc() / sizeof(complex));
+
+        if (thresholdQubitsPerPage > maxAllocQubits) {
+            thresholdQubitsPerPage = maxAllocQubits;
+        }
     }
 #endif
 


### PR DESCRIPTION
I'm experimenting with QPager on multi-accelerator cloud instances, and it seems that, with arbitrary numbers of processing elements, QPager might set a paging threshold above its device size. There's never a reason to set qubits-per-page higher than maximum device allocation, but its easy to restrict page sizes to less-than-or-equal-to the max allocation.