### PR TITLE
QEngine: don't ApplyM() if no effect

### DIFF
--- a/src/qengine/qengine.cpp
+++ b/src/qengine/qengine.cpp
@@ -44,7 +44,7 @@ bool QEngine::ForceM(bitLenInt qubit, bool result, bool doForce, bool doApply)
         throw "ERROR: Forced a measurement result with 0 probability";
     }
 
-    if (doApply) {
+    if (doApply && (nrmlzr != ONE_R1)) {
         bitCapInt qPower = pow2(qubit);
         ApplyM(qPower, result, GetNonunitaryPhase() / (real1)(std::sqrt(nrmlzr)));
     }
@@ -101,7 +101,9 @@ bitCapInt QEngine::ForceM(const bitLenInt* bits, const bitLenInt& length, const 
         }
         nrmlzr = ProbMask(regMask, result);
         nrm = phase / (real1)(std::sqrt(nrmlzr));
-        ApplyM(regMask, result, nrm);
+        if (nrmlzr != ONE_R1) {
+            ApplyM(regMask, result, nrm);
+        }
 
         // No need to check against probabilities:
         return result;
@@ -153,7 +155,7 @@ bitCapInt QEngine::ForceM(const bitLenInt* bits, const bitLenInt& length, const 
 
     nrm = phase / (real1)(std::sqrt(nrmlzr));
 
-    if (doApply) {
+    if (doApply && (nrmlzr != ONE_BCI)) {
         ApplyM(regMask, result, nrm);
     }
 

--- a/src/qengine/qengine.cpp
+++ b/src/qengine/qengine.cpp
@@ -155,7 +155,7 @@ bitCapInt QEngine::ForceM(const bitLenInt* bits, const bitLenInt& length, const 
 
     nrm = phase / (real1)(std::sqrt(nrmlzr));
 
-    if (doApply && (nrmlzr != ONE_BCI)) {
+    if (doApply && (nrmlzr != ONE_R1)) {
         ApplyM(regMask, result, nrm);
     }
 


### PR DESCRIPTION
`QEngine` based measurement checks probability, non-deterministically decides its measurement result, then "collapses" the state vector to agree. If the state vector is in a deterministic eigenstate for measurement, then the overhead associated with "collapsing" the state vector can be avoided.