### PR TITLE
Fix QPager w/ QEngineOCL Clone()

### DIFF
--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -2551,7 +2551,11 @@ QInterfacePtr QEngineOCL::Clone()
     copyPtr->runningNorm = runningNorm;
 
     EventVecPtr waitVec = ResetWaitEvents();
-    DISPATCH_COPY(waitVec, *stateBuffer, *(copyPtr->stateBuffer), sizeof(complex) * maxQPowerOcl);
+    if (stateBuffer) {
+        DISPATCH_COPY(waitVec, *stateBuffer, *(copyPtr->stateBuffer), sizeof(complex) * maxQPowerOcl);
+    } else {
+        copyPtr->ZeroAmplitudes();
+    }
     Finish();
 
     return copyPtr;

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -117,12 +117,12 @@ void QEngineOCL::SetAmplitudePage(
     QEngineOCLPtr pageEngineOclPtr = std::dynamic_pointer_cast<QEngineOCL>(pageEnginePtr);
     BufferPtr oStateBuffer = pageEngineOclPtr->stateBuffer;
 
+    clFinish();
+    pageEngineOclPtr->clFinish();
+
     if (!stateBuffer && !oStateBuffer) {
         return;
     }
-
-    clFinish();
-    pageEngineOclPtr->clFinish();
 
     if (!oStateBuffer) {
         if (length == maxQPower) {
@@ -130,6 +130,9 @@ void QEngineOCL::SetAmplitudePage(
         } else {
             ClearBuffer(stateBuffer, (bitCapIntOcl)dstOffset, (bitCapIntOcl)length);
         }
+
+        runningNorm = ZERO_R1;
+
         return;
     }
 

--- a/src/qengine/utility.cpp
+++ b/src/qengine/utility.cpp
@@ -22,6 +22,8 @@ QInterfacePtr QEngineCPU::Clone()
         randGlobalPhase, false, 0, (hardware_rand_generator == NULL) ? false : true, isSparse);
     if (stateVec) {
         std::dynamic_pointer_cast<QEngineCPU>(clone)->stateVec->copy(stateVec);
+    } else {
+        std::dynamic_pointer_cast<QEngineCPU>(clone)->ZeroAmplitudes();
     }
     return clone;
 }

--- a/src/qengine/utility.cpp
+++ b/src/qengine/utility.cpp
@@ -18,12 +18,13 @@ QInterfacePtr QEngineCPU::Clone()
 {
     Finish();
 
-    QInterfacePtr clone = CreateQuantumInterface(QINTERFACE_CPU, qubitCount, 0, rand_generator, ONE_CMPLX, doNormalize,
-        randGlobalPhase, false, 0, (hardware_rand_generator == NULL) ? false : true, isSparse);
+    QEngineCPUPtr clone = std::dynamic_pointer_cast<QEngineCPU>(
+        CreateQuantumInterface(QINTERFACE_CPU, qubitCount, 0, rand_generator, ONE_CMPLX, doNormalize, randGlobalPhase,
+            false, 0, (hardware_rand_generator == NULL) ? false : true, isSparse));
     if (stateVec) {
-        std::dynamic_pointer_cast<QEngineCPU>(clone)->stateVec->copy(stateVec);
+        clone->stateVec->copy(stateVec);
     } else {
-        std::dynamic_pointer_cast<QEngineCPU>(clone)->ZeroAmplitudes();
+        clone->ZeroAmplitudes();
     }
     return clone;
 }

--- a/src/qpager.cpp
+++ b/src/qpager.cpp
@@ -526,7 +526,7 @@ void QPager::SetPermutation(bitCapInt perm, complex phaseFac)
         isPermInPage &= (perm < pagePerm);
 
         if (isPermInPage) {
-            qPages[i]->SetPermutation(perm - (pagePerm - pagePower));
+            qPages[i]->SetPermutation(perm - (pagePerm - pagePower), phaseFac);
             continue;
         }
 
@@ -1313,6 +1313,8 @@ void QPager::UpdateRunningNorm(real1_f norm_thresh)
 
 QInterfacePtr QPager::Clone()
 {
+    CombineEngines(baseQubitsPerPage);
+
     bitLenInt qpp = qubitsPerPage();
 
     QPagerPtr clone = std::dynamic_pointer_cast<QPager>(
@@ -1320,10 +1322,10 @@ QInterfacePtr QPager::Clone()
             randGlobalPhase, false, 0, (hardware_rand_generator == NULL) ? false : true, isSparse));
 
     clone->CombineEngines(qpp);
+    clone->SeparateEngines(qpp);
 
-    bitCapIntOcl pagePower = (bitCapIntOcl)pageMaxQPower();
     for (bitCapIntOcl i = 0; i < qPages.size(); i++) {
-        clone->qPages[i]->SetAmplitudePage(qPages[i], 0, 0, pagePower);
+        clone->qPages[i] = std::dynamic_pointer_cast<QEngine>(qPages[i]->Clone());
     }
 
     return clone;


### PR DESCRIPTION
This seems to fix all remaining unit test failures, for `QPager` (over `QEngineOCL`). There was a problem in the `Clone()` method.