### PR TITLE
QPager optimization

### DIFF
--- a/include/common/parallel_for.hpp
+++ b/include/common/parallel_for.hpp
@@ -75,7 +75,7 @@ public:
     /** Calculate the normal for the array, (with flooring). */
     real1_f par_norm(const bitCapInt maxQPower, const StateVectorPtr stateArray, real1_f norm_thresh = ZERO_R1);
 
-    /** Calculate the normal for the array, (without flooring. */
+    /** Calculate the normal for the array, (without flooring.) */
     real1_f par_norm_exact(const bitCapInt maxQPower, const StateVectorPtr stateArray);
 };
 

--- a/include/qengine.hpp
+++ b/include/qengine.hpp
@@ -51,11 +51,15 @@ public:
 
     virtual ~QEngine() { Finish(); }
 
-    virtual real1_f GetRunningNorm() { return runningNorm; }
+    virtual real1_f GetRunningNorm()
+    {
+        Finish();
+        return runningNorm;
+    }
 
     virtual void ZeroAmplitudes() = 0;
 
-    virtual void CopyStateVec(QInterfacePtr src) = 0;
+    virtual void CopyStateVec(QEnginePtr src) = 0;
 
     virtual void GetAmplitudePage(complex* pagePtr, const bitCapInt offset, const bitCapInt length) = 0;
     virtual void SetAmplitudePage(const complex* pagePtr, const bitCapInt offset, const bitCapInt length) = 0;

--- a/include/qengine_cpu.hpp
+++ b/include/qengine_cpu.hpp
@@ -163,7 +163,7 @@ public:
         engineCpu->runningNorm = REAL1_DEFAULT_ARG;
     }
 
-    virtual void CopyStateVec(QInterfacePtr src)
+    virtual void CopyStateVec(QEnginePtr src)
     {
         Finish();
         src->Finish();
@@ -181,6 +181,8 @@ public:
             SetQuantumState(sv);
             delete[] sv;
         }
+
+        runningNorm = src->GetRunningNorm();
     }
 
     virtual void QueueSetDoNormalize(const bool& doNorm)

--- a/include/qengine_opencl.hpp
+++ b/include/qengine_opencl.hpp
@@ -221,7 +221,7 @@ public:
         }
     }
 
-    virtual void CopyStateVec(QInterfacePtr src)
+    virtual void CopyStateVec(QEnginePtr src)
     {
         Finish();
         src->Finish();
@@ -229,6 +229,8 @@ public:
         LockSync(CL_MAP_WRITE);
         src->GetQuantumState(stateVec);
         UnlockSync();
+
+        runningNorm = src->GetRunningNorm();
     }
 
     virtual void GetAmplitudePage(complex* pagePtr, const bitCapInt offset, const bitCapInt length);

--- a/include/qhybrid.hpp
+++ b/include/qhybrid.hpp
@@ -69,6 +69,8 @@ public:
         isGpu = useGpu;
     }
 
+    virtual real1_f GetRunningNorm() { return engine->GetRunningNorm(); }
+
     virtual void ZeroAmplitudes() { engine->ZeroAmplitudes(); }
 
     virtual void CopyStateVec(QEnginePtr src) { CopyStateVec(std::dynamic_pointer_cast<QHybrid>(src)); }

--- a/include/qhybrid.hpp
+++ b/include/qhybrid.hpp
@@ -71,7 +71,7 @@ public:
 
     virtual void ZeroAmplitudes() { engine->ZeroAmplitudes(); }
 
-    virtual void CopyStateVec(QInterfacePtr src) { CopyStateVec(std::dynamic_pointer_cast<QHybrid>(src)); }
+    virtual void CopyStateVec(QEnginePtr src) { CopyStateVec(std::dynamic_pointer_cast<QHybrid>(src)); }
     virtual void CopyStateVec(QHybridPtr src)
     {
         SwitchModes(src->isGpu);

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -1424,6 +1424,10 @@ real1_f QEngineOCL::Prob(bitLenInt qubit)
         return ProbAll(1);
     }
 
+    if (!stateBuffer) {
+        return ZERO_R1;
+    }
+
     bitCapIntOcl qPower = pow2Ocl(qubit);
 
     bitCapIntOcl bciArgs[BCI_ARG_LEN] = { maxQPowerOcl >> ONE_BCI, qPower, 0, 0, 0, 0, 0, 0, 0, 0 };
@@ -2610,6 +2614,7 @@ void QEngineOCL::NormalizeState(real1_f nrm, real1_f norm_thresh)
 void QEngineOCL::UpdateRunningNorm(real1_f norm_thresh)
 {
     if (!stateBuffer) {
+        runningNorm = ZERO_R1;
         return;
     }
 

--- a/src/qpager.cpp
+++ b/src/qpager.cpp
@@ -642,13 +642,10 @@ void QPager::ApplyEitherControlledSingleBit(const bool& anti, const bitLenInt* c
 
     if (metaControls.size() == 0) {
         if (target >= qpp) {
-            std::vector<bitLenInt>::iterator intraControl = intraControls.begin();
-            while (intraControl < intraControls.end()) {
-                if (*intraControl == (qpp - 1U)) {
-                    intraControls.erase(intraControl);
-                } else {
-                    intraControl++;
-                }
+            std::vector<bitLenInt>::iterator intraControl =
+                std::find(intraControls.begin(), intraControls.end(), qpp - 1U);
+            if (intraControl != intraControls.end()) {
+                intraControls.erase(intraControl);
             }
         }
         SingleBitGate(target, sg);

--- a/src/qpager.cpp
+++ b/src/qpager.cpp
@@ -1245,9 +1245,7 @@ void QPager::FSim(real1_f theta, real1_f phi, bitLenInt qubit1, bitLenInt qubit2
 
 real1_f QPager::Prob(bitLenInt qubit)
 {
-    if (qubit < qubitsPerPage()) {
-        SeparateEngines(qubit + 1U);
-    }
+    SeparateEngines(qubit + 1U);
 
     if (qPages.size() == 1U) {
         return qPages[0]->Prob(qubit);


### PR DESCRIPTION
Ultimately, `QPager` should readily serve as a stand-in for "Schrödinger method" "canonical" distributed simulation runtimes, if only basic gate functionality is used, including measurement. This PR is already more optimal, and it works, but I'm trying to get a benchmark like `test_ccz_ccx_h` to run on two OpenCL accelerators without needing to move any data between them by bus.