### PR TITLE
QPager edge case debugging

### DIFF
--- a/include/qpager.hpp
+++ b/include/qpager.hpp
@@ -59,7 +59,8 @@ protected:
     void SeparateEngines(bitLenInt thresholdBits);
     void SeparateEngines() { SeparateEngines(baseQubitsPerPage); }
 
-    template <typename Qubit1Fn> void SingleBitGate(bitLenInt target, Qubit1Fn fn);
+    template <typename Qubit1Fn>
+    void SingleBitGate(bitLenInt target, Qubit1Fn fn, const bool& isMetaCtrl = false, const bool& isAnti = false);
     template <typename Qubit1Fn>
     void MetaControlled(bool anti, std::vector<bitLenInt> controls, bitLenInt target, Qubit1Fn fn, const complex* mtrx);
     template <typename Qubit1Fn>

--- a/src/qpager.cpp
+++ b/src/qpager.cpp
@@ -42,16 +42,16 @@ QPager::QPager(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState, q
 
 #if ENABLE_OPENCL
     if ((thresholdQubitsPerPage == 0) && ((eng == QINTERFACE_OPENCL) || (eng == QINTERFACE_HYBRID))) {
+        // Try 2 less than device maximum, (as is typically optimal on the developer's RTX 2070).
+        thresholdQubitsPerPage =
+            log2(OCLEngine::Instance()->GetDeviceContextPtr(devID)->GetMaxAlloc() / sizeof(complex)) - 2U;
+
         // Single bit gates act pairwise on amplitudes, so add at least 1 qubit to the log2 of the preferred
         // concurrency.
-        thresholdQubitsPerPage =
-            log2(OCLEngine::Instance()->GetDeviceContextPtr(devID)->GetPreferredConcurrency()) + 12U;
+        bitLenInt minQubits = log2(OCLEngine::Instance()->GetDeviceContextPtr(devID)->GetPreferredConcurrency()) + 1U;
 
-        bitLenInt maxAllocQubits =
-            log2(OCLEngine::Instance()->GetDeviceContextPtr(devID)->GetMaxAlloc() / sizeof(complex));
-
-        if (thresholdQubitsPerPage > maxAllocQubits) {
-            thresholdQubitsPerPage = maxAllocQubits;
+        if (thresholdQubitsPerPage < minQubits) {
+            thresholdQubitsPerPage = minQubits;
         }
     }
 #endif


### PR DESCRIPTION
If a control bit is dropped for applications as `QPager::SingleBitGate()`, then the `QEngine` pairs acted on by the method are effectively "meta-controlled."