### PR TITLE
Restore QPager optimized Decompose()/Dispose() variants

### DIFF
--- a/src/qpager.cpp
+++ b/src/qpager.cpp
@@ -508,40 +508,93 @@ void QPager::Decompose(bitLenInt start, QPagerPtr dest)
 
     bitLenInt inPage = qubitCount - (start + dest->qubitCount);
 
-    CombineEngines(inPage + dest->qubitCount);
-    qPages[0]->Decompose(qPages[0]->GetQubitCount() - (inPage + dest->qubitCount), dest->qPages[0]);
-    // To be clear, under the assumption of perfect decomposibility, all further pages should produce the exact same
-    // "dest" as the line above, hence we can take just the first one and "Dispose" the rest. (This might pose a
-    // problem or limitation for "approximate separability.")
-    for (bitCapIntOcl i = 1; i < qPages.size(); i++) {
-        qPages[i]->Dispose(qPages[i]->GetQubitCount() - (inPage + dest->qubitCount), dest->qubitCount);
+    if (start <= inPage) {
+        if (start == 0) {
+            CombineEngines(start + dest->qubitCount + 1U);
+        } else {
+            CombineEngines(start + dest->qubitCount);
+        }
+        qPages[0]->Decompose(start, dest->qPages[0]);
+        // To be clear, under the assumption of perfect decomposibility, all further pages should produce the exact same
+        // "dest" as the line above, hence we can take just the first one and "Dispose" the rest. (This might pose a
+        // problem or limitation for "approximate separability.")
+        for (bitCapIntOcl i = 1; i < qPages.size(); i++) {
+            qPages[i]->Dispose(start, dest->qubitCount);
+        }
+    } else {
+        if ((qPages[0]->GetQubitCount() - (inPage + dest->qubitCount)) == 0) {
+            CombineEngines(inPage + dest->qubitCount + 1U);
+        } else {
+            CombineEngines(inPage + dest->qubitCount);
+        }
+        qPages[0]->Decompose(qPages[0]->GetQubitCount() - (inPage + dest->qubitCount), dest->qPages[0]);
+        // (Same as above)
+        for (bitCapIntOcl i = 1; i < qPages.size(); i++) {
+            qPages[i]->Dispose(qPages[i]->GetQubitCount() - (inPage + dest->qubitCount), dest->qubitCount);
+        }
     }
 
     SetQubitCount(qubitCount - dest->qubitCount);
+
+    CombineEngines(baseQubitsPerPage);
 }
 
 void QPager::Dispose(bitLenInt start, bitLenInt length)
 {
     bitLenInt inPage = qubitCount - (start + length);
 
-    CombineEngines(inPage + length);
-    for (bitCapIntOcl i = 0; i < qPages.size(); i++) {
-        qPages[i]->Dispose(qPages[i]->GetQubitCount() - (inPage + length), length);
+    if (start <= inPage) {
+        if (start == 0) {
+            CombineEngines(start + length + 1U);
+        } else {
+            CombineEngines(start + length);
+        }
+        for (bitCapIntOcl i = 0; i < qPages.size(); i++) {
+            qPages[i]->Dispose(start, length);
+        }
+    } else {
+        if ((qPages[0]->GetQubitCount() - (inPage + length)) == 0) {
+            CombineEngines(inPage + length + 1U);
+        } else {
+            CombineEngines(inPage + length);
+        }
+        for (bitCapIntOcl i = 0; i < qPages.size(); i++) {
+            qPages[i]->Dispose(qPages[i]->GetQubitCount() - (inPage + length), length);
+        }
     }
 
     SetQubitCount(qubitCount - length);
+
+    CombineEngines(baseQubitsPerPage);
 }
 
 void QPager::Dispose(bitLenInt start, bitLenInt length, bitCapInt disposedPerm)
 {
     bitLenInt inPage = qubitCount - (start + length);
 
-    CombineEngines(inPage + length);
-    for (bitCapIntOcl i = 0; i < qPages.size(); i++) {
-        qPages[i]->Dispose(qPages[i]->GetQubitCount() - (inPage + length), length, disposedPerm);
+    if (start <= inPage) {
+        if (start == 0) {
+            CombineEngines(start + length + 1U);
+        } else {
+            CombineEngines(start + length);
+        }
+        for (bitCapIntOcl i = 0; i < qPages.size(); i++) {
+            qPages[i]->Dispose(start, length, disposedPerm);
+        }
+    } else {
+        if ((qPages[0]->GetQubitCount() - (inPage + length)) == 0) {
+            CombineEngines(inPage + length + 1U);
+        } else {
+            CombineEngines(inPage + length);
+        }
+        for (bitCapIntOcl i = 0; i < qPages.size(); i++) {
+            qPages[i]->Dispose(qPages[i]->GetQubitCount() - (inPage + length), length, disposedPerm);
+        }
     }
 
     SetQubitCount(qubitCount - length);
+
+    CombineEngines(baseQubitsPerPage);
 }
 
 void QPager::SetQuantumState(const complex* inputState)

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -3274,17 +3274,19 @@ QInterfacePtr QUnit::CMULEntangle(std::vector<bitLenInt> controlVec, bitLenInt s
     bits[controlVec.size() + 1] = carryStart;
     std::sort(bits.begin(), bits.end());
 
-    std::vector<bitLenInt*> ebits(controlVec.size() + 2);
-    for (bitLenInt i = 0; i < (controlVec.size() + 2); i++) {
+    std::vector<bitLenInt*> ebits(bits.size());
+    for (bitLenInt i = 0; i < ebits.size(); i++) {
         ebits[i] = &bits[i];
     }
 
     QInterfacePtr unit = Entangle(ebits);
 
-    controlsMapped->resize(!controlVec.size() ? 1 : controlVec.size());
-    for (bitLenInt i = 0; i < controlVec.size(); i++) {
-        (*controlsMapped)[i] = shards[controlVec[i]].mapped;
-        shards[controlVec[i]].isPhaseDirty = true;
+    if (controlVec.size()) {
+        controlsMapped->resize(controlVec.size());
+        for (bitLenInt i = 0; i < controlVec.size(); i++) {
+            (*controlsMapped)[i] = shards[controlVec[i]].mapped;
+            shards[controlVec[i]].isPhaseDirty = true;
+        }
     }
 
     return unit;
@@ -3304,8 +3306,8 @@ void QUnit::CMULx(CMULFn fn, bitCapInt toMod, bitLenInt start, bitLenInt carrySt
     std::vector<bitLenInt> controlsMapped;
     QInterfacePtr unit = CMULEntangle(controlVec, start, carryStart, length, &controlsMapped);
 
-    ((*unit).*fn)(
-        toMod, shards[start].mapped, shards[carryStart].mapped, length, &(controlsMapped[0]), controlVec.size());
+    ((*unit).*fn)(toMod, shards[start].mapped, shards[carryStart].mapped, length,
+        controlVec.size() ? &(controlsMapped[0]) : NULL, controlVec.size());
 
     DirtyShardRange(start, length);
 }
@@ -3316,8 +3318,8 @@ void QUnit::CMULModx(CMULModFn fn, bitCapInt toMod, bitCapInt modN, bitLenInt st
     std::vector<bitLenInt> controlsMapped;
     QInterfacePtr unit = CMULEntangle(controlVec, start, carryStart, length, &controlsMapped);
 
-    ((*unit).*fn)(
-        toMod, modN, shards[start].mapped, shards[carryStart].mapped, length, &(controlsMapped[0]), controlVec.size());
+    ((*unit).*fn)(toMod, modN, shards[start].mapped, shards[carryStart].mapped, length,
+        controlVec.size() ? &(controlsMapped[0]) : NULL, controlVec.size());
 
     DirtyShardRangePhase(start, length);
 }


### PR DESCRIPTION
So far, this PR attempts to restore optimized QPager Decompose()/Dispose() variants, by ensuring that page segments are not of identical length to the segment requested to be decomposed. Ultimately, I will address QUnit->QPager unit test failures before merging.