### PR TITLE
QPager::SetPermutation() was not safe for unit tests

### DIFF
--- a/include/qpager.hpp
+++ b/include/qpager.hpp
@@ -60,9 +60,10 @@ protected:
     void SeparateEngines() { SeparateEngines(baseQubitsPerPage); }
 
     template <typename Qubit1Fn>
-    void SingleBitGate(bitLenInt target, Qubit1Fn fn, const bool& isMetaCtrl = false, const bool& isAnti = false);
+    void SingleBitGate(bitLenInt target, Qubit1Fn fn, const bool& isSqiCtrl = false, const bool& isAnti = false);
     template <typename Qubit1Fn>
-    void MetaControlled(bool anti, std::vector<bitLenInt> controls, bitLenInt target, Qubit1Fn fn, const complex* mtrx);
+    void MetaControlled(bool anti, std::vector<bitLenInt> controls, bitLenInt target, Qubit1Fn fn, const complex* mtrx,
+        const bool& isSqiCtrl = false, const bool& isAnti = false);
     template <typename Qubit1Fn>
     void SemiMetaControlled(bool anti, std::vector<bitLenInt> controls, bitLenInt target, Qubit1Fn fn);
     void MetaSwap(bitLenInt qubit1, bitLenInt qubit2, bool isIPhaseFac);

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -4155,6 +4155,12 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_entanglement")
         qftReg->X(i);
     }
     REQUIRE_THAT(qftReg, HasProbability(0, 20, 0x1));
+
+    qftReg->SetPermutation(0xffffff);
+    for (bitLenInt i = qftReg->GetQubitCount() - 3; i > 2; i -= 3) {
+        qftReg->CCNOT(i - 2, i - 1, i);
+    }
+    REQUIRE_THAT(qftReg, HasProbability(0, 20, 0xdb6df));
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_swap_bit")


### PR DESCRIPTION
The unit tests sometimes use `SetPermutation()` with values that are higher than the maximum permutation of qubits, apparently. This is usually a nonissue, because all other QInterface instances effectively mask for only the valid part of the permutation, but not QPager. It's simple to make QPager respect this use case, though.