### PR TITLE
Add device list option to tests/benchmarks, for QPager and QUnitMulti

### DIFF
--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -48,7 +48,7 @@ double formatTime(double t, bool logNormal)
 QInterfacePtr MakeRandQubit()
 {
     QInterfacePtr qubit = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 1U, 0, rng,
-        ONE_CMPLX, enable_normalization, true, false, device_id, !disable_hardware_rng);
+        ONE_CMPLX, enable_normalization, true, false, device_id, !disable_hardware_rng, sparse, REAL1_EPSILON, devList);
 
     real1 theta = 2 * M_PI * qubit->Rand();
     real1 phi = 2 * M_PI * qubit->Rand();
@@ -103,7 +103,8 @@ void benchmarkLoopVariable(std::function<void(QInterfacePtr, bitLenInt)> fn, bit
                 qftReg.reset();
             }
             qftReg = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, numBits, 0, rng,
-                ONE_CMPLX, enable_normalization, true, false, device_id, !disable_hardware_rng, sparse);
+                ONE_CMPLX, enable_normalization, true, false, device_id, !disable_hardware_rng, sparse, REAL1_EPSILON,
+                devList);
         }
         avgt = 0.0;
 

--- a/test/benchmarks_main.cpp
+++ b/test/benchmarks_main.cpp
@@ -37,6 +37,7 @@ std::string mOutputFileName;
 std::ofstream mOutputFile;
 bool isBinaryOutput = false;
 int benchmarkSamples = 100;
+std::vector<int> devList;
 
 int main(int argc, char* argv[])
 {
@@ -55,6 +56,8 @@ int main(int argc, char* argv[])
     bool hybrid = false;
     bool stabilizer = false;
     bool stabilizer_qpager = false;
+
+    std::string devListStr;
 
     int mxQbts = 24;
 
@@ -94,7 +97,9 @@ int main(int argc, char* argv[])
         Opt(single_qubit_run)["--single"]("Only run single (maximum) qubit count for tests") |
         Opt(sparse)["--sparse"](
             "(For QEngineCPU, under QUnit:) Use a state vector optimized for sparse representation and iteration.") |
-        Opt(benchmarkSamples, "samples")["--benchmark-samples"]("number of samples to collect (default: 100)");
+        Opt(benchmarkSamples, "samples")["--benchmark-samples"]("number of samples to collect (default: 100)") |
+        Opt(devListStr, "devices")["--devices"](
+            "list of devices, for QPager (default is solely default OpenCL device)");
 
     session.cli(cli);
 
@@ -134,6 +139,15 @@ int main(int argc, char* argv[])
         stabilizer = true;
         // Unstable:
         // stabilizer_qpager = true;
+    }
+
+    if (devListStr.compare("") != 0) {
+        std::stringstream devListStr_stream(devListStr);
+        while (devListStr_stream.good()) {
+            std::string substr;
+            getline(devListStr_stream, substr, ',');
+            devList.push_back(stoi(substr));
+        }
     }
 
     if (mxQbts == -1) {

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -34,6 +34,7 @@ std::string mOutputFileName;
 std::ofstream mOutputFile;
 bool isBinaryOutput;
 int benchmarkSamples;
+std::vector<int> devList;
 
 int main(int argc, char* argv[])
 {
@@ -52,6 +53,8 @@ int main(int argc, char* argv[])
     bool hybrid = false;
     bool stabilizer = false;
     bool stabilizer_qpager = false;
+
+    std::string devListStr;
 
     using namespace Catch::clara;
 
@@ -86,7 +89,9 @@ int main(int argc, char* argv[])
                                                "human-readable.)") |
         Opt(sparse)["--sparse"](
             "(For QEngineCPU, under QUnit:) Use a state vector optimized for sparse representation and iteration.") |
-        Opt(benchmarkSamples, "samples")["--benchmark-samples"]("number of samples to collect (default: 100)");
+        Opt(benchmarkSamples, "samples")["--benchmark-samples"]("number of samples to collect (default: 100)") |
+        Opt(devListStr, "devices")["--devices"](
+            "list of devices, for QPager (default is solely default OpenCL device)");
 
     session.cli(cli);
 
@@ -126,6 +131,15 @@ int main(int argc, char* argv[])
         stabilizer = true;
         // Unstable:
         // stabilizer_qpager = true;
+    }
+
+    if (devListStr.compare("") != 0) {
+        std::stringstream devListStr_stream(devListStr);
+        while (devListStr_stream.good()) {
+            std::string substr;
+            getline(devListStr_stream, substr, ',');
+            devList.push_back(stoi(substr));
+        }
     }
 
     int num_failed = 0;
@@ -348,5 +362,5 @@ QInterfaceTestFixture::QInterfaceTestFixture()
     rng->seed(rngSeed);
 
     qftReg = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 20, 0, rng, ONE_CMPLX,
-        enable_normalization, true, false, device_id, !disable_hardware_rng, sparse);
+        enable_normalization, true, false, device_id, !disable_hardware_rng, sparse, REAL1_EPSILON, devList);
 }

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -66,7 +66,7 @@ void log(QInterfacePtr p) { std::cout << std::endl << std::showpoint << p << std
 QInterfacePtr MakeEngine(bitLenInt qubitCount)
 {
     return CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, qubitCount, 0, rng,
-        ONE_CMPLX, enable_normalization, true, false, device_id, !disable_hardware_rng, sparse);
+        ONE_CMPLX, enable_normalization, true, false, device_id, !disable_hardware_rng, sparse, REAL1_EPSILON, devList);
 }
 
 TEST_CASE("test_complex")
@@ -507,7 +507,7 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_cswap")
 
     QInterfacePtr qftReg2 = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 20U, 0, rng,
         ONE_CMPLX, enable_normalization, true, false, device_id, !disable_hardware_rng, sparse, REAL1_DEFAULT_ARG,
-        std::vector<int>{}, 10);
+        devList, 10);
 
     control[0] = 9;
     qftReg2->SetPermutation((1U << 9U) | (1U << 10U));
@@ -3342,7 +3342,7 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_zero_phase_flip")
 
     QInterfacePtr qftReg2 = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 20U, 0, rng,
         ONE_CMPLX, enable_normalization, true, false, device_id, !disable_hardware_rng, sparse, REAL1_DEFAULT_ARG,
-        std::vector<int>{}, 10);
+        devList, 10);
 
     qftReg2->SetPermutation(3U << 9U);
     qftReg2->H(10);
@@ -3592,7 +3592,8 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_decompose")
 
     // Try across device/heap allocation case:
     qftReg2 = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 4, 0, rng,
-        complex(ONE_R1, ZERO_R1), enable_normalization, true, true, device_id, !disable_hardware_rng, sparse);
+        complex(ONE_R1, ZERO_R1), enable_normalization, true, true, device_id, !disable_hardware_rng, sparse,
+        REAL1_EPSILON, devList);
 
     qftReg->SetPermutation(0x2b);
     qftReg->Decompose(0, qftReg2);
@@ -4587,7 +4588,7 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_inversion_buffers", "[supreme]")
     std::map<bitCapInt, int> testCaseResult = qftReg->MultiShotMeasureMask(qPowers, 8, 10000);
 
     QInterfacePtr goldStandard = CreateQuantumInterface(testSubEngineType, testSubSubEngineType, 8, 0, rng, ONE_CMPLX,
-        false, true, false, device_id, !disable_hardware_rng);
+        false, true, false, device_id, !disable_hardware_rng, sparse, REAL1_EPSILON, devList);
 
     goldStandard->SetPermutation(0);
     goldStandard->H(0);
@@ -4856,7 +4857,7 @@ TEST_CASE("test_universal_circuit_digital_cross_entropy", "[supreme]")
         false, true, false, device_id, !disable_hardware_rng);
 
     QInterfacePtr testCase = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, n, 0, rng,
-        ONE_CMPLX, enable_normalization, true, false, device_id, !disable_hardware_rng, sparse);
+        ONE_CMPLX, enable_normalization, true, false, device_id, !disable_hardware_rng, sparse, REAL1_EPSILON, devList);
 
     for (int trial = 0; trial < TRIALS; trial++) {
         std::vector<std::vector<int>> gate1QbRands(Depth);
@@ -5082,7 +5083,7 @@ TEST_CASE("test_quantum_supremacy_cross_entropy", "[supreme]")
         false, true, false, device_id, !disable_hardware_rng);
 
     QInterfacePtr testCase = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, n, 0, rng,
-        ONE_CMPLX, enable_normalization, true, false, device_id, !disable_hardware_rng, sparse);
+        ONE_CMPLX, enable_normalization, true, false, device_id, !disable_hardware_rng, sparse, REAL1_EPSILON, devList);
 
     for (int trial = 0; trial < TRIALS; trial++) {
         std::list<bitLenInt> gateSequence = { 0, 3, 2, 1, 2, 1, 0, 3 };

--- a/test/tests.hpp
+++ b/test/tests.hpp
@@ -41,6 +41,7 @@ extern std::string mOutputFileName;
 extern std::ofstream mOutputFile;
 extern bool isBinaryOutput;
 extern int benchmarkSamples;
+extern std::vector<int> devList;
 
 /* Declare the stream-to-probability prior to including catch.hpp. */
 namespace Qrack {


### PR DESCRIPTION
With this PR, device IDs can be selected for QPager and QUnitMulti with a comma-separated list of integers.

You may use the device ID printed in the header, or `-1` aliases the default device, (in addition to its non-negative device ID). Device indices can be specified more than once, and often should be. For example, to run 2 pages on one device before using a second device, the argument could be `--devices=0,0,1,1`.