### PR TITLE
Restore optimized ApplySingleEither()

### DIFF
--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -182,7 +182,7 @@ protected:
         toFree = NULL;
     }
 
-    bool IsIdentity(const complex* mtrx, const bool isControlled = false);
+    bool IsIdentity(const complex* mtrx, const bool isControlled);
 
     complex GetNonunitaryPhase()
     {

--- a/include/qpager.hpp
+++ b/include/qpager.hpp
@@ -223,8 +223,6 @@ public:
     virtual void ISqrtSwap(bitLenInt qubitIndex1, bitLenInt qubitIndex2);
     virtual void FSim(real1_f theta, real1_f phi, bitLenInt qubitIndex1, bitLenInt qubitIndex2);
 
-    virtual void ZeroPhaseFlip(bitLenInt start, bitLenInt length);
-
     virtual real1_f Prob(bitLenInt qubitIndex);
     virtual real1_f ProbAll(bitCapInt fullRegister);
     virtual real1_f ProbMask(const bitCapInt& mask, const bitCapInt& permutation);

--- a/include/qpager.hpp
+++ b/include/qpager.hpp
@@ -223,6 +223,8 @@ public:
     virtual void ISqrtSwap(bitLenInt qubitIndex1, bitLenInt qubitIndex2);
     virtual void FSim(real1_f theta, real1_f phi, bitLenInt qubitIndex1, bitLenInt qubitIndex2);
 
+    virtual void ZeroPhaseFlip(bitLenInt start, bitLenInt length);
+
     virtual real1_f Prob(bitLenInt qubitIndex);
     virtual real1_f ProbAll(bitCapInt fullRegister);
     virtual real1_f ProbMask(const bitCapInt& mask, const bitCapInt& permutation);

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -221,6 +221,7 @@ public:
     virtual void SqrtSwap(bitLenInt qubit1, bitLenInt qubit2);
     virtual void ISqrtSwap(bitLenInt qubit1, bitLenInt qubit2);
     virtual void FSim(real1_f theta, real1_f phi, bitLenInt qubit1, bitLenInt qubit2);
+    virtual void ZeroPhaseFlip(bitLenInt start, bitLenInt length);
 
     /** @} */
 

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -221,7 +221,6 @@ public:
     virtual void SqrtSwap(bitLenInt qubit1, bitLenInt qubit2);
     virtual void ISqrtSwap(bitLenInt qubit1, bitLenInt qubit2);
     virtual void FSim(real1_f theta, real1_f phi, bitLenInt qubit1, bitLenInt qubit2);
-    virtual void ZeroPhaseFlip(bitLenInt start, bitLenInt length);
 
     /** @} */
 

--- a/src/qengine/qengine.cpp
+++ b/src/qengine/qengine.cpp
@@ -164,7 +164,7 @@ bitCapInt QEngine::ForceM(const bitLenInt* bits, const bitLenInt& length, const 
 
 void QEngine::ApplySingleBit(const complex* mtrx, bitLenInt qubit)
 {
-    if (randGlobalPhase && IsIdentity(mtrx)) {
+    if (IsIdentity(mtrx, false)) {
         return;
     }
 
@@ -179,7 +179,7 @@ void QEngine::ApplySingleBit(const complex* mtrx, bitLenInt qubit)
 void QEngine::ApplyControlledSingleBit(
     const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& target, const complex* mtrx)
 {
-    if (randGlobalPhase && IsIdentity(mtrx)) {
+    if (IsIdentity(mtrx, true)) {
         return;
     }
 
@@ -200,7 +200,7 @@ void QEngine::ApplyControlledSingleBit(
 void QEngine::ApplyAntiControlledSingleBit(
     const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& target, const complex* mtrx)
 {
-    if (randGlobalPhase && IsIdentity(mtrx)) {
+    if (IsIdentity(mtrx, true)) {
         return;
     }
 

--- a/src/qengine/qengine.cpp
+++ b/src/qengine/qengine.cpp
@@ -164,7 +164,7 @@ bitCapInt QEngine::ForceM(const bitLenInt* bits, const bitLenInt& length, const 
 
 void QEngine::ApplySingleBit(const complex* mtrx, bitLenInt qubit)
 {
-    if (IsIdentity(mtrx)) {
+    if (randGlobalPhase && IsIdentity(mtrx)) {
         return;
     }
 
@@ -179,7 +179,7 @@ void QEngine::ApplySingleBit(const complex* mtrx, bitLenInt qubit)
 void QEngine::ApplyControlledSingleBit(
     const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& target, const complex* mtrx)
 {
-    if (IsIdentity(mtrx)) {
+    if (randGlobalPhase && IsIdentity(mtrx)) {
         return;
     }
 
@@ -200,7 +200,7 @@ void QEngine::ApplyControlledSingleBit(
 void QEngine::ApplyAntiControlledSingleBit(
     const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& target, const complex* mtrx)
 {
-    if (IsIdentity(mtrx)) {
+    if (randGlobalPhase && IsIdentity(mtrx)) {
         return;
     }
 

--- a/src/qinterface/gates.cpp
+++ b/src/qinterface/gates.cpp
@@ -361,7 +361,7 @@ void QInterface::UniformlyControlledSingleBit(const bitLenInt* controls, const b
 void QInterface::PhaseFlip()
 {
     if (!randGlobalPhase) {
-        ApplySinglePhase(ONE_CMPLX, ONE_CMPLX, 0);
+        ApplySinglePhase(-ONE_CMPLX, -ONE_CMPLX, 0);
     }
 }
 

--- a/src/qinterface/protected.cpp
+++ b/src/qinterface/protected.cpp
@@ -225,7 +225,7 @@ bool QInterface::IsIdentity(const complex* mtrx, bool isControlled)
 {
     // If the effect of applying the buffer would be (approximately or exactly) that of applying the identity
     // operator, then we can discard this buffer without applying it.
-    if ((mtrx[0] != mtrx[3]) || (norm(mtrx[1]) != 0) || (norm(mtrx[2]) != 0)) {
+    if ((mtrx[0] != mtrx[3]) || (mtrx[1] != ZERO_CMPLX) || (mtrx[2] != ZERO_CMPLX)) {
         return false;
     }
 

--- a/src/qinterface/protected.cpp
+++ b/src/qinterface/protected.cpp
@@ -235,7 +235,7 @@ bool QInterface::IsIdentity(const complex* mtrx, bool isControlled)
     // the user's purposes. If the global phase offset has not been randomized, user code might explicitly depend on
     // the global phase offset.
 
-    if ((isControlled || !randGlobalPhase) && (imag(mtrx[0]) != ONE_CMPLX)) {
+    if ((isControlled || !randGlobalPhase) && (mtrx[0] != ONE_CMPLX)) {
         return false;
     }
 

--- a/src/qinterface/protected.cpp
+++ b/src/qinterface/protected.cpp
@@ -235,7 +235,7 @@ bool QInterface::IsIdentity(const complex* mtrx, bool isControlled)
     // the user's purposes. If the global phase offset has not been randomized, user code might explicitly depend on
     // the global phase offset.
 
-    if ((isControlled || !randGlobalPhase) && (imag(mtrx[0]) != ONE_R1)) {
+    if ((isControlled || !randGlobalPhase) && (imag(mtrx[0]) != ONE_CMPLX)) {
         return false;
     }
 

--- a/src/qinterface/protected.cpp
+++ b/src/qinterface/protected.cpp
@@ -229,13 +229,13 @@ bool QInterface::IsIdentity(const complex* mtrx, bool isControlled)
         return false;
     }
 
-    // Now, we now that mtrx[1] and mtrx[2] are 0 and mtrx[0]==mtrx[3].
+    // Now, we know that mtrx[1] and mtrx[2] are 0 and mtrx[0]==mtrx[3].
 
     // If the global phase offset has been randomized, we assume that global phase offsets are inconsequential, for
     // the user's purposes. If the global phase offset has not been randomized, user code might explicitly depend on
-    // the global phase offset (but shouldn't).
+    // the global phase offset.
 
-    if ((isControlled || !randGlobalPhase) && (imag(mtrx[0]) != 0)) {
+    if ((isControlled || !randGlobalPhase) && (imag(mtrx[0]) != ONE_R1)) {
         return false;
     }
 

--- a/src/qpager.cpp
+++ b/src/qpager.cpp
@@ -1233,6 +1233,15 @@ void QPager::FSim(real1_f theta, real1_f phi, bitLenInt qubit1, bitLenInt qubit2
     CombineAndOp([&](QEnginePtr engine) { engine->FSim(theta, phi, qubit1, qubit2); }, { qubit1, qubit2 });
 }
 
+void QPager::ZeroPhaseFlip(bitLenInt start, bitLenInt length)
+{
+    // TODO: Get rid of this entirely. The need for this points to a bug in the general area of
+    // ApplyAntiControlledSingleBit().
+
+    CombineAndOp([&](QEnginePtr engine) { engine->ZeroPhaseFlip(start, length); },
+        { static_cast<bitLenInt>(start + length - 1U) });
+}
+
 real1_f QPager::Prob(bitLenInt qubit)
 {
     if (qPages.size() == 1U) {

--- a/src/qpager.cpp
+++ b/src/qpager.cpp
@@ -597,12 +597,54 @@ void QPager::ApplySingleBit(const complex* mtrx, bitLenInt target)
 void QPager::ApplySingleEither(const bool& isInvert, complex top, complex bottom, bitLenInt target)
 {
     SeparateEngines();
-    if (isInvert) {
-        SingleBitGate(target,
-            [top, bottom](QEnginePtr engine, bitLenInt lTarget) { engine->ApplySingleInvert(top, bottom, lTarget); });
-    } else {
-        SingleBitGate(target,
-            [top, bottom](QEnginePtr engine, bitLenInt lTarget) { engine->ApplySinglePhase(top, bottom, lTarget); });
+    bitLenInt qpp = qubitsPerPage();
+
+    if (target < qpp) {
+        if (isInvert) {
+            SingleBitGate(target, [top, bottom](QEnginePtr engine, bitLenInt lTarget) {
+                engine->ApplySingleInvert(top, bottom, lTarget);
+            });
+        } else {
+            SingleBitGate(target, [top, bottom](QEnginePtr engine, bitLenInt lTarget) {
+                engine->ApplySinglePhase(top, bottom, lTarget);
+            });
+        }
+
+        return;
+    }
+
+    if (randGlobalPhase) {
+        bottom /= top;
+        top = ONE_CMPLX;
+    }
+
+    target -= qpp;
+    bitCapIntOcl targetPow = pow2Ocl(target);
+    bitCapIntOcl qMask = targetPow - 1U;
+
+    bitCapIntOcl maxLCV = qPages.size() >> 1U;
+    std::vector<std::future<void>> futures(maxLCV);
+    bitCapIntOcl i;
+    for (i = 0; i < maxLCV; i++) {
+        futures[i] = std::async(std::launch::async, [this, i, &isInvert, &top, &bottom, &targetPow, &qMask]() {
+            bitCapIntOcl j = i & qMask;
+            j |= (i ^ j) << ONE_BCI;
+
+            if (isInvert) {
+                std::swap(qPages[j], qPages[j + targetPow]);
+            }
+
+            if (top != ONE_CMPLX) {
+                qPages[j]->ApplySinglePhase(top, top, 0);
+            }
+            if (bottom != ONE_CMPLX) {
+                qPages[j + targetPow]->ApplySinglePhase(bottom, bottom, 0);
+            }
+        });
+    }
+
+    for (i = 0; i < maxLCV; i++) {
+        futures[i].get();
     }
 }
 

--- a/src/qpager.cpp
+++ b/src/qpager.cpp
@@ -1237,42 +1237,8 @@ void QPager::ZeroPhaseFlip(bitLenInt start, bitLenInt length)
 {
     // TODO: Get rid of this entirely. The need for this points to a bug in the general area of
     // ApplyAntiControlledSingleBit().
-
-    bitLenInt qpp = qubitsPerPage();
-
-    bitCapIntOcl i;
-
-    if (start >= qpp) {
-        // Entirely meta-
-        start -= qpp;
-        bitCapIntOcl mask = pow2Ocl(start + length) - pow2Ocl(start);
-        for (i = 0; i < qPages.size(); i++) {
-            if ((i & mask) == 0U) {
-                qPages[i]->PhaseFlip();
-            }
-        }
-
-        return;
-    }
-
-    if ((start + length) > qpp) {
-        // Semi-meta-
-        bitLenInt metaLen = (start + length) - qpp;
-        bitLenInt remainderLen = length - metaLen;
-        bitCapIntOcl mask = pow2Ocl(metaLen) - ONE_BCI;
-        for (i = 0; i < qPages.size(); i++) {
-            if ((i & mask) == 0U) {
-                qPages[i]->ZeroPhaseFlip(start, remainderLen);
-            }
-        }
-
-        return;
-    }
-
-    // Contained in sub-units
-    for (i = 0; i < qPages.size(); i++) {
-        qPages[i]->ZeroPhaseFlip(start, length);
-    }
+    CombineAndOp([&](QEnginePtr engine) { engine->ZeroPhaseFlip(start, length); },
+        { static_cast<bitLenInt>(start + length - 1U) });
 }
 
 real1_f QPager::Prob(bitLenInt qubit)

--- a/src/qpager.cpp
+++ b/src/qpager.cpp
@@ -1233,14 +1233,6 @@ void QPager::FSim(real1_f theta, real1_f phi, bitLenInt qubit1, bitLenInt qubit2
     CombineAndOp([&](QEnginePtr engine) { engine->FSim(theta, phi, qubit1, qubit2); }, { qubit1, qubit2 });
 }
 
-void QPager::ZeroPhaseFlip(bitLenInt start, bitLenInt length)
-{
-    // TODO: Get rid of this entirely. The need for this points to a bug in the general area of
-    // ApplyAntiControlledSingleBit().
-    CombineAndOp([&](QEnginePtr engine) { engine->ZeroPhaseFlip(start, length); },
-        { static_cast<bitLenInt>(start + length - 1U) });
-}
-
 real1_f QPager::Prob(bitLenInt qubit)
 {
     if (qPages.size() == 1U) {

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1301,28 +1301,6 @@ void QUnit::FSim(real1_f theta, real1_f phi, bitLenInt qubit1, bitLenInt qubit2)
     shard2.MakeDirty();
 }
 
-void QUnit::ZeroPhaseFlip(bitLenInt start, bitLenInt length)
-{
-    if (!length) {
-        return;
-    }
-
-    if (length == 1U) {
-        ApplySinglePhase(-ONE_CMPLX, ONE_CMPLX, start);
-        return;
-    }
-
-    if ((engine == QINTERFACE_QPAGER) || (subEngine == QINTERFACE_QPAGER)) {
-        // TODO: Case below this should work for QPager, but doesn't
-        EntangleRange(start, length);
-        shards[start].unit->ZeroPhaseFlip(shards[start].mapped, length);
-        DirtyShardRange(start, length);
-        return;
-    }
-
-    QInterface::ZeroPhaseFlip(start, length);
-}
-
 void QUnit::UniformlyControlledSingleBit(const bitLenInt* controls, const bitLenInt& controlLen, bitLenInt qubitIndex,
     const complex* mtrxs, const bitCapInt* mtrxSkipPowers, const bitLenInt mtrxSkipLen,
     const bitCapInt& mtrxSkipValueMask)

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1301,6 +1301,28 @@ void QUnit::FSim(real1_f theta, real1_f phi, bitLenInt qubit1, bitLenInt qubit2)
     shard2.MakeDirty();
 }
 
+void QUnit::ZeroPhaseFlip(bitLenInt start, bitLenInt length)
+{
+    if (!length) {
+        return;
+    }
+
+    if (length == 1U) {
+        ApplySinglePhase(-ONE_CMPLX, ONE_CMPLX, start);
+        return;
+    }
+
+    if ((engine == QINTERFACE_QPAGER) || (subEngine == QINTERFACE_QPAGER)) {
+        // TODO: Case below this should work for QPager, but doesn't
+        EntangleRange(start, length);
+        shards[start].unit->ZeroPhaseFlip(shards[start].mapped, length);
+        DirtyShardRange(start, length);
+        return;
+    }
+
+    QInterface::ZeroPhaseFlip(start, length);
+}
+
 void QUnit::UniformlyControlledSingleBit(const bitLenInt* controls, const bitLenInt& controlLen, bitLenInt qubitIndex,
     const complex* mtrxs, const bitCapInt* mtrxSkipPowers, const bitLenInt mtrxSkipLen,
     const bitCapInt& mtrxSkipValueMask)


### PR DESCRIPTION
I found the problem with `QPager::ApplySingleEither()`: `QEngine` was not considering `randGlobalPhase` before making global phase shift optimizations.