### PR TITLE
Fix IS_0_NORM() macro

### DIFF
--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -30,7 +30,7 @@
 
 #define DIRTY(shard) (shard.isPhaseDirty || shard.isProbDirty)
 #define IS_NORM_0(c) (norm(c) <= FP_NORM_EPSILON)
-#define IS_0_R1(r) (r == ZERO_R1)
+#define IS_0_R1(r) ((r <= FP_NORM_EPSILON) && (-r <= FP_NORM_EPSILON))
 #define IS_1_R1(r) (r == ONE_R1)
 #define IS_1_CMPLX(c) (c == ONE_CMPLX)
 #define SHARD_STATE(shard) (norm(shard.amp0) < (ONE_R1 / 2))


### PR DESCRIPTION
I need to see whether the PR CI passes, but this seems to address the problem with the CI float epsilon.