### PR TITLE
Smarter QHybrid threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,9 @@ Qrack was originally written so that the disassembler of VM6502Q should show the
 
 Copyright (c) Daniel Strano and the Qrack contributors 2017-2021. All rights reserved.
 
-Daniel Strano would like to specifically note that Benn Bollay is almost entirely responsible for the initial implementation of QUnit and tooling, including unit tests, in addition to large amounts of work on the documentation and many other various contributions in intensive reviews. Also, thank you to Marek Karcz for supplying an awesome base classical 6502 emulator for proof-of-concept. We thank the Unitary Fund for its generous support, in a project to help standardize benchmarks across quantum computer simulator software! (Additionally, the font for the Qrack logo is "Electrickle," distributed as "Freeware" from [https://www.fontspace.com/fontastic/electrickle](https://www.fontspace.com/fontastic/electrickle).) Thank you to any and all contributors!
+Daniel Strano would like to specifically note that Benn Bollay is almost entirely responsible for the initial implementation of QUnit and tooling, including unit tests, in addition to large amounts of work on the documentation and many other various contributions in intensive reviews. Also, thank you to Marek Karcz for supplying an awesome base classical 6502 emulator for proof-of-concept. For unit tests and benchmarks, Qrack uses Catch v2.13.2 under the Boost Software License, Version 1.0. (Additionally, the font for the Qrack logo is "Electrickle," distributed as "Freeware" from [https://www.fontspace.com/fontastic/electrickle](https://www.fontspace.com/fontastic/electrickle).)
+
+We thank the Unitary Fund for its generous support, in a project to help standardize benchmarks across quantum computer simulator software!  Thank you to any and all contributors!
 
 Licensed under the GNU Lesser General Public License V3.
 

--- a/src/qhybrid.cpp
+++ b/src/qhybrid.cpp
@@ -35,10 +35,14 @@ QHybrid::QHybrid(bitLenInt qBitCount, bitCapInt initState, qrack_rand_gen_ptr rg
     } else {
         // Single bit gates act pairwise on amplitudes, so add at least 1 qubit to the log2 of the preferred
         // concurrency.
+#if ENABLE_OPENCL
         bitLenInt gpuQubits = log2(OCLEngine::Instance()->GetDeviceContextPtr(devID)->GetPreferredConcurrency()) + 1U;
         bitLenInt cpuQubits = (concurrency == 1 ? PSTRIDEPOW : (log2(concurrency - 1) + PSTRIDEPOW + 1));
 
         thresholdQubits = gpuQubits < cpuQubits ? gpuQubits : cpuQubits;
+#else
+        thresholdQubits = (concurrency == 1 ? PSTRIDEPOW : (log2(concurrency - 1) + PSTRIDEPOW + 1));
+#endif
     }
 
     isGpu = (qubitCount >= thresholdQubits);

--- a/src/qhybrid.cpp
+++ b/src/qhybrid.cpp
@@ -25,9 +25,18 @@ QHybrid::QHybrid(bitLenInt qBitCount, bitCapInt initState, qrack_rand_gen_ptr rg
     , isSparse(useSparseStateVec)
 {
     concurrency = std::thread::hardware_concurrency();
-    thresholdQubits = (qubitThreshold != 0)
-        ? qubitThreshold
-        : (concurrency == 1 ? PSTRIDEPOW : (log2(concurrency - 1) + PSTRIDEPOW + 1));
+
+    if (qubitThreshold != 0) {
+        thresholdQubits = qubitThreshold;
+    } else {
+        // Single bit gates act pairwise on amplitudes, so add at least 1 qubit to the log2 of the preferred
+        // concurrency.
+        bitLenInt gpuQubits = log2(OCLEngine::Instance()->GetDeviceContextPtr(devID)->GetPreferredConcurrency()) + 1U;
+        bitLenInt cpuQubits = (concurrency == 1 ? PSTRIDEPOW : (log2(concurrency - 1) + PSTRIDEPOW + 1));
+
+        thresholdQubits = gpuQubits < cpuQubits ? gpuQubits : cpuQubits;
+    }
+
     isGpu = (qubitCount >= thresholdQubits);
     engine = MakeEngine(qubitCount >= thresholdQubits, initState);
 }

--- a/src/qhybrid.cpp
+++ b/src/qhybrid.cpp
@@ -10,7 +10,10 @@
 
 #include <thread>
 
+#if ENABLE_OPENCL
 #include "common/oclengine.hpp"
+#endif
+
 #include "qfactory.hpp"
 #include "qhybrid.hpp"
 

--- a/src/qhybrid.cpp
+++ b/src/qhybrid.cpp
@@ -10,6 +10,7 @@
 
 #include <thread>
 
+#include "common/oclengine.hpp"
 #include "qfactory.hpp"
 #include "qhybrid.hpp"
 


### PR DESCRIPTION
When `QHybrid` switch-off threshold from `QEngineCPU` is overlapped with paging threshold from `QPager`, favor the threshold of `QPager`.