### PR TITLE
Only include QHybrid if OpenCL enabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,6 @@ add_library (qrack STATIC
     src/qengine/utility.cpp
     src/qunit.cpp
     src/qpager.cpp
-    src/qhybrid.cpp
     src/qstabilizer.cpp
     src/qstabilizerhybrid.cpp
     )

--- a/cmake/OpenCL.cmake
+++ b/cmake/OpenCL.cmake
@@ -105,6 +105,7 @@ if (ENABLE_OPENCL)
         ${COMPILED_RESOURCES}
         src/common/oclengine.cpp
         src/qengine/opencl.cpp
+        src/qhybrid.cpp
         src/qunitmulti.cpp
         )
 

--- a/include/qhybrid.hpp
+++ b/include/qhybrid.hpp
@@ -11,6 +11,10 @@
 // for details.
 #pragma once
 
+#if !ENABLE_OPENCL
+#error OpenCL has not been enabled
+#endif
+
 #include "qengine.hpp"
 
 namespace Qrack {

--- a/src/qhybrid.cpp
+++ b/src/qhybrid.cpp
@@ -10,9 +10,7 @@
 
 #include <thread>
 
-#if ENABLE_OPENCL
 #include "common/oclengine.hpp"
-#endif
 
 #include "qfactory.hpp"
 #include "qhybrid.hpp"
@@ -35,14 +33,10 @@ QHybrid::QHybrid(bitLenInt qBitCount, bitCapInt initState, qrack_rand_gen_ptr rg
     } else {
         // Single bit gates act pairwise on amplitudes, so add at least 1 qubit to the log2 of the preferred
         // concurrency.
-#if ENABLE_OPENCL
         bitLenInt gpuQubits = log2(OCLEngine::Instance()->GetDeviceContextPtr(devID)->GetPreferredConcurrency()) + 1U;
         bitLenInt cpuQubits = (concurrency == 1 ? PSTRIDEPOW : (log2(concurrency - 1) + PSTRIDEPOW + 1));
 
         thresholdQubits = gpuQubits < cpuQubits ? gpuQubits : cpuQubits;
-#else
-        thresholdQubits = (concurrency == 1 ? PSTRIDEPOW : (log2(concurrency - 1) + PSTRIDEPOW + 1));
-#endif
     }
 
     isGpu = (qubitCount >= thresholdQubits);


### PR DESCRIPTION
There is no point in compiling `QHybrid` for use if OpenCL is not enabled. (This also reduces the size of the compiled binary.)