### PR TITLE
Fix QEngineOCL headers

### DIFF
--- a/include/qengine_opencl.hpp
+++ b/include/qengine_opencl.hpp
@@ -12,6 +12,8 @@
 
 #pragma once
 
+#include "common/qrack_types.hpp"
+
 #if !ENABLE_OPENCL
 #error OpenCL has not been enabled
 #endif

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -12,9 +12,7 @@
 
 #include <memory>
 
-#include "oclengine.hpp"
 #include "qengine_opencl.hpp"
-#include "qfactory.hpp"
 
 namespace Qrack {
 


### PR DESCRIPTION
The header inclusions for `QEngineOCL` have been simplified/corrected.