### PR TITLE
Don't default to OpenCL if 0 devices available

### DIFF
--- a/include/qpager.hpp
+++ b/include/qpager.hpp
@@ -38,6 +38,7 @@ protected:
     bitLenInt minPageQubits;
     bitLenInt maxPageQubits;
     bitLenInt thresholdQubitsPerPage;
+    bitLenInt pStridePow;
     bitLenInt baseQubitsPerPage;
     bitCapInt basePageCount;
     bitCapIntOcl basePageMaxQPower;
@@ -69,7 +70,7 @@ protected:
         } else if (useHardwareThreshold) {
             thresholdQubitsPerPage = qubitCount - qpd;
 
-            minPageQubits = log2(std::thread::hardware_concurrency()) + PSTRIDEPOW;
+            minPageQubits = log2(std::thread::hardware_concurrency()) + pStridePow;
             if (thresholdQubitsPerPage < minPageQubits) {
                 thresholdQubitsPerPage = minPageQubits;
             }

--- a/src/qhybrid.cpp
+++ b/src/qhybrid.cpp
@@ -8,6 +8,10 @@
 // See LICENSE.md in the project root or https://www.gnu.org/licenses/lgpl-3.0.en.html
 // for details.
 
+#if defined(_WIN32) && !defined(__CYGWIN__)
+#include <direct.h>
+#endif
+
 #include <thread>
 
 #include "common/oclengine.hpp"
@@ -34,7 +38,11 @@ QHybrid::QHybrid(bitLenInt qBitCount, bitCapInt initState, qrack_rand_gen_ptr rg
         // Single bit gates act pairwise on amplitudes, so add at least 1 qubit to the log2 of the preferred
         // concurrency.
         bitLenInt gpuQubits = log2(OCLEngine::Instance()->GetDeviceContextPtr(devID)->GetPreferredConcurrency()) + 1U;
-        bitLenInt cpuQubits = (concurrency == 1 ? PSTRIDEPOW : (log2(concurrency - 1) + PSTRIDEPOW + 1));
+
+        bitLenInt pStridePow =
+            getenv("QRACK_PSTRIDEPOW") ? (bitLenInt)std::stoi(std::string(getenv("QRACK_PSTRIDEPOW"))) : PSTRIDEPOW;
+
+        bitLenInt cpuQubits = (concurrency == 1 ? pStridePow : (log2(concurrency - 1) + pStridePow + 1));
 
         thresholdQubits = gpuQubits < cpuQubits ? gpuQubits : cpuQubits;
     }

--- a/src/qpager.cpp
+++ b/src/qpager.cpp
@@ -34,6 +34,7 @@ QPager::QPager(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState, q
     , deviceIDs(devList)
     , useHardwareThreshold(false)
     , thresholdQubitsPerPage(qubitThreshold)
+    , pStridePow(PSTRIDEPOW)
 {
 #if !ENABLE_OPENCL
     if (engine == QINTERFACE_HYBRID) {
@@ -87,7 +88,11 @@ QPager::QPager(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState, q
         thresholdQubitsPerPage = qubitCount - qpd;
 
         maxPageQubits = -1;
-        minPageQubits = log2(std::thread::hardware_concurrency()) + PSTRIDEPOW;
+
+        pStridePow =
+            getenv("QRACK_PSTRIDEPOW") ? (bitLenInt)std::stoi(std::string(getenv("QRACK_PSTRIDEPOW"))) : PSTRIDEPOW;
+
+        minPageQubits = log2(std::thread::hardware_concurrency()) + pStridePow;
 
         if (thresholdQubitsPerPage < minPageQubits) {
             thresholdQubitsPerPage = minPageQubits;

--- a/src/qpager.cpp
+++ b/src/qpager.cpp
@@ -53,6 +53,10 @@ QPager::QPager(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState, q
     }
 
 #if ENABLE_OPENCL
+    if (!(OCLEngine::Instance()->GetDeviceCount())) {
+        engine = QINTERFACE_CPU;
+    }
+
     if ((thresholdQubitsPerPage == 0) && ((engine == QINTERFACE_OPENCL) || (engine == QINTERFACE_HYBRID))) {
         useHardwareThreshold = true;
 

--- a/src/qstabilizerhybrid.cpp
+++ b/src/qstabilizerhybrid.cpp
@@ -35,7 +35,7 @@ QStabilizerHybrid::QStabilizerHybrid(QInterfaceEngine eng, QInterfaceEngine subE
 {
     if (subEngineType == QINTERFACE_STABILIZER_HYBRID) {
 #if ENABLE_OPENCL
-        subEngineType = QINTERFACE_HYBRID;
+        subEngineType = OCLEngine::Instance()->GetDeviceCount() ? QINTERFACE_HYBRID : QINTERFACE_CPU;
 #else
         subEngineType = QINTERFACE_CPU;
 #endif
@@ -43,7 +43,7 @@ QStabilizerHybrid::QStabilizerHybrid(QInterfaceEngine eng, QInterfaceEngine subE
 
     if (engineType == QINTERFACE_STABILIZER_HYBRID) {
 #if ENABLE_OPENCL
-        engineType = QINTERFACE_HYBRID;
+        engineType = OCLEngine::Instance()->GetDeviceCount() ? QINTERFACE_HYBRID : QINTERFACE_CPU;
 #else
         engineType = QINTERFACE_CPU;
 #endif
@@ -51,7 +51,7 @@ QStabilizerHybrid::QStabilizerHybrid(QInterfaceEngine eng, QInterfaceEngine subE
 
     if ((engineType == QINTERFACE_QPAGER) && (subEngineType == QINTERFACE_QPAGER)) {
 #if ENABLE_OPENCL
-        subEngineType = QINTERFACE_HYBRID;
+        subEngineType = OCLEngine::Instance()->GetDeviceCount() ? QINTERFACE_HYBRID : QINTERFACE_CPU;
 #else
         subEngineType = QINTERFACE_CPU;
 #endif


### PR DESCRIPTION
It's not a case that I've frequently encountered, but it's possible that Qrack is built on a system with the OpenCL library, but no available devices at the time. Actually, it's probably a relatively _common_ scenario, particularly for pre-compiled binaries as in my experiments with packaging the compiled library for Unity, or similarly with our Q# support. We already had an API method to count the available devices, so `QHybrid` and `QEngineOCL` sub-layers should always be replaced with `QEngineCPU`, in this case, at least for defaults. 