### PR TITLE
Check if 0 devices before defaulting to OpenCL

### DIFF
--- a/src/common/oclengine.cpp
+++ b/src/common/oclengine.cpp
@@ -257,7 +257,7 @@ void OCLEngine::InitOCL(bool buildFromSource, bool saveBinaries, std::string hom
 
     if (all_platforms.size() == 0) {
         std::cout << " No platforms found. Check OpenCL installation!\n";
-        exit(1);
+        return;
     }
 
     // get all devices
@@ -279,7 +279,7 @@ void OCLEngine::InitOCL(bool buildFromSource, bool saveBinaries, std::string hom
     }
     if (all_devices.size() == 0) {
         std::cout << " No devices found. Check OpenCL installation!\n";
-        exit(1);
+        return;
     }
 
     int deviceCount = all_devices.size();

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -425,11 +425,11 @@ real1_f QEngineOCL::ProbAll(bitCapInt fullRegister)
 
 void QEngineOCL::SetDevice(const int& dID, const bool& forceReInit)
 {
-    bool didInit = (nrmArray != NULL);
-
     if (!(OCLEngine::Instance()->GetDeviceCount())) {
-        throw std::runtime_error("Tried to initialize QEngineOCL, nut no available OpenCL devices.");
+        throw std::runtime_error("Tried to initialize QEngineOCL, but no available OpenCL devices.");
     }
+
+    bool didInit = (nrmArray != NULL);
 
     clFinish();
 

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -427,6 +427,10 @@ void QEngineOCL::SetDevice(const int& dID, const bool& forceReInit)
 {
     bool didInit = (nrmArray != NULL);
 
+    if (!(OCLEngine::Instance()->GetDeviceCount())) {
+        throw std::runtime_error("Tried to initialize QEngineOCL, nut no available OpenCL devices.");
+    }
+
     clFinish();
 
     int oldContextId = device_context ? device_context->context_id : 0;

--- a/src/qpager.cpp
+++ b/src/qpager.cpp
@@ -53,6 +53,10 @@ QPager::QPager(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState, q
     }
 
 #if ENABLE_OPENCL
+    if (!(OCLEngine::Instance()->GetDeviceCount())) {
+        engine = QINTERFACE_CPU;
+    }
+
     if ((thresholdQubitsPerPage == 0) && ((engine == QINTERFACE_OPENCL) || (engine == QINTERFACE_HYBRID))) {
         useHardwareThreshold = true;
 

--- a/src/qstabilizerhybrid.cpp
+++ b/src/qstabilizerhybrid.cpp
@@ -35,7 +35,7 @@ QStabilizerHybrid::QStabilizerHybrid(QInterfaceEngine eng, QInterfaceEngine subE
 {
     if (subEngineType == QINTERFACE_STABILIZER_HYBRID) {
 #if ENABLE_OPENCL
-        subEngineType = QINTERFACE_HYBRID;
+        subEngineType = OCLEngine::Instance()->GetDeviceCount() ? QINTERFACE_HYBRID : QINTERFACE_CPU;
 #else
         subEngineType = QINTERFACE_CPU;
 #endif
@@ -43,7 +43,7 @@ QStabilizerHybrid::QStabilizerHybrid(QInterfaceEngine eng, QInterfaceEngine subE
 
     if (engineType == QINTERFACE_STABILIZER_HYBRID) {
 #if ENABLE_OPENCL
-        engineType = QINTERFACE_HYBRID;
+        engineType = OCLEngine::Instance()->GetDeviceCount() ? QINTERFACE_HYBRID : QINTERFACE_CPU;
 #else
         engineType = QINTERFACE_CPU;
 #endif
@@ -51,7 +51,7 @@ QStabilizerHybrid::QStabilizerHybrid(QInterfaceEngine eng, QInterfaceEngine subE
 
     if ((engineType == QINTERFACE_QPAGER) && (subEngineType == QINTERFACE_QPAGER)) {
 #if ENABLE_OPENCL
-        subEngineType = QINTERFACE_HYBRID;
+        subEngineType = OCLEngine::Instance()->GetDeviceCount() ? QINTERFACE_HYBRID : QINTERFACE_CPU;
 #else
         subEngineType = QINTERFACE_CPU;
 #endif


### PR DESCRIPTION
(Cherry-picked from #672.)

It's not a case that I've frequently encountered, but it's possible that Qrack is built on a system with the OpenCL library, but no available devices at the time. Actually, it's probably a relatively common scenario, particularly for pre-compiled binaries as in my experiments with packaging the compiled library for Unity, or similarly with our Q# support. We already had an API method to count the available devices, so QHybrid and QEngineOCL sub-layers should always be replaced with QEngineCPU, in this case, at least for defaults.