### PR TITLE
Handle switching with 0 OpenCL devices available w/ OpenCL build

### DIFF
--- a/examples/ordered_list_search.cpp
+++ b/examples/ordered_list_search.cpp
@@ -32,7 +32,8 @@ int main()
     // At each step of the search, we select the quadrant with bounds that could contain our value. In an ideal
     // noiseless quantum computer, this search should be deterministic.
 
-    bitCapIntOcl i, j;
+    bitCapIntOcl i;
+    int64_t j;
     bitLenInt partStart;
     bitLenInt partLength;
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -81,7 +81,11 @@ QUnit::QUnit(QInterfaceEngine eng, QInterfaceEngine subEng, bitLenInt qBitCount,
     }
 
     if ((subEngine == QINTERFACE_QUNIT) || (subEngine == QINTERFACE_QUNIT_MULTI)) {
+#if ENABLE_OPENCL
         subEngine = OCLEngine::Instance()->GetDeviceCount() ? QINTERFACE_OPTIMAL_G1_CHILD : QINTERFACE_CPU;
+#else
+        subEngine = QINTERFACE_OPTIMAL_G1_CHILD;
+#endif
     }
 
     shards = QEngineShardMap();

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -81,7 +81,7 @@ QUnit::QUnit(QInterfaceEngine eng, QInterfaceEngine subEng, bitLenInt qBitCount,
     }
 
     if ((subEngine == QINTERFACE_QUNIT) || (subEngine == QINTERFACE_QUNIT_MULTI)) {
-        subEngine = QINTERFACE_OPTIMAL_G1_CHILD;
+        subEngine = OCLEngine::Instance()->GetDeviceCount() ? QINTERFACE_OPTIMAL_G1_CHILD : QINTERFACE_CPU;
     }
 
     shards = QEngineShardMap();

--- a/test/accuracy_main.cpp
+++ b/test/accuracy_main.cpp
@@ -20,6 +20,11 @@
 #define CATCH_CONFIG_RUNNER /* Access to the configuration. */
 #include "tests.hpp"
 
+#define SHOW_OCL_BANNER()                                                                                              \
+    if (OCLEngine::Instance()->GetDeviceCount()) {                                                                     \
+        CreateQuantumInterface(QINTERFACE_OPENCL, 1, 0).reset();                                                       \
+    }
+
 using namespace Qrack;
 
 enum QInterfaceEngine testEngineType = QINTERFACE_CPU;
@@ -107,7 +112,7 @@ int main(int argc, char* argv[])
             session.config().stream() << "############ QEngine -> OpenCL ############" << std::endl;
             testEngineType = QINTERFACE_OPENCL;
             testSubEngineType = QINTERFACE_OPENCL;
-            CreateQuantumInterface(QINTERFACE_OPENCL, 1, 0).reset(); /* Get the OpenCL banner out of the way. */
+            SHOW_OCL_BANNER();
             num_failed = session.run();
         }
 #endif
@@ -125,7 +130,7 @@ int main(int argc, char* argv[])
         if (num_failed == 0 && opencl_single) {
             session.config().stream() << "############ QUnit -> QEngine -> OpenCL ############" << std::endl;
             testSubEngineType = QINTERFACE_OPENCL;
-            CreateQuantumInterface(QINTERFACE_OPENCL, 1, 0).reset(); /* Get the OpenCL banner out of the way. */
+            SHOW_OCL_BANNER();
             num_failed = session.run();
         }
 #endif

--- a/test/benchmarks_main.cpp
+++ b/test/benchmarks_main.cpp
@@ -40,6 +40,11 @@ bool isBinaryOutput = false;
 int benchmarkSamples = 100;
 std::vector<int> devList;
 
+#define SHOW_OCL_BANNER()                                                                                              \
+    if (OCLEngine::Instance()->GetDeviceCount()) {                                                                     \
+        CreateQuantumInterface(QINTERFACE_OPENCL, 1, 0).reset();                                                       \
+    }
+
 int main(int argc, char* argv[])
 {
     Catch::Session session;
@@ -158,7 +163,7 @@ int main(int argc, char* argv[])
         if (opencl || hybrid || stabilizer || stabilizer_qpager) {
 #if ENABLE_OPENCL
             // Make sure the context singleton is initialized.
-            CreateQuantumInterface(QINTERFACE_OPENCL, 1, 0).reset();
+            SHOW_OCL_BANNER();
 
             DeviceContextPtr device_context = OCLEngine::Instance()->GetDeviceContextPtr(device_id);
             size_t maxMem = device_context->device.getInfo<CL_DEVICE_GLOBAL_MEM_SIZE>() / sizeof(complex);
@@ -206,7 +211,7 @@ int main(int argc, char* argv[])
             session.config().stream() << "############ QEngine -> OpenCL ############" << std::endl;
             testEngineType = QINTERFACE_OPENCL;
             testSubEngineType = QINTERFACE_OPENCL;
-            CreateQuantumInterface(QINTERFACE_OPENCL, 1, 0).reset(); /* Get the OpenCL banner out of the way. */
+            SHOW_OCL_BANNER();
             num_failed = session.run();
         }
 
@@ -214,7 +219,7 @@ int main(int argc, char* argv[])
             session.config().stream() << "############ QStabilizerHybrid -> QHybrid ############" << std::endl;
             testEngineType = QINTERFACE_STABILIZER_HYBRID;
             testSubEngineType = QINTERFACE_HYBRID;
-            CreateQuantumInterface(QINTERFACE_OPENCL, 1, 0).reset(); /* Get the OpenCL banner out of the way. */
+            SHOW_OCL_BANNER();
             num_failed = session.run();
         }
 #else
@@ -239,14 +244,14 @@ int main(int argc, char* argv[])
         if (num_failed == 0 && opencl) {
             session.config().stream() << "############ QPager -> QEngine -> OpenCL ############" << std::endl;
             testSubEngineType = QINTERFACE_OPENCL;
-            CreateQuantumInterface(QINTERFACE_OPENCL, 1, 0).reset(); /* Get the OpenCL banner out of the way. */
+            SHOW_OCL_BANNER();
             num_failed = session.run();
         }
 
         if (num_failed == 0 && hybrid) {
             session.config().stream() << "############ QPager -> QEngine -> Hybrid ############" << std::endl;
             testSubEngineType = QINTERFACE_HYBRID;
-            CreateQuantumInterface(QINTERFACE_OPENCL, 1, 0).reset(); /* Get the OpenCL banner out of the way. */
+            SHOW_OCL_BANNER();
             num_failed = session.run();
         }
 #endif
@@ -278,14 +283,14 @@ int main(int argc, char* argv[])
         if (num_failed == 0 && opencl) {
             session.config().stream() << "############ QUnit -> QEngine -> OpenCL ############" << std::endl;
             testSubEngineType = QINTERFACE_OPENCL;
-            CreateQuantumInterface(QINTERFACE_OPENCL, 1, 0).reset(); /* Get the OpenCL banner out of the way. */
+            SHOW_OCL_BANNER();
             num_failed = session.run();
         }
 
         if (num_failed == 0 && hybrid) {
             session.config().stream() << "############ QUnit -> QHybrid ############" << std::endl;
             testSubEngineType = QINTERFACE_HYBRID;
-            CreateQuantumInterface(QINTERFACE_OPENCL, 1, 0).reset(); /* Get the OpenCL banner out of the way. */
+            SHOW_OCL_BANNER();
             num_failed = session.run();
         }
 
@@ -293,7 +298,7 @@ int main(int argc, char* argv[])
             session.config().stream() << "############ QUnit -> QStabilizerHybrid -> QHybrid ############" << std::endl;
             testSubEngineType = QINTERFACE_STABILIZER_HYBRID;
             testSubSubEngineType = QINTERFACE_HYBRID;
-            CreateQuantumInterface(QINTERFACE_OPENCL, 1, 0).reset(); /* Get the OpenCL banner out of the way. */
+            SHOW_OCL_BANNER();
             num_failed = session.run();
         }
 
@@ -302,7 +307,7 @@ int main(int argc, char* argv[])
                                       << std::endl;
             testSubEngineType = QINTERFACE_STABILIZER_HYBRID;
             testSubSubEngineType = QINTERFACE_QPAGER;
-            CreateQuantumInterface(QINTERFACE_OPENCL, 1, 0).reset(); /* Get the OpenCL banner out of the way. */
+            SHOW_OCL_BANNER();
             num_failed = session.run();
         }
     }
@@ -313,7 +318,7 @@ int main(int argc, char* argv[])
             testEngineType = QINTERFACE_QUNIT_MULTI;
             testSubEngineType = QINTERFACE_OPENCL;
             testSubSubEngineType = QINTERFACE_OPENCL;
-            CreateQuantumInterface(QINTERFACE_OPENCL, 1, 0).reset(); /* Get the OpenCL banner out of the way. */
+            SHOW_OCL_BANNER();
             num_failed = session.run();
         }
 
@@ -322,7 +327,7 @@ int main(int argc, char* argv[])
             testEngineType = QINTERFACE_QUNIT_MULTI;
             testSubEngineType = QINTERFACE_HYBRID;
             testSubSubEngineType = QINTERFACE_HYBRID;
-            CreateQuantumInterface(QINTERFACE_OPENCL, 1, 0).reset(); /* Get the OpenCL banner out of the way. */
+            SHOW_OCL_BANNER();
             num_failed = session.run();
         }
 
@@ -332,7 +337,7 @@ int main(int argc, char* argv[])
             testEngineType = QINTERFACE_QUNIT_MULTI;
             testSubEngineType = QINTERFACE_STABILIZER_HYBRID;
             testSubSubEngineType = QINTERFACE_HYBRID;
-            CreateQuantumInterface(QINTERFACE_OPENCL, 1, 0).reset(); /* Get the OpenCL banner out of the way. */
+            SHOW_OCL_BANNER();
             num_failed = session.run();
         }
 #else
@@ -361,14 +366,14 @@ int main(int argc, char* argv[])
         if (num_failed == 0 && opencl) {
             session.config().stream() << "############ QUnit -> QPager -> OpenCL ############" << std::endl;
             testSubSubEngineType = QINTERFACE_OPENCL;
-            CreateQuantumInterface(QINTERFACE_OPENCL, 1, 0).reset(); /* Get the OpenCL banner out of the way. */
+            SHOW_OCL_BANNER();
             num_failed = session.run();
         }
 
         if (num_failed == 0 && hybrid) {
             session.config().stream() << "############ QUnit -> QPager -> QHybrid ############" << std::endl;
             testSubSubEngineType = QINTERFACE_HYBRID;
-            CreateQuantumInterface(QINTERFACE_OPENCL, 1, 0).reset(); /* Get the OpenCL banner out of the way. */
+            SHOW_OCL_BANNER();
             num_failed = session.run();
         }
 
@@ -387,7 +392,7 @@ int main(int argc, char* argv[])
             testEngineType = QINTERFACE_QUNIT_MULTI;
             testSubEngineType = QINTERFACE_QPAGER;
             testSubSubEngineType = QINTERFACE_HYBRID;
-            CreateQuantumInterface(QINTERFACE_OPENCL, 1, 0).reset(); /* Get the OpenCL banner out of the way. */
+            SHOW_OCL_BANNER();
             num_failed = session.run();
         }
 #endif

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -37,6 +37,11 @@ bool isBinaryOutput;
 int benchmarkSamples;
 std::vector<int> devList;
 
+#define SHOW_OCL_BANNER()                                                                                              \
+    if (OCLEngine::Instance()->GetDeviceCount()) {                                                                     \
+        CreateQuantumInterface(QINTERFACE_OPENCL, 1, 0).reset();                                                       \
+    }
+
 int main(int argc, char* argv[])
 {
     Catch::Session session;
@@ -159,7 +164,7 @@ int main(int argc, char* argv[])
             session.config().stream() << "############ QEngine -> OpenCL ############" << std::endl;
             testEngineType = QINTERFACE_OPENCL;
             testSubEngineType = QINTERFACE_OPENCL;
-            CreateQuantumInterface(QINTERFACE_OPENCL, 1, 0).reset(); /* Get the OpenCL banner out of the way. */
+            SHOW_OCL_BANNER();
             num_failed = session.run();
         }
 
@@ -167,7 +172,7 @@ int main(int argc, char* argv[])
             session.config().stream() << "############ QStabilizerHybrid -> QHybrid ############" << std::endl;
             testEngineType = QINTERFACE_STABILIZER_HYBRID;
             testSubEngineType = QINTERFACE_HYBRID;
-            CreateQuantumInterface(QINTERFACE_OPENCL, 1, 0).reset(); /* Get the OpenCL banner out of the way. */
+            SHOW_OCL_BANNER();
             num_failed = session.run();
         }
 #else
@@ -192,14 +197,14 @@ int main(int argc, char* argv[])
         if (num_failed == 0 && opencl) {
             session.config().stream() << "############ QPager -> QEngine -> OpenCL ############" << std::endl;
             testSubEngineType = QINTERFACE_OPENCL;
-            CreateQuantumInterface(QINTERFACE_OPENCL, 1, 0).reset(); /* Get the OpenCL banner out of the way. */
+            SHOW_OCL_BANNER();
             num_failed = session.run();
         }
 
         if (num_failed == 0 && hybrid) {
             session.config().stream() << "############ QPager -> QEngine -> Hybrid ############" << std::endl;
             testSubEngineType = QINTERFACE_HYBRID;
-            CreateQuantumInterface(QINTERFACE_OPENCL, 1, 0).reset(); /* Get the OpenCL banner out of the way. */
+            SHOW_OCL_BANNER();
             num_failed = session.run();
         }
 #endif
@@ -231,14 +236,14 @@ int main(int argc, char* argv[])
         if (num_failed == 0 && opencl) {
             session.config().stream() << "############ QUnit -> QEngine -> OpenCL ############" << std::endl;
             testSubEngineType = QINTERFACE_OPENCL;
-            CreateQuantumInterface(QINTERFACE_OPENCL, 1, 0).reset(); /* Get the OpenCL banner out of the way. */
+            SHOW_OCL_BANNER();
             num_failed = session.run();
         }
 
         if (num_failed == 0 && hybrid) {
             session.config().stream() << "############ QUnit -> QHybrid ############" << std::endl;
             testSubEngineType = QINTERFACE_HYBRID;
-            CreateQuantumInterface(QINTERFACE_OPENCL, 1, 0).reset(); /* Get the OpenCL banner out of the way. */
+            SHOW_OCL_BANNER();
             num_failed = session.run();
         }
 
@@ -246,7 +251,7 @@ int main(int argc, char* argv[])
             session.config().stream() << "############ QUnit -> QStabilizerHybrid -> QHybrid ############" << std::endl;
             testSubEngineType = QINTERFACE_STABILIZER_HYBRID;
             testSubSubEngineType = QINTERFACE_HYBRID;
-            CreateQuantumInterface(QINTERFACE_OPENCL, 1, 0).reset(); /* Get the OpenCL banner out of the way. */
+            SHOW_OCL_BANNER();
             num_failed = session.run();
         }
 
@@ -255,7 +260,7 @@ int main(int argc, char* argv[])
                                       << std::endl;
             testSubEngineType = QINTERFACE_STABILIZER_HYBRID;
             testSubSubEngineType = QINTERFACE_QPAGER;
-            CreateQuantumInterface(QINTERFACE_OPENCL, 1, 0).reset(); /* Get the OpenCL banner out of the way. */
+            SHOW_OCL_BANNER();
             num_failed = session.run();
         }
     }
@@ -266,7 +271,7 @@ int main(int argc, char* argv[])
             testEngineType = QINTERFACE_QUNIT_MULTI;
             testSubEngineType = QINTERFACE_OPENCL;
             testSubSubEngineType = QINTERFACE_OPENCL;
-            CreateQuantumInterface(QINTERFACE_OPENCL, 1, 0).reset(); /* Get the OpenCL banner out of the way. */
+            SHOW_OCL_BANNER();
             num_failed = session.run();
         }
 
@@ -275,7 +280,7 @@ int main(int argc, char* argv[])
             testEngineType = QINTERFACE_QUNIT_MULTI;
             testSubEngineType = QINTERFACE_HYBRID;
             testSubSubEngineType = QINTERFACE_HYBRID;
-            CreateQuantumInterface(QINTERFACE_OPENCL, 1, 0).reset(); /* Get the OpenCL banner out of the way. */
+            SHOW_OCL_BANNER();
             num_failed = session.run();
         }
 
@@ -285,7 +290,7 @@ int main(int argc, char* argv[])
             testEngineType = QINTERFACE_QUNIT_MULTI;
             testSubEngineType = QINTERFACE_STABILIZER_HYBRID;
             testSubSubEngineType = QINTERFACE_HYBRID;
-            CreateQuantumInterface(QINTERFACE_OPENCL, 1, 0).reset(); /* Get the OpenCL banner out of the way. */
+            SHOW_OCL_BANNER();
             num_failed = session.run();
         }
 #else
@@ -314,14 +319,14 @@ int main(int argc, char* argv[])
         if (num_failed == 0 && opencl) {
             session.config().stream() << "############ QUnit -> QPager -> OpenCL ############" << std::endl;
             testSubSubEngineType = QINTERFACE_OPENCL;
-            CreateQuantumInterface(QINTERFACE_OPENCL, 1, 0).reset(); /* Get the OpenCL banner out of the way. */
+            SHOW_OCL_BANNER();
             num_failed = session.run();
         }
 
         if (num_failed == 0 && hybrid) {
             session.config().stream() << "############ QUnit -> QPager -> QHybrid ############" << std::endl;
             testSubSubEngineType = QINTERFACE_HYBRID;
-            CreateQuantumInterface(QINTERFACE_OPENCL, 1, 0).reset(); /* Get the OpenCL banner out of the way. */
+            SHOW_OCL_BANNER();
             num_failed = session.run();
         }
 
@@ -340,7 +345,7 @@ int main(int argc, char* argv[])
             testEngineType = QINTERFACE_QUNIT_MULTI;
             testSubEngineType = QINTERFACE_QPAGER;
             testSubSubEngineType = QINTERFACE_HYBRID;
-            CreateQuantumInterface(QINTERFACE_OPENCL, 1, 0).reset(); /* Get the OpenCL banner out of the way. */
+            SHOW_OCL_BANNER();
             num_failed = session.run();
         }
 #endif


### PR DESCRIPTION
With an OpenCL build, I didn't handle default switching under QStabilizerHybrid when 0 OpenCL devices are available.