### PR TITLE
Extended stabilizer under QUnit

### DIFF
--- a/include/qstabilizerhybrid.hpp
+++ b/include/qstabilizerhybrid.hpp
@@ -20,8 +20,32 @@
 
 namespace Qrack {
 
+class QStabilizerShard;
+typedef std::shared_ptr<QStabilizerShard> QStabilizerShardPtr;
+
 class QStabilizerHybrid;
 typedef std::shared_ptr<QStabilizerHybrid> QStabilizerHybridPtr;
+
+struct QStabilizerShard {
+    complex gate[4];
+
+    QStabilizerShard()
+    {
+        gate[0] = ONE_CMPLX;
+        gate[1] = ZERO_CMPLX;
+        gate[2] = ZERO_CMPLX;
+        gate[3] = ONE_CMPLX;
+    }
+
+    QStabilizerShard(complex* g) { std::copy(g, g + 4, gate); }
+
+    void Compose(const complex* g)
+    {
+        complex o[4];
+        std::copy(gate, gate + 4, o);
+        mul2x2((complex*)g, o, gate);
+    }
+};
 
 /**
  * A "Qrack::QStabilizerHybrid" internally switched between Qrack::QEngineCPU and Qrack::QEngineOCL to maximize
@@ -33,6 +57,7 @@ protected:
     QInterfaceEngine subEngineType;
     QInterfacePtr engine;
     QStabilizerPtr stabilizer;
+    std::vector<QStabilizerShardPtr> shards;
     int devID;
     complex phaseFactor;
     bool doNormalize;
@@ -91,6 +116,48 @@ public:
         }
     }
 
+    virtual void SetQubitCount(bitLenInt qb)
+    {
+        QInterface::SetQubitCount(qb);
+        shards.resize(qb);
+    }
+
+    virtual void FlushBuffers()
+    {
+        bitLenInt i;
+
+        if (stabilizer) {
+            for (i = 0; i < qubitCount; i++) {
+                if (shards[i]) {
+                    // This will call FlushBuffers() again after no longer stabilizer.
+                    SwitchToEngine();
+                    return;
+                }
+            }
+        }
+
+        if (stabilizer) {
+            return;
+        }
+
+        for (i = 0; i < qubitCount; i++) {
+            QStabilizerShardPtr shard = shards[i];
+            if (shard) {
+                shards[i] = NULL;
+                ApplySingleBit(shard->gate, i);
+            }
+        }
+    }
+
+    virtual void DumpBuffers()
+    {
+        for (bitLenInt i = 0; i < qubitCount; i++) {
+            if (shards[i]) {
+                shards[i] = NULL;
+            }
+        }
+    }
+
     /**
      * Switches between CPU and GPU used modes. (This will not incur a performance penalty, if the chosen mode matches
      * the current mode.) Mode switching happens automatically when qubit counts change, but Compose() and Decompose()
@@ -103,6 +170,8 @@ public:
     /// Apply a CNOT gate with control and target
     virtual void CNOT(bitLenInt control, bitLenInt target)
     {
+        FlushBuffers();
+
         if (stabilizer) {
             stabilizer->CNOT(control, target);
         } else {
@@ -115,6 +184,13 @@ public:
     /// Apply a Hadamard gate to target
     virtual void H(bitLenInt target)
     {
+        if (shards[target]) {
+            complex mtrx[4] = { complex((real1)M_SQRT1_2, ZERO_R1), complex((real1)M_SQRT1_2, ZERO_R1),
+                complex((real1)M_SQRT1_2, ZERO_R1), complex((real1)-M_SQRT1_2, ZERO_R1) };
+            ApplySingleBit(mtrx, target);
+            return;
+        }
+
         if (stabilizer) {
             stabilizer->H(target);
         } else {
@@ -127,6 +203,12 @@ public:
     /// Apply a phase gate (|0>->|0>, |1>->i|1>, or "S") to qubit b
     virtual void S(bitLenInt target)
     {
+        if (shards[target]) {
+            complex mtrx[4] = { ONE_CMPLX, ZERO_CMPLX, ZERO_CMPLX, I_CMPLX };
+            ApplySingleBit(mtrx, target);
+            return;
+        }
+
         if (stabilizer) {
             stabilizer->S(target);
         } else {
@@ -139,6 +221,12 @@ public:
     // TODO: Custom implementations for decompositions:
     virtual void Z(bitLenInt target)
     {
+        if (shards[target]) {
+            complex mtrx[4] = { ONE_CMPLX, ZERO_CMPLX, ZERO_CMPLX, -ONE_CMPLX };
+            ApplySingleBit(mtrx, target);
+            return;
+        }
+
         if (stabilizer) {
             stabilizer->Z(target);
         } else {
@@ -148,6 +236,12 @@ public:
 
     virtual void IS(bitLenInt target)
     {
+        if (shards[target]) {
+            complex mtrx[4] = { ONE_CMPLX, ZERO_CMPLX, ZERO_CMPLX, -I_CMPLX };
+            ApplySingleBit(mtrx, target);
+            return;
+        }
+
         if (stabilizer) {
             stabilizer->IS(target);
         } else {
@@ -159,6 +253,12 @@ public:
 
     virtual void X(bitLenInt target)
     {
+        if (shards[target]) {
+            complex mtrx[4] = { ZERO_CMPLX, ONE_CMPLX, ONE_CMPLX, ZERO_CMPLX };
+            ApplySingleBit(mtrx, target);
+            return;
+        }
+
         if (stabilizer) {
             stabilizer->X(target);
         } else {
@@ -168,6 +268,12 @@ public:
 
     virtual void Y(bitLenInt target)
     {
+        if (shards[target]) {
+            complex mtrx[4] = { ZERO_CMPLX, -I_CMPLX, I_CMPLX, ZERO_CMPLX };
+            ApplySingleBit(mtrx, target);
+            return;
+        }
+
         if (stabilizer) {
             stabilizer->Y(target);
         } else {
@@ -177,6 +283,8 @@ public:
 
     virtual void CZ(bitLenInt control, bitLenInt target)
     {
+        FlushBuffers();
+
         if (stabilizer) {
             stabilizer->CZ(control, target);
         } else {
@@ -192,6 +300,8 @@ public:
             return;
         }
 
+        FlushBuffers();
+
         if (stabilizer) {
             stabilizer->Swap(qubit1, qubit2);
         } else {
@@ -205,6 +315,8 @@ public:
             return;
         }
 
+        FlushBuffers();
+
         if (stabilizer) {
             stabilizer->ISwap(qubit1, qubit2);
         } else {
@@ -215,6 +327,9 @@ public:
     using QInterface::Compose;
     virtual bitLenInt Compose(QStabilizerHybridPtr toCopy)
     {
+        FlushBuffers();
+        toCopy->FlushBuffers();
+
         bitLenInt toRet;
 
         if (engine) {
@@ -237,6 +352,9 @@ public:
     }
     virtual bitLenInt Compose(QStabilizerHybridPtr toCopy, bitLenInt start)
     {
+        FlushBuffers();
+        toCopy->FlushBuffers();
+
         bitLenInt toRet;
 
         if (engine) {
@@ -268,6 +386,8 @@ public:
     virtual void SetQuantumState(const complex* inputState);
     virtual void GetQuantumState(complex* outputState)
     {
+        FlushBuffers();
+
         if (stabilizer) {
             stabilizer->GetQuantumState(outputState);
         } else {
@@ -287,6 +407,8 @@ public:
     }
     virtual void SetPermutation(bitCapInt perm, complex phaseFac = CMPLX_DEFAULT_ARG)
     {
+        DumpBuffers();
+
         if (stabilizer) {
             stabilizer->SetPermutation(perm);
         } else {
@@ -395,6 +517,8 @@ public:
 
     virtual bool ForceM(bitLenInt qubit, bool result, bool doForce = true, bool doApply = true)
     {
+        FlushBuffers();
+
         // TODO: QStabilizer appears not to be decomposable after measurement and in many cases where a bit is in an
         // eigenstate.
         if (stabilizer &&
@@ -601,6 +725,8 @@ public:
 
     virtual real1_f Prob(bitLenInt qubitIndex)
     {
+        FlushBuffers();
+
         if (engine) {
             return engine->Prob(qubitIndex);
         }
@@ -676,6 +802,9 @@ public:
 
     virtual bool ApproxCompare(QStabilizerHybridPtr toCompare, real1_f error_tol = REAL1_EPSILON)
     {
+        FlushBuffers();
+        toCompare->FlushBuffers();
+
         if (!stabilizer == !(toCompare->engine)) {
             SwitchToEngine();
             toCompare->SwitchToEngine();

--- a/include/qstabilizerhybrid.hpp
+++ b/include/qstabilizerhybrid.hpp
@@ -116,12 +116,6 @@ public:
         }
     }
 
-    virtual void SetQubitCount(bitLenInt qb)
-    {
-        QInterface::SetQubitCount(qb);
-        shards.resize(qb);
-    }
-
     virtual void FlushBuffers()
     {
         bitLenInt i;
@@ -327,9 +321,6 @@ public:
     using QInterface::Compose;
     virtual bitLenInt Compose(QStabilizerHybridPtr toCopy)
     {
-        FlushBuffers();
-        toCopy->FlushBuffers();
-
         bitLenInt toRet;
 
         if (engine) {
@@ -341,6 +332,8 @@ public:
         } else {
             toRet = stabilizer->Compose(toCopy->stabilizer);
         }
+
+        shards.insert(shards.end(), toCopy->shards.begin(), toCopy->shards.end());
 
         SetQubitCount(qubitCount + toCopy->qubitCount);
 
@@ -366,6 +359,8 @@ public:
         } else {
             toRet = stabilizer->Compose(toCopy->stabilizer, start);
         }
+
+        shards.insert(shards.begin() + start, toCopy->shards.begin(), toCopy->shards.end());
 
         SetQubitCount(qubitCount + toCopy->qubitCount);
 

--- a/src/qstabilizerhybrid.cpp
+++ b/src/qstabilizerhybrid.cpp
@@ -25,6 +25,7 @@ QStabilizerHybrid::QStabilizerHybrid(QInterfaceEngine eng, QInterfaceEngine subE
     , engineType(eng)
     , subEngineType(subEng)
     , engine(NULL)
+    , shards(qubitCount)
     , devID(deviceId)
     , phaseFactor(phaseFac)
     , doNormalize(doNorm)
@@ -78,6 +79,8 @@ QInterfacePtr QStabilizerHybrid::MakeEngine(const bitCapInt& perm)
 
 QInterfacePtr QStabilizerHybrid::Clone()
 {
+    FlushBuffers();
+
     Finish();
 
     QStabilizerHybridPtr c =
@@ -113,6 +116,7 @@ void QStabilizerHybrid::SwitchToEngine()
 
     if (engineType != QINTERFACE_QUNIT) {
         stabilizer.reset();
+        FlushBuffers();
         return;
     }
 
@@ -138,10 +142,13 @@ void QStabilizerHybrid::SwitchToEngine()
     }
 
     stabilizer.reset();
+    FlushBuffers();
 }
 
 void QStabilizerHybrid::CCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target)
 {
+    FlushBuffers();
+
     if (stabilizer) {
         real1_f prob = Prob(control1);
         if (prob == ZERO_R1) {
@@ -169,6 +176,8 @@ void QStabilizerHybrid::CCNOT(bitLenInt control1, bitLenInt control2, bitLenInt 
 
 void QStabilizerHybrid::CH(bitLenInt control, bitLenInt target)
 {
+    FlushBuffers();
+
     if (stabilizer) {
         real1_f prob = Prob(control);
         if (prob == ZERO_R1) {
@@ -187,6 +196,8 @@ void QStabilizerHybrid::CH(bitLenInt control, bitLenInt target)
 
 void QStabilizerHybrid::CS(bitLenInt control, bitLenInt target)
 {
+    FlushBuffers();
+
     if (stabilizer) {
         real1_f prob = Prob(control);
         if (prob == ZERO_R1) {
@@ -205,6 +216,8 @@ void QStabilizerHybrid::CS(bitLenInt control, bitLenInt target)
 
 void QStabilizerHybrid::CIS(bitLenInt control, bitLenInt target)
 {
+    FlushBuffers();
+
     if (stabilizer) {
         real1_f prob = Prob(control);
         if (prob == ZERO_R1) {
@@ -223,6 +236,8 @@ void QStabilizerHybrid::CIS(bitLenInt control, bitLenInt target)
 
 void QStabilizerHybrid::CCZ(bitLenInt control1, bitLenInt control2, bitLenInt target)
 {
+    FlushBuffers();
+
     if (stabilizer) {
         real1_f prob = Prob(control1);
         if (prob == ZERO_R1) {
@@ -250,6 +265,9 @@ void QStabilizerHybrid::CCZ(bitLenInt control1, bitLenInt control2, bitLenInt ta
 
 void QStabilizerHybrid::Decompose(bitLenInt start, QStabilizerHybridPtr dest)
 {
+    FlushBuffers();
+    dest->FlushBuffers();
+
     bitLenInt length = dest->qubitCount;
 
     if (length == qubitCount) {
@@ -281,6 +299,8 @@ void QStabilizerHybrid::Decompose(bitLenInt start, QStabilizerHybridPtr dest)
 
 void QStabilizerHybrid::Dispose(bitLenInt start, bitLenInt length)
 {
+    FlushBuffers();
+
     if (length == qubitCount) {
         stabilizer = NULL;
         engine = NULL;
@@ -301,6 +321,8 @@ void QStabilizerHybrid::Dispose(bitLenInt start, bitLenInt length)
 
 void QStabilizerHybrid::Dispose(bitLenInt start, bitLenInt length, bitCapInt disposedPerm)
 {
+    FlushBuffers();
+
     if (length == qubitCount) {
         stabilizer = NULL;
         engine = NULL;
@@ -321,6 +343,8 @@ void QStabilizerHybrid::Dispose(bitLenInt start, bitLenInt length, bitCapInt dis
 
 void QStabilizerHybrid::SetQuantumState(const complex* inputState)
 {
+    DumpBuffers();
+
     if (qubitCount == 1U) {
         bool isClifford = false;
         bool isSet;
@@ -373,6 +397,8 @@ void QStabilizerHybrid::SetQuantumState(const complex* inputState)
 
 void QStabilizerHybrid::GetProbs(real1* outputProbs)
 {
+    FlushBuffers();
+
     if (stabilizer) {
         complex* stateVec = new complex[(bitCapIntOcl)maxQPower];
         stabilizer->GetQuantumState(stateVec);
@@ -385,8 +411,18 @@ void QStabilizerHybrid::GetProbs(real1* outputProbs)
     }
 }
 
-void QStabilizerHybrid::ApplySingleBit(const complex* mtrx, bitLenInt target)
+void QStabilizerHybrid::ApplySingleBit(const complex* lMtrx, bitLenInt target)
 {
+    complex mtrx[4];
+    if (shards[target]) {
+        QStabilizerShardPtr shard = shards[target];
+        shard->Compose(lMtrx);
+        std::copy(shard->gate, shard->gate + 4, mtrx);
+        shards[target] = NULL;
+    } else {
+        std::copy(lMtrx, lMtrx + 4, mtrx);
+    }
+
     if (IsIdentity(mtrx, true)) {
         return;
     }
@@ -423,12 +459,23 @@ void QStabilizerHybrid::ApplySingleBit(const complex* mtrx, bitLenInt target)
         return;
     }
 
+    if (stabilizer) {
+        shards[target] = std::make_shared<QStabilizerShard>(mtrx);
+        return;
+    }
+
     SwitchToEngine();
     engine->ApplySingleBit(mtrx, target);
 }
 
 void QStabilizerHybrid::ApplySinglePhase(const complex topLeft, const complex bottomRight, bitLenInt target)
 {
+    if (shards[target]) {
+        complex mtrx[4] = { topLeft, ZERO_CMPLX, ZERO_CMPLX, bottomRight };
+        ApplySingleBit(mtrx, target);
+        return;
+    }
+
     if (engine) {
         engine->ApplySinglePhase(topLeft, bottomRight, target);
         return;
@@ -461,6 +508,12 @@ void QStabilizerHybrid::ApplySinglePhase(const complex topLeft, const complex bo
 
 void QStabilizerHybrid::ApplySingleInvert(const complex topRight, const complex bottomLeft, bitLenInt target)
 {
+    if (shards[target]) {
+        complex mtrx[4] = { ZERO_CMPLX, topRight, bottomLeft, ZERO_CMPLX };
+        ApplySingleBit(mtrx, target);
+        return;
+    }
+
     if (engine) {
         engine->ApplySingleInvert(topRight, bottomLeft, target);
         return;
@@ -541,6 +594,8 @@ void QStabilizerHybrid::ApplyControlledSinglePhase(const bitLenInt* controls, co
         SwitchToEngine();
     }
 
+    FlushBuffers();
+
     if (engine) {
         engine->ApplyControlledSinglePhase(controls, controlLen, target, topLeft, bottomRight);
         return;
@@ -593,6 +648,8 @@ void QStabilizerHybrid::ApplyControlledSingleInvert(const bitLenInt* controls, c
     if (controlLen > 1U) {
         SwitchToEngine();
     }
+
+    FlushBuffers();
 
     if (engine) {
         engine->ApplyControlledSingleInvert(controls, controlLen, target, topRight, bottomLeft);
@@ -665,6 +722,8 @@ void QStabilizerHybrid::ApplyAntiControlledSinglePhase(const bitLenInt* controls
         SwitchToEngine();
     }
 
+    FlushBuffers();
+
     if (engine) {
         engine->ApplyAntiControlledSinglePhase(controls, controlLen, target, topLeft, bottomRight);
         return;
@@ -713,6 +772,8 @@ void QStabilizerHybrid::ApplyAntiControlledSingleInvert(const bitLenInt* control
         ApplySingleInvert(topRight, bottomLeft, target);
         return;
     }
+
+    FlushBuffers();
 
     // TODO: Generalize to trim all possible controls, like in QUnit.
     if (stabilizer && (controlLen == 2U) && IS_SAME(topRight, ONE_CMPLX) && IS_SAME(bottomLeft, ONE_CMPLX)) {
@@ -790,6 +851,8 @@ void QStabilizerHybrid::ApplyAntiControlledSingleInvert(const bitLenInt* control
 
 bitCapInt QStabilizerHybrid::MAll()
 {
+    FlushBuffers();
+
     if (stabilizer) {
         bitCapIntOcl toRet = 0;
         for (bitLenInt i = 0; i < qubitCount; i++) {

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -2055,13 +2055,15 @@ void QUnit::CCZ(bitLenInt control1, bitLenInt control2, bitLenInt target)
 
 void QUnit::ApplySinglePhase(const complex topLeft, const complex bottomRight, bitLenInt target)
 {
-    if (IS_NORM_0(topLeft - bottomRight) && (randGlobalPhase || IS_1_R1(topLeft))) {
-        return;
-    }
+    if (randGlobalPhase || IS_1_R1(topLeft)) {
+        if (IS_NORM_0(topLeft - bottomRight)) {
+            return;
+        }
 
-    if (IS_NORM_0(topLeft + bottomRight) && (randGlobalPhase || IS_1_R1(topLeft))) {
-        Z(target);
-        return;
+        if (IS_NORM_0(topLeft + bottomRight)) {
+            Z(target);
+            return;
+        }
     }
 
     QEngineShard& shard = shards[target];
@@ -2081,71 +2083,7 @@ void QUnit::ApplySinglePhase(const complex topLeft, const complex bottomRight, b
         }
     }
 
-    if (!freezeBasisH && shard.isPauliY) {
-        if (randGlobalPhase || IS_1_R1(topLeft)) {
-            if (IS_NORM_0((I_CMPLX * topLeft) - bottomRight)) {
-                shard.isPauliX = true;
-                shard.isPauliY = false;
-                XBase(target);
-                return;
-            } else if (IS_NORM_0((I_CMPLX * topLeft) + bottomRight)) {
-                shard.isPauliX = true;
-                shard.isPauliY = false;
-                return;
-            }
-        }
-
-        complex mtrx[4] = { ZERO_CMPLX, ZERO_CMPLX, ZERO_CMPLX, ZERO_CMPLX };
-        TransformPhase(topLeft, bottomRight, mtrx);
-
-        if (shard.unit) {
-            shard.unit->ApplySingleBit(mtrx, shard.mapped);
-        }
-        if (DIRTY(shard)) {
-            shard.MakeDirty();
-            return;
-        }
-
-        complex Y0 = shard.amp0;
-
-        shard.amp0 = (mtrx[0] * Y0) + (mtrx[1] * shard.amp1);
-        shard.amp1 = (mtrx[2] * Y0) + (mtrx[3] * shard.amp1);
-        if (doNormalize) {
-            shard.ClampAmps(amplitudeFloor);
-        }
-    } else if (shard.isPauliX) {
-        if (!freezeBasisH && (randGlobalPhase || IS_1_R1(topLeft))) {
-            if (IS_NORM_0((I_CMPLX * topLeft) - bottomRight)) {
-                shard.isPauliX = false;
-                shard.isPauliY = true;
-                return;
-            } else if (IS_NORM_0((I_CMPLX * topLeft) + bottomRight)) {
-                shard.isPauliX = false;
-                shard.isPauliY = true;
-                XBase(target);
-                return;
-            }
-        }
-
-        complex mtrx[4] = { ZERO_CMPLX, ZERO_CMPLX, ZERO_CMPLX, ZERO_CMPLX };
-        TransformPhase(topLeft, bottomRight, mtrx);
-
-        if (shard.unit) {
-            shard.unit->ApplySingleBit(mtrx, shard.mapped);
-        }
-        if (DIRTY(shard)) {
-            shard.MakeDirty();
-            return;
-        }
-
-        complex Y0 = shard.amp0;
-
-        shard.amp0 = (mtrx[0] * Y0) + (mtrx[1] * shard.amp1);
-        shard.amp1 = (mtrx[2] * Y0) + (mtrx[3] * shard.amp1);
-        if (doNormalize) {
-            shard.ClampAmps(amplitudeFloor);
-        }
-    } else {
+    if (!shard.isPauliX && !shard.isPauliY) {
         if (shard.unit) {
             shard.unit->ApplySinglePhase(topLeft, bottomRight, shard.mapped);
         }
@@ -2159,6 +2097,55 @@ void QUnit::ApplySinglePhase(const complex topLeft, const complex bottomRight, b
         if (doNormalize) {
             shard.ClampAmps(amplitudeFloor);
         }
+
+        return;
+    }
+
+    if (!freezeBasisH) {
+        if (IS_NORM_0((I_CMPLX * topLeft) - bottomRight)) {
+            if (shard.isPauliY) {
+                shard.isPauliX = true;
+                shard.isPauliY = false;
+                XBase(target);
+                return;
+            } else if (shard.isPauliX) {
+                shard.isPauliX = false;
+                shard.isPauliY = true;
+                return;
+            }
+        }
+
+        if (IS_NORM_0((I_CMPLX * topLeft) + bottomRight)) {
+            if (shard.isPauliY) {
+                shard.isPauliX = true;
+                shard.isPauliY = false;
+                return;
+            } else if (shard.isPauliX) {
+                shard.isPauliX = false;
+                shard.isPauliY = true;
+                XBase(target);
+                return;
+            }
+        }
+    }
+
+    complex mtrx[4] = { ZERO_CMPLX, ZERO_CMPLX, ZERO_CMPLX, ZERO_CMPLX };
+    TransformPhase(topLeft, bottomRight, mtrx);
+
+    if (shard.unit) {
+        shard.unit->ApplySingleBit(mtrx, shard.mapped);
+    }
+    if (DIRTY(shard)) {
+        shard.MakeDirty();
+        return;
+    }
+
+    complex Y0 = shard.amp0;
+
+    shard.amp0 = (mtrx[0] * Y0) + (mtrx[1] * shard.amp1);
+    shard.amp1 = (mtrx[2] * Y0) + (mtrx[3] * shard.amp1);
+    if (doNormalize) {
+        shard.ClampAmps(amplitudeFloor);
     }
 }
 
@@ -2228,9 +2215,16 @@ void QUnit::ApplyControlledSinglePhase(const bitLenInt* cControls, const bitLenI
         return;
     }
 
-    if ((controlLen == 1) && IS_NORM_0(topLeft - bottomRight)) {
-        ApplySinglePhase(ONE_CMPLX, bottomRight, cControls[0]);
-        return;
+    if (controlLen == 1) {
+        if (IS_NORM_0(topLeft - bottomRight)) {
+            ApplySinglePhase(ONE_CMPLX, bottomRight, cControls[0]);
+            return;
+        }
+
+        if (IS_1_CMPLX(topLeft) && IS_1_CMPLX(-bottomRight)) {
+            CZ(cControls[0], cTarget);
+            return;
+        }
     }
 
     bitLenInt* controls = new bitLenInt[controlLen];
@@ -2295,7 +2289,8 @@ void QUnit::ApplyControlledSinglePhase(const bitLenInt* cControls, const bitLenI
         RevertBasis2Qb(target, ONLY_INVERT, IS_1_CMPLX(topLeft) ? ONLY_TARGETS : CONTROLS_AND_TARGETS, CTRL_AND_ANTI,
             {}, { control });
 
-        if (!IS_SAME_UNIT(cShard, tShard)) {
+        // This is not a Clifford gate, so we buffer for stabilizer:
+        if (!IS_SAME_UNIT(cShard, tShard) || tShard.isClifford()) {
             delete[] controls;
             tShard.AddPhaseAngles(&cShard, topLeft, bottomRight);
             OptimizePairBuffers(control, target, false);
@@ -2337,9 +2332,11 @@ void QUnit::ApplyAntiControlledSinglePhase(const bitLenInt* cControls, const bit
         return;
     }
 
-    if ((controlLen == 1) && IS_NORM_0(topLeft - bottomRight)) {
-        ApplySinglePhase(topLeft, ONE_CMPLX, cControls[0]);
-        return;
+    if (controlLen == 1) {
+        if (IS_NORM_0(topLeft - bottomRight)) {
+            ApplySinglePhase(topLeft, ONE_CMPLX, cControls[0]);
+            return;
+        }
     }
 
     bitLenInt* controls = new bitLenInt[controlLen];
@@ -2390,7 +2387,9 @@ void QUnit::ApplyAntiControlledSinglePhase(const bitLenInt* cControls, const bit
         RevertBasis2Qb(target, ONLY_INVERT, IS_1_CMPLX(bottomRight) ? ONLY_TARGETS : CONTROLS_AND_TARGETS,
             CTRL_AND_ANTI, {}, { control });
 
-        if (!IS_SAME_UNIT(cShard, tShard)) {
+        // If this is not a Clifford gate, we buffer for stabilizer:
+        if (!IS_SAME_UNIT(cShard, tShard) ||
+            (tShard.isClifford() && (!IS_1_CMPLX(topLeft) || !IS_1_CMPLX(-bottomRight)))) {
             delete[] controls;
             tShard.AddAntiPhaseAngles(&cShard, bottomRight, topLeft);
             OptimizePairBuffers(control, target, true);

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -4086,9 +4086,16 @@ void QUnit::OptimizePairBuffers(const bitLenInt& control, const bitLenInt& targe
     PhaseShardPtr buffer = phaseShard->second;
 
     if (IS_NORM_0(buffer->cmplxDiff - buffer->cmplxSame)) {
-        tShard.RemovePhaseControl(&cShard);
-        ApplyBuffer(buffer, control, target, anti);
-        return;
+        if (IS_1_CMPLX(buffer->cmplxDiff)) {
+            tShard.RemovePhaseControl(&cShard);
+            return;
+        }
+
+        if (!cShard.isClifford() && !tShard.isClifford()) {
+            tShard.RemovePhaseControl(&cShard);
+            ApplyBuffer(buffer, control, target, anti);
+            return;
+        }
     }
 
     ShardToPhaseMap& antiTargets = anti ? tShard.targetOfShards : tShard.antiTargetOfShards;


### PR DESCRIPTION
Per #683, the domain of `QStabilizerHybrid` shards under `QUnit` has been expanded. If a shard-level single bit gate is not Clifford, gate fusion is attempted on the chance of producing a fused Clifford gate at a later point. For controlled gates, `QUnit` buffering has been conditioned to proactively preserve underlying stabilizer representation in shards. (QFT might be a tiny amount faster, but I don't have a perfect baseline reading on my new development environment.)