### PR TITLE
Extended stabilizer: phase doesn't matter if Z eigenstate

### DIFF
--- a/include/pinvoke_api.hpp
+++ b/include/pinvoke_api.hpp
@@ -115,6 +115,9 @@ MICROSOFT_QUANTUM_DECL void CLXNOR(_In_ unsigned sid, _In_ bool ci, _In_ unsigne
 
 MICROSOFT_QUANTUM_DECL double Prob(_In_ unsigned sid, _In_ unsigned q);
 
+MICROSOFT_QUANTUM_DECL void QFT(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c);
+MICROSOFT_QUANTUM_DECL void IQFT(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c);
+
 #if !(FPPOW < 6 && !ENABLE_COMPLEX_X2)
 MICROSOFT_QUANTUM_DECL void TimeEvolve(_In_ unsigned sid, _In_ double t, _In_ unsigned n,
     _In_reads_(n) _QrackTimeEvolveOpHeader* teos, unsigned mn, _In_reads_(mn) double* mtrx);

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -1838,6 +1838,14 @@ public:
      */
     virtual void QFT(bitLenInt start, bitLenInt length, bool trySeparate = false);
 
+    /** Quantum Fourier Transform (random access) - Apply the quantum Fourier transform to the register.
+     *
+     * "trySeparate" is an optional hit-or-miss optimization, specifically for QUnit types. Our suggestion is, turn it
+     * on for speed and memory effciency if you expect the result of the QFT to be in a permutation basis eigenstate.
+     * Otherwise, turning it on will probably take longer.
+     */
+    virtual void QFTR(bitLenInt* qubits, bitLenInt length, bool trySeparate = false);
+
     /** Inverse Quantum Fourier Transform - Apply the inverse quantum Fourier transform to the register.
      *
      * "trySeparate" is an optional hit-or-miss optimization, specifically for QUnit types. Our suggestion is, turn it
@@ -1845,6 +1853,14 @@ public:
      * Otherwise, turning it on will probably take longer.
      */
     virtual void IQFT(bitLenInt start, bitLenInt length, bool trySeparate = false);
+
+    /** Inverse Quantum Fourier Transform (random access) - Apply the inverse quantum Fourier transform to the register.
+     *
+     * "trySeparate" is an optional hit-or-miss optimization, specifically for QUnit types. Our suggestion is, turn it
+     * on for speed and memory effciency if you expect the result of the QFT to be in a permutation basis eigenstate.
+     * Otherwise, turning it on will probably take longer.
+     */
+    virtual void IQFTR(bitLenInt* qubits, bitLenInt length, bool trySeparate = false);
 
     /** Reverse the phase of the state where the register equals zero. */
     virtual void ZeroPhaseFlip(bitLenInt start, bitLenInt length);

--- a/src/pinvoke_api.cpp
+++ b/src/pinvoke_api.cpp
@@ -960,6 +960,35 @@ MICROSOFT_QUANTUM_DECL double Prob(_In_ unsigned sid, _In_ unsigned q)
     return simulator->Prob(shards[simulator][q]);
 }
 
+MICROSOFT_QUANTUM_DECL void QFT(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c)
+{
+    SIMULATOR_LOCK_GUARD(sid)
+
+    QInterfacePtr simulator = simulators[sid];
+#if (QBCAPPOW >= 16) && (QBCAPPOW < 32)
+    simulator->QFTR(c, n);
+#else
+    bitLenInt* q = new bitLenInt[n];
+    std::copy(c, c + n, q);
+    simulator->QFTR(q, n);
+    delete[] q;
+#endif
+}
+MICROSOFT_QUANTUM_DECL void IQFT(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c)
+{
+    SIMULATOR_LOCK_GUARD(sid)
+
+    QInterfacePtr simulator = simulators[sid];
+#if (QBCAPPOW >= 16) && (QBCAPPOW < 32)
+    simulator->IQFTR(c, n);
+#else
+    bitLenInt* q = new bitLenInt[n];
+    std::copy(c, c + n, q);
+    simulator->IQFTR(q, n);
+    delete[] q;
+#endif
+}
+
 #if !(FPPOW < 6 && !ENABLE_COMPLEX_X2)
 /**
  * (External API) Simulate a Hamiltonian

--- a/src/qinterface/qinterface.cpp
+++ b/src/qinterface/qinterface.cpp
@@ -548,6 +548,47 @@ void QInterface::IQFT(bitLenInt start, bitLenInt length, bool trySeparate)
     }
 }
 
+/// Quantum Fourier Transform - Optimized for going from |0>/|1> to |+>/|-> basis
+void QInterface::QFTR(bitLenInt* qubits, bitLenInt length, bool trySeparate)
+{
+    if (length == 0) {
+        return;
+    }
+
+    bitLenInt end = (length - 1U);
+    bitLenInt i, j;
+    for (i = 0; i < length; i++) {
+        H(qubits[end - i]);
+        for (j = 0; j < ((length - 1U) - i); j++) {
+            CPhaseRootN(j + 2U, qubits[(end - i) - (j + 1U)], qubits[end - i]);
+        }
+
+        if (trySeparate) {
+            TrySeparate(qubits[end - i]);
+        }
+    }
+}
+
+/// Inverse Quantum Fourier Transform - Quantum Fourier transform optimized for going from |+>/|-> to |0>/|1> basis
+void QInterface::IQFTR(bitLenInt* qubits, bitLenInt length, bool trySeparate)
+{
+    if (length == 0) {
+        return;
+    }
+
+    bitLenInt i, j;
+    for (i = 0; i < length; i++) {
+        for (j = 0; j < i; j++) {
+            CIPhaseRootN(j + 2U, qubits[i - (j + 1U)], qubits[i]);
+        }
+        H(qubits[i]);
+
+        if (trySeparate) {
+            TrySeparate(qubits[i]);
+        }
+    }
+}
+
 /// Set register bits to given permutation
 void QInterface::SetReg(bitLenInt start, bitLenInt length, bitCapInt value)
 {


### PR DESCRIPTION
For extending stabilizer simulation, phase can be ignored, if non-Clifford phase or "inversion" gates act on a Z basis eigenstate.