### PR TITLE
Extended stabilizer: phase doesn't matter if Z eigenstate

### DIFF
--- a/include/qstabilizerhybrid.hpp
+++ b/include/qstabilizerhybrid.hpp
@@ -62,6 +62,7 @@ protected:
     QInterfacePtr engine;
     QStabilizerPtr stabilizer;
     std::vector<QStabilizerShardPtr> shards;
+    std::vector<bool> shardsZ;
     int devID;
     complex phaseFactor;
     bool doNormalize;
@@ -366,6 +367,7 @@ public:
         }
 
         shards.insert(shards.end(), toCopy->shards.begin(), toCopy->shards.end());
+        shardsZ.insert(shardsZ.end(), toCopy->shardsZ.begin(), toCopy->shardsZ.end());
 
         SetQubitCount(qubitCount + toCopy->qubitCount);
 
@@ -393,6 +395,7 @@ public:
         }
 
         shards.insert(shards.begin() + start, toCopy->shards.begin(), toCopy->shards.end());
+        shardsZ.insert(shardsZ.begin() + start, toCopy->shardsZ.begin(), toCopy->shardsZ.end());
 
         SetQubitCount(qubitCount + toCopy->qubitCount);
 

--- a/src/qstabilizerhybrid.cpp
+++ b/src/qstabilizerhybrid.cpp
@@ -431,17 +431,17 @@ void QStabilizerHybrid::GetProbs(real1* outputProbs)
 
 void QStabilizerHybrid::ApplySingleBit(const complex* lMtrx, bitLenInt target)
 {
+    bool wasCached;
     complex mtrx[4];
     if (shards[target]) {
         QStabilizerShardPtr shard = shards[target];
         shard->Compose(lMtrx);
         std::copy(shard->gate, shard->gate + 4, mtrx);
         shards[target] = NULL;
+        wasCached = true;
     } else {
         std::copy(lMtrx, lMtrx + 4, mtrx);
-        if (stabilizer) {
-            shardsZ[target] = stabilizer->IsSeparableZ(target);
-        }
+        wasCached = false;
     }
 
     if (IsIdentity(mtrx, true)) {
@@ -481,6 +481,10 @@ void QStabilizerHybrid::ApplySingleBit(const complex* lMtrx, bitLenInt target)
     }
 
     if (stabilizer) {
+        if (!wasCached) {
+            shardsZ[target] = stabilizer->IsSeparableZ(target);
+        }
+
         if (shardsZ[target]) {
             if ((norm(mtrx[1]) < REAL1_EPSILON) && (norm(mtrx[2]) < REAL1_EPSILON)) {
                 return;


### PR DESCRIPTION
For extending stabilizer simulation, phase can be ignored, if non-Clifford phase or "inversion" gates act on a Z basis eigenstate.