### PR TITLE
Only flush QStabilizerHybrid on blocked bits

### DIFF
--- a/include/qstabilizerhybrid.hpp
+++ b/include/qstabilizerhybrid.hpp
@@ -197,7 +197,9 @@ public:
     /// Apply a CNOT gate with control and target
     virtual void CNOT(bitLenInt control, bitLenInt target)
     {
-        FlushBuffers();
+        if (shards[control] || shards[target]) {
+            FlushBuffers();
+        }
 
         if (stabilizer) {
             stabilizer->CNOT(control, target);
@@ -310,7 +312,9 @@ public:
 
     virtual void CZ(bitLenInt control, bitLenInt target)
     {
-        FlushBuffers();
+        if (shards[control] || shards[target]) {
+            FlushBuffers();
+        }
 
         if (stabilizer) {
             stabilizer->CZ(control, target);
@@ -327,7 +331,9 @@ public:
             return;
         }
 
-        FlushBuffers();
+        if (shards[qubit1] || shards[qubit2]) {
+            FlushBuffers();
+        }
 
         if (stabilizer) {
             stabilizer->Swap(qubit1, qubit2);
@@ -342,7 +348,9 @@ public:
             return;
         }
 
-        FlushBuffers();
+        if (shards[qubit1] || shards[qubit2]) {
+            FlushBuffers();
+        }
 
         if (stabilizer) {
             stabilizer->ISwap(qubit1, qubit2);
@@ -379,9 +387,6 @@ public:
     }
     virtual bitLenInt Compose(QStabilizerHybridPtr toCopy, bitLenInt start)
     {
-        FlushBuffers();
-        toCopy->FlushBuffers();
-
         bitLenInt toRet;
 
         if (engine) {

--- a/include/qstabilizerhybrid.hpp
+++ b/include/qstabilizerhybrid.hpp
@@ -75,6 +75,23 @@ protected:
     QStabilizerPtr MakeStabilizer(const bitCapInt& perm = 0);
     QInterfacePtr MakeEngine(const bitCapInt& perm = 0);
 
+    void FlushIfBlocked(std::vector<bitLenInt> controls, bitLenInt target)
+    {
+        bool isBlocked = (bool)shards[target];
+        if (!isBlocked) {
+            for (bitLenInt i = 0; i < controls.size(); i++) {
+                if (shards[controls[i]]) {
+                    isBlocked = true;
+                    break;
+                }
+            }
+        }
+
+        if (isBlocked) {
+            FlushBuffers();
+        }
+    }
+
 public:
     QStabilizerHybrid(QInterfaceEngine eng, QInterfaceEngine subEng, bitLenInt qBitCount, bitCapInt initState = 0,
         qrack_rand_gen_ptr rgp = nullptr, complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = false,

--- a/src/qstabilizerhybrid.cpp
+++ b/src/qstabilizerhybrid.cpp
@@ -152,7 +152,9 @@ void QStabilizerHybrid::SwitchToEngine()
 
 void QStabilizerHybrid::CCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target)
 {
-    FlushBuffers();
+    if (shards[control1] || shards[control2] || shards[target]) {
+        FlushBuffers();
+    }
 
     if (stabilizer) {
         real1_f prob = Prob(control1);
@@ -181,7 +183,9 @@ void QStabilizerHybrid::CCNOT(bitLenInt control1, bitLenInt control2, bitLenInt 
 
 void QStabilizerHybrid::CH(bitLenInt control, bitLenInt target)
 {
-    FlushBuffers();
+    if (shards[control] || shards[target]) {
+        FlushBuffers();
+    }
 
     if (stabilizer) {
         real1_f prob = Prob(control);
@@ -201,7 +205,9 @@ void QStabilizerHybrid::CH(bitLenInt control, bitLenInt target)
 
 void QStabilizerHybrid::CS(bitLenInt control, bitLenInt target)
 {
-    FlushBuffers();
+    if (shards[control] || shards[target]) {
+        FlushBuffers();
+    }
 
     if (stabilizer) {
         real1_f prob = Prob(control);
@@ -221,7 +227,9 @@ void QStabilizerHybrid::CS(bitLenInt control, bitLenInt target)
 
 void QStabilizerHybrid::CIS(bitLenInt control, bitLenInt target)
 {
-    FlushBuffers();
+    if (shards[control] || shards[target]) {
+        FlushBuffers();
+    }
 
     if (stabilizer) {
         real1_f prob = Prob(control);
@@ -241,7 +249,9 @@ void QStabilizerHybrid::CIS(bitLenInt control, bitLenInt target)
 
 void QStabilizerHybrid::CCZ(bitLenInt control1, bitLenInt control2, bitLenInt target)
 {
-    FlushBuffers();
+    if (shards[control1] || shards[control2] || shards[target]) {
+        FlushBuffers();
+    }
 
     if (stabilizer) {
         real1_f prob = Prob(control1);
@@ -309,8 +319,6 @@ void QStabilizerHybrid::Decompose(bitLenInt start, QStabilizerHybridPtr dest)
 
 void QStabilizerHybrid::Dispose(bitLenInt start, bitLenInt length)
 {
-    FlushBuffers();
-
     if (length == qubitCount) {
         stabilizer = NULL;
         engine = NULL;
@@ -335,8 +343,6 @@ void QStabilizerHybrid::Dispose(bitLenInt start, bitLenInt length)
 
 void QStabilizerHybrid::Dispose(bitLenInt start, bitLenInt length, bitCapInt disposedPerm)
 {
-    FlushBuffers();
-
     if (length == qubitCount) {
         stabilizer = NULL;
         engine = NULL;
@@ -680,7 +686,19 @@ void QStabilizerHybrid::ApplyControlledSinglePhase(const bitLenInt* lControls, c
         SwitchToEngine();
     }
 
-    FlushBuffers();
+    bool isBlocked = (bool)shards[target];
+    if (!isBlocked) {
+        for (bitLenInt i = 0; i < controls.size(); i++) {
+            if (shards[controls[i]]) {
+                isBlocked = true;
+                break;
+            }
+        }
+    }
+
+    if (isBlocked) {
+        FlushBuffers();
+    }
 
     if (engine) {
         engine->ApplyControlledSinglePhase(lControls, lControlLen, target, topLeft, bottomRight);
@@ -734,7 +752,19 @@ void QStabilizerHybrid::ApplyControlledSingleInvert(const bitLenInt* lControls, 
         SwitchToEngine();
     }
 
-    FlushBuffers();
+    bool isBlocked = (bool)shards[target];
+    if (!isBlocked) {
+        for (bitLenInt i = 0; i < controls.size(); i++) {
+            if (shards[controls[i]]) {
+                isBlocked = true;
+                break;
+            }
+        }
+    }
+
+    if (isBlocked) {
+        FlushBuffers();
+    }
 
     if (engine) {
         engine->ApplyControlledSingleInvert(lControls, lControlLen, target, topRight, bottomLeft);
@@ -823,7 +853,19 @@ void QStabilizerHybrid::ApplyAntiControlledSinglePhase(const bitLenInt* lControl
         SwitchToEngine();
     }
 
-    FlushBuffers();
+    bool isBlocked = (bool)shards[target];
+    if (!isBlocked) {
+        for (bitLenInt i = 0; i < controls.size(); i++) {
+            if (shards[controls[i]]) {
+                isBlocked = true;
+                break;
+            }
+        }
+    }
+
+    if (isBlocked) {
+        FlushBuffers();
+    }
 
     if (engine) {
         engine->ApplyAntiControlledSinglePhase(lControls, lControlLen, target, topLeft, bottomRight);
@@ -879,7 +921,19 @@ void QStabilizerHybrid::ApplyAntiControlledSingleInvert(const bitLenInt* lContro
         return;
     }
 
-    FlushBuffers();
+    bool isBlocked = (bool)shards[target];
+    if (!isBlocked) {
+        for (bitLenInt i = 0; i < controls.size(); i++) {
+            if (shards[controls[i]]) {
+                isBlocked = true;
+                break;
+            }
+        }
+    }
+
+    if (isBlocked) {
+        FlushBuffers();
+    }
 
     if (controls.size() > 1U) {
         SwitchToEngine();

--- a/src/qstabilizerhybrid.cpp
+++ b/src/qstabilizerhybrid.cpp
@@ -686,19 +686,7 @@ void QStabilizerHybrid::ApplyControlledSinglePhase(const bitLenInt* lControls, c
         SwitchToEngine();
     }
 
-    bool isBlocked = (bool)shards[target];
-    if (!isBlocked) {
-        for (bitLenInt i = 0; i < controls.size(); i++) {
-            if (shards[controls[i]]) {
-                isBlocked = true;
-                break;
-            }
-        }
-    }
-
-    if (isBlocked) {
-        FlushBuffers();
-    }
+    FlushIfBlocked(controls, target);
 
     if (engine) {
         engine->ApplyControlledSinglePhase(lControls, lControlLen, target, topLeft, bottomRight);
@@ -752,19 +740,7 @@ void QStabilizerHybrid::ApplyControlledSingleInvert(const bitLenInt* lControls, 
         SwitchToEngine();
     }
 
-    bool isBlocked = (bool)shards[target];
-    if (!isBlocked) {
-        for (bitLenInt i = 0; i < controls.size(); i++) {
-            if (shards[controls[i]]) {
-                isBlocked = true;
-                break;
-            }
-        }
-    }
-
-    if (isBlocked) {
-        FlushBuffers();
-    }
+    FlushIfBlocked(controls, target);
 
     if (engine) {
         engine->ApplyControlledSingleInvert(lControls, lControlLen, target, topRight, bottomLeft);
@@ -853,19 +829,7 @@ void QStabilizerHybrid::ApplyAntiControlledSinglePhase(const bitLenInt* lControl
         SwitchToEngine();
     }
 
-    bool isBlocked = (bool)shards[target];
-    if (!isBlocked) {
-        for (bitLenInt i = 0; i < controls.size(); i++) {
-            if (shards[controls[i]]) {
-                isBlocked = true;
-                break;
-            }
-        }
-    }
-
-    if (isBlocked) {
-        FlushBuffers();
-    }
+    FlushIfBlocked(controls, target);
 
     if (engine) {
         engine->ApplyAntiControlledSinglePhase(lControls, lControlLen, target, topLeft, bottomRight);
@@ -921,19 +885,7 @@ void QStabilizerHybrid::ApplyAntiControlledSingleInvert(const bitLenInt* lContro
         return;
     }
 
-    bool isBlocked = (bool)shards[target];
-    if (!isBlocked) {
-        for (bitLenInt i = 0; i < controls.size(); i++) {
-            if (shards[controls[i]]) {
-                isBlocked = true;
-                break;
-            }
-        }
-    }
-
-    if (isBlocked) {
-        FlushBuffers();
-    }
+    FlushIfBlocked(controls, target);
 
     if (controls.size() > 1U) {
         SwitchToEngine();


### PR DESCRIPTION
Continuing with the QStabilizerHybrid optimization work of the last few days, we can avoid many unnecessary cases of non-Clifford single bit gate fusion buffer flushing, by only flushing buffers for multi-qubit gates when a target or control bit is blocked by a non-Clifford buffer.