### PR TITLE
Mid-range performance, with paging

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ QPager attempts to smartly allocate low qubit widths for maximum performance. Fo
 
 `QRACK_DEVICE_GLOBAL_QB=n`, alternatively, lets the user also choose the performance "hint" for preferred global qubits per device. By default, n=2, for 2 global qubits or equivalently 4 pages per device. Despite the "hint," `QPager` will allocate fewer pages per OpenCL device for small-enough widths, to keep processing elements better occupied. Also, `QPager` will allocate more qubits than the hint, per device, if the maximum allocation segment is exceeded as specified by `QRACK_SEGMENT_GLOBAL_QB`.
 
+If using `QPager` under the `QUnit` layer, then the environment variable `QRACK_QUNIT_PAGING_THRESHOLD` is the number of qubits in overall width at which `QUnit` will use paging, 21 qubits by default.
+
 ## QEngineCPU parallel stride
 QEngineCPU and QHybrid batch work items in groups of 2^`PSTRIDEPOW` before dispatching them to single CPU threads, potentially greatly reducing waiting on mutexes without signficantly hurting utilization and scheduling. The default for this option can be controlled at build time, by passing `-DPSTRIDEPOW=n` to CMake, with "n" being an integer greater than or equal to 0. (The default is n=9, which is approximately optimal on many typical PCs.) This can be overridden at run time by the enviroment variable `QRACK_PSTRIDEPOW=n`. If an environment variable is not defined for this option, the default from CMake build will be used.
 

--- a/include/qpager.hpp
+++ b/include/qpager.hpp
@@ -131,6 +131,18 @@ public:
         }
     }
 
+    virtual QEnginePtr ReleaseEngine()
+    {
+        CombineEngines();
+        return qPages[0];
+    }
+
+    virtual void LockEngine(QEnginePtr eng)
+    {
+        CombineEngines();
+        qPages[0] = eng;
+    }
+
     virtual void SetQuantumState(const complex* inputState);
     virtual void GetQuantumState(complex* outputState);
     virtual void GetProbs(real1* outputProbs);

--- a/include/qstabilizerhybrid.hpp
+++ b/include/qstabilizerhybrid.hpp
@@ -138,6 +138,32 @@ public:
         }
     }
 
+    virtual void TurnOnPaging()
+    {
+        if (engineType == QINTERFACE_QPAGER) {
+            return;
+        }
+        engineType = QINTERFACE_QPAGER;
+
+        if (engine) {
+            QPagerPtr nEngine = std::dynamic_pointer_cast<QPager>(MakeEngine(0));
+            nEngine->LockEngine(std::dynamic_pointer_cast<QEngine>(engine));
+            engine = nEngine;
+        }
+    }
+
+    virtual void TurnOffPaging()
+    {
+        if (engineType != QINTERFACE_QPAGER) {
+            return;
+        }
+        engineType = subEngineType;
+
+        if (engine) {
+            engine = std::dynamic_pointer_cast<QPager>(engine)->ReleaseEngine();
+        }
+    }
+
     virtual void FlushBuffers()
     {
         bitLenInt i;

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -37,10 +37,24 @@ protected:
     bool freezeBasisH;
     bool freezeBasis2Qb;
     bool freezeClifford;
+    bool isPagingSuppressed;
     bitLenInt thresholdQubits;
+    bitLenInt pagingThresholdQubits;
     std::vector<int> deviceIDs;
 
     QInterfacePtr MakeEngine(bitLenInt length, bitCapInt perm);
+    QInterfacePtr MakeEngine(bitLenInt length, bitCapInt perm, bool isPaging);
+
+    virtual void TurnOnPaging();
+    virtual void TurnOffPaging();
+    virtual void ConvertPaging(const bool& isPaging)
+    {
+        if (isPaging) {
+            TurnOnPaging();
+        } else {
+            TurnOffPaging();
+        }
+    }
 
 public:
     QUnit(QInterfaceEngine eng, QInterfaceEngine subEng, bitLenInt qBitCount, bitCapInt initState = 0,

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -43,7 +43,6 @@ protected:
     std::vector<int> deviceIDs;
 
     QInterfacePtr MakeEngine(bitLenInt length, bitCapInt perm);
-    QInterfacePtr MakeEngine(bitLenInt length, bitCapInt perm, bool isPaging);
 
     virtual void TurnOnPaging();
     virtual void TurnOffPaging();

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -152,14 +152,17 @@ void QUnit::TurnOnPaging()
     if (engine == QINTERFACE_QPAGER) {
         for (bitLenInt i = 0; i < qubitCount; i++) {
             QEnginePtr unit = std::dynamic_pointer_cast<QEngine>(shards[i].unit);
-            if (nEngines.find(unit) == nEngines.end()) {
+            if (unit && nEngines.find(unit) == nEngines.end()) {
                 nEngines[unit] = std::dynamic_pointer_cast<QPager>(MakeEngine(0, unit->GetQubitCount(), true));
                 nEngines[unit]->LockEngine(unit);
             }
         }
 
         for (bitLenInt i = 0; i < qubitCount; i++) {
-            shards[i].unit = nEngines[shards[i].unit];
+            QInterfacePtr unit = shards[i].unit;
+            if (unit) {
+                shards[i].unit = nEngines[shards[i].unit];
+            }
         }
     }
 }
@@ -179,14 +182,16 @@ void QUnit::TurnOffPaging()
     if (engine == QINTERFACE_QPAGER) {
         for (bitLenInt i = 0; i < qubitCount; i++) {
             QPagerPtr unit = std::dynamic_pointer_cast<QPager>(shards[i].unit);
-            if (nEngines.find(unit) == nEngines.end()) {
+            if (unit && nEngines.find(unit) == nEngines.end()) {
                 nEngines[unit] = unit->ReleaseEngine();
             }
         }
 
         for (bitLenInt i = 0; i < qubitCount; i++) {
             QPagerPtr unit = std::dynamic_pointer_cast<QPager>(shards[i].unit);
-            shards[i].unit = nEngines[unit];
+            if (unit) {
+                shards[i].unit = nEngines[unit];
+            }
         }
     }
 }

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -81,8 +81,6 @@ QUnit::QUnit(QInterfaceEngine eng, QInterfaceEngine subEng, bitLenInt qBitCount,
         pagingThresholdQubits = (bitLenInt)std::stoi(std::string(getenv("QRACK_QUNIT_PAGING_THRESHOLD")));
     }
 
-    isPagingSuppressed = (qubitCount < pagingThresholdQubits);
-
     if ((engine == QINTERFACE_QUNIT) || (engine == QINTERFACE_QUNIT_MULTI)) {
         engine = QINTERFACE_OPTIMAL_G0_CHILD;
     }
@@ -94,6 +92,10 @@ QUnit::QUnit(QInterfaceEngine eng, QInterfaceEngine subEng, bitLenInt qBitCount,
         subEngine = QINTERFACE_OPTIMAL_G1_CHILD;
 #endif
     }
+
+    isPagingSuppressed = (qubitCount < pagingThresholdQubits) &&
+        ((engine == QINTERFACE_QPAGER) ||
+            ((engine == QINTERFACE_STABILIZER_HYBRID) && (subEngine == QINTERFACE_QPAGER)));
 
     shards = QEngineShardMap();
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -81,9 +81,7 @@ QUnit::QUnit(QInterfaceEngine eng, QInterfaceEngine subEng, bitLenInt qBitCount,
         pagingThresholdQubits = (bitLenInt)std::stoi(std::string(getenv("QRACK_QUNIT_PAGING_THRESHOLD")));
     }
 
-    isPagingSuppressed = (qubitCount < pagingThresholdQubits) &&
-        ((engine == QINTERFACE_QPAGER) ||
-            ((engine == QINTERFACE_STABILIZER_HYBRID) && (subEngine == QINTERFACE_QPAGER)));
+    isPagingSuppressed = (qubitCount < pagingThresholdQubits);
 
     if ((engine == QINTERFACE_QUNIT) || (engine == QINTERFACE_QUNIT_MULTI)) {
         engine = QINTERFACE_OPTIMAL_G0_CHILD;

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -3679,6 +3679,39 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_trydecompose")
     REQUIRE_THAT(qftReg2, HasProbability(0, 4, 0xb));
 }
 
+TEST_CASE_METHOD(QInterfaceTestFixture, "test_qunit_paging")
+{
+    qftReg = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 18, 1, rng, ONE_CMPLX);
+    QInterfacePtr qftReg2 =
+        CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 4, 2, rng, ONE_CMPLX);
+
+    qftReg->H(0, 3);
+    qftReg->CCZ(0, 1, 2);
+
+    qftReg2->H(0, 3);
+    qftReg2->CCZ(0, 1, 2);
+
+    qftReg->Compose(qftReg2);
+
+    qftReg->CCZ(0, 1, 2);
+    qftReg->H(0, 3);
+
+    qftReg->CCZ(18, 19, 20);
+    qftReg->H(18, 3);
+
+    REQUIRE_THAT(qftReg, HasProbability(0, 22, 1 | (2 << 18)));
+
+    qftReg->H(0, 3);
+    qftReg->CCZ(0, 1, 2);
+
+    qftReg->Decompose(18, qftReg2);
+
+    qftReg->CCZ(0, 1, 2);
+    qftReg->H(0, 3);
+
+    REQUIRE_THAT(qftReg, HasProbability(0, 18, 1));
+}
+
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_setbit")
 {
     qftReg->SetPermutation(0x02);


### PR DESCRIPTION
Middle qubit ranges have suffered with an optimal stack including `QPager`, compared to `QUnit` without paging. I tried to implement a performance fix for this 2 or 3 other different ways, with hypothetically better separation of concerns, but none of those approaches actually met the requirement of _fixing_ _the_ _performance_. As a result, we're temporarily stuck with this, which shoves a threshold-crossing cost under the rug, in a situation where it's not currently likely to come up.

At 21 qubits overall width, or as specified by the `QRACK_QUNIT_PAGING_THRESHOLD` environment variable, there is a transition under `QUnit` from no paging at lower qubits, to paging at higher qubits. This generally will not be used in flight, with plugins for third party frameworks.