### PR TITLE
Optimize prob/measure parity

### DIFF
--- a/include/qengineshard.hpp
+++ b/include/qengineshard.hpp
@@ -659,7 +659,7 @@ public:
     bitLenInt GetQubitCount() { return unit ? unit->GetQubitCount() : 1U; };
     real1_f Prob()
     {
-        if (!unit) {
+        if (!unit || !isProbDirty) {
             return norm(amp1);
         }
 

--- a/include/qengineshard.hpp
+++ b/include/qengineshard.hpp
@@ -659,7 +659,7 @@ public:
     bitLenInt GetQubitCount() { return unit ? unit->GetQubitCount() : 1U; };
     real1_f Prob()
     {
-        if (!isProbDirty || !unit) {
+        if (!unit) {
             return norm(amp1);
         }
 

--- a/include/qengineshard.hpp
+++ b/include/qengineshard.hpp
@@ -659,7 +659,7 @@ public:
     bitLenInt GetQubitCount() { return unit ? unit->GetQubitCount() : 1U; };
     real1_f Prob()
     {
-        if (!unit || !isProbDirty) {
+        if (!isProbDirty || !unit) {
             return norm(amp1);
         }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1037,7 +1037,13 @@ real1_f QUnit::ProbParity(const bitCapInt& mask)
     for (bitCapInt v = mask; v; v = nV) {
         nV &= (v - ONE_BCI); // clear the least significant bit set
         qIndices.push_back(log2((v ^ nV) & v));
-        RevertBasis2Qb(qIndices.back(), ONLY_INVERT);
+
+        QEngineShard& shard = shards[qIndices.back()];
+        if (shard.isPauliX || shard.isPauliY) {
+            RevertBasis2Qb(qIndices.back());
+        } else {
+            RevertBasis2Qb(qIndices.back(), ONLY_INVERT);
+        }
     }
 
     std::map<QInterfacePtr, bitCapInt> units;
@@ -1086,8 +1092,8 @@ bool QUnit::ForceMParity(const bitCapInt& mask, bool result, bool doForce)
     for (bitCapInt v = mask; v; v = nV) {
         nV &= (v - ONE_BCI); // clear the least significant bit set
         qIndices.push_back(log2((v ^ nV) & v));
-        RevertBasis2Qb(qIndices.back(), ONLY_INVERT);
         RevertBasis1Qb(qIndices.back());
+        RevertBasis2Qb(qIndices.back(), ONLY_INVERT);
     }
 
     bool flipResult = false;

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1038,11 +1038,11 @@ real1_f QUnit::ProbParity(const bitCapInt& mask)
         nV &= (v - ONE_BCI); // clear the least significant bit set
         qIndices.push_back(log2((v ^ nV) & v));
 
+        RevertBasis2Qb(qIndices.back(), ONLY_INVERT);
+
         QEngineShard& shard = shards[qIndices.back()];
-        if (shard.isPauliX || shard.isPauliY) {
-            RevertBasis2Qb(qIndices.back());
-        } else {
-            RevertBasis2Qb(qIndices.back(), ONLY_INVERT);
+        if (QUEUED_PHASE(shard)) {
+            RevertBasis1Qb(qIndices.back());
         }
     }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1037,7 +1037,7 @@ real1_f QUnit::ProbParity(const bitCapInt& mask)
     for (bitCapInt v = mask; v; v = nV) {
         nV &= (v - ONE_BCI); // clear the least significant bit set
         qIndices.push_back(log2((v ^ nV) & v));
-        ToPermBasis(qIndices.back());
+        RevertBasis2Qb(qIndices.back(), ONLY_INVERT);
     }
 
     std::map<QInterfacePtr, bitCapInt> units;
@@ -1046,9 +1046,15 @@ real1_f QUnit::ProbParity(const bitCapInt& mask)
     for (bitLenInt i = 0; i < qIndices.size(); i++) {
         QEngineShard& shard = shards[qIndices[i]];
         if (!(shard.unit)) {
-            nOddChance = shard.Prob();
+            nOddChance = (shard.isPauliX || shard.isPauliY) ? norm(((real1)M_SQRT1_2) * (shard.amp0 - shard.amp1))
+                                                            : shard.Prob();
             oddChance = (oddChance * (ONE_R1 - nOddChance)) + ((ONE_R1 - oddChance) * nOddChance);
-        } else if (units.find(shard.unit) == units.end()) {
+            continue;
+        }
+
+        RevertBasis1Qb(qIndices[i]);
+
+        if (units.find(shard.unit) == units.end()) {
             units[shard.unit] = pow2(shard.mapped);
         } else {
             units[shard.unit] |= pow2(shard.mapped);
@@ -1080,7 +1086,8 @@ bool QUnit::ForceMParity(const bitCapInt& mask, bool result, bool doForce)
     for (bitCapInt v = mask; v; v = nV) {
         nV &= (v - ONE_BCI); // clear the least significant bit set
         qIndices.push_back(log2((v ^ nV) & v));
-        ToPermBasis(qIndices.back());
+        RevertBasis2Qb(qIndices.back(), ONLY_INVERT);
+        RevertBasis1Qb(qIndices.back());
     }
 
     bool flipResult = false;


### PR DESCRIPTION
For `ProbParity()` and `ForceMParity()`, if a bit is not cached in Pauli X or Y basis, then a cached phase gate can have no effect on the outcome of these methods. Hence, cached phase gates do not need to be flushed, if a bit is in Pauli Z basis. (Further, these methods do not _collapse_ any observable associated with these cached phase gates, so these cached gates are retained.)

For ProbParity(), if a separable bit is cached in Pauli X or Y basis, we can calculate its effect on parity probability without converting to Z basis.