### PR TITLE
Cached phase gates don't affect Prob()

### DIFF
--- a/include/qengineshard.hpp
+++ b/include/qengineshard.hpp
@@ -163,6 +163,13 @@ public:
         }
         return didClamp;
     }
+    void DumpMultiBit()
+    {
+        controlsShards.clear();
+        antiControlsShards.clear();
+        targetOfShards.clear();
+        antiTargetOfShards.clear();
+    }
 
 protected:
     void RemoveBuffer(QEngineShardPtr p, ShardToPhaseMap& localMap, GetBufferFn remoteMapGet)

--- a/include/qengineshard.hpp
+++ b/include/qengineshard.hpp
@@ -165,10 +165,28 @@ public:
     }
     void DumpMultiBit()
     {
-        controlsShards.clear();
-        antiControlsShards.clear();
-        targetOfShards.clear();
-        antiTargetOfShards.clear();
+        ShardToPhaseMap::iterator phaseShard;
+
+        phaseShard = controlsShards.begin();
+        while (phaseShard != controlsShards.end()) {
+            RemoveTarget(phaseShard->first);
+            phaseShard = controlsShards.begin();
+        }
+        phaseShard = targetOfShards.begin();
+        while (phaseShard != targetOfShards.end()) {
+            RemoveControl(phaseShard->first);
+            phaseShard = targetOfShards.begin();
+        }
+        phaseShard = antiControlsShards.begin();
+        while (phaseShard != antiControlsShards.end()) {
+            RemoveAntiTarget(phaseShard->first);
+            phaseShard = antiControlsShards.begin();
+        }
+        phaseShard = antiTargetOfShards.begin();
+        while (phaseShard != antiTargetOfShards.end()) {
+            RemoveAntiControl(phaseShard->first);
+            phaseShard = antiTargetOfShards.begin();
+        }
     }
 
 protected:
@@ -182,13 +200,13 @@ protected:
     }
 
 public:
-    void RemovePhaseControl(QEngineShardPtr p) { RemoveBuffer(p, targetOfShards, &QEngineShard::GetControlsShards); }
-    void RemovePhaseTarget(QEngineShardPtr p) { RemoveBuffer(p, controlsShards, &QEngineShard::GetTargetOfShards); }
-    void RemovePhaseAntiControl(QEngineShardPtr p)
+    void RemoveControl(QEngineShardPtr p) { RemoveBuffer(p, targetOfShards, &QEngineShard::GetControlsShards); }
+    void RemoveTarget(QEngineShardPtr p) { RemoveBuffer(p, controlsShards, &QEngineShard::GetTargetOfShards); }
+    void RemoveAntiControl(QEngineShardPtr p)
     {
         RemoveBuffer(p, antiTargetOfShards, &QEngineShard::GetAntiControlsShards);
     }
-    void RemovePhaseAntiTarget(QEngineShardPtr p)
+    void RemoveAntiTarget(QEngineShardPtr p)
     {
         RemoveBuffer(p, antiControlsShards, &QEngineShard::GetAntiTargetOfShards);
     }
@@ -225,22 +243,18 @@ protected:
     }
 
 public:
-    void DumpControlOf()
-    {
-        DumpBuffer(&QEngineShard::OptimizeTargets, controlsShards, &QEngineShard::RemovePhaseTarget);
-    }
+    void DumpControlOf() { DumpBuffer(&QEngineShard::OptimizeTargets, controlsShards, &QEngineShard::RemoveTarget); }
     void DumpAntiControlOf()
     {
-        DumpBuffer(&QEngineShard::OptimizeAntiTargets, antiControlsShards, &QEngineShard::RemovePhaseAntiTarget);
+        DumpBuffer(&QEngineShard::OptimizeAntiTargets, antiControlsShards, &QEngineShard::RemoveAntiTarget);
     }
     void DumpSamePhaseControlOf()
     {
-        DumpSamePhaseBuffer(&QEngineShard::OptimizeTargets, controlsShards, &QEngineShard::RemovePhaseTarget);
+        DumpSamePhaseBuffer(&QEngineShard::OptimizeTargets, controlsShards, &QEngineShard::RemoveTarget);
     }
     void DumpSamePhaseAntiControlOf()
     {
-        DumpSamePhaseBuffer(
-            &QEngineShard::OptimizeAntiTargets, antiControlsShards, &QEngineShard::RemovePhaseAntiTarget);
+        DumpSamePhaseBuffer(&QEngineShard::OptimizeAntiTargets, antiControlsShards, &QEngineShard::RemoveAntiTarget);
     }
 
 protected:
@@ -292,12 +306,12 @@ public:
     void AddPhaseAngles(QEngineShardPtr control, const complex& cmplxDiff, const complex& cmplxSame)
     {
         AddAngles(control, cmplxDiff, cmplxSame, &QEngineShard::MakePhaseControlledBy, targetOfShards,
-            &QEngineShard::RemovePhaseControl);
+            &QEngineShard::RemoveControl);
     }
     void AddAntiPhaseAngles(QEngineShardPtr control, const complex& cmplxDiff, const complex& cmplxSame)
     {
         AddAngles(control, cmplxDiff, cmplxSame, &QEngineShard::MakePhaseAntiControlledBy, antiTargetOfShards,
-            &QEngineShard::RemovePhaseAntiControl);
+            &QEngineShard::RemoveAntiControl);
     }
     void AddInversionAngles(QEngineShardPtr control, const complex& cmplxDiff, const complex& cmplxSame)
     {

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -461,6 +461,38 @@ protected:
         }
     }
     void ToPermBasisAll() { ToPermBasis(0, qubitCount); }
+    void ToPermBasisProb(const bitLenInt& qubit)
+    {
+        RevertBasis1Qb(qubit);
+        RevertBasis2Qb(qubit, ONLY_INVERT, ONLY_TARGETS);
+    }
+    void ToPermBasisProb(const bitLenInt& start, const bitLenInt& length)
+    {
+        bitLenInt i;
+        for (i = 0; i < length; i++) {
+            RevertBasis1Qb(start + i);
+        }
+        for (i = 0; i < length; i++) {
+            RevertBasis2Qb(start + i, ONLY_INVERT, ONLY_TARGETS);
+        }
+    }
+    void ToPermBasisMeasure(const bitLenInt& qubit)
+    {
+        if (qubitCount == 1U) {
+            ToPermBasisAllMeasure();
+            return;
+        }
+
+        RevertBasis1Qb(qubit);
+        RevertBasis2Qb(qubit, ONLY_INVERT);
+        RevertBasis2Qb(qubit, ONLY_PHASE, ONLY_CONTROLS);
+
+        QEngineShard& shard = shards[qubit];
+        shard.controlsShards.clear();
+        shard.antiControlsShards.clear();
+        shard.targetOfShards.clear();
+        shard.antiTargetOfShards.clear();
+    }
     void ToPermBasisMeasure(const bitLenInt& start, const bitLenInt& length)
     {
         if ((start == 0) && (length == qubitCount)) {
@@ -474,12 +506,8 @@ protected:
         for (i = 0; i < length; i++) {
             exceptBits.insert(start + i);
         }
-
         for (i = 0; i < length; i++) {
-            RevertBasisY(start + i);
-        }
-        for (i = 0; i < length; i++) {
-            RevertBasisX(start + i);
+            RevertBasis1Qb(start + i);
         }
         for (i = 0; i < length; i++) {
             RevertBasis2Qb(start + i, ONLY_INVERT);
@@ -491,10 +519,7 @@ protected:
     {
         bitLenInt i;
         for (i = 0; i < qubitCount; i++) {
-            RevertBasisY(i);
-        }
-        for (i = 0; i < qubitCount; i++) {
-            RevertBasisX(i);
+            RevertBasis1Qb(i);
         }
         for (i = 0; i < qubitCount; i++) {
             shards[i].ClearInvertPhase();

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -507,7 +507,7 @@ protected:
         }
         for (i = 0; i < length; i++) {
             RevertBasis2Qb(start + i, ONLY_INVERT);
-            RevertBasis2Qb(start + i, ONLY_PHASE, ONLY_CONTROLS, CTRL_AND_ANTI, exceptBits, exceptBits);
+            RevertBasis2Qb(start + i, ONLY_PHASE, ONLY_CONTROLS, CTRL_AND_ANTI, exceptBits);
             shards[start + i].DumpMultiBit();
         }
     }

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -487,11 +487,7 @@ protected:
         RevertBasis2Qb(qubit, ONLY_INVERT);
         RevertBasis2Qb(qubit, ONLY_PHASE, ONLY_CONTROLS);
 
-        QEngineShard& shard = shards[qubit];
-        shard.controlsShards.clear();
-        shard.antiControlsShards.clear();
-        shard.targetOfShards.clear();
-        shard.antiTargetOfShards.clear();
+        shards[qubit].DumpMultiBit();
     }
     void ToPermBasisMeasure(const bitLenInt& start, const bitLenInt& length)
     {
@@ -511,8 +507,8 @@ protected:
         }
         for (i = 0; i < length; i++) {
             RevertBasis2Qb(start + i, ONLY_INVERT);
-            RevertBasis2Qb(
-                start + i, INVERT_AND_PHASE, CONTROLS_AND_TARGETS, CTRL_AND_ANTI, exceptBits, exceptBits, true);
+            RevertBasis2Qb(start + i, ONLY_PHASE, ONLY_CONTROLS, CTRL_AND_ANTI, exceptBits, exceptBits);
+            shards[start + i].DumpMultiBit();
         }
     }
     void ToPermBasisAllMeasure()
@@ -523,7 +519,8 @@ protected:
         }
         for (i = 0; i < qubitCount; i++) {
             shards[i].ClearInvertPhase();
-            RevertBasis2Qb(i, ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI, {}, {}, true);
+            RevertBasis2Qb(i, ONLY_INVERT);
+            shards[i].DumpMultiBit();
         }
     }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -3976,7 +3976,7 @@ void QUnit::ApplyBufferMap(const bitLenInt& bitIndex, ShardToPhaseMap bufferMap,
             ((exclusivity == ONLY_PHASE) && phaseShard->second->isInvert)) {
             bufferMap.erase(phaseShard);
             if (dumpSkipped) {
-                shard.RemovePhaseTarget(partner);
+                shard.RemoveTarget(partner);
             }
             continue;
         }
@@ -3988,15 +3988,15 @@ void QUnit::ApplyBufferMap(const bitLenInt& bitIndex, ShardToPhaseMap bufferMap,
             if (dumpSkipped) {
                 if (isControl) {
                     if (isAnti) {
-                        shard.RemovePhaseAntiTarget(partner);
+                        shard.RemoveAntiTarget(partner);
                     } else {
-                        shard.RemovePhaseTarget(partner);
+                        shard.RemoveTarget(partner);
                     }
                 } else {
                     if (isAnti) {
-                        shard.RemovePhaseAntiControl(partner);
+                        shard.RemoveAntiControl(partner);
                     } else {
-                        shard.RemovePhaseControl(partner);
+                        shard.RemoveControl(partner);
                     }
                 }
             }
@@ -4005,16 +4005,16 @@ void QUnit::ApplyBufferMap(const bitLenInt& bitIndex, ShardToPhaseMap bufferMap,
 
         if (isControl) {
             if (isAnti) {
-                shard.RemovePhaseAntiTarget(partner);
+                shard.RemoveAntiTarget(partner);
             } else {
-                shard.RemovePhaseTarget(partner);
+                shard.RemoveTarget(partner);
             }
             ApplyBuffer(phaseShard->second, bitIndex, partnerIndex, isAnti);
         } else {
             if (isAnti) {
-                shard.RemovePhaseAntiControl(partner);
+                shard.RemoveAntiControl(partner);
             } else {
-                shard.RemovePhaseControl(partner);
+                shard.RemoveControl(partner);
             }
             ApplyBuffer(phaseShard->second, partnerIndex, bitIndex, isAnti);
         }
@@ -4103,10 +4103,10 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
         polarSame = buffer->cmplxSame;
 
         if (IS_ARG_0(polarDiff) && IS_ARG_PI(polarSame)) {
-            shard.RemovePhaseTarget(partner);
+            shard.RemoveTarget(partner);
             shard.AddPhaseAngles(partner, ONE_CMPLX, -ONE_CMPLX);
         } else if (IS_ARG_PI(polarDiff) && IS_ARG_0(polarSame)) {
-            shard.RemovePhaseTarget(partner);
+            shard.RemoveTarget(partner);
             shard.AddAntiPhaseAngles(partner, -ONE_CMPLX, ONE_CMPLX);
         }
     }
@@ -4125,10 +4125,10 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
         polarSame = buffer->cmplxSame;
 
         if (IS_ARG_0(polarDiff) && IS_ARG_PI(polarSame)) {
-            shard.RemovePhaseAntiTarget(partner);
+            shard.RemoveAntiTarget(partner);
             shard.AddAntiPhaseAngles(partner, ONE_CMPLX, -ONE_CMPLX);
         } else if (IS_ARG_PI(polarDiff) && IS_ARG_0(polarSame)) {
-            shard.RemovePhaseAntiTarget(partner);
+            shard.RemoveAntiTarget(partner);
             shard.AddPhaseAngles(partner, -ONE_CMPLX, ONE_CMPLX);
         }
     }
@@ -4161,7 +4161,7 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
         }
 
         control = FindShardIndex(partner);
-        shard.RemovePhaseControl(partner);
+        shard.RemoveControl(partner);
         ApplyBuffer(buffer, control, bitIndex, false);
     }
 
@@ -4185,7 +4185,7 @@ void QUnit::CommuteH(const bitLenInt& bitIndex)
         }
 
         control = FindShardIndex(partner);
-        shard.RemovePhaseAntiControl(partner);
+        shard.RemoveAntiControl(partner);
         ApplyBuffer(buffer, control, bitIndex, true);
     }
 
@@ -4209,12 +4209,12 @@ void QUnit::OptimizePairBuffers(const bitLenInt& control, const bitLenInt& targe
 
     if (IS_NORM_0(buffer->cmplxDiff - buffer->cmplxSame)) {
         if (IS_1_CMPLX(buffer->cmplxDiff)) {
-            tShard.RemovePhaseControl(&cShard);
+            tShard.RemoveControl(&cShard);
             return;
         }
 
         if (!cShard.isClifford() && !tShard.isClifford()) {
-            tShard.RemovePhaseControl(&cShard);
+            tShard.RemoveControl(&cShard);
             ApplyBuffer(buffer, control, target, anti);
             return;
         }
@@ -4231,8 +4231,8 @@ void QUnit::OptimizePairBuffers(const bitLenInt& control, const bitLenInt& targe
     PhaseShardPtr aBuffer = antiShard->second;
 
     if (IS_NORM_0(buffer->cmplxDiff - aBuffer->cmplxSame) && IS_NORM_0(buffer->cmplxSame - aBuffer->cmplxDiff)) {
-        tShard.RemovePhaseControl(&cShard);
-        tShard.RemovePhaseAntiControl(&cShard);
+        tShard.RemoveControl(&cShard);
+        tShard.RemoveAntiControl(&cShard);
         if (anti) {
             ApplySinglePhase(buffer->cmplxSame, buffer->cmplxDiff, target);
         } else {

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1019,7 +1019,8 @@ bool QUnit::TrySeparateCliffordBit(const bitLenInt& qubit)
 
 real1_f QUnit::Prob(bitLenInt qubit)
 {
-    ToPermBasis(qubit);
+    RevertBasis1Qb(qubit);
+    RevertBasis2Qb(qubit, ONLY_INVERT, ONLY_TARGETS);
     return ProbBase(qubit);
 }
 


### PR DESCRIPTION
As the title and commit message say, "Cached phase gates don't affect `Prob()`." For that matter, neither do cached "inversion" gates where the `Prob()` bit target is a _control_ bit, rather than a target bit. (Amazing that I missed this opportunity for so long, in such a core part of the API).