### PR TITLE
Windows doesn't need 64-bit complex, standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,10 +82,10 @@ CMake on Windows will set up a 32-bit Visual Studio project by default, (if usin
 ```
     $ mkdir _build
     $ cd _build
-    $ cmake -DCMAKE_GENERATOR_PLATFORM=x64 -DFPPOW=6 -DXXD_BIN="C:/Program Files (x86)/Vim/vim82/xxd.exe" ..
+    $ cmake -DCMAKE_GENERATOR_PLATFORM=x64 -DXXD_BIN="C:/Program Files (x86)/Vim/vim82/xxd.exe" ..
 ```
 
-After CMake, the project must be built in Visual Studio. (`-DFPPOW=6` disables single `float` accuracy in favor of `double`, which should usually be used for building the Q# runtime with `QrackSimulator`.)
+After CMake, the project must be built in Visual Studio. Once installed, the `qrack_pinvoke` DLL is compatible with the Qrack Q# runtime fork, to provide `QrackSimulator`.
 
 ## Performing code coverage
 


### PR DESCRIPTION
I have tested Q# runtime unit tests, at this stage of development, and 64-bit complex amplitudes are not necessary to pass. 64-bit complex amplitudes are always an option, but there's no need to recommend them  in the README for Windows.