### PR TITLE
QStabilizerHybrid::SetQuantumState(): Always cache single qubit

### DIFF
--- a/src/qstabilizerhybrid.cpp
+++ b/src/qstabilizerhybrid.cpp
@@ -415,7 +415,6 @@ void QStabilizerHybrid::SetQuantumState(const complex* inputState)
             return;
         }
 
-        engine.reset();
         if (stabilizer) {
             stabilizer->SetPermutation(0);
         } else {

--- a/src/qstabilizerhybrid.cpp
+++ b/src/qstabilizerhybrid.cpp
@@ -398,8 +398,9 @@ void QStabilizerHybrid::SetQuantumState(const complex* inputState)
             isY = true;
         }
 
+        engine.reset();
+
         if (isClifford) {
-            engine.reset();
             if (stabilizer) {
                 stabilizer->SetPermutation(isSet ? 1 : 0);
             } else {
@@ -413,6 +414,21 @@ void QStabilizerHybrid::SetQuantumState(const complex* inputState)
             }
             return;
         }
+
+        engine.reset();
+        if (stabilizer) {
+            stabilizer->SetPermutation(0);
+        } else {
+            stabilizer = MakeStabilizer(0);
+        }
+
+        real1 sqrtProb = sqrt(norm(inputState[1]));
+        real1 sqrt1MinProb = sqrt(norm(inputState[0]));
+        complex probMatrix[4] = { sqrt1MinProb, sqrtProb, sqrtProb, -sqrt1MinProb };
+        ApplySingleBit(probMatrix, 0);
+        ApplySinglePhase(inputState[0] / sqrt1MinProb, inputState[1] / sqrtProb, 0);
+
+        return;
     }
 
     SwitchToEngine();


### PR DESCRIPTION
Using `SetQuantumState()`, `QStabilizerHybrid` attempts to recover a stabilizer state if possible from introspection of a single qubit pair of amplitudes. Now that we have a single qubit fusion buffer system in `QStabilizerHybrid`, it is _always_ possible to cache a single bit as a stabilizer state with or without a single bit fusion buffer. This is mostly important for cases where `QUnit` creates hybrid stabilizer "shards," potentially.