### PR TITLE
More general QUnit::TrySeparate()

### DIFF
--- a/include/qstabilizerhybrid.hpp
+++ b/include/qstabilizerhybrid.hpp
@@ -823,7 +823,7 @@ public:
 
     virtual real1_f Prob(bitLenInt qubitIndex)
     {
-        if (stabilizer && shards[qubitIndex]) {
+        if (stabilizer && shards[qubitIndex] && !shards[qubitIndex]->IsPhase()) {
             FlushBuffers();
         }
 

--- a/include/qstabilizerhybrid.hpp
+++ b/include/qstabilizerhybrid.hpp
@@ -823,8 +823,13 @@ public:
 
     virtual real1_f Prob(bitLenInt qubitIndex)
     {
-        if (stabilizer && shards[qubitIndex] && !shards[qubitIndex]->IsPhase()) {
-            FlushBuffers();
+        bool isCachedInvert = false;
+        if (stabilizer && shards[qubitIndex]) {
+            if (shards[qubitIndex]->IsInvert()) {
+                isCachedInvert = true;
+            } else if (!shards[qubitIndex]->IsPhase()) {
+                FlushBuffers();
+            }
         }
 
         if (engine) {
@@ -832,7 +837,7 @@ public:
         }
 
         if (stabilizer->IsSeparableZ(qubitIndex)) {
-            return stabilizer->M(qubitIndex) ? ONE_R1 : ZERO_R1;
+            return (isCachedInvert != stabilizer->M(qubitIndex)) ? ONE_R1 : ZERO_R1;
         } else {
             return ONE_R1 / 2;
         }

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -597,6 +597,8 @@ protected:
     void CommuteH(const bitLenInt& bitIndex);
 
     void OptimizePairBuffers(const bitLenInt& control, const bitLenInt& target, const bool& anti);
+
+    void CacheSingleQubitShard(bitLenInt target);
 };
 
 } // namespace Qrack

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -883,7 +883,7 @@ real1_f QUnit::ProbBase(const bitLenInt& qubit)
     shard.amp1 = complex((real1)sqrt(prob), ZERO_R1);
     shard.amp0 = complex((real1)sqrt(ONE_R1 - prob), ZERO_R1);
 
-    if (unit && unit->isClifford() && !TrySeparateCliffordBit(qubit)) {
+    if (unit && unit->isClifford(mapped) && !TrySeparateCliffordBit(qubit)) {
         return prob;
     }
 


### PR DESCRIPTION
This generalizes the potentially successful cases of `QUnit::TrySeparate()` for a single bit. If the bit _can_ be put into a separated representation, under the currently active 2-qubit gate buffers, then this improvement should _always_ do so, within floating point rounding error.

(I also noticed that `QStabilizerHybrid::Prob()` doesn't need to flush single bit buffers if the active buffer is a phase gate, and `QUnit::ApplyEitherControlled()` should first consider whether a single bit buffer is cached, before trying to separate Clifford sub-units.)