### PR TITLE
#705: Variable benchmark depth

### DIFF
--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -503,7 +503,6 @@ TEST_CASE("test_quantum_triviality", "[supreme]")
 {
     const int GateCount1Qb = 4;
     const int GateCountMultiQb = 5;
-    const int Depth = 20;
 
     benchmarkLoop(
         [&](QInterfacePtr qReg, bitLenInt n) {
@@ -513,7 +512,7 @@ TEST_CASE("test_quantum_triviality", "[supreme]")
             bitLenInt b1, b2, b3;
             int maxGates;
 
-            for (d = 0; d < Depth; d++) {
+            for (d = 0; d < benchmarkDepth; d++) {
 
                 for (i = 0; i < n; i++) {
                     gateRand = qReg->Rand();
@@ -572,7 +571,6 @@ TEST_CASE("test_stabilizer", "[supreme]")
 {
     const int GateCount1Qb = 4;
     const int GateCountMultiQb = 2;
-    const int Depth = 20;
 
     benchmarkLoop(
         [&](QInterfacePtr qReg, bitLenInt n) {
@@ -581,7 +579,7 @@ TEST_CASE("test_stabilizer", "[supreme]")
             real1_f gateRand;
             bitLenInt b1, b2;
 
-            for (d = 0; d < Depth; d++) {
+            for (d = 0; d < benchmarkDepth; d++) {
 
                 for (i = 0; i < n; i++) {
                     gateRand = qReg->Rand();
@@ -625,7 +623,6 @@ TEST_CASE("test_stabilizer", "[supreme]")
 TEST_CASE("test_universal_circuit_continuous", "[supreme]")
 {
     const int GateCountMultiQb = 2;
-    const int Depth = 20;
 
     benchmarkLoop(
         [&](QInterfacePtr qReg, bitLenInt n) {
@@ -634,7 +631,7 @@ TEST_CASE("test_universal_circuit_continuous", "[supreme]")
             real1_f theta, phi, lambda;
             bitLenInt b1, b2;
 
-            for (d = 0; d < Depth; d++) {
+            for (d = 0; d < benchmarkDepth; d++) {
 
                 for (i = 0; i < n; i++) {
                     theta = 2 * M_PI * qReg->Rand();
@@ -672,7 +669,6 @@ TEST_CASE("test_universal_circuit_discrete", "[supreme]")
 {
     const int GateCount1Qb = 2;
     const int GateCountMultiQb = 2;
-    const int Depth = 20;
 
     benchmarkLoop(
         [&](QInterfacePtr qReg, bitLenInt n) {
@@ -682,7 +678,7 @@ TEST_CASE("test_universal_circuit_discrete", "[supreme]")
             bitLenInt b1, b2, b3;
             int maxGates;
 
-            for (d = 0; d < Depth; d++) {
+            for (d = 0; d < benchmarkDepth; d++) {
 
                 for (i = 0; i < n; i++) {
                     gateRand = qReg->Rand();
@@ -729,7 +725,6 @@ TEST_CASE("test_universal_circuit_digital", "[supreme]")
 {
     const int GateCount1Qb = 4;
     const int GateCountMultiQb = 4;
-    const int Depth = 20;
 
     benchmarkLoop(
         [&](QInterfacePtr qReg, bitLenInt n) {
@@ -739,7 +734,7 @@ TEST_CASE("test_universal_circuit_digital", "[supreme]")
             bitLenInt b1, b2, b3;
             int maxGates;
 
-            for (d = 0; d < Depth; d++) {
+            for (d = 0; d < benchmarkDepth; d++) {
 
                 for (i = 0; i < n; i++) {
                     gateRand = qReg->Rand();
@@ -795,7 +790,6 @@ TEST_CASE("test_universal_circuit_analog", "[supreme]")
 {
     const int GateCount1Qb = 3;
     const int GateCountMultiQb = 4;
-    const int Depth = 20;
 
     benchmarkLoop(
         [&](QInterfacePtr qReg, bitLenInt n) {
@@ -808,7 +802,7 @@ TEST_CASE("test_universal_circuit_analog", "[supreme]")
             bool canDo3;
             int gateThreshold, gateMax;
 
-            for (d = 0; d < Depth; d++) {
+            for (d = 0; d < benchmarkDepth; d++) {
 
                 for (i = 0; i < n; i++) {
                     gateRand = qReg->Rand();
@@ -871,7 +865,6 @@ TEST_CASE("test_ccz_ccx_h", "[supreme]")
 
     const int GateCount1Qb = 4;
     const int GateCountMultiQb = 4;
-    const int Depth = 20;
 
     benchmarkLoop(
         [&](QInterfacePtr qReg, bitLenInt n) {
@@ -881,7 +874,7 @@ TEST_CASE("test_ccz_ccx_h", "[supreme]")
             bitLenInt b1, b2, b3;
             int maxGates;
 
-            for (d = 0; d < Depth; d++) {
+            for (d = 0; d < benchmarkDepth; d++) {
 
                 for (i = 0; i < n; i++) {
                     gateRand = GateCount1Qb * qReg->Rand();
@@ -939,8 +932,6 @@ TEST_CASE("test_quantum_supremacy", "[supreme]")
     // This is an attempt to simulate the circuit argued to establish quantum supremacy.
     // See https://doi.org/10.1038/s41586-019-1666-5
 
-    const int depth = 20;
-
     benchmarkLoop([&](QInterfacePtr qReg, bitLenInt n) {
         // The test runs 2 bit gates according to a tiling sequence.
         // The 1 bit indicates +/- column offset.
@@ -979,7 +970,7 @@ TEST_CASE("test_quantum_supremacy", "[supreme]")
         // We repeat the entire prepartion for "depth" iterations.
         // We can avoid maximal representational entanglement of the state as a single Schr{\"o}dinger method unit.
         // See https://arxiv.org/abs/1710.05867
-        for (d = 0; d < depth; d++) {
+        for (d = 0; d < benchmarkDepth; d++) {
             for (i = 0; i < n; i++) {
                 gateRand = qReg->Rand();
 

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -501,6 +501,8 @@ bitLenInt pickRandomBit(QInterfacePtr qReg, std::set<bitLenInt>* unusedBitsPtr)
 
 TEST_CASE("test_quantum_triviality", "[supreme]")
 {
+    std::cout << "(random circuit depth: " << benchmarkDepth << ")";
+
     const int GateCount1Qb = 4;
     const int GateCountMultiQb = 5;
 
@@ -569,6 +571,8 @@ TEST_CASE("test_quantum_triviality", "[supreme]")
 
 TEST_CASE("test_stabilizer", "[supreme]")
 {
+    std::cout << "(random circuit depth: " << benchmarkDepth << ")";
+
     const int GateCount1Qb = 4;
     const int GateCountMultiQb = 2;
 
@@ -622,6 +626,8 @@ TEST_CASE("test_stabilizer", "[supreme]")
 
 TEST_CASE("test_universal_circuit_continuous", "[supreme]")
 {
+    std::cout << "(random circuit depth: " << benchmarkDepth << ")";
+
     const int GateCountMultiQb = 2;
 
     benchmarkLoop(
@@ -667,6 +673,8 @@ TEST_CASE("test_universal_circuit_continuous", "[supreme]")
 
 TEST_CASE("test_universal_circuit_discrete", "[supreme]")
 {
+    std::cout << "(random circuit depth: " << benchmarkDepth << ")";
+
     const int GateCount1Qb = 2;
     const int GateCountMultiQb = 2;
 
@@ -723,6 +731,8 @@ TEST_CASE("test_universal_circuit_discrete", "[supreme]")
 
 TEST_CASE("test_universal_circuit_digital", "[supreme]")
 {
+    std::cout << "(random circuit depth: " << benchmarkDepth << ")";
+
     const int GateCount1Qb = 4;
     const int GateCountMultiQb = 4;
 
@@ -788,6 +798,8 @@ TEST_CASE("test_universal_circuit_digital", "[supreme]")
 
 TEST_CASE("test_universal_circuit_analog", "[supreme]")
 {
+    std::cout << "(random circuit depth: " << benchmarkDepth << ")";
+
     const int GateCount1Qb = 3;
     const int GateCountMultiQb = 4;
 
@@ -862,6 +874,7 @@ TEST_CASE("test_universal_circuit_analog", "[supreme]")
 
 TEST_CASE("test_ccz_ccx_h", "[supreme]")
 {
+    std::cout << "(random circuit depth: " << benchmarkDepth << ")";
 
     const int GateCount1Qb = 4;
     const int GateCountMultiQb = 4;
@@ -929,6 +942,8 @@ TEST_CASE("test_ccz_ccx_h", "[supreme]")
 
 TEST_CASE("test_quantum_supremacy", "[supreme]")
 {
+    std::cout << "(random circuit depth: " << benchmarkDepth << ")";
+
     // This is an attempt to simulate the circuit argued to establish quantum supremacy.
     // See https://doi.org/10.1038/s41586-019-1666-5
 

--- a/test/benchmarks_main.cpp
+++ b/test/benchmarks_main.cpp
@@ -38,6 +38,7 @@ std::string mOutputFileName;
 std::ofstream mOutputFile;
 bool isBinaryOutput = false;
 int benchmarkSamples = 100;
+int benchmarkDepth = 20;
 std::vector<int> devList;
 
 #define SHOW_OCL_BANNER()                                                                                              \
@@ -104,6 +105,9 @@ int main(int argc, char* argv[])
         Opt(sparse)["--sparse"](
             "(For QEngineCPU, under QUnit:) Use a state vector optimized for sparse representation and iteration.") |
         Opt(benchmarkSamples, "samples")["--benchmark-samples"]("number of samples to collect (default: 100)") |
+        Opt(benchmarkDepth, "depth")["--benchmark-depth"](
+            "depth of randomly constructed circuits, when applicable, with 1 round of single qubit and 1 round of "
+            "multi-qubit gates being 1 unit of depth (default: 20)") |
         Opt(devListStr, "devices")["--devices"](
             "list of devices, for QPager (default is solely default OpenCL device)");
 

--- a/test/tests.hpp
+++ b/test/tests.hpp
@@ -41,6 +41,7 @@ extern std::string mOutputFileName;
 extern std::ofstream mOutputFile;
 extern bool isBinaryOutput;
 extern int benchmarkSamples;
+extern int benchmarkDepth;
 extern std::vector<int> devList;
 
 /* Declare the stream-to-probability prior to including catch.hpp. */


### PR DESCRIPTION
This lets the user select benchmark depth for randomly constructed circuit benchmarks from the command line. (1 unit of depth is 1 round of single bit gates with 1 round of multi-qubit gates, as indicated with the `-?` option text.)