### PR TITLE
Improved QUnit caching

### DIFF
--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -366,7 +366,8 @@ protected:
 
     template <typename CF, typename F>
     void ApplyEitherControlled(const bitLenInt* controls, const bitLenInt& controlLen,
-        const std::vector<bitLenInt> targets, const bool& anti, CF cfn, F f, const bool& inCurrentBasis = false);
+        const std::vector<bitLenInt> targets, const bool& anti, CF cfn, F f, const bool& isPhase = false,
+        const bool& inCurrentBasis = false);
 
     bitCapInt GetIndexedEigenstate(bitLenInt indexStart, bitLenInt indexLength, bitLenInt valueStart,
         bitLenInt valueLength, unsigned char* values);

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -2201,7 +2201,7 @@ void QUnit::ApplySinglePhase(const complex topLeft, const complex bottomRight, b
             shard.unit->ApplySinglePhase(topLeft, bottomRight, shard.mapped);
         }
         if (DIRTY(shard)) {
-            shard.MakeDirty();
+            shard.isPhaseDirty = true;
             return;
         }
 
@@ -2306,7 +2306,8 @@ void QUnit::ApplySingleInvert(const complex topRight, const complex bottomLeft, 
             shard.unit->ApplySingleInvert(topRight, bottomLeft, shard.mapped);
         }
         if (DIRTY(shard)) {
-            shard.MakeDirty();
+            shard.isPhaseDirty = true;
+            std::swap(shard.amp0, shard.amp1);
             return;
         }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1648,7 +1648,8 @@ void QUnit::XBase(const bitLenInt& target)
         shard.unit->X(shard.mapped);
     }
     if (DIRTY(shard)) {
-        shard.MakeDirty();
+        shard.isPhaseDirty = true;
+        std::swap(shard.amp0, shard.amp1);
         return;
     }
 
@@ -1663,7 +1664,8 @@ void QUnit::YBase(const bitLenInt& target)
         shard.unit->Y(shard.mapped);
     }
     if (DIRTY(shard)) {
-        shard.MakeDirty();
+        shard.isPhaseDirty = true;
+        std::swap(shard.amp0, shard.amp1);
         return;
     }
 
@@ -1680,7 +1682,7 @@ void QUnit::ZBase(const bitLenInt& target)
         shard.unit->Z(shard.mapped);
     }
     if (DIRTY(shard)) {
-        shard.MakeDirty();
+        shard.isPhaseDirty = true;
         return;
     }
 


### PR DESCRIPTION
I've identified a few additional cases where probability caching for single bits in `QUnit` can be preserved.

For controlled gates, we filter the caching by whether the public method call is a phase gate and whether the target bit is in Pauli Z basis. We miss cases in Pauli X and Y bases, this way, but the comparative complication of implementing those cases might be sufficient reason to leave them out, at least for now.