### PR TITLE
QUnit approximate Z basis separability

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,9 @@ After CMake, the project must be built in Visual Studio. Once installed, the `qr
     $ python -m http.server
 ```
 
+## QUnit separability threshold
+QUnit caches and introspects information about single qubits, to proactively maintain a Schmidt decomposed representation of state. By default, QUnit tolerance for determining Z basis eigenstates is `FP_NORM_EPSILON` defined in `include/common/qrack_types.hpp`, and this can usually be considered an "exact" simulation. To override this separability threshold in an environment, define the `QRACK_QUNIT_SEPARABILITY_THRESHOLD` with a float value between 0 and 1. The lower the value, the more precise are Z basis eigenstate separability checks. Adjusting this threshold can trade off between precision/accuracy vs. RAM usage and execution time.
+
 ## QPager distributed simulation options
 QPager attempts to smartly allocate low qubit widths for maximum performance. For wider qubit simulations, based on `clinfo`, you can segment your maximum OpenCL accelerator state vector page allocation into global qubits with the environment variable `QRACK_SEGMENT_GLOBAL_QB=n`, where n is an integer >=0. The default n is 0, meaning that maximum allocation segment of your GPU RAM is a single page. (For 1 global qubit, one segment would have 2 pages, akin to 2 single amplitudes, therefore one "global qubit," or 4 pages for n=2, because 2^2=4, etc., by exponent.)
 

--- a/README.md
+++ b/README.md
@@ -77,12 +77,12 @@ Qrack supports building on Windows, but some special configuration is required. 
 
 Qrack requires the `xxd` command to convert its OpenCL kernel code into hexadecimal format for building. `xxd` is not natively available on Windows systems, but Windows executables for it are provided by sources including the [Vim editor Windows port](https://www.vim.org/download.php).
 
-CMake on Windows will set up a 32-bit Visual Studio project by default, (if using Visual Studio,) whereas 64-bit will probably be typically desired. Putting together all of the above considerations, after installing the CUDA Toolkit and Vim, a typical CMake command for Windows might look like this:
+CMake on Windows will set up a 32-bit Visual Studio project by default, (if using Visual Studio,) whereas 64-bit will probably be typically desired. `-DFPPOW=6` is used to set the systemic floating point accuracy to `double`, which is typically necessary for Q# accuracy tolerances. Putting together all of the above considerations, after installing the CUDA Toolkit and Vim, a typical CMake command for Windows might look like this:
 
 ```
     $ mkdir _build
     $ cd _build
-    $ cmake -DCMAKE_GENERATOR_PLATFORM=x64 -DXXD_BIN="C:/Program Files (x86)/Vim/vim82/xxd.exe" ..
+    $ cmake -DCMAKE_GENERATOR_PLATFORM=x64 -DXXD_BIN="C:/Program Files (x86)/Vim/vim82/xxd.exe" -DFPPOW=6 ..
 ```
 
 After CMake, the project must be built in Visual Studio. Once installed, the `qrack_pinvoke` DLL is compatible with the Qrack Q# runtime fork, to provide `QrackSimulator`.

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -41,6 +41,7 @@ protected:
     bool canSuppressPaging;
     bitLenInt thresholdQubits;
     bitLenInt pagingThresholdQubits;
+    real1_f separabilityThreshold;
     std::vector<int> deviceIDs;
 
     QInterfacePtr MakeEngine(bitLenInt length, bitCapInt perm);

--- a/src/qhybrid.cpp
+++ b/src/qhybrid.cpp
@@ -8,10 +8,6 @@
 // See LICENSE.md in the project root or https://www.gnu.org/licenses/lgpl-3.0.en.html
 // for details.
 
-#if defined(_WIN32) && !defined(__CYGWIN__)
-#include <direct.h>
-#endif
-
 #include <thread>
 
 #include "common/oclengine.hpp"

--- a/src/qpager.cpp
+++ b/src/qpager.cpp
@@ -8,10 +8,6 @@
 // See LICENSE.md in the project root or https://www.gnu.org/licenses/lgpl-3.0.en.html
 // for details.
 
-#if defined(_WIN32) && !defined(__CYGWIN__)
-#include <direct.h>
-#endif
-
 #include <future>
 #include <string>
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -29,7 +29,7 @@
 #include "qunit.hpp"
 
 #define DIRTY(shard) (shard.isPhaseDirty || shard.isProbDirty)
-#define IS_NORM_0(c) (norm(c) <= FP_NORM_EPSILON)
+#define IS_NORM_0(c) (norm(c) <= separabilityThreshold)
 #define IS_0_R1(r) (r == ZERO_R1)
 #define IS_1_R1(r) (r == ONE_R1)
 #define IS_1_CMPLX(c) (c == ONE_CMPLX)
@@ -75,10 +75,15 @@ QUnit::QUnit(QInterfaceEngine eng, QInterfaceEngine subEng, bitLenInt qBitCount,
     , freezeClifford(false)
     , thresholdQubits(qubitThreshold)
     , pagingThresholdQubits(21)
+    , separabilityThreshold(FP_NORM_EPSILON)
     , deviceIDs(devList)
 {
     if (getenv("QRACK_QUNIT_PAGING_THRESHOLD")) {
         pagingThresholdQubits = (bitLenInt)std::stoi(std::string(getenv("QRACK_QUNIT_PAGING_THRESHOLD")));
+    }
+
+    if (getenv("QRACK_QUNIT_SEPARABILITY_THRESHOLD")) {
+        separabilityThreshold = (real1_f)std::stof(std::string(getenv("QRACK_QUNIT_SEPARABILITY_THRESHOLD")));
     }
 
     if ((engine == QINTERFACE_QUNIT) || (engine == QINTERFACE_QUNIT_MULTI)) {


### PR DESCRIPTION
As a further experiment in "approximate separability," this PR defines an environment variable to directly override `QUnit` floating point threshold for considering a qubit to be in a Z basis eigenstate. It would probably make sense to also have a constructor argument for this, and to only override the constructor variable if the environment variable is defined, but the environment variable alone is more immediately useful for experimentation. The threshold variable takes a floating point value between 0 and 1.

Also, the `direct.h` header on Windows is for directory manipulation; it was erroneously included in several places that didn't use it. It has been removed, there.