### PR TITLE
Debug QUnit::TrySeparate()

### DIFF
--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -729,7 +729,7 @@ bool QUnit::TrySeparate(bitLenInt start, bitLenInt length, real1_f error_tol)
     // We check X basis:
     shard.unit->H(shard.mapped);
     prob = ProbBase(start);
-    didSeparate |= (shard.GetQubitCount() == 1);
+    didSeparate = (shard.GetQubitCount() == 1);
 
     if (didSeparate || (abs(prob - ONE_R1 / 2) > separabilityThreshold)) {
         H(start);
@@ -737,14 +737,14 @@ bool QUnit::TrySeparate(bitLenInt start, bitLenInt length, real1_f error_tol)
     }
 
     // We check Y basis:
-    complex mtrx[4] = { complex(ONE_R1, ONE_R1) / (real1)2.0f, complex(ONE_R1, -ONE_R1) / (real1)2.0f,
-        complex(ONE_R1, -ONE_R1) / (real1)2.0f, complex(ONE_R1, ONE_R1) / (real1)2.0f };
+    complex mtrx[4] = { complex(ONE_R1, -ONE_R1) / (real1)2.0f, complex(ONE_R1, ONE_R1) / (real1)2.0f,
+        complex(ONE_R1, ONE_R1) / (real1)2.0f, complex(ONE_R1, -ONE_R1) / (real1)2.0f };
     shard.unit->ApplySingleBit(mtrx, shard.mapped);
     prob = ProbBase(start);
-    didSeparate |= (shard.GetQubitCount() == 1);
+    didSeparate = (shard.GetQubitCount() == 1);
 
-    IS(start);
     H(start);
+    S(start);
 
     return didSeparate;
 }

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -719,17 +719,17 @@ bool QUnit::TrySeparate(bitLenInt start, bitLenInt length, real1_f error_tol)
 
     // We check Z basis:
     real1_f prob = ProbBase(start);
-    bool didSeparate = ((prob <= separabilityThreshold) || ((ONE_R1 - prob) <= separabilityThreshold));
+    bool didSeparate = (shard.GetQubitCount() == 1);
 
     // If this is 0.5, it wasn't Z basis, but it's worth checking X basis.
-    if (abs(prob - ONE_R1 / 2) > separabilityThreshold) {
+    if (didSeparate || (abs(prob - ONE_R1 / 2) > separabilityThreshold)) {
         return didSeparate;
     }
 
     // We check X basis:
     shard.unit->H(shard.mapped);
     prob = ProbBase(start);
-    didSeparate |= ((prob <= separabilityThreshold) || ((ONE_R1 - prob) <= separabilityThreshold));
+    didSeparate |= (shard.GetQubitCount() == 1);
 
     if (didSeparate || (abs(prob - ONE_R1 / 2) > separabilityThreshold)) {
         H(start);
@@ -741,7 +741,7 @@ bool QUnit::TrySeparate(bitLenInt start, bitLenInt length, real1_f error_tol)
         complex(ONE_R1, -ONE_R1) / (real1)2.0f, complex(ONE_R1, ONE_R1) / (real1)2.0f };
     shard.unit->ApplySingleBit(mtrx, shard.mapped);
     prob = ProbBase(start);
-    didSeparate |= ((prob <= separabilityThreshold) || ((ONE_R1 - prob) <= separabilityThreshold));
+    didSeparate |= (shard.GetQubitCount() == 1);
 
     H(start);
     S(start);

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -743,8 +743,8 @@ bool QUnit::TrySeparate(bitLenInt start, bitLenInt length, real1_f error_tol)
     prob = ProbBase(start);
     didSeparate |= (shard.GetQubitCount() == 1);
 
+    IS(start);
     H(start);
-    S(start);
 
     return didSeparate;
 }


### PR DESCRIPTION
`QUnit::TrySeparate()` had a problem converting shard types. However, by basically reverting #703, we fix this problem and typically get better performance, even if generality is lost.