### PR TITLE
QPager Compose()/Decompose() debug

### DIFF
--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -1221,7 +1221,7 @@ void QEngineOCL::DecomposeDispose(bitLenInt start, bitLenInt length, QEngineOCLP
         return;
     }
 
-    if (!destination->stateBuffer) {
+    if (destination && !destination->stateBuffer) {
         // Reinitialize stateVec RAM
         destination->SetPermutation(0);
     }

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -1221,6 +1221,11 @@ void QEngineOCL::DecomposeDispose(bitLenInt start, bitLenInt length, QEngineOCLP
         return;
     }
 
+    if (!destination->stateBuffer) {
+        // Reinitialize stateVec RAM
+        destination->SetPermutation(0);
+    }
+
     if (doNormalize) {
         NormalizeState();
     }

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -1113,7 +1113,7 @@ void QEngineOCL::ApplyM(bitCapInt mask, bitCapInt result, complex nrm)
 
 void QEngineOCL::Compose(OCLAPI apiCall, bitCapIntOcl* bciArgs, QEngineOCLPtr toCopy)
 {
-    if (!stateBuffer) {
+    if (!stateBuffer || !toCopy->stateBuffer) {
         // Compose will have a wider but 0 stateVec
         SetQubitCount(qubitCount + toCopy->qubitCount);
         return;

--- a/src/qengine/state.cpp
+++ b/src/qengine/state.cpp
@@ -667,7 +667,7 @@ bitLenInt QEngineCPU::Compose(QEngineCPUPtr toCopy)
     bitLenInt result = qubitCount;
     bitLenInt nQubitCount = qubitCount + toCopy->qubitCount;
 
-    if (!stateVec) {
+    if (!stateVec || !toCopy->stateVec) {
         // Compose will have a wider but 0 stateVec
         SetQubitCount(nQubitCount);
         return result;

--- a/src/qengine/state.cpp
+++ b/src/qengine/state.cpp
@@ -835,6 +835,11 @@ void QEngineCPU::DecomposeDispose(bitLenInt start, bitLenInt length, QEngineCPUP
         return;
     }
 
+    if (!destination->stateVec) {
+        // Reinitialize stateVec RAM
+        destination->SetPermutation(0);
+    }
+
     bitLenInt nLength = qubitCount - length;
 
     bitCapIntOcl partPower = pow2Ocl(length);

--- a/src/qengine/state.cpp
+++ b/src/qengine/state.cpp
@@ -835,7 +835,7 @@ void QEngineCPU::DecomposeDispose(bitLenInt start, bitLenInt length, QEngineCPUP
         return;
     }
 
-    if (!destination->stateVec) {
+    if (destination && !destination->stateVec) {
         // Reinitialize stateVec RAM
         destination->SetPermutation(0);
     }

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -714,7 +714,7 @@ bool QUnit::TrySeparate(bitLenInt start, bitLenInt length, real1_f error_tol)
         return true;
     }
 
-    if (shard.unit->isClifford()) {
+    if (shard.isClifford()) {
         return TrySeparateCliffordBit(start);
     }
 
@@ -959,7 +959,7 @@ bool QUnit::TrySeparateCliffordBit(const bitLenInt& qubit)
         return true;
     }
 
-    if (freezeClifford || !shard.unit->isClifford(shard.mapped)) {
+    if (freezeClifford || !shard.isClifford()) {
         return false;
     }
 


### PR DESCRIPTION
It is possible for `QEngine` pages under `QPager` to have no allocated state vector RAM, if the total probability in that page is 0. This edge case needs to be anticipated in `QEngineCPU` and `QEngineOCL`, when composing and decomposing.