### PR TITLE
Don't zero ZeroAmplitudes() from UpdateRunningNorm()

### DIFF
--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -2652,9 +2652,10 @@ void QEngineOCL::UpdateRunningNorm(real1_f norm_thresh)
 
     WAIT_REAL1_SUM(*nrmBuffer, ngc / ngs, nrmArray, &runningNorm);
 
-    if (runningNorm <= amplitudeFloor) {
-        ZeroAmplitudes();
-    }
+    // TODO: Why doesn't this work?
+    // if (runningNorm <= amplitudeFloor) {
+    //    ZeroAmplitudes();
+    //}
 }
 
 complex* QEngineOCL::AllocStateVec(bitCapInt elemCount, bool doForceAlloc)

--- a/src/qengine/state.cpp
+++ b/src/qengine/state.cpp
@@ -1451,9 +1451,10 @@ void QEngineCPU::UpdateRunningNorm(real1_f norm_thresh)
     }
     runningNorm = par_norm(maxQPower, stateVec, norm_thresh);
 
-    if (runningNorm <= amplitudeFloor) {
-        ZeroAmplitudes();
-    }
+    // TODO: Why doesn't this work?
+    // if (runningNorm <= amplitudeFloor) {
+    //    ZeroAmplitudes();
+    //}
 }
 
 StateVectorPtr QEngineCPU::AllocStateVec(bitCapInt elemCount)


### PR DESCRIPTION
For approximate separability tests, these `ZeroAmplitude()` calls in `UpdateRunningNorm()` seem to have been causing crashes.