### PR TITLE
#716: 2-qubit TrySeparate()

### DIFF
--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -2228,6 +2228,7 @@ public:
      * for simulation optimization purposes. This is not a truly quantum computational operation, but it also does not
      * lead to nonphysical effects.
      */
+    virtual bool TrySeparate(bitLenInt* qubits, bitLenInt length, real1_f error_tol = REAL1_EPSILON) { return false; }
     virtual bool TrySeparate(bitLenInt start, bitLenInt length = 1, real1_f error_tol = REAL1_EPSILON) { return false; }
 
     /**

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -281,6 +281,7 @@ public:
     virtual bool isClifford(const bitLenInt& qubit) { return shards[qubit].isClifford(); };
 
     using QInterface::TrySeparate;
+    virtual bool TrySeparate(bitLenInt* qubits, bitLenInt length, real1_f error_tol = REAL1_EPSILON);
     virtual bool TrySeparate(bitLenInt start, bitLenInt length = 1, real1_f error_tol = REAL1_EPSILON);
 
     virtual QInterfacePtr Clone();

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -872,6 +872,12 @@ TEST_CASE("test_universal_circuit_analog", "[supreme]")
         false, false, testEngineType == QINTERFACE_QUNIT);
 }
 
+// void try_separate(QInterfacePtr qReg, bitLenInt b1, bitLenInt b2)
+// {
+//     bitLenInt a[2] = { b1, b2 };
+//     qReg->TrySeparate(a, 2);
+// }
+
 TEST_CASE("test_ccz_ccx_h", "[supreme]")
 {
     std::cout << "(random circuit depth: " << benchmarkDepth << ")";
@@ -904,8 +910,6 @@ TEST_CASE("test_ccz_ccx_h", "[supreme]")
 
                 std::set<bitLenInt> unusedBits;
                 for (i = 0; i < n; i++) {
-                    // In the past, "qReg->TrySeparate(i)" was also used, here, to attempt optimization. Be aware that
-                    // the method can give performance advantages, under opportune conditions, but it does not, here.
                     unusedBits.insert(unusedBits.end(), i);
                 }
 
@@ -921,16 +925,25 @@ TEST_CASE("test_ccz_ccx_h", "[supreme]")
 
                     gateRand = maxGates * qReg->Rand();
 
+                    // The try_separate method defined above works well with approximate simulation.
                     if (gateRand < ONE_R1) {
                         qReg->CZ(b1, b2);
+                        // try_separate(qReg, b1, b2);
                     } else if ((unusedBits.size() == 0) || (gateRand < 2)) {
                         qReg->CNOT(b1, b2);
+                        // try_separate(qReg, b1, b2);
                     } else if (gateRand < 3) {
                         b3 = pickRandomBit(qReg, &unusedBits);
                         qReg->CCZ(b1, b2, b3);
+                        // try_separate(qReg, b1, b2);
+                        // try_separate(qReg, b1, b3);
+                        // try_separate(qReg, b2, b3);
                     } else {
                         b3 = pickRandomBit(qReg, &unusedBits);
                         qReg->CCNOT(b1, b2, b3);
+                        // try_separate(qReg, b1, b2);
+                        // try_separate(qReg, b1, b3);
+                        // try_separate(qReg, b2, b3);
                     }
                 }
             }

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -3326,7 +3326,7 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_tryseparate")
     qftReg->CNOT(0, 1);
     qftReg->CNOT(0, 2);
     qftReg->CNOT(0, 2);
-    qftReg->TrySeparate(0, 2);
+    qftReg->TrySeparate((bitLenInt)0, 2);
     qftReg->CNOT(0, 1);
     qftReg->Z(0);
     qftReg->H(0);


### PR DESCRIPTION
I'm still considering coverage for this, and larger numbers of qubits, but the work here should decompose all approximate 1 and 2 qubit stabilizer states upon `TrySeparate()`.