### PR TITLE
#716: Refactor TrySeparate()

### DIFF
--- a/include/qhybrid.hpp
+++ b/include/qhybrid.hpp
@@ -427,11 +427,6 @@ public:
 
     virtual bool isFinished() { return engine->isFinished(); }
 
-    virtual bool TrySeparate(bitLenInt start, bitLenInt length = 1, real1_f error_tol = REAL1_EPSILON)
-    {
-        return engine->TrySeparate(start, length, error_tol);
-    }
-
     virtual QInterfacePtr Clone();
 
     virtual void SetDevice(const int& dID, const bool& forceReInit = false)

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -2228,8 +2228,15 @@ public:
      * for simulation optimization purposes. This is not a truly quantum computational operation, but it also does not
      * lead to nonphysical effects.
      */
-    virtual bool TrySeparate(bitLenInt* qubits, bitLenInt length, real1_f error_tol = REAL1_EPSILON) { return false; }
-    virtual bool TrySeparate(bitLenInt start, bitLenInt length = 1, real1_f error_tol = REAL1_EPSILON) { return false; }
+    virtual bool TrySeparate(bitLenInt* qubits, bitLenInt length, real1_f error_tol) { return false; }
+    /**
+     *  Single-qubit TrySeparate()
+     */
+    virtual bool TrySeparate(bitLenInt qubit) { return false; }
+    /**
+     *  Two-qubit TrySeparate()
+     */
+    virtual bool TrySeparate(bitLenInt qubit1, bitLenInt qubit2) { return false; }
 
     /**
      *  Clone this QInterface

--- a/include/qstabilizerhybrid.hpp
+++ b/include/qstabilizerhybrid.hpp
@@ -954,13 +954,11 @@ public:
                 std::swap(qubit1, qubit2);
             }
 
-            stabilizer->Swap(0, qubit1);
-            stabilizer->Swap(1, qubit2);
+            stabilizer->Swap(qubit1 + 1U, qubit2);
 
-            bool toRet = stabilizer->CanDecomposeDispose(0, 2);
+            bool toRet = stabilizer->CanDecomposeDispose(qubit1, 2);
 
-            stabilizer->Swap(0, qubit1);
-            stabilizer->Swap(1, qubit2);
+            stabilizer->Swap(qubit1 + 1U, qubit2);
 
             return toRet;
         }

--- a/include/qstabilizerhybrid.hpp
+++ b/include/qstabilizerhybrid.hpp
@@ -937,13 +937,35 @@ public:
         }
     }
 
-    virtual bool TrySeparate(bitLenInt start, bitLenInt length = 1, real1_f error_tol = REAL1_EPSILON)
+    using QInterface::TrySeparate;
+    virtual bool TrySeparate(bitLenInt qubit)
     {
         if (stabilizer) {
-            return stabilizer->CanDecomposeDispose(start, length);
+            return stabilizer->CanDecomposeDispose(qubit, 1);
         }
 
-        return engine->TrySeparate(start, length, error_tol);
+        return engine->TrySeparate(qubit);
+    }
+
+    virtual bool TrySeparate(bitLenInt qubit1, bitLenInt qubit2)
+    {
+        if (stabilizer) {
+            if (qubit2 < qubit1) {
+                std::swap(qubit1, qubit2);
+            }
+
+            stabilizer->Swap(0, qubit1);
+            stabilizer->Swap(1, qubit2);
+
+            bool toRet = stabilizer->CanDecomposeDispose(0, 2);
+
+            stabilizer->Swap(0, qubit1);
+            stabilizer->Swap(1, qubit2);
+
+            return toRet;
+        }
+
+        return engine->TrySeparate(qubit1, qubit2);
     }
 
     virtual QInterfacePtr Clone();

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -280,9 +280,9 @@ public:
     virtual void Dump();
     virtual bool isClifford(const bitLenInt& qubit) { return shards[qubit].isClifford(); };
 
-    using QInterface::TrySeparate;
-    virtual bool TrySeparate(bitLenInt* qubits, bitLenInt length, real1_f error_tol = REAL1_EPSILON);
-    virtual bool TrySeparate(bitLenInt start, bitLenInt length = 1, real1_f error_tol = REAL1_EPSILON);
+    virtual bool TrySeparate(bitLenInt* qubits, bitLenInt length, real1_f error_tol);
+    virtual bool TrySeparate(bitLenInt qubit);
+    virtual bool TrySeparate(bitLenInt qubit1, bitLenInt qubit2);
 
     virtual QInterfacePtr Clone();
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -704,7 +704,13 @@ bool QUnit::TrySeparate(bitLenInt* qubits, bitLenInt length, real1_f error_tol)
         Swap(i, q[i]);
     }
 
-    bool toRet = TrySeparate((bitLenInt)0U, length, error_tol);
+    QInterfacePtr dest = std::make_shared<QUnit>(
+        engine, subEngine, length, 0, rand_generator, ONE_CMPLX, doNormalize, randGlobalPhase, useHostRam);
+
+    bool toRet = TryDecompose(0, dest, error_tol);
+    if (toRet) {
+        Compose(dest, 0);
+    }
 
     for (bitLenInt i = 0; i < length; i++) {
         Swap(i, q[i]);
@@ -713,54 +719,13 @@ bool QUnit::TrySeparate(bitLenInt* qubits, bitLenInt length, real1_f error_tol)
     return toRet;
 }
 
-bool QUnit::TrySeparate(bitLenInt start, bitLenInt length, real1_f error_tol)
+bool QUnit::TrySeparate(bitLenInt qubit)
 {
-    if (length > 2U) {
-        QInterfacePtr dest = std::make_shared<QUnit>(
-            engine, subEngine, length, 0, rand_generator, ONE_CMPLX, doNormalize, randGlobalPhase, useHostRam);
-
-        if (TryDecompose(start, dest, error_tol)) {
-            Compose(dest, start);
-            return true;
-        }
-
-        return false;
-    }
-
-    if (length == 2U) {
-        // If either shard separates as a single bit, there's no point in checking for entanglement.
-        bool isShard1Sep = TrySeparate(start);
-        bool isShard2Sep = TrySeparate(start + 1U);
-        if (isShard1Sep || isShard2Sep) {
-            return isShard1Sep && isShard2Sep;
-        }
-
-        QEngineShard& shard1 = shards[start];
-        QEngineShard& shard2 = shards[start + 1U];
-
-        // Both shards have non-null units, and we've tried everything, if they're not the same unit.
-        if (shard1.unit != shard2.unit) {
-            return false;
-        }
-
-        // Both shards are in the same unit. Try all remaining stabilizer states.
-        RevertBasis1Qb(start);
-        RevertBasis1Qb(start + 1U);
-
-        // "Kick up" the one possible bit of entanglement entropy into a 2-qubit buffer.
-        QInterfacePtr unit = shard1.unit;
-        unit->CZ(shard1.mapped, shard2.mapped);
-        CZ(start, start + 1U);
-
-        // Once we try both bits separately again, we've tried everything, for stabilizer states.
-        return TrySeparate(start) && TrySeparate(start + 1U);
-    }
-
     // Otherwise, we're trying to separate a single bit.
-    QEngineShard& shard = shards[start];
+    QEngineShard& shard = shards[qubit];
 
     if (shard.isClifford()) {
-        return TrySeparateCliffordBit(start);
+        return TrySeparateCliffordBit(qubit);
     }
 
     if (shard.GetQubitCount() == 1) {
@@ -768,7 +733,7 @@ bool QUnit::TrySeparate(bitLenInt start, bitLenInt length, real1_f error_tol)
     }
 
     // We check Z basis:
-    real1_f prob = ProbBase(start);
+    real1_f prob = ProbBase(qubit);
     bool didSeparate = (shard.GetQubitCount() == 1);
 
     // If this is 0.5, it wasn't Z basis, but it's worth checking X basis.
@@ -778,11 +743,11 @@ bool QUnit::TrySeparate(bitLenInt start, bitLenInt length, real1_f error_tol)
 
     // We check X basis:
     shard.unit->H(shard.mapped);
-    prob = ProbBase(start);
+    prob = ProbBase(qubit);
     didSeparate = (shard.GetQubitCount() == 1);
 
     if (didSeparate || (abs(prob - ONE_R1 / 2) > separabilityThreshold)) {
-        H(start);
+        H(qubit);
         return didSeparate;
     }
 
@@ -790,13 +755,42 @@ bool QUnit::TrySeparate(bitLenInt start, bitLenInt length, real1_f error_tol)
     complex mtrx[4] = { complex(ONE_R1, -ONE_R1) / (real1)2.0f, complex(ONE_R1, ONE_R1) / (real1)2.0f,
         complex(ONE_R1, ONE_R1) / (real1)2.0f, complex(ONE_R1, -ONE_R1) / (real1)2.0f };
     shard.unit->ApplySingleBit(mtrx, shard.mapped);
-    prob = ProbBase(start);
+    prob = ProbBase(qubit);
     didSeparate = (shard.GetQubitCount() == 1);
 
-    H(start);
-    S(start);
+    H(qubit);
+    S(qubit);
 
     return didSeparate;
+}
+bool QUnit::TrySeparate(bitLenInt qubit1, bitLenInt qubit2)
+{
+    // If either shard separates as a single bit, there's no point in checking for entanglement.
+    bool isShard1Sep = TrySeparate(qubit1);
+    bool isShard2Sep = TrySeparate(qubit2);
+    if (isShard1Sep || isShard2Sep) {
+        return isShard1Sep && isShard2Sep;
+    }
+
+    QEngineShard& shard1 = shards[qubit1];
+    QEngineShard& shard2 = shards[qubit2];
+
+    // Both shards have non-null units, and we've tried everything, if they're not the same unit.
+    if (shard1.unit != shard2.unit) {
+        return false;
+    }
+
+    // Both shards are in the same unit. Try all remaining stabilizer states.
+    RevertBasis1Qb(qubit1);
+    RevertBasis1Qb(qubit2);
+
+    // "Kick up" the one possible bit of entanglement entropy into a 2-qubit buffer.
+
+    shard1.unit->CZ(shard1.mapped, shard2.mapped);
+    CZ(qubit1, qubit2);
+
+    // Once we try both bits separately again, we've tried everything, for stabilizer states.
+    return TrySeparate(qubit1) && TrySeparate(qubit2);
 }
 
 void QUnit::OrderContiguous(QInterfacePtr unit)

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -768,6 +768,7 @@ bool QUnit::TrySeparate(bitLenInt qubit1, bitLenInt qubit2)
     // If either shard separates as a single bit, there's no point in checking for entanglement.
     bool isShard1Sep = TrySeparate(qubit1);
     bool isShard2Sep = TrySeparate(qubit2);
+
     if (isShard1Sep || isShard2Sep) {
         return isShard1Sep && isShard2Sep;
     }
@@ -789,8 +790,11 @@ bool QUnit::TrySeparate(bitLenInt qubit1, bitLenInt qubit2)
     shard1.unit->CZ(shard1.mapped, shard2.mapped);
     CZ(qubit1, qubit2);
 
-    // Once we try both bits separately again, we've tried everything, for stabilizer states.
-    return TrySeparate(qubit1) && TrySeparate(qubit2);
+    // It's possible that either qubit is separable, but not both:
+    isShard1Sep = TrySeparate(qubit1);
+    isShard2Sep = TrySeparate(qubit2);
+
+    return isShard1Sep && isShard2Sep;
 }
 
 void QUnit::OrderContiguous(QInterfacePtr unit)

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -872,12 +872,6 @@ TEST_CASE("test_universal_circuit_analog", "[supreme]")
         false, false, testEngineType == QINTERFACE_QUNIT);
 }
 
-// void try_separate(QInterfacePtr qReg, bitLenInt b1, bitLenInt b2)
-// {
-//     bitLenInt a[2] = { b1, b2 };
-//     qReg->TrySeparate(a, 2);
-// }
-
 TEST_CASE("test_ccz_ccx_h", "[supreme]")
 {
     std::cout << "(random circuit depth: " << benchmarkDepth << ")";
@@ -925,25 +919,25 @@ TEST_CASE("test_ccz_ccx_h", "[supreme]")
 
                     gateRand = maxGates * qReg->Rand();
 
-                    // The try_separate method defined above works well with approximate simulation.
+                    // The TrySeparate() method works well with approximate simulation.
                     if (gateRand < ONE_R1) {
                         qReg->CZ(b1, b2);
-                        // try_separate(qReg, b1, b2);
+                        // qReg->TrySeparate(b1, b2);
                     } else if ((unusedBits.size() == 0) || (gateRand < 2)) {
                         qReg->CNOT(b1, b2);
-                        // try_separate(qReg, b1, b2);
+                        // qReg->TrySeparate(b1, b2);
                     } else if (gateRand < 3) {
                         b3 = pickRandomBit(qReg, &unusedBits);
                         qReg->CCZ(b1, b2, b3);
-                        // try_separate(qReg, b1, b2);
-                        // try_separate(qReg, b1, b3);
-                        // try_separate(qReg, b2, b3);
+                        // qReg->TrySeparate(b1, b2);
+                        // qReg->TrySeparate(b1, b3);
+                        // qReg->TrySeparate(b2, b3);
                     } else {
                         b3 = pickRandomBit(qReg, &unusedBits);
                         qReg->CCNOT(b1, b2, b3);
-                        // try_separate(qReg, b1, b2);
-                        // try_separate(qReg, b1, b3);
-                        // try_separate(qReg, b2, b3);
+                        // qReg->TrySeparate(b1, b2);
+                        // qReg->TrySeparate(b1, b3);
+                        // qReg->TrySeparate(b2, b3);
                     }
                 }
             }

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -3307,6 +3307,8 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_isfinished")
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_tryseparate")
 {
+    bitLenInt toSep[2];
+
     qftReg->SetPermutation(85);
 
     int i;
@@ -3317,6 +3319,8 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_tryseparate")
 
     for (i = 0; i < 8; i++) {
         qftReg->TrySeparate(i);
+        toSep[0] = i;
+        qftReg->TrySeparate(toSep, 1, FP_NORM_EPSILON);
     }
 
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 85));
@@ -3326,7 +3330,10 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_tryseparate")
     qftReg->CNOT(0, 1);
     qftReg->CNOT(0, 2);
     qftReg->CNOT(0, 2);
-    qftReg->TrySeparate((bitLenInt)0, 2);
+    qftReg->TrySeparate(0, 1);
+    toSep[0] = 0;
+    toSep[1] = 1;
+    qftReg->TrySeparate(toSep, 2, FP_NORM_EPSILON);
     qftReg->CNOT(0, 1);
     qftReg->Z(0);
     qftReg->H(0);


### PR DESCRIPTION
I wasn't happy with the coverage or signatures for `TrySeparate()`, from #719.

Since stabilizer states and `QUnit` buffers only extend to 2-qubit gates, at most, it makes sense to have single-qubit and double-qubit signatures for `TrySeparate()`. If the `TryDecompose()` variant is desired for any number of qubits, then specify an explicit error tolerance.

Coverage has been also been improved.