### PR TITLE
Add TrySeparate() to DLL

### DIFF
--- a/include/pinvoke_api.hpp
+++ b/include/pinvoke_api.hpp
@@ -118,6 +118,11 @@ MICROSOFT_QUANTUM_DECL double Prob(_In_ unsigned sid, _In_ unsigned q);
 MICROSOFT_QUANTUM_DECL void QFT(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c);
 MICROSOFT_QUANTUM_DECL void IQFT(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c);
 
+MICROSOFT_QUANTUM_DECL bool TrySeparate1Qb(_In_ unsigned sid, _In_ unsigned qi1);
+MICROSOFT_QUANTUM_DECL bool TrySeparate2Qb(_In_ unsigned sid, _In_ unsigned qi1, _In_ unsigned qi2);
+MICROSOFT_QUANTUM_DECL bool TrySeparateTol(
+    _In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* q, _In_ double tol);
+
 #if !(FPPOW < 6 && !ENABLE_COMPLEX_X2)
 MICROSOFT_QUANTUM_DECL void TimeEvolve(_In_ unsigned sid, _In_ double t, _In_ unsigned n,
     _In_reads_(n) _QrackTimeEvolveOpHeader* teos, unsigned mn, _In_reads_(mn) double* mtrx);

--- a/src/pinvoke_api.cpp
+++ b/src/pinvoke_api.cpp
@@ -978,6 +978,29 @@ MICROSOFT_QUANTUM_DECL void IQFT(_In_ unsigned sid, _In_ unsigned n, _In_reads_(
 #endif
 }
 
+MICROSOFT_QUANTUM_DECL bool TrySeparate1Qb(_In_ unsigned sid, _In_ unsigned qi1)
+{
+    SIMULATOR_LOCK_GUARD(sid)
+    return simulators[sid]->TrySeparate(qi1);
+}
+
+MICROSOFT_QUANTUM_DECL bool TrySeparate2Qb(_In_ unsigned sid, _In_ unsigned qi1, _In_ unsigned qi2)
+{
+    SIMULATOR_LOCK_GUARD(sid)
+    return simulators[sid]->TrySeparate(qi1, qi2);
+}
+
+MICROSOFT_QUANTUM_DECL bool TrySeparateTol(
+    _In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* q, _In_ double tol)
+{
+    SIMULATOR_LOCK_GUARD(sid)
+
+    bitLenInt* qb = new bitLenInt[n];
+    std::copy(q, q + n, qb);
+
+    return simulators[sid]->TrySeparate(qb, (bitLenInt)n, (real1_f)tol);
+}
+
 #if !(FPPOW < 6 && !ENABLE_COMPLEX_X2)
 /**
  * (External API) Simulate a Hamiltonian


### PR DESCRIPTION
Since `TrySeparate()` variants are now achieving practical returns, it makes sense to expose them to Windows operating system environments in our DLL, as for Unity3D development.