### PR TITLE
QUnit::isAggressiveSeparate

### DIFF
--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -2237,6 +2237,14 @@ public:
      *  Two-qubit TrySeparate()
      */
     virtual bool TrySeparate(bitLenInt qubit1, bitLenInt qubit2) { return false; }
+    /**
+     *  Set aggressive separation
+     */
+    virtual void SetAggressiveSeparate(const bool& isAggSep) {}
+    /**
+     *  Get aggressive separation
+     */
+    virtual bool GetAggressiveSeparate() { return false; }
 
     /**
      *  Clone this QInterface

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -37,6 +37,8 @@ protected:
     bool freezeBasisH;
     bool freezeBasis2Qb;
     bool freezeClifford;
+    bool freezeTrySeparate;
+    bool isAggressiveSeparate;
     bool isPagingSuppressed;
     bool canSuppressPaging;
     bitLenInt thresholdQubits;
@@ -100,6 +102,9 @@ public:
             },
             ZERO_R1, ZERO_R1, threadsPerEngine);
     }
+
+    virtual void SetAggressiveSeparate(const bool& isAggSep) { isAggressiveSeparate = isAggSep; }
+    virtual bool GetAggressiveSeparate() { return isAggressiveSeparate; }
 
     virtual void SetQuantumState(const complex* inputState);
     virtual void GetQuantumState(complex* outputState);
@@ -371,7 +376,7 @@ protected:
     template <typename CF, typename F>
     void ApplyEitherControlled(const bitLenInt* controls, const bitLenInt& controlLen,
         const std::vector<bitLenInt> targets, const bool& anti, CF cfn, F f, const bool& isPhase = false,
-        const bool& inCurrentBasis = false);
+        const bool& isInvert = false, const bool& inCurrentBasis = false);
 
     bitCapInt GetIndexedEigenstate(bitLenInt indexStart, bitLenInt indexLength, bitLenInt valueStart,
         bitLenInt valueLength, unsigned char* values);

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -739,24 +739,22 @@ bool QUnit::TrySeparate(bitLenInt qubit)
     }
 
     // We check X basis:
+    H(qubit);
     shard.unit->H(shard.mapped);
     prob = ProbBase(qubit);
     didSeparate = (shard.GetQubitCount() == 1U);
 
     if (didSeparate || (abs(prob - ONE_R1 / 2) > separabilityThreshold)) {
-        H(qubit);
         return didSeparate;
     }
 
     // We check Y basis:
+    S(qubit);
     complex mtrx[4] = { complex(ONE_R1, -ONE_R1) / (real1)2.0f, complex(ONE_R1, ONE_R1) / (real1)2.0f,
         complex(ONE_R1, ONE_R1) / (real1)2.0f, complex(ONE_R1, -ONE_R1) / (real1)2.0f };
     shard.unit->ApplySingleBit(mtrx, shard.mapped);
     prob = ProbBase(qubit);
     didSeparate = (shard.GetQubitCount() == 1U);
-
-    H(qubit);
-    S(qubit);
 
     return didSeparate;
 }
@@ -783,8 +781,8 @@ bool QUnit::TrySeparate(bitLenInt qubit1, bitLenInt qubit2)
     RevertBasis1Qb(qubit2);
 
     // "Kick up" the one possible bit of entanglement entropy into a 2-qubit buffer.
-    shard1.unit->CZ(shard1.mapped, shard2.mapped);
     CZ(qubit1, qubit2);
+    shard1.unit->CZ(shard1.mapped, shard2.mapped);
 
     // It's possible that either qubit is separable, but not both:
     isShard1Sep = TrySeparate(qubit1);

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -2852,16 +2852,16 @@ void QUnit::ApplyEitherControlled(const bitLenInt* controls, const bitLenInt& co
         return;
     }
 
-    if (!isAggressiveSeparate || freezeTrySeparate || freezeBasis2Qb || (!isPhase && !isInvert) ||
-        (allBits.size() > 3U)) {
+    if (!isAggressiveSeparate || freezeTrySeparate || freezeBasis2Qb || (!isPhase && !isInvert)) {
         return;
     }
 
-    TrySeparate(allBits[0], allBits[1]);
+    bitLenInt j;
 
-    if (allBits.size() == 3U) {
-        TrySeparate(allBits[0], allBits[2]);
-        TrySeparate(allBits[1], allBits[2]);
+    for (i = 0; i < (allBits.size() - 1U); i++) {
+        for (j = i + 1; j < allBits.size(); j++) {
+            TrySeparate(allBits[i], allBits[j]);
+        }
     }
 }
 

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -887,6 +887,9 @@ TEST_CASE("test_ccz_ccx_h", "[supreme]")
             bitLenInt b1, b2, b3;
             int maxGates;
 
+            // The TrySeparate() method works well with approximate simulation.
+            // qReg->SetAggressiveSeparate(true);
+
             for (d = 0; d < benchmarkDepth; d++) {
 
                 for (i = 0; i < n; i++) {
@@ -919,7 +922,6 @@ TEST_CASE("test_ccz_ccx_h", "[supreme]")
 
                     gateRand = maxGates * qReg->Rand();
 
-                    // The TrySeparate() method works well with approximate simulation.
                     if (gateRand < ONE_R1) {
                         qReg->CZ(b1, b2);
                         // qReg->TrySeparate(b1, b2);


### PR DESCRIPTION
`QUnit` has a better window than user code should on situations in which one might call `TrySeparate()`. Following the general considerations I've thought to try in benchmarks, `QUnit` can aggressively try to separate bits in flight, (i.e. after-the-fact separation, in addition to proactive).

There's no point in making this a constructor argument, because depths of applicability for advantage are on order of 5x 1qb+2qb full layers, which cannot be readily tracked locally in `QUnit` internals. Off by default, `SetAggressiveSeparate(bool)` can be used in user programs to set a range a usefulness for reactive `TrySeparate()` attempts.