### PR TITLE
Prevent approximate hyper-separation

### DIFF
--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -29,7 +29,7 @@
 #include "qunit.hpp"
 
 #define DIRTY(shard) (shard.isPhaseDirty || shard.isProbDirty)
-#define IS_HYPER_SEPARATING(p) ((2 * abs(p - ONE_R1 / 2)) > M_SQRT1_2)
+#define IS_HYPER_SEPARATING(p) ((2 * abs(p - ONE_R1 / 2)) < M_SQRT1_2)
 #define IS_NORM_0(c) (norm(c) <= separabilityThreshold)
 #define IS_0_R1(r) (r == ZERO_R1)
 #define IS_1_R1(r) (r == ONE_R1)


### PR DESCRIPTION
If the rounding threshold on approximate separability is set so that rounding regions around the 6 Bloch sphere poles mapped overlap, then, before separating in any of the 3 bases, find the most accurate basis to separate in.