### PR TITLE
Fix hyper-separation of single bits

### DIFF
--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -417,6 +417,23 @@ protected:
 
     void RevertBasis1Qb(const bitLenInt& i)
     {
+        if (freezeBasisH) {
+            return;
+        }
+
+        QEngineShard& shard = shards[i];
+
+        if (shard.unit && shard.isPauliY) {
+            complex mtrx[4] = { complex(ONE_R1 / (real1)M_SQRT1_2, ZERO_R1),
+                complex(ONE_R1 / (real1)M_SQRT1_2, ZERO_R1), complex(ZERO_R1, ONE_R1 / (real1)M_SQRT1_2),
+                complex(ZERO_R1, -ONE_R1 / (real1)M_SQRT1_2) };
+            shard.unit->ApplySingleBit(mtrx, shard.mapped);
+            shard.MakeDirty();
+            shard.isPauliY = false;
+            shard.isPauliX = false;
+            return;
+        }
+
         RevertBasisY(i);
         RevertBasisX(i);
     }

--- a/src/qstabilizerhybrid.cpp
+++ b/src/qstabilizerhybrid.cpp
@@ -481,23 +481,21 @@ void QStabilizerHybrid::ApplySingleBit(const complex* lMtrx, bitLenInt target)
         ApplySingleInvert(mtrx[1], mtrx[2], target);
         return;
     }
-    if (IS_SAME(mtrx[0], complex((real1)M_SQRT1_2, ZERO_R1)) && IS_SAME(mtrx[0], mtrx[1]) &&
-        IS_SAME(mtrx[0], mtrx[2]) && IS_SAME(mtrx[2], -mtrx[3])) {
+    if (IS_SAME(mtrx[0], complex(SQRT1_2_R1, ZERO_R1)) && IS_SAME(mtrx[0], mtrx[1]) && IS_SAME(mtrx[0], mtrx[2]) &&
+        IS_SAME(mtrx[2], -mtrx[3])) {
         H(target);
         return;
     }
 
-    if (stabilizer && IS_SAME(mtrx[0], complex(ONE_R1 / (real1)M_SQRT1_2, ZERO_R1)) &&
-        IS_SAME(mtrx[3], complex(ZERO_R1, -ONE_R1 / (real1)M_SQRT1_2))) {
-        if (IS_SAME(mtrx[1], complex(ONE_R1 / (real1)M_SQRT1_2, ZERO_R1)) &&
-            IS_SAME(mtrx[2], complex(ZERO_R1, ONE_R1 / (real1)M_SQRT1_2))) {
+    if (stabilizer && IS_SAME(mtrx[0], complex(SQRT1_2_R1, ZERO_R1)) &&
+        IS_SAME(mtrx[3], complex(ZERO_R1, -SQRT1_2_R1))) {
+        if (IS_SAME(mtrx[1], complex(SQRT1_2_R1, ZERO_R1)) && IS_SAME(mtrx[2], complex(ZERO_R1, SQRT1_2_R1))) {
             H(target);
             S(target);
             return;
         }
 
-        if (IS_SAME(mtrx[1], complex(ZERO_R1, ONE_R1 / (real1)M_SQRT1_2)) &&
-            IS_SAME(mtrx[2], complex(ONE_R1 / (real1)M_SQRT1_2, ZERO_R1))) {
+        if (IS_SAME(mtrx[1], complex(ZERO_R1, SQRT1_2_R1)) && IS_SAME(mtrx[2], complex(SQRT1_2_R1, ZERO_R1))) {
             S(target);
             H(target);
             return;
@@ -540,16 +538,16 @@ void QStabilizerHybrid::ApplySingleBit(const complex* lMtrx, bitLenInt target)
             QStabilizerShardPtr nShard;
             // If in PauliX or PauliY basis, compose gate with conversion from/to PauliZ basis.
             if (shardsEigen[target] == PauliX) {
-                complex nMtrx[4] = { complex((real1)M_SQRT1_2, ZERO_R1), complex((real1)M_SQRT1_2, ZERO_R1),
-                    complex((real1)M_SQRT1_2, ZERO_R1), complex((real1)-M_SQRT1_2, ZERO_R1) };
+                complex nMtrx[4] = { complex(SQRT1_2_R1, ZERO_R1), complex(SQRT1_2_R1, ZERO_R1),
+                    complex(SQRT1_2_R1, ZERO_R1), complex(-SQRT1_2_R1, ZERO_R1) };
                 nShard = std::make_shared<QStabilizerShard>(nMtrx);
                 nShard->Compose(shard->gate);
                 nShard->Compose(nMtrx);
             } else if (shardsEigen[target] == PauliY) {
-                complex nMtrx[4] = { complex((real1)M_SQRT1_2, ZERO_R1), complex(ZERO_R1, (real1)-M_SQRT1_2),
-                    complex((real1)M_SQRT1_2, ZERO_R1), complex(ZERO_R1, (real1)-M_SQRT1_2) };
-                complex aMtrx[4] = { complex((real1)M_SQRT1_2, ZERO_R1), complex((real1)M_SQRT1_2, ZERO_R1),
-                    complex(ZERO_R1, (real1)M_SQRT1_2), complex(ZERO_R1, (real1)-M_SQRT1_2) };
+                complex nMtrx[4] = { complex(SQRT1_2_R1, ZERO_R1), complex(ZERO_R1, -SQRT1_2_R1),
+                    complex(SQRT1_2_R1, ZERO_R1), complex(ZERO_R1, -SQRT1_2_R1) };
+                complex aMtrx[4] = { complex(SQRT1_2_R1, ZERO_R1), complex(SQRT1_2_R1, ZERO_R1),
+                    complex(ZERO_R1, SQRT1_2_R1), complex(ZERO_R1, -SQRT1_2_R1) };
                 nShard = std::make_shared<QStabilizerShard>(nMtrx);
                 nShard->Compose(shard->gate);
                 nShard->Compose(aMtrx);
@@ -695,7 +693,7 @@ void QStabilizerHybrid::ApplyControlledSingleBit(
         return;
     }
 
-    if ((controls.size() == 1U) && IS_SAME(mtrx[0], complex((real1)M_SQRT1_2, ZERO_R1)) && IS_SAME(mtrx[0], mtrx[1]) &&
+    if ((controls.size() == 1U) && IS_SAME(mtrx[0], complex(SQRT1_2_R1, ZERO_R1)) && IS_SAME(mtrx[0], mtrx[1]) &&
         IS_SAME(mtrx[0], mtrx[2]) && IS_SAME(mtrx[2], -mtrx[3])) {
         CH(controls[0], target);
         return;

--- a/src/qstabilizerhybrid.cpp
+++ b/src/qstabilizerhybrid.cpp
@@ -487,6 +487,23 @@ void QStabilizerHybrid::ApplySingleBit(const complex* lMtrx, bitLenInt target)
         return;
     }
 
+    if (stabilizer && IS_SAME(mtrx[0], complex(ONE_R1 / (real1)M_SQRT1_2, ZERO_R1)) &&
+        IS_SAME(mtrx[3], complex(ZERO_R1, -ONE_R1 / (real1)M_SQRT1_2))) {
+        if (IS_SAME(mtrx[1], complex(ONE_R1 / (real1)M_SQRT1_2, ZERO_R1)) &&
+            IS_SAME(mtrx[2], complex(ZERO_R1, ONE_R1 / (real1)M_SQRT1_2))) {
+            H(target);
+            S(target);
+            return;
+        }
+
+        if (IS_SAME(mtrx[1], complex(ZERO_R1, ONE_R1 / (real1)M_SQRT1_2)) &&
+            IS_SAME(mtrx[2], complex(ONE_R1 / (real1)M_SQRT1_2, ZERO_R1))) {
+            S(target);
+            H(target);
+            return;
+        }
+    }
+
     if (stabilizer && IS_SAME(mtrx[0], complex(ONE_R1, -ONE_R1) / (real1)2.0f) &&
         IS_SAME(mtrx[1], complex(ONE_R1, ONE_R1) / (real1)2.0f) && IS_SAME(mtrx[0], mtrx[3]) &&
         IS_SAME(mtrx[1], mtrx[2])) {

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -787,19 +787,19 @@ bool QUnit::TrySeparate(bitLenInt qubit)
     if ((abs(probY) >= abs(probZ)) && (abs(probY) >= abs(probX))) {
         // Y is best.
         SeparateBit(probY >= ZERO_R1, qubit);
-    }
-
-    if ((abs(probX) >= abs(probZ)) && (abs(probX) >= abs(probY))) {
+    } else if ((abs(probX) >= abs(probZ)) && (abs(probX) >= abs(probY))) {
         // X is best.
         shard.isPauliX = true;
         shard.isPauliY = false;
         SeparateBit(probX >= ZERO_R1, qubit);
+    } else {
+        // Z is best.
+        shard.isPauliX = false;
+        shard.isPauliY = false;
+        SeparateBit(probZ >= ZERO_R1, qubit);
     }
 
-    // Z is best.
-    shard.isPauliX = false;
-    shard.isPauliY = false;
-    SeparateBit(probZ >= ZERO_R1, qubit);
+    freezeTrySeparate = false;
 
     return didSeparate;
 }

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -789,13 +789,18 @@ bool QUnit::TrySeparate(bitLenInt qubit)
         SeparateBit(probY >= ZERO_R1, qubit);
     } else if ((abs(probX) >= abs(probZ)) && (abs(probX) >= abs(probY))) {
         // X is best.
+        mtrx[0] = complex(ONE_R1, ONE_R1) / (real1)2.0f;
+        mtrx[1] = complex(ONE_R1, -ONE_R1) / (real1)2.0f;
+        mtrx[2] = complex(ONE_R1, -ONE_R1) / (real1)2.0f;
+        mtrx[3] = complex(ONE_R1, ONE_R1) / (real1)2.0f;
+        shard.unit->ApplySingleBit(mtrx, shard.mapped);
         shard.isPauliX = true;
         shard.isPauliY = false;
+        shard.MakeDirty();
         SeparateBit(probX >= ZERO_R1, qubit);
     } else {
         // Z is best.
-        shard.isPauliX = false;
-        shard.isPauliY = false;
+        RevertBasis1Qb(qubit);
         SeparateBit(probZ >= ZERO_R1, qubit);
     }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -967,6 +967,11 @@ real1_f QUnit::ProbBase(const bitLenInt& qubit)
         return prob;
     }
 
+    if ((2 * abs(prob - ONE_R1 / 2)) < (real1)M_SQRT1_2) {
+        // Projection on another basis is necessarily higher, so don't separate.
+        return prob;
+    }
+
     if (IS_NORM_0(shard.amp1)) {
         SeparateBit(false, qubit);
     } else if (IS_NORM_0(shard.amp0)) {

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -786,7 +786,9 @@ bool QUnit::TrySeparate(bitLenInt qubit)
 
     if ((abs(probY) >= abs(probZ)) && (abs(probY) >= abs(probX))) {
         // Y is best.
-        SeparateBit(probY >= ZERO_R1, qubit);
+        if (!shard.unit->isClifford() || shard.unit->TrySeparate(shard.mapped)) {
+            SeparateBit(probY >= ZERO_R1, qubit);
+        }
     } else if ((abs(probX) >= abs(probZ)) && (abs(probX) >= abs(probY))) {
         // X is best.
         mtrx[0] = complex(ONE_R1, ONE_R1) / (real1)2.0f;
@@ -797,11 +799,15 @@ bool QUnit::TrySeparate(bitLenInt qubit)
         shard.isPauliX = true;
         shard.isPauliY = false;
         shard.MakeDirty();
-        SeparateBit(probX >= ZERO_R1, qubit);
+        if (!shard.unit->isClifford() || shard.unit->TrySeparate(shard.mapped)) {
+            SeparateBit(probX >= ZERO_R1, qubit);
+        }
     } else {
         // Z is best.
         RevertBasis1Qb(qubit);
-        SeparateBit(probZ >= ZERO_R1, qubit);
+        if (!shard.unit->isClifford() || shard.unit->TrySeparate(shard.mapped)) {
+            SeparateBit(probZ >= ZERO_R1, qubit);
+        }
     }
 
     freezeTrySeparate = false;
@@ -997,7 +1003,7 @@ real1_f QUnit::ProbBase(const bitLenInt& qubit)
         return prob;
     }
 
-    if ((2 * abs(prob - ONE_R1 / 2)) < (real1)M_SQRT1_2) {
+    if ((abs(prob - ONE_R1 / 2)) < (real1)M_SQRT1_2 / 2) {
         // Projection on another basis could be higher, so don't separate.
         return prob;
     }

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -996,10 +996,10 @@ real1_f QUnit::ProbBase(const bitLenInt& qubit)
         return prob;
     }
 
-    // if ((abs(prob - ONE_R1 / 2)) < (real1)M_SQRT1_2 / 2) {
-    //     // Projection on another basis could be higher, so don't separate.
-    //     return prob;
-    // }
+    if (abs(prob - ONE_R1 / 2) < SQRT1_2_R1 / 2) {
+        // Projection on another basis could be higher, so don't separate.
+        return prob;
+    }
 
     if (IS_NORM_0(shard.amp1)) {
         SeparateBit(false, qubit);
@@ -1083,8 +1083,8 @@ real1_f QUnit::ProbParity(const bitCapInt& mask)
     for (bitLenInt i = 0; i < qIndices.size(); i++) {
         QEngineShard& shard = shards[qIndices[i]];
         if (!(shard.unit)) {
-            nOddChance = (shard.isPauliX || shard.isPauliY) ? norm(((real1)M_SQRT1_2) * (shard.amp0 - shard.amp1))
-                                                            : shard.Prob();
+            nOddChance =
+                (shard.isPauliX || shard.isPauliY) ? norm(SQRT1_2_R1 * (shard.amp0 - shard.amp1)) : shard.Prob();
             oddChance = (oddChance * (ONE_R1 - nOddChance)) + ((ONE_R1 - oddChance) * nOddChance);
             continue;
         }
@@ -1685,8 +1685,8 @@ void QUnit::H(bitLenInt target)
         return;
     }
 
-    complex tempAmp1 = ((real1)M_SQRT1_2) * (shard.amp0 - shard.amp1);
-    shard.amp0 = ((real1)M_SQRT1_2) * (shard.amp0 + shard.amp1);
+    complex tempAmp1 = SQRT1_2_R1 * (shard.amp0 - shard.amp1);
+    shard.amp0 = SQRT1_2_R1 * (shard.amp0 + shard.amp1);
     shard.amp1 = tempAmp1;
     if (doNormalize) {
         shard.ClampAmps(amplitudeFloor);
@@ -2601,18 +2601,18 @@ void QUnit::ApplySingleBit(const complex* mtrx, bitLenInt target)
         ApplySingleInvert(mtrx[1], mtrx[2], target);
         return;
     }
-    if (!shard.isPauliY && (randGlobalPhase || (mtrx[0] == complex((real1)M_SQRT1_2, ZERO_R1))) &&
-        (mtrx[0] == mtrx[1]) && (mtrx[0] == mtrx[2]) && (mtrx[2] == -mtrx[3])) {
+    if (!shard.isPauliY && (randGlobalPhase || (mtrx[0] == complex(SQRT1_2_R1, ZERO_R1))) && (mtrx[0] == mtrx[1]) &&
+        (mtrx[0] == mtrx[2]) && (mtrx[2] == -mtrx[3])) {
         H(target);
         return;
     }
-    if (!freezeBasisH && (randGlobalPhase || (mtrx[0] == complex((real1)M_SQRT1_2, ZERO_R1))) && (mtrx[0] == mtrx[1]) &&
+    if (!freezeBasisH && (randGlobalPhase || (mtrx[0] == complex(SQRT1_2_R1, ZERO_R1))) && (mtrx[0] == mtrx[1]) &&
         (mtrx[2] == -mtrx[3]) && (I_CMPLX * mtrx[0] == mtrx[2])) {
         H(target);
         S(target);
         return;
     }
-    if (!freezeBasisH && (randGlobalPhase || (mtrx[0] == complex((real1)M_SQRT1_2, ZERO_R1))) && (mtrx[0] == mtrx[2]) &&
+    if (!freezeBasisH && (randGlobalPhase || (mtrx[0] == complex(SQRT1_2_R1, ZERO_R1))) && (mtrx[0] == mtrx[2]) &&
         (mtrx[1] == -mtrx[3]) && (I_CMPLX * mtrx[2] == mtrx[3])) {
         IS(target);
         H(target);

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -748,7 +748,7 @@ bool QUnit::TrySeparate(bitLenInt qubit)
     bool willSeparate = IS_NORM_0(shard.amp0) || IS_NORM_0(shard.amp1);
 
     // If this is 0.5, it wasn't Z basis, but it's worth checking X basis.
-    if (didSeparate || (!willSeparate && (abs(probZ - ONE_R1 / 2) > separabilityThreshold))) {
+    if (didSeparate || (!willSeparate && (abs(probZ) > separabilityThreshold))) {
         freezeTrySeparate = false;
         return didSeparate;
     }
@@ -761,7 +761,7 @@ bool QUnit::TrySeparate(bitLenInt qubit)
     didSeparate = !shard.unit;
     willSeparate |= IS_NORM_0(shard.amp0) || IS_NORM_0(shard.amp1);
 
-    if (didSeparate || (!willSeparate && (abs(probX - ONE_R1 / 2) > separabilityThreshold))) {
+    if (didSeparate || (!willSeparate && (abs(probX) > separabilityThreshold))) {
         freezeTrySeparate = false;
         return didSeparate;
     }

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -993,7 +993,7 @@ real1_f QUnit::ProbBase(const bitLenInt& qubit)
     }
 
     if ((2 * abs(prob - ONE_R1 / 2)) < (real1)M_SQRT1_2) {
-        // Projection on another basis is necessarily higher, so don't separate.
+        // Projection on another basis could be higher, so don't separate.
         return prob;
     }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -996,10 +996,10 @@ real1_f QUnit::ProbBase(const bitLenInt& qubit)
         return prob;
     }
 
-    if ((abs(prob - ONE_R1 / 2)) < (real1)M_SQRT1_2 / 2) {
-        // Projection on another basis could be higher, so don't separate.
-        return prob;
-    }
+    // if ((abs(prob - ONE_R1 / 2)) < (real1)M_SQRT1_2 / 2) {
+    //     // Projection on another basis could be higher, so don't separate.
+    //     return prob;
+    // }
 
     if (IS_NORM_0(shard.amp1)) {
         SeparateBit(false, qubit);

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -748,7 +748,7 @@ bool QUnit::TrySeparate(bitLenInt qubit)
     bool willSeparate = IS_NORM_0(shard.amp0) || IS_NORM_0(shard.amp1);
 
     // If this is 0.5, it wasn't Z basis, but it's worth checking X basis.
-    if (didSeparate || (abs(probZ - ONE_R1 / 2) > separabilityThreshold)) {
+    if (didSeparate || (!willSeparate && (abs(probZ - ONE_R1 / 2) > separabilityThreshold))) {
         freezeTrySeparate = false;
         return didSeparate;
     }
@@ -761,7 +761,7 @@ bool QUnit::TrySeparate(bitLenInt qubit)
     didSeparate = !shard.unit;
     willSeparate |= IS_NORM_0(shard.amp0) || IS_NORM_0(shard.amp1);
 
-    if (didSeparate || (abs(probX - ONE_R1 / 2) > separabilityThreshold)) {
+    if (didSeparate || (!willSeparate && (abs(probX - ONE_R1 / 2) > separabilityThreshold))) {
         freezeTrySeparate = false;
         return didSeparate;
     }

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -761,7 +761,7 @@ bool QUnit::TrySeparate(bitLenInt qubit)
     didSeparate = !shard.unit;
     willSeparate |= IS_NORM_0(shard.amp0) || IS_NORM_0(shard.amp1);
 
-    if (didSeparate || (abs(probZ - ONE_R1 / 2) > separabilityThreshold)) {
+    if (didSeparate || (abs(probX - ONE_R1 / 2) > separabilityThreshold)) {
         freezeTrySeparate = false;
         return didSeparate;
     }


### PR DESCRIPTION
I'm making this up as I go along, but I suspect that entanglement degrees of freedom interfere with rotation of a projection upon a single bit Bloch sphere. In effect, when setting the clamping parameter for `TrySeparate()` higher than (1-1/Sqrt[2])/2, there _might_ be another single-bit Pauli basis axis with a larger projection, but there might not be. Entangled states, projected on a single-bit Bloch sphere, effectively looked mixed, with projection vectors terminating in the interior of the sphere.

In this case, separate in `ProbBase()` only if the projection is greater than a projection at a 45 degree angle. If any basis satisfies the rounding clamp, but none of them have greater projection than that of a single qubit state at a 45 degree angle, then compare all three Pauli bases and pick the best one, before separating.