### PR TITLE
Replace M_SQRT2 and M_SQRT1_2 constants

### DIFF
--- a/include/qstabilizerhybrid.hpp
+++ b/include/qstabilizerhybrid.hpp
@@ -259,8 +259,8 @@ public:
     virtual void H(bitLenInt target)
     {
         if (shards[target]) {
-            complex mtrx[4] = { complex((real1)M_SQRT1_2, ZERO_R1), complex((real1)M_SQRT1_2, ZERO_R1),
-                complex((real1)M_SQRT1_2, ZERO_R1), complex((real1)-M_SQRT1_2, ZERO_R1) };
+            complex mtrx[4] = { complex(SQRT1_2_R1, ZERO_R1), complex(SQRT1_2_R1, ZERO_R1),
+                complex(SQRT1_2_R1, ZERO_R1), complex(-SQRT1_2_R1, ZERO_R1) };
             ApplySingleBit(mtrx, target);
             return;
         }

--- a/src/qinterface/gates.cpp
+++ b/src/qinterface/gates.cpp
@@ -12,10 +12,10 @@
 
 #include "qinterface.hpp"
 
-#define C_SQRT1_2 complex((real1)M_SQRT1_2, ZERO_R1)
-#define C_I_SQRT1_2 complex(ZERO_R1, (real1)M_SQRT1_2)
-#define C_SQRT_I complex((real1)M_SQRT1_2, (real1)M_SQRT1_2)
-#define C_SQRT_N_I complex((real1)M_SQRT1_2, (real1)(-M_SQRT1_2))
+#define C_SQRT1_2 complex(SQRT1_2_R1, ZERO_R1)
+#define C_I_SQRT1_2 complex(ZERO_R1, SQRT1_2_R1)
+#define C_SQRT_I complex(SQRT1_2_R1, SQRT1_2_R1)
+#define C_SQRT_N_I complex(SQRT1_2_R1, -SQRT1_2_R1)
 #define ONE_PLUS_I_DIV_2 complex((real1)(ONE_R1 / 2), (real1)(ONE_R1 / 2))
 #define ONE_MINUS_I_DIV_2 complex((real1)(ONE_R1 / 2), (real1)(-ONE_R1 / 2))
 
@@ -175,9 +175,11 @@ GATE_1_BIT(SH, C_SQRT1_2, C_SQRT1_2, C_I_SQRT1_2, -C_I_SQRT1_2);
 GATE_1_BIT(HIS, C_SQRT1_2, -C_I_SQRT1_2, C_SQRT1_2, C_I_SQRT1_2);
 
 /// Square root of Hadamard gate
-GATE_1_BIT(SqrtH, complex((real1)((ONE_R1 + M_SQRT2) / (2 * M_SQRT2)), (real1)((-ONE_R1 + M_SQRT2) / (2 * M_SQRT2))),
-    complex((real1)(M_SQRT1_2 / 2), (real1)(-M_SQRT1_2 / 2)), complex((real1)(M_SQRT1_2 / 2), (real1)(-M_SQRT1_2 / 2)),
-    complex((real1)((-ONE_R1 + M_SQRT2) / (2 * M_SQRT2)), (real1)((ONE_R1 + M_SQRT2) / (2 * M_SQRT2))));
+GATE_1_BIT(SqrtH,
+    complex((real1)((ONE_R1 + SQRT2_R1) / (2 * SQRT2_R1)), (real1)((-ONE_R1 + SQRT2_R1) / (2 * SQRT2_R1))),
+    complex((real1)(SQRT1_2_R1 / 2), (real1)(-SQRT1_2_R1 / 2)),
+    complex((real1)(SQRT1_2_R1 / 2), (real1)(-SQRT1_2_R1 / 2)),
+    complex((real1)((-ONE_R1 + SQRT2_R1) / (2 * SQRT2_R1)), (real1)((ONE_R1 + SQRT2_R1) / (2 * SQRT2_R1))));
 
 /// Square root of NOT gate
 GATE_1_BIT(SqrtX, ONE_PLUS_I_DIV_2, ONE_MINUS_I_DIV_2, ONE_MINUS_I_DIV_2, ONE_PLUS_I_DIV_2);

--- a/src/qstabilizerhybrid.cpp
+++ b/src/qstabilizerhybrid.cpp
@@ -481,8 +481,8 @@ void QStabilizerHybrid::ApplySingleBit(const complex* lMtrx, bitLenInt target)
         ApplySingleInvert(mtrx[1], mtrx[2], target);
         return;
     }
-    if (IS_SAME(mtrx[0], complex((real1)M_SQRT1_2, ZERO_R1)) && IS_SAME(mtrx[0], mtrx[1]) &&
-        IS_SAME(mtrx[0], mtrx[2]) && IS_SAME(mtrx[2], -mtrx[3])) {
+    if (IS_SAME(mtrx[0], complex(SQRT1_2_R1, ZERO_R1)) && IS_SAME(mtrx[0], mtrx[1]) && IS_SAME(mtrx[0], mtrx[2]) &&
+        IS_SAME(mtrx[2], -mtrx[3])) {
         H(target);
         return;
     }
@@ -523,16 +523,16 @@ void QStabilizerHybrid::ApplySingleBit(const complex* lMtrx, bitLenInt target)
             QStabilizerShardPtr nShard;
             // If in PauliX or PauliY basis, compose gate with conversion from/to PauliZ basis.
             if (shardsEigen[target] == PauliX) {
-                complex nMtrx[4] = { complex((real1)M_SQRT1_2, ZERO_R1), complex((real1)M_SQRT1_2, ZERO_R1),
-                    complex((real1)M_SQRT1_2, ZERO_R1), complex((real1)-M_SQRT1_2, ZERO_R1) };
+                complex nMtrx[4] = { complex(SQRT1_2_R1, ZERO_R1), complex(SQRT1_2_R1, ZERO_R1),
+                    complex(SQRT1_2_R1, ZERO_R1), complex(-SQRT1_2_R1, ZERO_R1) };
                 nShard = std::make_shared<QStabilizerShard>(nMtrx);
                 nShard->Compose(shard->gate);
                 nShard->Compose(nMtrx);
             } else if (shardsEigen[target] == PauliY) {
-                complex nMtrx[4] = { complex((real1)M_SQRT1_2, ZERO_R1), complex(ZERO_R1, (real1)-M_SQRT1_2),
-                    complex((real1)M_SQRT1_2, ZERO_R1), complex(ZERO_R1, (real1)-M_SQRT1_2) };
-                complex aMtrx[4] = { complex((real1)M_SQRT1_2, ZERO_R1), complex((real1)M_SQRT1_2, ZERO_R1),
-                    complex(ZERO_R1, (real1)M_SQRT1_2), complex(ZERO_R1, (real1)-M_SQRT1_2) };
+                complex nMtrx[4] = { complex(SQRT1_2_R1, ZERO_R1), complex(ZERO_R1, -SQRT1_2_R1),
+                    complex(SQRT1_2_R1, ZERO_R1), complex(ZERO_R1, -SQRT1_2_R1) };
+                complex aMtrx[4] = { complex(SQRT1_2_R1, ZERO_R1), complex(SQRT1_2_R1, ZERO_R1),
+                    complex(ZERO_R1, SQRT1_2_R1), complex(ZERO_R1, -SQRT1_2_R1) };
                 nShard = std::make_shared<QStabilizerShard>(nMtrx);
                 nShard->Compose(shard->gate);
                 nShard->Compose(aMtrx);
@@ -678,7 +678,7 @@ void QStabilizerHybrid::ApplyControlledSingleBit(
         return;
     }
 
-    if ((controls.size() == 1U) && IS_SAME(mtrx[0], complex((real1)M_SQRT1_2, ZERO_R1)) && IS_SAME(mtrx[0], mtrx[1]) &&
+    if ((controls.size() == 1U) && IS_SAME(mtrx[0], complex(SQRT1_2_R1, ZERO_R1)) && IS_SAME(mtrx[0], mtrx[1]) &&
         IS_SAME(mtrx[0], mtrx[2]) && IS_SAME(mtrx[2], -mtrx[3])) {
         CH(controls[0], target);
         return;

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1049,8 +1049,8 @@ real1_f QUnit::ProbParity(const bitCapInt& mask)
     for (bitLenInt i = 0; i < qIndices.size(); i++) {
         QEngineShard& shard = shards[qIndices[i]];
         if (!(shard.unit)) {
-            nOddChance = (shard.isPauliX || shard.isPauliY) ? norm(((real1)M_SQRT1_2) * (shard.amp0 - shard.amp1))
-                                                            : shard.Prob();
+            nOddChance =
+                (shard.isPauliX || shard.isPauliY) ? norm(SQRT1_2_R1 * (shard.amp0 - shard.amp1)) : shard.Prob();
             oddChance = (oddChance * (ONE_R1 - nOddChance)) + ((ONE_R1 - oddChance) * nOddChance);
             continue;
         }
@@ -1651,8 +1651,8 @@ void QUnit::H(bitLenInt target)
         return;
     }
 
-    complex tempAmp1 = ((real1)M_SQRT1_2) * (shard.amp0 - shard.amp1);
-    shard.amp0 = ((real1)M_SQRT1_2) * (shard.amp0 + shard.amp1);
+    complex tempAmp1 = SQRT1_2_R1 * (shard.amp0 - shard.amp1);
+    shard.amp0 = SQRT1_2_R1 * (shard.amp0 + shard.amp1);
     shard.amp1 = tempAmp1;
     if (doNormalize) {
         shard.ClampAmps(amplitudeFloor);
@@ -2567,18 +2567,18 @@ void QUnit::ApplySingleBit(const complex* mtrx, bitLenInt target)
         ApplySingleInvert(mtrx[1], mtrx[2], target);
         return;
     }
-    if (!shard.isPauliY && (randGlobalPhase || (mtrx[0] == complex((real1)M_SQRT1_2, ZERO_R1))) &&
-        (mtrx[0] == mtrx[1]) && (mtrx[0] == mtrx[2]) && (mtrx[2] == -mtrx[3])) {
+    if (!shard.isPauliY && (randGlobalPhase || (mtrx[0] == complex(SQRT1_2_R1, ZERO_R1))) && (mtrx[0] == mtrx[1]) &&
+        (mtrx[0] == mtrx[2]) && (mtrx[2] == -mtrx[3])) {
         H(target);
         return;
     }
-    if (!freezeBasisH && (randGlobalPhase || (mtrx[0] == complex((real1)M_SQRT1_2, ZERO_R1))) && (mtrx[0] == mtrx[1]) &&
+    if (!freezeBasisH && (randGlobalPhase || (mtrx[0] == complex(SQRT1_2_R1, ZERO_R1))) && (mtrx[0] == mtrx[1]) &&
         (mtrx[2] == -mtrx[3]) && (I_CMPLX * mtrx[0] == mtrx[2])) {
         H(target);
         S(target);
         return;
     }
-    if (!freezeBasisH && (randGlobalPhase || (mtrx[0] == complex((real1)M_SQRT1_2, ZERO_R1))) && (mtrx[0] == mtrx[2]) &&
+    if (!freezeBasisH && (randGlobalPhase || (mtrx[0] == complex(SQRT1_2_R1, ZERO_R1))) && (mtrx[0] == mtrx[2]) &&
         (mtrx[1] == -mtrx[3]) && (I_CMPLX * mtrx[2] == mtrx[3])) {
         IS(target);
         H(target);


### PR DESCRIPTION
`qrack_types.hpp` defines `real1` compatible `sqrt(2)` and `1/sqrt(2)` macros. Now, we use these throughout.