### PR TITLE
Perform Pauli basis transformations as single gate

### DIFF
--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -417,6 +417,35 @@ protected:
 
     void RevertBasis1Qb(const bitLenInt& i)
     {
+        if (freezeBasisH) {
+            return;
+        }
+
+        QEngineShard& shard = shards[i];
+
+        if (shard.unit && shard.isPauliY) {
+            complex mtrx[4] = { complex(SQRT1_2_R1, ZERO_R1), complex(SQRT1_2_R1, ZERO_R1),
+                complex(ZERO_R1, SQRT1_2_R1), complex(ZERO_R1, -SQRT1_2_R1) };
+            shard.unit->ApplySingleBit(mtrx, shard.mapped);
+
+            shard.isPauliY = false;
+            shard.isPauliX = false;
+
+            if (shard.isPhaseDirty || shard.isProbDirty) {
+                shard.MakeDirty();
+                return;
+            }
+
+            complex tempAmp1 = complex(ZERO_R1, SQRT1_2_R1) * (shard.amp0 - shard.amp1);
+            shard.amp0 = SQRT1_2_R1 * (shard.amp0 + shard.amp1);
+            shard.amp1 = tempAmp1;
+            if (doNormalize) {
+                shard.ClampAmps(amplitudeFloor);
+            }
+
+            return;
+        }
+
         RevertBasisY(i);
         RevertBasisX(i);
     }

--- a/src/qstabilizerhybrid.cpp
+++ b/src/qstabilizerhybrid.cpp
@@ -487,6 +487,21 @@ void QStabilizerHybrid::ApplySingleBit(const complex* lMtrx, bitLenInt target)
         return;
     }
 
+    if (stabilizer && IS_SAME(mtrx[0], complex(SQRT1_2_R1, ZERO_R1)) &&
+        IS_SAME(mtrx[3], complex(ZERO_R1, -SQRT1_2_R1))) {
+        if (IS_SAME(mtrx[1], complex(SQRT1_2_R1, ZERO_R1)) && IS_SAME(mtrx[2], complex(ZERO_R1, SQRT1_2_R1))) {
+            H(target);
+            S(target);
+            return;
+        }
+
+        if (IS_SAME(mtrx[1], complex(ZERO_R1, SQRT1_2_R1)) && IS_SAME(mtrx[2], complex(SQRT1_2_R1, ZERO_R1))) {
+            S(target);
+            H(target);
+            return;
+        }
+    }
+
     if (stabilizer && IS_SAME(mtrx[0], complex(ONE_R1, -ONE_R1) / (real1)2.0f) &&
         IS_SAME(mtrx[1], complex(ONE_R1, ONE_R1) / (real1)2.0f) && IS_SAME(mtrx[0], mtrx[3]) &&
         IS_SAME(mtrx[1], mtrx[2])) {


### PR DESCRIPTION
When switching to and from Pauli Y basis, do it as a single gate, depending on stabilizer vs. Schrödinger method.