### PR TITLE
Fix secant overlap between mixed Pauli states

### DIFF
--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -743,8 +743,7 @@ bool QUnit::TrySeparate(bitLenInt qubit)
     // We check Z basis:
     real1_f probZ = ProbBase(qubit) - ONE_R1 / 2;
     bool didSeparate = !shard.unit;
-    bool canHyperSeparate = abs(probZ) < (SQRT1_2_R1 / 2);
-    bool willSeparate = canHyperSeparate && (IS_NORM_0(shard.amp0) || IS_NORM_0(shard.amp1));
+    bool willSeparate = (abs(probZ) < (SQRT1_2_R1 / 2)) && ((ONE_R1 / 2 - abs(probZ)) <= separabilityThreshold);
 
     // If this is 0.5, it wasn't Z basis, but it's worth checking X basis.
     if (didSeparate || (!willSeparate && (abs(probZ) > separabilityThreshold))) {
@@ -758,8 +757,7 @@ bool QUnit::TrySeparate(bitLenInt qubit)
     shard.MakeDirty();
     real1_f probX = ProbBase(qubit) - ONE_R1 / 2;
     didSeparate = !shard.unit;
-    canHyperSeparate = abs(probX) < (SQRT1_2_R1 / 2);
-    willSeparate |= canHyperSeparate && (IS_NORM_0(shard.amp0) || IS_NORM_0(shard.amp1));
+    willSeparate |= (abs(probX) < (SQRT1_2_R1 / 2)) && ((ONE_R1 / 2 - abs(probX)) <= separabilityThreshold);
 
     if (didSeparate || (!willSeparate && (abs(probX) > separabilityThreshold))) {
         freezeTrySeparate = false;
@@ -775,8 +773,7 @@ bool QUnit::TrySeparate(bitLenInt qubit)
     shard.MakeDirty();
     real1_f probY = ProbBase(qubit) - ONE_R1 / 2;
     didSeparate = !shard.unit;
-    canHyperSeparate = abs(probY) < (SQRT1_2_R1 / 2);
-    willSeparate |= canHyperSeparate && (IS_NORM_0(shard.amp0) || IS_NORM_0(shard.amp1));
+    willSeparate |= (abs(probX) < (SQRT1_2_R1 / 2)) && ((ONE_R1 / 2 - abs(probX)) <= separabilityThreshold);
 
     if (didSeparate || !willSeparate) {
         freezeTrySeparate = false;

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -773,7 +773,7 @@ bool QUnit::TrySeparate(bitLenInt qubit)
     shard.MakeDirty();
     real1_f probY = ProbBase(qubit) - ONE_R1 / 2;
     didSeparate = !shard.unit;
-    willSeparate |= (abs(probX) < (SQRT1_2_R1 / 2)) && ((ONE_R1 / 2 - abs(probX)) <= separabilityThreshold);
+    willSeparate |= (abs(probY) < (SQRT1_2_R1 / 2)) && ((ONE_R1 / 2 - abs(probY)) <= separabilityThreshold);
 
     if (didSeparate || !willSeparate) {
         freezeTrySeparate = false;

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -743,7 +743,7 @@ bool QUnit::TrySeparate(bitLenInt qubit)
     // We check Z basis:
     real1_f probZ = ProbBase(qubit) - ONE_R1 / 2;
     bool didSeparate = !shard.unit;
-    bool canHyperSeparate = abs(probZ - ONE_R1 / 2) < (SQRT1_2_R1 / 2);
+    bool canHyperSeparate = abs(probZ) < (SQRT1_2_R1 / 2);
     bool willSeparate = canHyperSeparate && (IS_NORM_0(shard.amp0) || IS_NORM_0(shard.amp1));
 
     // If this is 0.5, it wasn't Z basis, but it's worth checking X basis.
@@ -758,7 +758,7 @@ bool QUnit::TrySeparate(bitLenInt qubit)
     shard.MakeDirty();
     real1_f probX = ProbBase(qubit) - ONE_R1 / 2;
     didSeparate = !shard.unit;
-    canHyperSeparate = abs(probX - ONE_R1 / 2) < (SQRT1_2_R1 / 2);
+    canHyperSeparate = abs(probX) < (SQRT1_2_R1 / 2);
     willSeparate |= canHyperSeparate && (IS_NORM_0(shard.amp0) || IS_NORM_0(shard.amp1));
 
     if (didSeparate || (!willSeparate && (abs(probX) > separabilityThreshold))) {
@@ -775,7 +775,7 @@ bool QUnit::TrySeparate(bitLenInt qubit)
     shard.MakeDirty();
     real1_f probY = ProbBase(qubit) - ONE_R1 / 2;
     didSeparate = !shard.unit;
-    canHyperSeparate = abs(probY - ONE_R1 / 2) < (SQRT1_2_R1 / 2);
+    canHyperSeparate = abs(probY) < (SQRT1_2_R1 / 2);
     willSeparate |= canHyperSeparate && (IS_NORM_0(shard.amp0) || IS_NORM_0(shard.amp1));
 
     if (didSeparate || !willSeparate) {

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -732,11 +732,7 @@ bool QUnit::TrySeparate(bitLenInt qubit)
         return true;
     }
 
-    if (BLOCKED_SEPARATE(shard)) {
-        return false;
-    }
-
-    if (freezeTrySeparate) {
+    if (freezeTrySeparate || BLOCKED_SEPARATE(shard)) {
         return false;
     }
 
@@ -745,11 +741,13 @@ bool QUnit::TrySeparate(bitLenInt qubit)
     RevertBasis1Qb(qubit);
 
     // We check Z basis:
-    real1_f prob = ProbBase(qubit);
+    real1_f probZ = ProbBase(qubit) - ONE_R1 / 2;
     bool didSeparate = !shard.unit;
+    bool canHyperSeparate = abs(probZ - ONE_R1 / 2) < (SQRT1_2_R1 / 2);
+    bool willSeparate = canHyperSeparate && (IS_NORM_0(shard.amp0) || IS_NORM_0(shard.amp1));
 
     // If this is 0.5, it wasn't Z basis, but it's worth checking X basis.
-    if (didSeparate || (abs(prob - ONE_R1 / 2) > separabilityThreshold)) {
+    if (didSeparate || (!willSeparate && (abs(probZ) > separabilityThreshold))) {
         freezeTrySeparate = false;
         return didSeparate;
     }
@@ -758,10 +756,12 @@ bool QUnit::TrySeparate(bitLenInt qubit)
     shard.unit->H(shard.mapped);
     shard.isPauliX = true;
     shard.MakeDirty();
-    prob = ProbBase(qubit);
+    real1_f probX = ProbBase(qubit) - ONE_R1 / 2;
     didSeparate = !shard.unit;
+    canHyperSeparate = abs(probX - ONE_R1 / 2) < (SQRT1_2_R1 / 2);
+    willSeparate |= canHyperSeparate && (IS_NORM_0(shard.amp0) || IS_NORM_0(shard.amp1));
 
-    if (didSeparate || (abs(prob - ONE_R1 / 2) > separabilityThreshold)) {
+    if (didSeparate || (!willSeparate && (abs(probX) > separabilityThreshold))) {
         freezeTrySeparate = false;
         return didSeparate;
     }
@@ -773,13 +773,47 @@ bool QUnit::TrySeparate(bitLenInt qubit)
     shard.isPauliX = false;
     shard.isPauliY = true;
     shard.MakeDirty();
-    prob = ProbBase(qubit);
+    real1_f probY = ProbBase(qubit) - ONE_R1 / 2;
     didSeparate = !shard.unit;
+    canHyperSeparate = abs(probY - ONE_R1 / 2) < (SQRT1_2_R1 / 2);
+    willSeparate |= canHyperSeparate && (IS_NORM_0(shard.amp0) || IS_NORM_0(shard.amp1));
+
+    if (didSeparate || !willSeparate) {
+        freezeTrySeparate = false;
+        return didSeparate;
+    }
+
+    // If we made it here, we're hyper-separating single bits, and we need to pick the best fit of the 3.
+    if ((abs(probY) >= abs(probZ)) && (abs(probY) >= abs(probX))) {
+        // Y is best.
+        if (!BLOCKED_SEPARATE(shard)) {
+            SeparateBit(probY >= ZERO_R1, qubit);
+        }
+    } else if ((abs(probX) >= abs(probZ)) && (abs(probX) >= abs(probY))) {
+        // X is best.
+        mtrx[0] = complex(ONE_R1, ONE_R1) / (real1)2.0f;
+        mtrx[1] = complex(ONE_R1, -ONE_R1) / (real1)2.0f;
+        mtrx[2] = complex(ONE_R1, -ONE_R1) / (real1)2.0f;
+        mtrx[3] = complex(ONE_R1, ONE_R1) / (real1)2.0f;
+        shard.unit->ApplySingleBit(mtrx, shard.mapped);
+        shard.isPauliX = true;
+        shard.isPauliY = false;
+        shard.MakeDirty();
+        if (!BLOCKED_SEPARATE(shard)) {
+            SeparateBit(probX >= ZERO_R1, qubit);
+        }
+    } else {
+        // Z is best.
+        RevertBasis1Qb(qubit);
+        if (!BLOCKED_SEPARATE(shard)) {
+            SeparateBit(probZ >= ZERO_R1, qubit);
+        }
+    }
 
     freezeTrySeparate = false;
-
     return didSeparate;
 }
+
 bool QUnit::TrySeparate(bitLenInt qubit1, bitLenInt qubit2)
 {
     // If either shard separates as a single bit, there's no point in checking for entanglement.
@@ -964,6 +998,11 @@ real1_f QUnit::ProbBase(const bitLenInt& qubit)
     real1_f prob = unit->Prob(mapped);
     shard.amp1 = complex((real1)sqrt(prob), ZERO_R1);
     shard.amp0 = complex((real1)sqrt(ONE_R1 - prob), ZERO_R1);
+
+    if (abs(prob - ONE_R1 / 2) < (SQRT1_2_R1 / 2)) {
+        // Projection on another basis could be higher, so don't separate.
+        return prob;
+    }
 
     if (BLOCKED_SEPARATE(shard)) {
         return prob;


### PR DESCRIPTION
When the rounding threshold parameter is turned up higher than (1 - 1/Sqrt(2)) / 2, secant volumes of the single-qubit Bloch sphere can overlap. In this case, a state might qualify to round to one Pauli axis pole while having a larger projection on another single qubit basis, but there's no way to know without trying all 3 Pauli bases.