### PR TITLE
Parity method optimization

### DIFF
--- a/include/qstabilizer.hpp
+++ b/include/qstabilizer.hpp
@@ -148,6 +148,14 @@ protected:
     void rowmult(const bitLenInt& i, const bitLenInt& k);
 
     /**
+     * Do Gaussian elimination to put the stabilizer generators in the following form:
+     * At the top, a minimal set of generators containing X's and Y's, in "quasi-upper-triangular" form.
+     * (Return value = number of such generators = log_2 of number of nonzero basis states)
+     * At the bottom, generators containing Z's only in quasi-upper-triangular form.
+     */
+    bitLenInt gaussian();
+
+    /**
      * Finds a Pauli operator P such that the basis state P|0...0> occurs with nonzero amplitude in q, and
      * writes P to the scratch space of q.  For this to work, Gaussian elimination must already have been
      * performed on q.  g is the return value from gaussian(q).
@@ -160,14 +168,6 @@ protected:
     void DecomposeDispose(const bitLenInt start, const bitLenInt length, QStabilizerPtr toCopy);
 
 public:
-    /**
-     * Do Gaussian elimination to put the stabilizer generators in the following form:
-     * At the top, a minimal set of generators containing X's and Y's, in "quasi-upper-triangular" form.
-     * (Return value = number of such generators = log_2 of number of nonzero basis states)
-     * At the bottom, generators containing Z's only in quasi-upper-triangular form.
-     */
-    bitLenInt gaussian();
-
     /// Apply a CNOT gate with control and target
     void CNOT(const bitLenInt& control, const bitLenInt& target);
     /// Apply a Hadamard gate to target

--- a/src/qinterface/gates.cpp
+++ b/src/qinterface/gates.cpp
@@ -16,8 +16,8 @@
 #define C_I_SQRT1_2 complex(ZERO_R1, SQRT1_2_R1)
 #define C_SQRT_I complex(SQRT1_2_R1, SQRT1_2_R1)
 #define C_SQRT_N_I complex(SQRT1_2_R1, -SQRT1_2_R1)
-#define ONE_PLUS_I_DIV_2 complex((real1)(ONE_R1 / 2), (real1)(ONE_R1 / 2))
-#define ONE_MINUS_I_DIV_2 complex((real1)(ONE_R1 / 2), (real1)(-ONE_R1 / 2))
+#define ONE_PLUS_I_DIV_2 complex(ONE_R1 / 2, ONE_R1 / 2)
+#define ONE_MINUS_I_DIV_2 complex(ONE_R1 / 2, -ONE_R1 / 2)
 
 #define GATE_1_BIT(gate, mtrx00, mtrx01, mtrx10, mtrx11)                                                               \
     void QInterface::gate(bitLenInt qubit)                                                                             \
@@ -175,11 +175,9 @@ GATE_1_BIT(SH, C_SQRT1_2, C_SQRT1_2, C_I_SQRT1_2, -C_I_SQRT1_2);
 GATE_1_BIT(HIS, C_SQRT1_2, -C_I_SQRT1_2, C_SQRT1_2, C_I_SQRT1_2);
 
 /// Square root of Hadamard gate
-GATE_1_BIT(SqrtH,
-    complex((real1)((ONE_R1 + SQRT2_R1) / (2 * SQRT2_R1)), (real1)((-ONE_R1 + SQRT2_R1) / (2 * SQRT2_R1))),
-    complex((real1)(SQRT1_2_R1 / 2), (real1)(-SQRT1_2_R1 / 2)),
-    complex((real1)(SQRT1_2_R1 / 2), (real1)(-SQRT1_2_R1 / 2)),
-    complex((real1)((-ONE_R1 + SQRT2_R1) / (2 * SQRT2_R1)), (real1)((ONE_R1 + SQRT2_R1) / (2 * SQRT2_R1))));
+GATE_1_BIT(SqrtH, complex((ONE_R1 + SQRT2_R1) / (2 * SQRT2_R1), (-ONE_R1 + SQRT2_R1) / (2 * SQRT2_R1)),
+    complex(SQRT1_2_R1 / 2, -SQRT1_2_R1 / 2), complex(SQRT1_2_R1 / 2, -SQRT1_2_R1 / 2),
+    complex((-ONE_R1 + SQRT2_R1) / (2 * SQRT2_R1), (ONE_R1 + SQRT2_R1) / (2 * SQRT2_R1)));
 
 /// Square root of NOT gate
 GATE_1_BIT(SqrtX, ONE_PLUS_I_DIV_2, ONE_MINUS_I_DIV_2, ONE_MINUS_I_DIV_2, ONE_PLUS_I_DIV_2);

--- a/src/qstabilizerhybrid.cpp
+++ b/src/qstabilizerhybrid.cpp
@@ -310,7 +310,6 @@ void QStabilizerHybrid::Decompose(bitLenInt start, QStabilizerHybridPtr dest)
         dest->stabilizer = dest->MakeStabilizer(0);
     }
 
-    stabilizer->gaussian();
     stabilizer->Decompose(start, dest->stabilizer);
     std::copy(shards.begin() + start, shards.begin() + start + length, dest->shards.begin());
     shards.erase(shards.begin() + start, shards.begin() + start + length);
@@ -335,7 +334,6 @@ void QStabilizerHybrid::Dispose(bitLenInt start, bitLenInt length)
     if (engine) {
         engine->Dispose(start, length);
     } else {
-        stabilizer->gaussian();
         stabilizer->Dispose(start, length);
     }
 
@@ -360,7 +358,6 @@ void QStabilizerHybrid::Dispose(bitLenInt start, bitLenInt length, bitCapInt dis
     if (engine) {
         engine->Dispose(start, length, disposedPerm);
     } else {
-        stabilizer->gaussian();
         stabilizer->Dispose(start, length);
     }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -728,7 +728,7 @@ bool QUnit::TrySeparate(bitLenInt qubit)
     // Otherwise, we're trying to separate a single bit.
     QEngineShard& shard = shards[qubit];
 
-    if (!shard.unit) {
+    if (shard.GetQubitCount() == 1U) {
         return true;
     }
 
@@ -1067,6 +1067,10 @@ real1_f QUnit::ProbParity(const bitCapInt& mask)
         return ZERO_R1;
     }
 
+    if (!(mask & (mask - ONE_BCI))) {
+        return Prob(log2(mask));
+    }
+
     bitCapInt nV = mask;
     std::vector<bitLenInt> qIndices;
     for (bitCapInt v = mask; v; v = nV) {
@@ -1120,6 +1124,10 @@ bool QUnit::ForceMParity(const bitCapInt& mask, bool result, bool doForce)
     // If no bits in mask:
     if (!mask) {
         return false;
+    }
+
+    if (!(mask & (mask - ONE_BCI))) {
+        return ForceM(log2(mask), result, doForce);
     }
 
     bitCapInt nV = mask;


### PR DESCRIPTION
When parity methods are called with masks with a single bit set, they become single bit non-parity method cases.