### PR TITLE
3-basis 2 qubit TrySeparate

### DIFF
--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -424,30 +424,100 @@ protected:
         QEngineShard& shard = shards[i];
 
         if (shard.unit && shard.isPauliY) {
-            complex mtrx[4] = { complex(SQRT1_2_R1, ZERO_R1), complex(SQRT1_2_R1, ZERO_R1),
-                complex(ZERO_R1, SQRT1_2_R1), complex(ZERO_R1, -SQRT1_2_R1) };
-            shard.unit->ApplySingleBit(mtrx, shard.mapped);
-
-            shard.isPauliY = false;
-            shard.isPauliX = false;
-
-            if (shard.isPhaseDirty || shard.isProbDirty) {
-                shard.MakeDirty();
-                return;
-            }
-
-            complex tempAmp1 = complex(ZERO_R1, SQRT1_2_R1) * (shard.amp0 - shard.amp1);
-            shard.amp0 = SQRT1_2_R1 * (shard.amp0 + shard.amp1);
-            shard.amp1 = tempAmp1;
-            if (doNormalize) {
-                shard.ClampAmps(amplitudeFloor);
-            }
-
+            ConvertYToZ(i);
             return;
         }
 
         RevertBasisY(i);
         RevertBasisX(i);
+    }
+
+    virtual void ConvertZToX(const bitLenInt& target)
+    {
+        QEngineShard& shard = shards[target];
+        shard.isPauliX = true;
+        freezeBasisH = true;
+        H(target);
+        freezeBasisH = false;
+    }
+    virtual void ConvertXToY(const bitLenInt& target)
+    {
+        QEngineShard& shard = shards[target];
+
+        complex mtrx[4] = { complex(ONE_R1, -ONE_R1) / (real1)2.0f, complex(ONE_R1, ONE_R1) / (real1)2.0f,
+            complex(ONE_R1, ONE_R1) / (real1)2.0f, complex(ONE_R1, -ONE_R1) / (real1)2.0f };
+        if (shard.unit) {
+            shard.unit->ApplySingleBit(mtrx, shard.mapped);
+        }
+
+        shard.isPauliX = false;
+        shard.isPauliY = true;
+
+        if (shard.isPhaseDirty || shard.isProbDirty) {
+            shard.MakeDirty();
+            return;
+        }
+
+        complex tempAmp1 = mtrx[2] * shard.amp0 + mtrx[3] * shard.amp1;
+        shard.amp0 = mtrx[0] * shard.amp0 + mtrx[1] * shard.amp1;
+        shard.amp1 = tempAmp1;
+        if (doNormalize) {
+            shard.ClampAmps(amplitudeFloor);
+        }
+    }
+    virtual void ConvertYToZ(const bitLenInt& target)
+    {
+        QEngineShard& shard = shards[target];
+
+        if (!shard.unit) {
+            RevertBasisY(target);
+            RevertBasisX(target);
+            return;
+        }
+
+        complex mtrx[4] = { complex(SQRT1_2_R1, ZERO_R1), complex(SQRT1_2_R1, ZERO_R1), complex(ZERO_R1, SQRT1_2_R1),
+            complex(ZERO_R1, -SQRT1_2_R1) };
+        shard.unit->ApplySingleBit(mtrx, shard.mapped);
+
+        shard.isPauliY = false;
+        shard.isPauliX = false;
+
+        if (shard.isPhaseDirty || shard.isProbDirty) {
+            shard.MakeDirty();
+            return;
+        }
+
+        complex tempAmp1 = complex(ZERO_R1, SQRT1_2_R1) * (shard.amp0 - shard.amp1);
+        shard.amp0 = SQRT1_2_R1 * (shard.amp0 + shard.amp1);
+        shard.amp1 = tempAmp1;
+        if (doNormalize) {
+            shard.ClampAmps(amplitudeFloor);
+        }
+    }
+    virtual void ConvertZToY(const bitLenInt& target)
+    {
+        QEngineShard& shard = shards[target];
+
+        complex mtrx[4] = { complex(SQRT1_2_R1, ZERO_R1), complex(ZERO_R1, -SQRT1_2_R1), complex(SQRT1_2_R1, ZERO_R1),
+            complex(ZERO_R1, SQRT1_2_R1) };
+        if (!shard.unit) {
+            shard.unit->ApplySingleBit(mtrx, shard.mapped);
+        }
+
+        shard.isPauliY = true;
+        shard.isPauliX = false;
+
+        if (shard.isPhaseDirty || shard.isProbDirty) {
+            shard.MakeDirty();
+            return;
+        }
+
+        complex tempAmp1 = complex(ZERO_R1, SQRT1_2_R1) * (shard.amp0 - shard.amp1);
+        shard.amp0 = SQRT1_2_R1 * (shard.amp0 + shard.amp1);
+        shard.amp1 = tempAmp1;
+        if (doNormalize) {
+            shard.ClampAmps(amplitudeFloor);
+        }
     }
 
     enum RevertExclusivity { INVERT_AND_PHASE = 0, ONLY_INVERT = 1, ONLY_PHASE = 2 };

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -819,7 +819,7 @@ bool QUnit::TrySeparate(bitLenInt qubit1, bitLenInt qubit2)
     // If either shard separates as a single bit, there's no point in checking for entanglement.
     bool isShard1Sep = TrySeparate(qubit1);
     bool isShard2Sep = TrySeparate(qubit2);
-    
+
     QEngineShard& shard1 = shards[qubit1];
     QEngineShard& shard2 = shards[qubit2];
 
@@ -842,9 +842,9 @@ bool QUnit::TrySeparate(bitLenInt qubit1, bitLenInt qubit2)
     isShard1Sep = TrySeparate(qubit1);
     isShard2Sep = TrySeparate(qubit2);
     if (isShard1Sep || isShard2Sep) {
-       return isShard1Sep && isShard2Sep;
+        return isShard1Sep && isShard2Sep;
     }
-    
+
     // Try again, in second basis.
     RevertBasis1Qb(qubit1);
     if (!shard2.isPauliX && !shard2.isPauliY) {
@@ -852,7 +852,7 @@ bool QUnit::TrySeparate(bitLenInt qubit1, bitLenInt qubit2)
     } else if (shard2.isPauliY) {
         RevertBasisY(qubit2);
     }
-    
+
     freezeTrySeparate = true;
     CZ(qubit1, qubit2);
     shard1.unit->CNOT(shard1.mapped, shard2.mapped);
@@ -860,27 +860,7 @@ bool QUnit::TrySeparate(bitLenInt qubit1, bitLenInt qubit2)
 
     isShard1Sep = TrySeparate(qubit1);
     isShard2Sep = TrySeparate(qubit2);
-    /*if (isShard1Sep || isShard2Sep) {
-       return isShard1Sep && isShard2Sep;
-    }
-    
-    // Try again, in third basis.
-    RevertBasis1Qb(qubit1);
-    if (!shard2.isPauliX && !shard2.isPauliY) {
-        ConvertZToY(qubit2);
-    } else if (shard2.isPauliX) {
-        ConvertXToY(qubit2);
-    }
-    
-    freezeTrySeparate = true;
-    CZ(qubit1, qubit2);
-    bitLenInt c[1] = { shard1.mapped };
-    shard1.unit->ApplyControlledSingleInvert(c, 1U, shard2.mapped, I_CMPLX, -I_CMPLX);
-    freezeTrySeparate = false;
 
-    isShard1Sep = TrySeparate(qubit1);
-    isShard2Sep = TrySeparate(qubit2);*/
-    
     return isShard1Sep && isShard2Sep;
 }
 
@@ -2875,7 +2855,7 @@ void QUnit::ApplyEitherControlled(const bitLenInt* controls, const bitLenInt& co
         shard.isProbDirty |= !isPhase || shard.isPauliX || shard.isPauliY;
         shard.isPhaseDirty = true;
     }
-    
+
     if (unit->isClifford()) {
         for (i = 0; i < allBits.size(); i++) {
             TrySeparate(allBits[i]);

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -837,10 +837,13 @@ bool QUnit::TrySeparate(bitLenInt qubit1, bitLenInt qubit2)
     RevertBasis1Qb(qubit2);
 
     // "Kick up" the one possible bit of entanglement entropy into a 2-qubit buffer.
+    ConvertZToX(qubit1);
+    ConvertZToX(qubit2);
     freezeTrySeparate = true;
     CZ(qubit1, qubit2);
-    freezeTrySeparate = false;
     shard1.unit->CZ(shard1.mapped, shard2.mapped);
+    freezeTrySeparate = false;
+    RevertBasisX(qubit2);
 
     // It's possible that either qubit is separable, but not both:
     isShard1Sep = TrySeparate(qubit1);

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -855,11 +855,7 @@ bool QUnit::TrySeparate(bitLenInt qubit1, bitLenInt qubit2)
 
     // Try again, in second basis.
     RevertBasis1Qb(qubit1);
-    if (!shard2.isPauliX && !shard2.isPauliY) {
-        ConvertZToX(qubit2);
-    } else if (shard2.isPauliY) {
-        RevertBasisY(qubit2);
-    }
+    ConvertZToX(qubit2);
 
     freezeTrySeparate = true;
     CZ(qubit1, qubit2);

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -738,42 +738,43 @@ bool QUnit::TrySeparate(bitLenInt qubit)
 
     freezeTrySeparate = true;
 
-    RevertBasis1Qb(qubit);
+    real1 prob;
+    real1 probX = ZERO_R1;
+    real1 probY = ZERO_R1;
+    real1 probZ = ZERO_R1;
+    bool didSeparate, willSeparate;
 
-    // We check Z basis:
-    real1_f probZ = ProbBase(qubit) - ONE_R1 / 2;
-    bool didSeparate = !shard.unit;
-    bool willSeparate = (abs(probZ) < (SQRT1_2_R1 / 2)) && ((ONE_R1 / 2 - abs(probZ)) <= separabilityThreshold);
+    for (bitLenInt i = 0; i < 3; i++) {
+        prob = ProbBase(qubit) - ONE_R1 / 2;
+        if (!shard.isPauliX && !shard.isPauliY) {
+            probZ = prob;
+        } else if (shard.isPauliX) {
+            probX = prob;
+        } else {
+            probY = prob;
+        }
 
-    // If this is 0.5, it wasn't Z basis, but it's worth checking X basis.
-    if (didSeparate || (!willSeparate && (abs(probZ) > separabilityThreshold))) {
-        freezeTrySeparate = false;
-        return didSeparate;
+        didSeparate = !shard.unit;
+        willSeparate = (abs(prob) < (SQRT1_2_R1 / 2)) && ((ONE_R1 / 2 - abs(prob)) <= separabilityThreshold);
+
+        if (i >= 2) {
+            continue;
+        }
+
+        // If this is 0.5, it wasn't this basis, but it's worth checking the next basis.
+        if (didSeparate || (!willSeparate && (abs(prob) > separabilityThreshold))) {
+            freezeTrySeparate = false;
+            return didSeparate;
+        }
+
+        if (!shard.isPauliX && !shard.isPauliY) {
+            ConvertZToX(qubit);
+        } else if (shard.isPauliX) {
+            ConvertXToY(qubit);
+        } else {
+            ConvertYToZ(qubit);
+        }
     }
-
-    // We check X basis:
-    shard.unit->H(shard.mapped);
-    shard.isPauliX = true;
-    shard.MakeDirty();
-    real1_f probX = ProbBase(qubit) - ONE_R1 / 2;
-    didSeparate = !shard.unit;
-    willSeparate |= (abs(probX) < (SQRT1_2_R1 / 2)) && ((ONE_R1 / 2 - abs(probX)) <= separabilityThreshold);
-
-    if (didSeparate || (!willSeparate && (abs(probX) > separabilityThreshold))) {
-        freezeTrySeparate = false;
-        return didSeparate;
-    }
-
-    // We check Y basis:
-    complex mtrx[4] = { complex(ONE_R1, -ONE_R1) / (real1)2.0f, complex(ONE_R1, ONE_R1) / (real1)2.0f,
-        complex(ONE_R1, ONE_R1) / (real1)2.0f, complex(ONE_R1, -ONE_R1) / (real1)2.0f };
-    shard.unit->ApplySingleBit(mtrx, shard.mapped);
-    shard.isPauliX = false;
-    shard.isPauliY = true;
-    shard.MakeDirty();
-    real1_f probY = ProbBase(qubit) - ONE_R1 / 2;
-    didSeparate = !shard.unit;
-    willSeparate |= (abs(probY) < (SQRT1_2_R1 / 2)) && ((ONE_R1 / 2 - abs(probY)) <= separabilityThreshold);
 
     if (didSeparate || !willSeparate) {
         freezeTrySeparate = false;
@@ -783,19 +784,21 @@ bool QUnit::TrySeparate(bitLenInt qubit)
     // If we made it here, we're hyper-separating single bits, and we need to pick the best fit of the 3.
     if ((abs(probY) >= abs(probZ)) && (abs(probY) >= abs(probX))) {
         // Y is best.
+        if (!shard.isPauliX && !shard.isPauliY) {
+            ConvertZToY(qubit);
+        } else if (shard.isPauliX) {
+            ConvertXToY(qubit);
+        }
         if (!BLOCKED_SEPARATE(shard)) {
             SeparateBit(probY >= ZERO_R1, qubit);
         }
     } else if ((abs(probX) >= abs(probZ)) && (abs(probX) >= abs(probY))) {
         // X is best.
-        mtrx[0] = complex(ONE_R1, ONE_R1) / (real1)2.0f;
-        mtrx[1] = complex(ONE_R1, -ONE_R1) / (real1)2.0f;
-        mtrx[2] = complex(ONE_R1, -ONE_R1) / (real1)2.0f;
-        mtrx[3] = complex(ONE_R1, ONE_R1) / (real1)2.0f;
-        shard.unit->ApplySingleBit(mtrx, shard.mapped);
-        shard.isPauliX = true;
-        shard.isPauliY = false;
-        shard.MakeDirty();
+        if (!shard.isPauliX && !shard.isPauliY) {
+            ConvertZToX(qubit);
+        } else if (shard.isPauliY) {
+            RevertBasisY(qubit);
+        }
         if (!BLOCKED_SEPARATE(shard)) {
             SeparateBit(probX >= ZERO_R1, qubit);
         }

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -879,7 +879,11 @@ bool QUnit::TrySeparate(bitLenInt qubit1, bitLenInt qubit2)
     freezeTrySeparate = false;
 
     // Try again, in third basis.
-    ConvertXToY(qubit2);
+    if (!shard2.isPauliX && !shard2.isPauliY) {
+        ConvertZToY(qubit2);
+    } else if (shard2.isPauliX) {
+        ConvertXToY(qubit2);
+    }
 
     bitLenInt c[1] = { qubit1 };
     freezeTrySeparate = true;

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -837,13 +837,14 @@ bool QUnit::TrySeparate(bitLenInt qubit1, bitLenInt qubit2)
     RevertBasis1Qb(qubit2);
 
     // "Kick up" the one possible bit of entanglement entropy into a 2-qubit buffer.
-    ConvertZToX(qubit1);
+    // From Z basis eigenstates, we apply H(q1), CNOT(q1,q2) to reach a completely entangled state.
+    // Run this in reverse, prefering to cache as CZ over CNOT, conscious of the permutation through Pauli bases coming
+    // after.
     ConvertZToX(qubit2);
     freezeTrySeparate = true;
     CZ(qubit1, qubit2);
-    shard1.unit->CZ(shard1.mapped, shard2.mapped);
+    shard1.unit->CNOT(shard1.mapped, shard2.mapped);
     freezeTrySeparate = false;
-    RevertBasisX(qubit2);
 
     // It's possible that either qubit is separable, but not both:
     isShard1Sep = TrySeparate(qubit1);

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -817,6 +817,7 @@ bool QUnit::TrySeparate(bitLenInt qubit)
 bool QUnit::TrySeparate(bitLenInt qubit1, bitLenInt qubit2)
 {
     // We want qubit2 displaced by Z-to-X basis transformation, when we try disentangling.
+    RevertBasis1Qb(qubit1);
     RevertBasis1Qb(qubit2);
 
     // If either shard separates as a single bit, there's no point in checking for entanglement.
@@ -836,12 +837,13 @@ bool QUnit::TrySeparate(bitLenInt qubit1, bitLenInt qubit2)
     }
 
     // Both shards are in the same unit. Try a maximally disentangling operation, than continue.
+    RevertBasis1Qb(qubit1);
+    RevertBasis1Qb(qubit2);
 
     // "Kick up" the one possible bit of entanglement entropy into a 2-qubit buffer.
     // From Z basis eigenstates, we apply H(q1), CNOT(q1,q2) to reach a completely entangled state.
     // Run this in reverse, prefering to cache as CZ over CNOT, conscious of the permutation through Pauli bases coming
     // after.
-    RevertBasis1Qb(qubit2);
     ConvertZToX(qubit2);
     freezeTrySeparate = true;
     CZ(qubit1, qubit2);

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -816,6 +816,9 @@ bool QUnit::TrySeparate(bitLenInt qubit)
 
 bool QUnit::TrySeparate(bitLenInt qubit1, bitLenInt qubit2)
 {
+    // We want qubit2 displaced by Z-to-X basis transformation, when we try disentangling.
+    RevertBasis1Qb(qubit2);
+
     // If either shard separates as a single bit, there's no point in checking for entanglement.
     bool isShard1Sep = TrySeparate(qubit1);
     bool isShard2Sep = TrySeparate(qubit2);
@@ -832,13 +835,13 @@ bool QUnit::TrySeparate(bitLenInt qubit1, bitLenInt qubit2)
         return false;
     }
 
-    // Both shards are in the same unit. Try all remaining stabilizer states.
-    RevertBasis1Qb(qubit2);
+    // Both shards are in the same unit. Try a maximally disentangling operation, than continue.
 
     // "Kick up" the one possible bit of entanglement entropy into a 2-qubit buffer.
     // From Z basis eigenstates, we apply H(q1), CNOT(q1,q2) to reach a completely entangled state.
     // Run this in reverse, prefering to cache as CZ over CNOT, conscious of the permutation through Pauli bases coming
     // after.
+    RevertBasis1Qb(qubit2);
     ConvertZToX(qubit2);
     freezeTrySeparate = true;
     CZ(qubit1, qubit2);

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -816,13 +816,18 @@ bool QUnit::TrySeparate(bitLenInt qubit)
 
 bool QUnit::TrySeparate(bitLenInt qubit1, bitLenInt qubit2)
 {
-    // We want qubit2 displaced by Z-to-X basis transformation, when we try disentangling.
-    RevertBasis1Qb(qubit1);
+    // We want qubit1 in Z basis and qubit2 displaced by Z-to-X basis transformation, when we try disentangling.
     RevertBasis1Qb(qubit2);
 
     // If either shard separates as a single bit, there's no point in checking for entanglement.
     bool isShard1Sep = TrySeparate(qubit1);
+    if (!isShard1Sep) {
+        RevertBasis1Qb(qubit1);
+    }
     bool isShard2Sep = TrySeparate(qubit2);
+    if (!isShard2Sep) {
+        RevertBasis1Qb(qubit2);
+    }
 
     if (isShard1Sep || isShard2Sep) {
         return isShard1Sep && isShard2Sep;
@@ -837,8 +842,6 @@ bool QUnit::TrySeparate(bitLenInt qubit1, bitLenInt qubit2)
     }
 
     // Both shards are in the same unit. Try a maximally disentangling operation, than continue.
-    RevertBasis1Qb(qubit1);
-    RevertBasis1Qb(qubit2);
 
     // "Kick up" the one possible bit of entanglement entropy into a 2-qubit buffer.
     // From Z basis eigenstates, we apply H(q1), CNOT(q1,q2) to reach a completely entangled state.

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -816,25 +816,26 @@ bool QUnit::TrySeparate(bitLenInt qubit)
 
 bool QUnit::TrySeparate(bitLenInt qubit1, bitLenInt qubit2)
 {
-    // We want qubit1 in Z basis and qubit2 displaced by Z-to-X basis transformation, when we try disentangling.
-    RevertBasis1Qb(qubit2);
+    QEngineShard& shard1 = shards[qubit1];
+    QEngineShard& shard2 = shards[qubit2];
+
+    // We want to permute qubit1 with qubit2 in X basis, before trying CNOT
+    if (!shard2.isPauliX && !shard2.isPauliY) {
+        ConvertZToX(qubit2);
+    } else if (shard2.isPauliY) {
+        RevertBasisY(qubit2);
+    }
 
     // If either shard separates as a single bit, there's no point in checking for entanglement.
     bool isShard1Sep = TrySeparate(qubit1);
-    if (!isShard1Sep) {
+    if (!isShard1Sep || (shard1.unit != shard2.unit)) {
         RevertBasis1Qb(qubit1);
     }
     bool isShard2Sep = TrySeparate(qubit2);
-    if (!isShard2Sep) {
-        RevertBasis1Qb(qubit2);
-    }
 
     if (isShard1Sep || isShard2Sep) {
         return isShard1Sep && isShard2Sep;
     }
-
-    QEngineShard& shard1 = shards[qubit1];
-    QEngineShard& shard2 = shards[qubit2];
 
     // Both shards have non-null units, and we've tried everything, if they're not the same unit.
     if (shard1.unit != shard2.unit) {
@@ -847,6 +848,7 @@ bool QUnit::TrySeparate(bitLenInt qubit1, bitLenInt qubit2)
     // From Z basis eigenstates, we apply H(q1), CNOT(q1,q2) to reach a completely entangled state.
     // Run this in reverse, prefering to cache as CZ over CNOT, conscious of the permutation through Pauli bases coming
     // after.
+    RevertBasis1Qb(qubit2);
     ConvertZToX(qubit2);
     freezeTrySeparate = true;
     CZ(qubit1, qubit2);

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -845,6 +845,14 @@ bool QUnit::TrySeparate(bitLenInt qubit1, bitLenInt qubit2)
         return isShard1Sep && isShard2Sep;
     }
 
+    // Revert first basis.
+    RevertBasis1Qb(qubit1);
+    RevertBasis1Qb(qubit2);
+    freezeTrySeparate = true;
+    CZ(qubit1, qubit2);
+    shard1.unit->CZ(shard1.mapped, shard2.mapped);
+    freezeTrySeparate = false;
+
     // Try again, in second basis.
     RevertBasis1Qb(qubit1);
     if (!shard2.isPauliX && !shard2.isPauliY) {

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -838,7 +838,6 @@ bool QUnit::TrySeparate(bitLenInt qubit1, bitLenInt qubit2)
     shard1.unit->CZ(shard1.mapped, shard2.mapped);
     freezeTrySeparate = false;
 
-    // It's possible that either qubit is separable, but not both:
     isShard1Sep = TrySeparate(qubit1);
     isShard2Sep = TrySeparate(qubit2);
     if (isShard1Sep || isShard2Sep) {
@@ -857,8 +856,8 @@ bool QUnit::TrySeparate(bitLenInt qubit1, bitLenInt qubit2)
     ConvertZToX(qubit2);
 
     freezeTrySeparate = true;
-    CZ(qubit1, qubit2);
-    shard1.unit->CNOT(shard1.mapped, shard2.mapped);
+    CNOT(qubit1, qubit2);
+    shard1.unit->CZ(shard1.mapped, shard2.mapped);
     freezeTrySeparate = false;
 
     isShard1Sep = TrySeparate(qubit1);
@@ -875,17 +874,17 @@ bool QUnit::TrySeparate(bitLenInt qubit1, bitLenInt qubit2)
         RevertBasisY(qubit2);
     }
     freezeTrySeparate = true;
-    CZ(qubit1, qubit2);
-    shard1.unit->CNOT(shard1.mapped, shard2.mapped);
+    CNOT(qubit1, qubit2);
+    shard1.unit->CZ(shard1.mapped, shard2.mapped);
     freezeTrySeparate = false;
 
     // Try again, in third basis.
     ConvertXToY(qubit2);
 
-    bitLenInt c[1] = { shard1.mapped };
+    bitLenInt c[1] = { qubit1 };
     freezeTrySeparate = true;
-    CZ(qubit1, qubit2);
-    shard1.unit->ApplyControlledSingleInvert(c, 1U, shard2.mapped, -I_CMPLX, I_CMPLX);
+    ApplyControlledSingleInvert(c, 1U, qubit2, -I_CMPLX, I_CMPLX);
+    shard1.unit->CZ(shard1.mapped, shard2.mapped);
     freezeTrySeparate = false;
 
     isShard1Sep = TrySeparate(qubit1);

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -833,7 +833,6 @@ bool QUnit::TrySeparate(bitLenInt qubit1, bitLenInt qubit2)
     }
 
     // Both shards are in the same unit. Try all remaining stabilizer states.
-    RevertBasis1Qb(qubit1);
     RevertBasis1Qb(qubit2);
 
     // "Kick up" the one possible bit of entanglement entropy into a 2-qubit buffer.

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -933,7 +933,7 @@ TEST_CASE("test_ccz_ccx_h", "[supreme]")
                 }
 
                 // The TrySeparate() method works well with approximate simulation.
-                qReg->SetReactiveSeparate(d < 4);
+                qReg->SetReactiveSeparate(true);
             }
 
             qReg->MAll();
@@ -1081,7 +1081,7 @@ TEST_CASE("test_quantum_supremacy", "[supreme]")
                     qReg->ApplyControlledSinglePhase(controls, 1U, b2, ONE_CMPLX, sixthRoot);
                     // Note that these gates are both symmetric under exchange of "b1" and "b2".
 
-                    // qReg->TrySeparate(b1, b2);
+                    qReg->TrySeparate(b1, b2);
 
                     // std::cout<<"("<<b1<<", "<<b2<<")"<<std::endl;
                 }

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -933,7 +933,7 @@ TEST_CASE("test_ccz_ccx_h", "[supreme]")
                 }
 
                 // The TrySeparate() method works well with approximate simulation.
-                qReg->SetReactiveSeparate(true);
+                qReg->SetReactiveSeparate(d < 4);
             }
 
             qReg->MAll();
@@ -1081,7 +1081,7 @@ TEST_CASE("test_quantum_supremacy", "[supreme]")
                     qReg->ApplyControlledSinglePhase(controls, 1U, b2, ONE_CMPLX, sixthRoot);
                     // Note that these gates are both symmetric under exchange of "b1" and "b2".
 
-                    qReg->TrySeparate(b1, b2);
+                    // qReg->TrySeparate(b1, b2);
 
                     // std::cout<<"("<<b1<<", "<<b2<<")"<<std::endl;
                 }


### PR DESCRIPTION
Thinking about `TrySeparate()` to 2 qubits at once, we want decompose a potential Bell pair that has been transformed into any local qubit X/Y/Z basis. If we assume we are given a Bell pair, we probably want to try all of CZ/CX/CY to decompose it, progressively as any previous attempts fail.

With `QUnit`->`QPager`->`QHybrid`, on a machine capable of doing 30 fully entangled qubits, this seems capable as taking depth=4 circuits of `test_ccz_ccx_h` to a very rough neighborhood of 50 qubits or higher. Single basis decomposition attempts did not seem nearly as likely to accommodate this width.