### PR TITLE
Stabilizer CY gate

### DIFF
--- a/include/qstabilizer.hpp
+++ b/include/qstabilizer.hpp
@@ -209,6 +209,13 @@ public:
         H(target);
     }
 
+    virtual void CY(const bitLenInt& control, const bitLenInt& target)
+    {
+        IS(target);
+        CNOT(control, target);
+        S(target);
+    }
+
     virtual void Swap(const bitLenInt& qubit1, const bitLenInt& qubit2)
     {
         if (qubit1 == qubit2) {

--- a/src/qstabilizerhybrid.cpp
+++ b/src/qstabilizerhybrid.cpp
@@ -820,6 +820,11 @@ void QStabilizerHybrid::ApplyControlledSingleInvert(const bitLenInt* lControls, 
         }
     }
 
+    if (IS_SAME(topRight, -I_CMPLX) && IS_SAME(bottomLeft, I_CMPLX)) {
+        stabilizer->CY(controls[0], target);
+        return;
+    }
+
     SwitchToEngine();
     engine->ApplyControlledSingleInvert(lControls, lControlLen, target, topRight, bottomLeft);
 }

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -629,7 +629,7 @@ TEST_CASE("test_stabilizer_t", "[supreme]")
     std::cout << "(random circuit depth: " << benchmarkDepth << ")";
 
     const int GateCount1Qb = 5;
-    const int GateCountMultiQb = 2;
+    const int GateCountMultiQb = 4;
 
     benchmarkLoop(
         [&](QInterfacePtr qReg, bitLenInt n) {
@@ -683,10 +683,12 @@ TEST_CASE("test_stabilizer_t", "[supreme]")
                         } else {
                             qReg->Swap(b1, b2);
                         }
-                    } else {
+                    } else if (gateRand < (2 * ONE_R1)) {
                         qReg->CZ(b1, b2);
+                    } else if (gateRand < (3 * ONE_R1)) {
+                        qReg->CY(b1, b2);
                     }
-                    // TODO: CY and "CI" as equal probability options
+                    // else - identity
                 }
 
                 qReg->SetReactiveSeparate(true);


### PR DESCRIPTION
This adds the `CY` gate to hybrid stabilizer simulation, for inclusion in the `test_stabilizer_t` benchmark, and generally.