### PR TITLE
Add test_stabilizer_t_cc

### DIFF
--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -619,6 +619,66 @@ public:
     virtual void AntiCNOT(bitLenInt control, bitLenInt target);
 
     /**
+     * Controlled Y gate
+     *
+     * If the "control" bit is set to 1, then the Pauli "Y" operator is applied
+     * to "target."
+     */
+    virtual void CY(bitLenInt control, bitLenInt target);
+
+    /**
+     * Anti controlled Y gate
+     *
+     * If the control is set to 0, then the Pauli "Y" operator is applied to the target.
+     */
+    virtual void AntiCY(bitLenInt control, bitLenInt target);
+
+    /**
+     * Doubly-Controlled Y gate
+     *
+     * If both "control" bits are set to 1, then the Pauli "Y" operator is applied
+     * to "target."
+     */
+    virtual void CCY(bitLenInt control1, bitLenInt control2, bitLenInt target);
+
+    /**
+     * Anti doubly-controlled Y gate
+     *
+     * If both controls are set to 0, apply Pauli Y operation to target bit.
+     */
+    virtual void AntiCCY(bitLenInt control1, bitLenInt control2, bitLenInt target);
+
+    /**
+     * Controlled Z gate
+     *
+     * If the "control" bit is set to 1, then the Pauli "Z" operator is applied
+     * to "target."
+     */
+    virtual void CZ(bitLenInt control, bitLenInt target);
+
+    /**
+     * Anti controlled Z gate
+     *
+     * If the control is set to 0, then the Pauli "Z" operator is applied to the target.
+     */
+    virtual void AntiCZ(bitLenInt control, bitLenInt target);
+
+    /**
+     * Doubly-Controlled Z gate
+     *
+     * If both "control" bits are set to 1, then the Pauli "Z" operator is applied
+     * to "target."
+     */
+    virtual void CCZ(bitLenInt control1, bitLenInt control2, bitLenInt target);
+
+    /**
+     * Anti doubly-controlled Z gate
+     *
+     * If both controls are set to 0, apply Pauli Z operation to target bit.
+     */
+    virtual void AntiCCZ(bitLenInt control1, bitLenInt control2, bitLenInt target);
+
+    /**
      * General unitary gate
      *
      * Applies a gate guaranteed to be unitary, from three angles, as commonly defined, spanning all possible single bit
@@ -854,38 +914,6 @@ public:
      * effects.
      */
     virtual void ISqrtY(bitLenInt qubitIndex);
-
-    /**
-     * Controlled Y gate
-     *
-     * If the "control" bit is set to 1, then the Pauli "Y" operator is applied
-     * to "target."
-     */
-    virtual void CY(bitLenInt control, bitLenInt target);
-
-    /**
-     * Doubly-Controlled Y gate
-     *
-     * If both "control" bits are set to 1, then the Pauli "Y" operator is applied
-     * to "target."
-     */
-    virtual void CCY(bitLenInt control1, bitLenInt control2, bitLenInt target);
-
-    /**
-     * Controlled Z gate
-     *
-     * If the "control" bit is set to 1, then the Pauli "Z" operator is applied
-     * to "target."
-     */
-    virtual void CZ(bitLenInt control, bitLenInt target);
-
-    /**
-     * Doubly-Controlled Z gate
-     *
-     * If both "control" bits are set to 1, then the Pauli "Z" operator is applied
-     * to "target."
-     */
-    virtual void CCZ(bitLenInt control1, bitLenInt control2, bitLenInt target);
 
     /**
      * Controlled H gate
@@ -1360,6 +1388,30 @@ public:
     /** Bitwise doubly "anti-"controlled-not */
     virtual void AntiCCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target, bitLenInt length);
 
+    /** Bitwise controlled-Y */
+    virtual void CY(bitLenInt control, bitLenInt target, bitLenInt length);
+
+    /** Bitwise "anti-"controlled-Y */
+    virtual void AntiCY(bitLenInt inputBits, bitLenInt targetBits, bitLenInt length);
+
+    /** Bitwise doubly controlled-Y */
+    virtual void CCY(bitLenInt control1, bitLenInt control2, bitLenInt target, bitLenInt length);
+
+    /** Bitwise doubly "anti-"controlled-Y */
+    virtual void AntiCCY(bitLenInt control1, bitLenInt control2, bitLenInt target, bitLenInt length);
+
+    /** Bitwise controlled-Z */
+    virtual void CZ(bitLenInt control, bitLenInt target, bitLenInt length);
+
+    /** Bitwise "anti-"controlled-Z */
+    virtual void AntiCZ(bitLenInt inputBits, bitLenInt targetBits, bitLenInt length);
+
+    /** Bitwise doubly controlled-Z */
+    virtual void CCZ(bitLenInt control1, bitLenInt control2, bitLenInt target, bitLenInt length);
+
+    /** Bitwise doubly "anti-"controlled-Z */
+    virtual void AntiCCZ(bitLenInt control1, bitLenInt control2, bitLenInt target, bitLenInt length);
+
     /**
      * Bitwise "AND"
      *
@@ -1585,38 +1637,6 @@ public:
      * operator
      */
     virtual void ExpZDyad(int numerator, int denomPower, bitLenInt start, bitLenInt length);
-
-    /**
-     * Bitwise controlled Y gate
-     *
-     * If the "control" bit is set to 1, then the Pauli "Y" operator is applied
-     * to "target."
-     */
-    virtual void CY(bitLenInt control, bitLenInt target, bitLenInt length);
-
-    /**
-     * Bitwise doubly-controlled Y gate
-     *
-     * If both "control" bits are set to 1, then the Pauli "Y" operator is applied
-     * to "target."
-     */
-    virtual void CCY(bitLenInt control1, bitLenInt control2, bitLenInt target, bitLenInt length);
-
-    /**
-     * Bitwise controlled Z gate
-     *
-     * If the "control" bit is set to 1, then the Pauli "Z" operator is applied
-     * to "target."
-     */
-    virtual void CZ(bitLenInt control, bitLenInt target, bitLenInt length);
-
-    /**
-     * Bitwise doubly-controlled Z gate
-     *
-     * If both "control" bits are set to 1, then the Pauli "Z" operator is applied
-     * to "target."
-     */
-    virtual void CCZ(bitLenInt control1, bitLenInt control2, bitLenInt target, bitLenInt length);
 
     /**
      * Bitwise controlled H gate

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -864,6 +864,14 @@ public:
     virtual void CY(bitLenInt control, bitLenInt target);
 
     /**
+     * Doubly-Controlled Y gate
+     *
+     * If both "control" bits are set to 1, then the Pauli "Y" operator is applied
+     * to "target."
+     */
+    virtual void CCY(bitLenInt control1, bitLenInt control2, bitLenInt target);
+
+    /**
      * Controlled Z gate
      *
      * If the "control" bit is set to 1, then the Pauli "Z" operator is applied

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -1595,6 +1595,14 @@ public:
     virtual void CY(bitLenInt control, bitLenInt target, bitLenInt length);
 
     /**
+     * Bitwise doubly-controlled Y gate
+     *
+     * If both "control" bits are set to 1, then the Pauli "Y" operator is applied
+     * to "target."
+     */
+    virtual void CCY(bitLenInt control1, bitLenInt control2, bitLenInt target, bitLenInt length);
+
+    /**
      * Bitwise controlled Z gate
      *
      * If the "control" bit is set to 1, then the Pauli "Z" operator is applied

--- a/include/qstabilizerhybrid.hpp
+++ b/include/qstabilizerhybrid.hpp
@@ -370,6 +370,8 @@ public:
 
     virtual void CCZ(bitLenInt control1, bitLenInt control2, bitLenInt target);
 
+    virtual void CCY(bitLenInt control1, bitLenInt control2, bitLenInt target);
+
     virtual void Swap(bitLenInt qubit1, bitLenInt qubit2)
     {
         if (qubit1 == qubit2) {

--- a/src/qinterface/gates.cpp
+++ b/src/qinterface/gates.cpp
@@ -235,6 +235,13 @@ void QInterface::CY(bitLenInt control, bitLenInt target)
     ApplyControlledSingleInvert(controls, 1, target, -I_CMPLX, I_CMPLX);
 }
 
+/// Apply doubly-controlled Pauli Z matrix to bit
+void QInterface::CCY(bitLenInt control1, bitLenInt control2, bitLenInt target)
+{
+    bitLenInt controls[2] = { control1, control2 };
+    ApplyControlledSinglePhase(controls, 2, target, -I_CMPLX, I_CMPLX);
+}
+
 /// Apply controlled Pauli Z matrix to bit
 void QInterface::CZ(bitLenInt control, bitLenInt target)
 {

--- a/src/qinterface/gates.cpp
+++ b/src/qinterface/gates.cpp
@@ -239,7 +239,7 @@ void QInterface::CY(bitLenInt control, bitLenInt target)
 void QInterface::CCY(bitLenInt control1, bitLenInt control2, bitLenInt target)
 {
     bitLenInt controls[2] = { control1, control2 };
-    ApplyControlledSinglePhase(controls, 2, target, -I_CMPLX, I_CMPLX);
+    ApplyControlledSingleInvert(controls, 2, target, -I_CMPLX, I_CMPLX);
 }
 
 /// Apply controlled Pauli Z matrix to bit

--- a/src/qinterface/gates.cpp
+++ b/src/qinterface/gates.cpp
@@ -242,6 +242,20 @@ void QInterface::CCY(bitLenInt control1, bitLenInt control2, bitLenInt target)
     ApplyControlledSingleInvert(controls, 2, target, -I_CMPLX, I_CMPLX);
 }
 
+/// "Anti-doubly-controlled Y" - Apply Pauli Y if control bits are both zero, do not apply if either control bit is one.
+void QInterface::AntiCCY(bitLenInt control1, bitLenInt control2, bitLenInt target)
+{
+    bitLenInt controls[2] = { control1, control2 };
+    ApplyAntiControlledSingleInvert(controls, 2, target, -I_CMPLX, I_CMPLX);
+}
+
+/// "Anti-controlled not" - Apply "not" if control bit is zero, do not apply if control bit is one.
+void QInterface::AntiCY(bitLenInt control, bitLenInt target)
+{
+    bitLenInt controls[1] = { control };
+    ApplyAntiControlledSingleInvert(controls, 1, target, -I_CMPLX, I_CMPLX);
+}
+
 /// Apply controlled Pauli Z matrix to bit
 void QInterface::CZ(bitLenInt control, bitLenInt target)
 {
@@ -254,6 +268,20 @@ void QInterface::CCZ(bitLenInt control1, bitLenInt control2, bitLenInt target)
 {
     bitLenInt controls[2] = { control1, control2 };
     ApplyControlledSinglePhase(controls, 2, target, ONE_CMPLX, -ONE_CMPLX);
+}
+
+/// "Anti-doubly-controlled Z" - Apply Pauli Z if control bits are both zero, do not apply if either control bit is one.
+void QInterface::AntiCCZ(bitLenInt control1, bitLenInt control2, bitLenInt target)
+{
+    bitLenInt controls[2] = { control1, control2 };
+    ApplyAntiControlledSinglePhase(controls, 2, target, ONE_CMPLX, -ONE_CMPLX);
+}
+
+/// "Anti-controlled Z" - Apply Pauli Z if control bit is zero, do not apply if control bit is one.
+void QInterface::AntiCZ(bitLenInt control, bitLenInt target)
+{
+    bitLenInt controls[1] = { control };
+    ApplyAntiControlledSinglePhase(controls, 1, target, ONE_CMPLX, -ONE_CMPLX);
 }
 
 /// Apply controlled Pauli Z matrix to bit

--- a/src/qinterface/qinterface.cpp
+++ b/src/qinterface/qinterface.cpp
@@ -122,8 +122,17 @@ void QInterface::FSim(real1_f theta, real1_f phi, bitLenInt qubit1, bitLenInt qu
     }
 }
 
+/// Bit-wise apply "anti-"controlled-z to two control registers and one target register
+REG_GATE_C2_1(AntiCCZ);
+
 /// Bit-wise apply doubly-controlled-z to two control registers and one target register
 REG_GATE_C2_1(CCZ);
+
+/// Apply "Anti-"CZ gate for "length" starting from "control" and "target," respectively
+REG_GATE_C1_1(AntiCZ);
+
+/// Apply controlled Pauli Z matrix to each bit
+REG_GATE_C1_1(CZ);
 
 /// Bit-wise apply "anti-"controlled-not to two control registers and one target register
 REG_GATE_C2_1(AntiCCNOT);
@@ -137,8 +146,17 @@ REG_GATE_C1_1(AntiCNOT);
 /// Apply CNOT gate for "length" starting from "control" and "target," respectively
 REG_GATE_C1_1(CNOT);
 
-/// Bit-wise apply doubly-controlled-z to two control registers and one target register
+/// Bit-wise apply "anti-"controlled-y to two control registers and one target register
+REG_GATE_C2_1(AntiCCY);
+
+/// Bit-wise apply doubly-controlled-y to two control registers and one target register
 REG_GATE_C2_1(CCY);
+
+// Apply "Anti-"CY gate for "length" starting from "control" and "target," respectively
+REG_GATE_C1_1(AntiCY);
+
+/// Apply controlled Pauli Y matrix to each bit
+REG_GATE_C1_1(CY);
 
 /// Apply S gate (1/4 phase rotation) to each bit in "length," starting from bit index "start"
 REG_GATE_1(S);
@@ -190,12 +208,6 @@ REG_GATE_1(ISqrtY);
 
 /// Apply Pauli Z matrix to each bit
 REG_GATE_1(Z);
-
-/// Apply controlled Pauli Y matrix to each bit
-REG_GATE_C1_1(CY);
-
-/// Apply controlled Pauli Z matrix to each bit
-REG_GATE_C1_1(CZ);
 
 /// Apply controlled H gate to each bit
 REG_GATE_C1_1(CH);

--- a/src/qinterface/qinterface.cpp
+++ b/src/qinterface/qinterface.cpp
@@ -137,6 +137,9 @@ REG_GATE_C1_1(AntiCNOT);
 /// Apply CNOT gate for "length" starting from "control" and "target," respectively
 REG_GATE_C1_1(CNOT);
 
+/// Bit-wise apply doubly-controlled-z to two control registers and one target register
+REG_GATE_C2_1(CCY);
+
 /// Apply S gate (1/4 phase rotation) to each bit in "length," starting from bit index "start"
 REG_GATE_1(S);
 

--- a/src/qstabilizerhybrid.cpp
+++ b/src/qstabilizerhybrid.cpp
@@ -279,6 +279,37 @@ void QStabilizerHybrid::CCZ(bitLenInt control1, bitLenInt control2, bitLenInt ta
     engine->CCZ(control1, control2, target);
 }
 
+void QStabilizerHybrid::CCY(bitLenInt control1, bitLenInt control2, bitLenInt target)
+{
+    if (shards[control1] || shards[control2] || shards[target]) {
+        FlushBuffers();
+    }
+
+    if (stabilizer) {
+        real1_f prob = Prob(control1);
+        if (prob == ZERO_R1) {
+            return;
+        }
+        if (prob == ONE_R1) {
+            stabilizer->CY(control2, target);
+            return;
+        }
+
+        prob = Prob(control2);
+        if (prob == ZERO_R1) {
+            return;
+        }
+        if (prob == ONE_R1) {
+            stabilizer->CY(control1, target);
+            return;
+        }
+
+        SwitchToEngine();
+    }
+
+    engine->CCY(control1, control2, target);
+}
+
 void QStabilizerHybrid::Decompose(bitLenInt start, QStabilizerHybridPtr dest)
 {
     bitLenInt length = dest->qubitCount;

--- a/src/qstabilizerhybrid.cpp
+++ b/src/qstabilizerhybrid.cpp
@@ -1013,6 +1013,13 @@ void QStabilizerHybrid::ApplyAntiControlledSingleInvert(const bitLenInt* lContro
         }
     }
 
+    if (IS_SAME(topRight, -I_CMPLX) && IS_SAME(bottomLeft, I_CMPLX)) {
+        stabilizer->X(controls[0]);
+        stabilizer->CY(controls[0], target);
+        stabilizer->X(controls[0]);
+        return;
+    }
+
     SwitchToEngine();
     engine->ApplyAntiControlledSingleInvert(lControls, lControlLen, target, topRight, bottomLeft);
 }

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -780,7 +780,7 @@ TEST_CASE("test_stabilizer_t_double", "[supreme]")
                                 qReg->CCNOT(b1, b2, b3);
                             } else {
                                 bitLenInt c[1] = { b1 };
-                                qReg->CSwap(c, 1, b1, b2);
+                                qReg->CSwap(c, 1, b2, b3);
                             }
                         } else if (gateRand < (2 * ONE_R1)) {
                             qReg->CCZ(b1, b2, b3);

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -689,14 +689,29 @@ TEST_CASE("test_stabilizer_t", "[supreme]")
                     if (gateRand < ONE_R1) {
                         gateRand = 4 * qReg->Rand();
                         if (gateRand < (3 * ONE_R1)) {
-                            qReg->CNOT(b1, b2);
+                            gateRand = 2 * qReg->Rand();
+                            if (gateRand < ONE_R1) {
+                                qReg->CNOT(b1, b2);
+                            } else {
+                                qReg->AntiCNOT(b1, b2);
+                            }
                         } else {
                             qReg->Swap(b1, b2);
                         }
                     } else if (gateRand < (2 * ONE_R1)) {
-                        qReg->CZ(b1, b2);
+                        gateRand = 2 * qReg->Rand();
+                        if (gateRand < ONE_R1) {
+                            qReg->CY(b1, b2);
+                        } else {
+                            qReg->AntiCY(b1, b2);
+                        }
                     } else if (gateRand < (3 * ONE_R1)) {
-                        qReg->CY(b1, b2);
+                        gateRand = 2 * qReg->Rand();
+                        if (gateRand < ONE_R1) {
+                            qReg->CZ(b1, b2);
+                        } else {
+                            qReg->AntiCZ(b1, b2);
+                        }
                     }
                     // else - identity
                 }
@@ -792,20 +807,19 @@ TEST_CASE("test_stabilizer_t_cc", "[supreme]")
                         } else if (gateRand < (2 * ONE_R1)) {
                             gateRand = 2 * qReg->Rand();
                             if (gateRand < ONE_R1) {
-                                qReg->CZ(b1, b2);
-                            } else {
-                                qReg->AntiCZ(b1, b2);
-                            }
-                        } else if (gateRand < (3 * ONE_R1)) {
-                            gateRand = 2 * qReg->Rand();
-                            if (gateRand < ONE_R1) {
                                 qReg->CY(b1, b2);
                             } else {
                                 qReg->AntiCY(b1, b2);
                             }
+                        } else if (gateRand < (3 * ONE_R1)) {
+                            gateRand = 2 * qReg->Rand();
+                            if (gateRand < ONE_R1) {
+                                qReg->CZ(b1, b2);
+                            } else {
+                                qReg->AntiCZ(b1, b2);
+                            }
                         }
                         // else - identity
-
                     } else {
                         b3 = pickRandomBit(qReg, &unusedBits);
 
@@ -821,16 +835,16 @@ TEST_CASE("test_stabilizer_t_cc", "[supreme]")
                         } else if (gateRand < (2 * ONE_R1)) {
                             gateRand = 2 * qReg->Rand();
                             if (gateRand < ONE_R1) {
-                                qReg->CCZ(b1, b2, b3);
+                                qReg->CCY(b1, b2, b3);
                             } else {
-                                qReg->AntiCCZ(b1, b2, b3);
+                                qReg->AntiCCY(b1, b2, b3);
                             }
                         } else if (gateRand < (3 * ONE_R1)) {
                             gateRand = 2 * qReg->Rand();
                             if (gateRand < ONE_R1) {
-                                qReg->CCY(b1, b2, b3);
+                                qReg->CCZ(b1, b2, b3);
                             } else {
-                                qReg->AntiCCY(b1, b2, b3);
+                                qReg->AntiCCZ(b1, b2, b3);
                             }
                         }
                         // else - identity

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -699,7 +699,7 @@ TEST_CASE("test_stabilizer_t", "[supreme]")
         false, false, testEngineType == QINTERFACE_QUNIT);
 }
 
-TEST_CASE("test_stabilizer_t_double", "[supreme]")
+TEST_CASE("test_stabilizer_t_cc", "[supreme]")
 {
     std::cout << "(random circuit depth: " << benchmarkDepth << ")";
 

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -775,7 +775,13 @@ TEST_CASE("test_stabilizer_t_double", "[supreme]")
                         gateRand = GateCountMultiQb * qReg->Rand();
 
                         if (gateRand < ONE_R1) {
-                            qReg->CCNOT(b1, b2, b3);
+                            gateRand = 4 * qReg->Rand();
+                            if (gateRand < (3 * ONE_R1)) {
+                                qReg->CCNOT(b1, b2, b3);
+                            } else {
+                                bitLenInt c[1] = { b1 };
+                                qReg->CSwap(c, 1, b1, b2);
+                            }
                         } else if (gateRand < (2 * ONE_R1)) {
                             qReg->CCZ(b1, b2, b3);
                         } else if (gateRand < (3 * ONE_R1)) {

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -775,13 +775,7 @@ TEST_CASE("test_stabilizer_t_double", "[supreme]")
                         gateRand = GateCountMultiQb * qReg->Rand();
 
                         if (gateRand < ONE_R1) {
-                            gateRand = 4 * qReg->Rand();
-                            if (gateRand < (3 * ONE_R1)) {
-                                qReg->CCNOT(b1, b2, b3);
-                            } else {
-                                bitLenInt c[1] = { b1 };
-                                qReg->CSwap(c, 1, b2, b3);
-                            }
+                            qReg->CCNOT(b1, b2, b3);
                         } else if (gateRand < (2 * ONE_R1)) {
                             qReg->CCZ(b1, b2, b3);
                         } else if (gateRand < (3 * ONE_R1)) {

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -655,9 +655,19 @@ TEST_CASE("test_stabilizer_t", "[supreme]")
                         if (gateRand < ONE_R1) {
                             qReg->Z(i);
                         } else if (gateRand < (2 * ONE_R1)) {
-                            qReg->S(i);
+                            gateRand = 2 * qReg->Rand();
+                            if (gateRand < ONE_R1) {
+                                qReg->S(i);
+                            } else {
+                                qReg->IS(i);
+                            }
                         } else {
-                            qReg->T(i);
+                            gateRand = 2 * qReg->Rand();
+                            if (gateRand < ONE_R1) {
+                                qReg->T(i);
+                            } else {
+                                qReg->IT(i);
+                            }
                         }
                     }
                     // else - identity
@@ -730,9 +740,19 @@ TEST_CASE("test_stabilizer_t_cc", "[supreme]")
                         if (gateRand < ONE_R1) {
                             qReg->Z(i);
                         } else if (gateRand < (2 * ONE_R1)) {
-                            qReg->S(i);
+                            gateRand = 2 * qReg->Rand();
+                            if (gateRand < ONE_R1) {
+                                qReg->S(i);
+                            } else {
+                                qReg->IS(i);
+                            }
                         } else {
-                            qReg->T(i);
+                            gateRand = 2 * qReg->Rand();
+                            if (gateRand < ONE_R1) {
+                                qReg->T(i);
+                            } else {
+                                qReg->IT(i);
+                            }
                         }
                     }
                     // else - identity

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -771,6 +771,8 @@ TEST_CASE("test_stabilizer_t_cc", "[supreme]")
 
                     gateRand = 2 * qReg->Rand();
 
+                    // TODO: Target "anti-" variants for optimization
+
                     if ((gateRand < ONE_R1) || !unusedBits.size()) {
 
                         gateRand = GateCountMultiQb * qReg->Rand();
@@ -778,14 +780,29 @@ TEST_CASE("test_stabilizer_t_cc", "[supreme]")
                         if (gateRand < ONE_R1) {
                             gateRand = 4 * qReg->Rand();
                             if (gateRand < (3 * ONE_R1)) {
-                                qReg->CNOT(b1, b2);
+                                gateRand = 2 * qReg->Rand();
+                                if (gateRand < ONE_R1) {
+                                    qReg->CNOT(b1, b2);
+                                } else {
+                                    qReg->AntiCNOT(b1, b2);
+                                }
                             } else {
                                 qReg->Swap(b1, b2);
                             }
                         } else if (gateRand < (2 * ONE_R1)) {
-                            qReg->CZ(b1, b2);
+                            gateRand = 2 * qReg->Rand();
+                            if (gateRand < ONE_R1) {
+                                qReg->CZ(b1, b2);
+                            } else {
+                                qReg->AntiCZ(b1, b2);
+                            }
                         } else if (gateRand < (3 * ONE_R1)) {
-                            qReg->CY(b1, b2);
+                            gateRand = 2 * qReg->Rand();
+                            if (gateRand < ONE_R1) {
+                                qReg->CY(b1, b2);
+                            } else {
+                                qReg->AntiCY(b1, b2);
+                            }
                         }
                         // else - identity
 
@@ -795,11 +812,26 @@ TEST_CASE("test_stabilizer_t_cc", "[supreme]")
                         gateRand = GateCountMultiQb * qReg->Rand();
 
                         if (gateRand < ONE_R1) {
-                            qReg->CCNOT(b1, b2, b3);
+                            gateRand = 2 * qReg->Rand();
+                            if (gateRand < ONE_R1) {
+                                qReg->CCNOT(b1, b2, b3);
+                            } else {
+                                qReg->AntiCCNOT(b1, b2, b3);
+                            }
                         } else if (gateRand < (2 * ONE_R1)) {
-                            qReg->CCZ(b1, b2, b3);
+                            gateRand = 2 * qReg->Rand();
+                            if (gateRand < ONE_R1) {
+                                qReg->CCZ(b1, b2, b3);
+                            } else {
+                                qReg->AntiCCZ(b1, b2, b3);
+                            }
                         } else if (gateRand < (3 * ONE_R1)) {
-                            qReg->CCY(b1, b2, b3);
+                            gateRand = 2 * qReg->Rand();
+                            if (gateRand < ONE_R1) {
+                                qReg->CCY(b1, b2, b3);
+                            } else {
+                                qReg->AntiCCY(b1, b2, b3);
+                            }
                         }
                         // else - identity
                     }

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -699,6 +699,100 @@ TEST_CASE("test_stabilizer_t", "[supreme]")
         false, false, testEngineType == QINTERFACE_QUNIT);
 }
 
+TEST_CASE("test_stabilizer_t_double", "[supreme]")
+{
+    std::cout << "(random circuit depth: " << benchmarkDepth << ")";
+
+    const int GateCount1Qb = 5;
+    const int GateCountMultiQb = 4;
+
+    benchmarkLoop(
+        [&](QInterfacePtr qReg, bitLenInt n) {
+            int d;
+            bitLenInt i;
+            real1_f gateRand;
+            bitLenInt b1, b2, b3;
+
+            qReg->SetReactiveSeparate(false);
+
+            for (d = 0; d < benchmarkDepth; d++) {
+
+                for (i = 0; i < n; i++) {
+                    gateRand = GateCount1Qb * qReg->Rand();
+                    if (gateRand < ONE_R1) {
+                        qReg->H(i);
+                    } else if (gateRand < (2 * ONE_R1)) {
+                        qReg->X(i);
+                    } else if (gateRand < (3 * ONE_R1)) {
+                        qReg->Y(i);
+                    } else if (gateRand < (4 * ONE_R1)) {
+                        gateRand = 3 * qReg->Rand();
+                        if (gateRand < ONE_R1) {
+                            qReg->Z(i);
+                        } else if (gateRand < (2 * ONE_R1)) {
+                            qReg->S(i);
+                        } else {
+                            qReg->T(i);
+                        }
+                    }
+                    // else - identity
+                }
+
+                std::set<bitLenInt> unusedBits;
+                for (i = 0; i < n; i++) {
+                    // In the past, "qReg->TrySeparate(i)" was also used, here, to attempt optimization. Be aware that
+                    // the method can give performance advantages, under opportune conditions, but it does not, here.
+                    unusedBits.insert(unusedBits.end(), i);
+                }
+
+                while (unusedBits.size() > 1) {
+                    b1 = pickRandomBit(qReg, &unusedBits);
+                    b2 = pickRandomBit(qReg, &unusedBits);
+
+                    gateRand = 2 * qReg->Rand();
+
+                    if ((gateRand < ONE_R1) || !unusedBits.size()) {
+
+                        gateRand = GateCountMultiQb * qReg->Rand();
+
+                        if (gateRand < ONE_R1) {
+                            gateRand = 4 * qReg->Rand();
+                            if (gateRand < (3 * ONE_R1)) {
+                                qReg->CNOT(b1, b2);
+                            } else {
+                                qReg->Swap(b1, b2);
+                            }
+                        } else if (gateRand < (2 * ONE_R1)) {
+                            qReg->CZ(b1, b2);
+                        } else if (gateRand < (3 * ONE_R1)) {
+                            qReg->CY(b1, b2);
+                        }
+                        // else - identity
+
+                    } else {
+                        b3 = pickRandomBit(qReg, &unusedBits);
+
+                        gateRand = GateCountMultiQb * qReg->Rand();
+
+                        if (gateRand < ONE_R1) {
+                            qReg->CCNOT(b1, b2, b3);
+                        } else if (gateRand < (2 * ONE_R1)) {
+                            qReg->CCZ(b1, b2, b3);
+                        } else if (gateRand < (3 * ONE_R1)) {
+                            qReg->CCY(b1, b2, b3);
+                        }
+                        // else - identity
+                    }
+                }
+
+                qReg->SetReactiveSeparate(true);
+            }
+
+            qReg->MAll();
+        },
+        false, false, testEngineType == QINTERFACE_QUNIT);
+}
+
 TEST_CASE("test_universal_circuit_continuous", "[supreme]")
 {
     std::cout << "(random circuit depth: " << benchmarkDepth << ")";

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -1363,6 +1363,25 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_cy_reg")
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x36));
 }
 
+TEST_CASE_METHOD(QInterfaceTestFixture, "test_ccy")
+{
+    qftReg->SetPermutation(0xCAC00);
+    REQUIRE_THAT(qftReg, HasProbability(0xCAC00));
+    qftReg->CCY(16, 12, 8, 4);
+    REQUIRE_THAT(qftReg, HasProbability(0xCA400));
+
+    bitLenInt controls[2] = { 0, 1 };
+
+    qftReg->SetPermutation(0x03);
+    qftReg->H(0, 3);
+    qftReg->CCY(0, 1, 2);
+    qftReg->ApplyControlledSinglePhase(controls, 2, 2, I_CMPLX, -I_CMPLX);
+    qftReg->H(2);
+    qftReg->ApplyControlledSinglePhase(controls, 2, 2, ONE_CMPLX, -ONE_CMPLX);
+    qftReg->H(0, 2);
+    REQUIRE_THAT(qftReg, HasProbability(0x03));
+}
+
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_cz")
 {
     qftReg->SetReg(0, 8, 0x35);

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -385,6 +385,42 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_anticnot")
     REQUIRE_THAT(qftReg, HasProbability(0x00));
 }
 
+TEST_CASE_METHOD(QInterfaceTestFixture, "test_anticy")
+{
+    qftReg->SetPermutation(0x55F00);
+    REQUIRE_THAT(qftReg, HasProbability(0x55F00));
+    qftReg->AntiCY(12, 4, 8);
+    REQUIRE_THAT(qftReg, HasProbability(0x555A0));
+    qftReg->SetPermutation(0x00001);
+    REQUIRE_THAT(qftReg, HasProbability(0x00001));
+    qftReg->AntiCY(18, 19);
+    REQUIRE_THAT(qftReg, HasProbability(0x80001));
+
+    bitLenInt controls[1] = { 0 };
+
+    qftReg->SetPermutation(0x01);
+    qftReg->H(0, 2);
+    qftReg->AntiCY(0, 1);
+    qftReg->ApplyAntiControlledSinglePhase(controls, 1, 1, I_CMPLX, -I_CMPLX);
+    qftReg->H(0, 2);
+    REQUIRE_THAT(qftReg, HasProbability(0x01));
+
+    qftReg->SetPermutation(0x00);
+    qftReg->H(0, 2);
+    qftReg->Z(0);
+    qftReg->AntiCY(0, 1);
+    qftReg->ApplyAntiControlledSinglePhase(controls, 1, 1, I_CMPLX, -I_CMPLX);
+    qftReg->H(0, 2);
+    REQUIRE_THAT(qftReg, HasProbability(0x01));
+
+    qftReg->SetPermutation(0x00);
+    qftReg->H(0, 2);
+    qftReg->AntiCY(0, 1);
+    qftReg->ApplyAntiControlledSinglePhase(controls, 1, 1, I_CMPLX, -I_CMPLX);
+    qftReg->H(0, 2);
+    REQUIRE_THAT(qftReg, HasProbability(0x00));
+}
+
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_ccnot")
 {
     qftReg->SetPermutation(0xCAC00);
@@ -424,6 +460,44 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_anticcnot")
     qftReg->SetPermutation(0x00);
     qftReg->H(0, 3);
     qftReg->AntiCCNOT(0, 1, 2);
+    qftReg->H(2);
+    qftReg->ApplyAntiControlledSinglePhase(controls, 2, 2, ONE_CMPLX, -ONE_CMPLX);
+    qftReg->H(0, 2);
+    REQUIRE_THAT(qftReg, HasProbability(0x00));
+}
+
+TEST_CASE_METHOD(QInterfaceTestFixture, "test_anticcy")
+{
+    qftReg->SetPermutation(0xCAC00);
+    REQUIRE_THAT(qftReg, HasProbability(0xCAC00));
+    qftReg->AntiCCY(16, 12, 8, 4);
+    REQUIRE_THAT(qftReg, HasProbability(0xCAD00));
+
+    bitLenInt controls[2] = { 0, 1 };
+
+    qftReg->SetPermutation(0x00);
+    qftReg->H(0, 3);
+    qftReg->AntiCCY(0, 1, 2);
+    qftReg->ApplyAntiControlledSinglePhase(controls, 2, 2, I_CMPLX, -I_CMPLX);
+    qftReg->H(2);
+    qftReg->ApplyAntiControlledSinglePhase(controls, 2, 2, ONE_CMPLX, -ONE_CMPLX);
+    qftReg->H(0, 2);
+    REQUIRE_THAT(qftReg, HasProbability(0x00));
+}
+
+TEST_CASE_METHOD(QInterfaceTestFixture, "test_anticcz")
+{
+    qftReg->SetPermutation(0xCAC00);
+    REQUIRE_THAT(qftReg, HasProbability(0xCAC00));
+    qftReg->AntiCCZ(16, 12, 8, 4);
+    REQUIRE_THAT(qftReg, HasProbability(0xCAC00));
+
+    bitLenInt controls[2] = { 0, 1 };
+
+    qftReg->SetPermutation(0x00);
+    qftReg->H(0, 3);
+    qftReg->AntiCCZ(0, 1, 2);
+    qftReg->ApplyAntiControlledSinglePhase(controls, 2, 2, I_CMPLX, -I_CMPLX);
     qftReg->H(2);
     qftReg->ApplyAntiControlledSinglePhase(controls, 2, 2, ONE_CMPLX, -ONE_CMPLX);
     qftReg->H(0, 2);
@@ -1402,12 +1476,38 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_cz")
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x03));
 }
 
-TEST_CASE_METHOD(QInterfaceTestFixture, "test_cz_reg")
+TEST_CASE_METHOD(QInterfaceTestFixture, "test_anticz")
 {
     qftReg->SetReg(0, 8, 0x35);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x35));
     qftReg->H(0, 4);
-    qftReg->CZ(4, 0, 4);
+    qftReg->X(4, 4);
+    qftReg->AntiCZ(4, 0);
+    qftReg->AntiCZ(5, 1);
+    qftReg->AntiCZ(6, 2);
+    qftReg->AntiCZ(7, 3);
+    qftReg->X(4, 4);
+    qftReg->H(0, 4);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x36));
+
+    qftReg->SetPermutation(0x03);
+    qftReg->H(0);
+    qftReg->X(0);
+    qftReg->AntiCZ(0, 1);
+    qftReg->AntiCZ(0, 1);
+    qftReg->X(0);
+    qftReg->H(0);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x03));
+}
+
+TEST_CASE_METHOD(QInterfaceTestFixture, "test_anticz_reg")
+{
+    qftReg->SetReg(0, 8, 0x35);
+    REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x35));
+    qftReg->H(0, 4);
+    qftReg->X(4, 4);
+    qftReg->AntiCZ(4, 0, 4);
+    qftReg->X(4, 4);
     qftReg->H(0, 4);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x36));
 }


### PR DESCRIPTION
In the search for a more representatively general benchmark, I'd like to have `test_stabilizer_t` variants with and without doubly-controlled gates. (This still works above Schrödinger' method limits.)