### PR TITLE
CNOT optimize

### DIFF
--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1981,9 +1981,8 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
         }
     }
 
-    RevertBasisY(target);
-
-    bool pmBasis = (cShard.isPauliX && tShard.isPauliX && !QUEUED_PHASE(cShard) && !QUEUED_PHASE(tShard));
+    bool pmBasis =
+        (cShard.isPauliX && (tShard.isPauliX || tShard.isPauliY) && !QUEUED_PHASE(cShard) && !QUEUED_PHASE(tShard));
 
     if (!freezeBasis2Qb && !pmBasis) {
         RevertBasis2Qb(control, ONLY_INVERT, ONLY_TARGETS);
@@ -2010,6 +2009,7 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
     // is equivalent to the gate with bits flipped. We just let ApplyEitherControlled() know to leave the current basis
     // alone, by way of the last optional "true" argument in the call.
     if (pmBasis) {
+        RevertBasisY(target);
         std::swap(controls[0], target);
         ApplyEitherControlled(
             controls, controlLen, { target }, false,

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -4289,6 +4289,7 @@ QInterfacePtr QUnit::Clone()
     // TODO: Copy buffers instead of flushing?
     for (bitLenInt i = 0; i < qubitCount; i++) {
         RevertBasis2Qb(i);
+        EndEmulation(i);
     }
 
     QUnitPtr copyPtr = std::make_shared<QUnit>(
@@ -4304,11 +4305,6 @@ QInterfacePtr QUnit::CloneBody(QUnitPtr copyPtr)
     std::vector<QInterfacePtr>::iterator origEngine;
     bitLenInt engineIndex;
     for (bitLenInt i = 0; i < qubitCount; i++) {
-        if (!shards[i].unit) {
-            copyPtr->shards[i] = QEngineShard(shards[i]);
-            continue;
-        }
-
         if (find(shardEngines.begin(), shardEngines.end(), shards[i].unit) == shardEngines.end()) {
             shardEngines.push_back(shards[i].unit);
             dupeEngines.push_back(shards[i].unit->Clone());


### PR DESCRIPTION
(Sorry for the rapid-fire commits to main, but I'm testing locally, and I have all day to work to on Qrack, and more time than that!)

`QUnit::CNOT` flushes Y basis to X basis to attempt the gate with both bits in X basis. This flush can be deferred until after it is determined whether or not the optimization will succeed.

I also tanked the `Clone()` method, earlier, and I'm partially reverting that work.