### PR TITLE
Stabilizer/QPager switch: resize pages rather than combine

### DIFF
--- a/include/qpager.hpp
+++ b/include/qpager.hpp
@@ -141,7 +141,7 @@ public:
 
     virtual void LockEngine(QEnginePtr eng)
     {
-        CombineEngines();
+        qPages.resize(1);
         qPages[0] = eng;
     }
 


### PR DESCRIPTION
We can avoid a potentially costly `CombineEngines()`, when using `QPager` under `QStabilizerHybrid`.