### PR TITLE
Expose SetReactiveSeparate() through DLL

### DIFF
--- a/include/pinvoke_api.hpp
+++ b/include/pinvoke_api.hpp
@@ -122,6 +122,7 @@ MICROSOFT_QUANTUM_DECL bool TrySeparate1Qb(_In_ unsigned sid, _In_ unsigned qi1)
 MICROSOFT_QUANTUM_DECL bool TrySeparate2Qb(_In_ unsigned sid, _In_ unsigned qi1, _In_ unsigned qi2);
 MICROSOFT_QUANTUM_DECL bool TrySeparateTol(
     _In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* q, _In_ double tol);
+MICROSOFT_QUANTUM_DECL void SetReactiveSeparate(_In_ unsigned sid, _In_ bool irs);
 
 #if !(FPPOW < 6 && !ENABLE_COMPLEX_X2)
 MICROSOFT_QUANTUM_DECL void TimeEvolve(_In_ unsigned sid, _In_ double t, _In_ unsigned n,

--- a/src/pinvoke_api.cpp
+++ b/src/pinvoke_api.cpp
@@ -1001,6 +1001,12 @@ MICROSOFT_QUANTUM_DECL bool TrySeparateTol(
     return simulators[sid]->TrySeparate(qb, (bitLenInt)n, (real1_f)tol);
 }
 
+MICROSOFT_QUANTUM_DECL void SetReactiveSeparate(_In_ unsigned sid, _In_ bool irs)
+{
+    SIMULATOR_LOCK_GUARD(sid)
+    simulators[sid]->SetReactiveSeparate(irs);
+}
+
 #if !(FPPOW < 6 && !ENABLE_COMPLEX_X2)
 /**
  * (External API) Simulate a Hamiltonian


### PR DESCRIPTION
This is HPC territory, but I'd like to experiment with exposing `SetReactiveSeparate()` through our DLL, as for Unity3D integration. (Even at less than HPC scales, it could prove to be a useful optimization, both in "game world space-time" and as a back end plugin.)