### PR TITLE
Buffer ApplySinglePhase/Invert in stabilizer

### DIFF
--- a/src/qstabilizerhybrid.cpp
+++ b/src/qstabilizerhybrid.cpp
@@ -678,10 +678,10 @@ void QStabilizerHybrid::ApplySinglePhase(const complex topLeft, const complex bo
     }
 
     complex mtrx[4] = { topLeft, ZERO_CMPLX, ZERO_CMPLX, bottomRight };
-    if (!shards[target]) {
-        shards[target] = std::make_shared<QStabilizerShard>(mtrx);
-    } else {
+    if (shards[target]) {
         shards[target]->Compose(mtrx);
+    } else {
+        shards[target] = std::make_shared<QStabilizerShard>(mtrx);
     }
 }
 
@@ -724,10 +724,10 @@ void QStabilizerHybrid::ApplySingleInvert(const complex topRight, const complex 
     }
 
     complex mtrx[4] = { ZERO_CMPLX, topRight, bottomLeft, ZERO_CMPLX };
-    if (!shards[target]) {
-        shards[target] = std::make_shared<QStabilizerShard>(mtrx);
-    } else {
+    if (shards[target]) {
         shards[target]->Compose(mtrx);
+    } else {
+        shards[target] = std::make_shared<QStabilizerShard>(mtrx);
     }
 }
 

--- a/src/qstabilizerhybrid.cpp
+++ b/src/qstabilizerhybrid.cpp
@@ -677,8 +677,12 @@ void QStabilizerHybrid::ApplySinglePhase(const complex topLeft, const complex bo
         return;
     }
 
-    SwitchToEngine();
-    engine->ApplySinglePhase(topLeft, bottomRight, target);
+    complex mtrx[4] = { topLeft, ZERO_CMPLX, ZERO_CMPLX, bottomRight };
+    if (!shards[target]) {
+        shards[target] = std::make_shared<QStabilizerShard>(mtrx);
+    } else {
+        shards[target]->Compose(mtrx);
+    }
 }
 
 void QStabilizerHybrid::ApplySingleInvert(const complex topRight, const complex bottomLeft, bitLenInt target)
@@ -719,8 +723,12 @@ void QStabilizerHybrid::ApplySingleInvert(const complex topRight, const complex 
         return;
     }
 
-    SwitchToEngine();
-    engine->ApplySingleInvert(topRight, bottomLeft, target);
+    complex mtrx[4] = { ZERO_CMPLX, topRight, bottomLeft, ZERO_CMPLX };
+    if (!shards[target]) {
+        shards[target] = std::make_shared<QStabilizerShard>(mtrx);
+    } else {
+        shards[target]->Compose(mtrx);
+    }
 }
 
 void QStabilizerHybrid::ApplyControlledSingleBit(


### PR DESCRIPTION
All stabilizer to Schrödinger conversions among single-bit phase, inversion, and general matrix gates should occur in `ApplySingleBit()`.