### PR TITLE
Add X^(1/4) and Y^(1/4) to benchmarks

### DIFF
--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -724,7 +724,7 @@ TEST_CASE("test_stabilizer_t", "[supreme]")
                             } else if (gateRand < (2 * ONE_R1)) {
                                 qReg->ISqrtY(i);
                             }
-                            // else - no SqrtX correction
+                            // else - no SqrtY correction
 
                             gateRand = 3 * qReg->Rand();
                             if (gateRand < ONE_R1) {
@@ -750,7 +750,6 @@ TEST_CASE("test_stabilizer_t", "[supreme]")
                             qReg->Z(i);
 
                             // Axis fine correction:
-
                             gateRand = 3 * qReg->Rand();
                             if (gateRand < ONE_R1) {
                                 qReg->S(i);
@@ -901,7 +900,7 @@ TEST_CASE("test_stabilizer_t_cc", "[supreme]")
                             } else if (gateRand < (2 * ONE_R1)) {
                                 qReg->ISqrtY(i);
                             }
-                            // else - no SqrtX correction
+                            // else - no SqrtY correction
 
                             gateRand = 3 * qReg->Rand();
                             if (gateRand < ONE_R1) {
@@ -927,7 +926,6 @@ TEST_CASE("test_stabilizer_t_cc", "[supreme]")
                             qReg->Z(i);
 
                             // Axis fine correction:
-
                             gateRand = 3 * qReg->Rand();
                             if (gateRand < ONE_R1) {
                                 qReg->S(i);

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -692,7 +692,7 @@ TEST_CASE("test_stabilizer_t", "[supreme]")
                         if (gateRand < ONE_R1) {
                             // Axis gross gate:
                             qReg->X(i);
-                            
+
                             // Axis fine correction:
                             gateRand = 3 * qReg->Rand();
                             if (gateRand < ONE_R1) {
@@ -701,10 +701,22 @@ TEST_CASE("test_stabilizer_t", "[supreme]")
                                 qReg->ISqrtX(i);
                             }
                             // else - no SqrtX correction
+
+                            gateRand = 3 * qReg->Rand();
+                            if (gateRand < ONE_R1) {
+                                qReg->H(i);
+                                qReg->T(i);
+                                qReg->H(i);
+                            } else if (gateRand < (2 * ONE_R1)) {
+                                qReg->H(i);
+                                qReg->IT(i);
+                                qReg->H(i);
+                            }
+                            // else - no X^(1/4) correction
                         } else if (gateRand < (2 * ONE_R1)) {
                             // Axis gross gate:
                             qReg->Y(i);
-                            
+
                             // Axis fine correction:
                             gateRand = 3 * qReg->Rand();
                             if (gateRand < ONE_R1) {
@@ -713,6 +725,22 @@ TEST_CASE("test_stabilizer_t", "[supreme]")
                                 qReg->ISqrtY(i);
                             }
                             // else - no SqrtX correction
+
+                            gateRand = 3 * qReg->Rand();
+                            if (gateRand < ONE_R1) {
+                                qReg->IS(i);
+                                qReg->H(i);
+                                qReg->T(i);
+                                qReg->H(i);
+                                qReg->S(i);
+                            } else if (gateRand < (2 * ONE_R1)) {
+                                qReg->IS(i);
+                                qReg->H(i);
+                                qReg->IT(i);
+                                qReg->H(i);
+                                qReg->S(i);
+                            }
+                            // else - no Y^(1/4) correction
                         } else if (gateRand < (3 * ONE_R1)) {
                             // Replace the body below with this for continuous Z axis root gates:
                             // gateRand = 2 * PI_R1 * qReg->Rand();
@@ -841,7 +869,7 @@ TEST_CASE("test_stabilizer_t_cc", "[supreme]")
                         if (gateRand < ONE_R1) {
                             // Axis gross gate:
                             qReg->X(i);
-                            
+
                             // Axis fine correction:
                             gateRand = 3 * qReg->Rand();
                             if (gateRand < ONE_R1) {
@@ -850,10 +878,22 @@ TEST_CASE("test_stabilizer_t_cc", "[supreme]")
                                 qReg->ISqrtX(i);
                             }
                             // else - no SqrtX correction
+
+                            gateRand = 3 * qReg->Rand();
+                            if (gateRand < ONE_R1) {
+                                qReg->H(i);
+                                qReg->T(i);
+                                qReg->H(i);
+                            } else if (gateRand < (2 * ONE_R1)) {
+                                qReg->H(i);
+                                qReg->IT(i);
+                                qReg->H(i);
+                            }
+                            // else - no X^(1/4) correction
                         } else if (gateRand < (2 * ONE_R1)) {
                             // Axis gross gate:
                             qReg->Y(i);
-                            
+
                             // Axis fine correction:
                             gateRand = 3 * qReg->Rand();
                             if (gateRand < ONE_R1) {
@@ -862,6 +902,22 @@ TEST_CASE("test_stabilizer_t_cc", "[supreme]")
                                 qReg->ISqrtY(i);
                             }
                             // else - no SqrtX correction
+
+                            gateRand = 3 * qReg->Rand();
+                            if (gateRand < ONE_R1) {
+                                qReg->IS(i);
+                                qReg->H(i);
+                                qReg->T(i);
+                                qReg->H(i);
+                                qReg->S(i);
+                            } else if (gateRand < (2 * ONE_R1)) {
+                                qReg->IS(i);
+                                qReg->H(i);
+                                qReg->IT(i);
+                                qReg->H(i);
+                                qReg->S(i);
+                            }
+                            // else - no Y^(1/4) correction
                         } else if (gateRand < (3 * ONE_R1)) {
                             // Replace the body below with this for continuous Z axis root gates:
                             // gateRand = 2 * PI_R1 * qReg->Rand();


### PR DESCRIPTION
In addition to `T` as a subdivision of `Z`, I have added the equivalent of `T` as subdivision of `X` and `Y`.