### PR TITLE
Rounding

### DIFF
--- a/src/qinterface/protected.cpp
+++ b/src/qinterface/protected.cpp
@@ -228,7 +228,8 @@ bool QInterface::IsIdentity(const complex* mtrx, bool isControlled)
 {
     // If the effect of applying the buffer would be (approximately or exactly) that of applying the identity
     // operator, then we can discard this buffer without applying it.
-    if ((mtrx[0] != mtrx[3]) || (mtrx[1] != ZERO_CMPLX) || (mtrx[2] != ZERO_CMPLX)) {
+    if ((norm(mtrx[0] - mtrx[3]) > FP_NORM_EPSILON) || (norm(mtrx[1]) > FP_NORM_EPSILON) ||
+        (norm(mtrx[2]) > FP_NORM_EPSILON)) {
         return false;
     }
 
@@ -238,7 +239,7 @@ bool QInterface::IsIdentity(const complex* mtrx, bool isControlled)
     // the user's purposes. If the global phase offset has not been randomized, user code might explicitly depend on
     // the global phase offset.
 
-    if ((isControlled || !randGlobalPhase) && (mtrx[0] != ONE_CMPLX)) {
+    if ((isControlled || !randGlobalPhase) && (norm(mtrx[0] - ONE_CMPLX) > FP_NORM_EPSILON)) {
         return false;
     }
 

--- a/src/qpager.cpp
+++ b/src/qpager.cpp
@@ -14,6 +14,8 @@
 #include "qfactory.hpp"
 #include "qpager.hpp"
 
+#define IS_NORM_0(c) (norm(c) <= FP_NORM_EPSILON)
+
 namespace Qrack {
 
 QPager::QPager(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState, qrack_rand_gen_ptr rgp, complex phaseFac,
@@ -286,12 +288,12 @@ void QPager::MetaControlled(bool anti, std::vector<bitLenInt> controls, bitLenIn
 
     bool isSpecial, isInvert;
     complex top, bottom;
-    if ((mtrx[1] == ZERO_CMPLX) && (mtrx[2] == ZERO_CMPLX)) {
+    if (IS_NORM_0(mtrx[1]) && IS_NORM_0(mtrx[2])) {
         isSpecial = true;
         isInvert = false;
         top = mtrx[0];
         bottom = mtrx[3];
-    } else if ((mtrx[0] == ZERO_CMPLX) && (mtrx[3] == ZERO_CMPLX)) {
+    } else if (IS_NORM_0(mtrx[0]) && IS_NORM_0(mtrx[3])) {
         isSpecial = true;
         isInvert = true;
         top = mtrx[1];

--- a/src/qstabilizerhybrid.cpp
+++ b/src/qstabilizerhybrid.cpp
@@ -13,7 +13,7 @@
 #include "qfactory.hpp"
 #include "qstabilizerhybrid.hpp"
 
-#define IS_NORM_0(c) (norm(c) <= amplitudeFloor)
+#define IS_NORM_0(c) (norm(c) <= FP_NORM_EPSILON)
 
 namespace Qrack {
 
@@ -338,8 +338,7 @@ void QStabilizerHybrid::Dispose(bitLenInt start, bitLenInt length)
         return;
     }
 
-    if (stabilizer && !stabilizer->CanDecomposeDispose(start, length))
-    {
+    if (stabilizer && !stabilizer->CanDecomposeDispose(start, length)) {
         SwitchToEngine();
     }
 

--- a/src/qstabilizerhybrid.cpp
+++ b/src/qstabilizerhybrid.cpp
@@ -13,7 +13,7 @@
 #include "qfactory.hpp"
 #include "qstabilizerhybrid.hpp"
 
-#define IS_NORM_0(c) (norm(c) <= FP_NORM_EPSILON)
+#define IS_NORM_0(c) (norm(c) <= amplitudeFloor)
 
 namespace Qrack {
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -355,7 +355,7 @@ complex QUnit::GetAmplitude(bitCapInt perm)
         }
     }
 
-    if ((shards[0].GetQubitCount() > 1) && IS_1_R1(norm(result)) && (randGlobalPhase || (result == ONE_CMPLX))) {
+    if ((shards[0].GetQubitCount() > 1) && IS_1_R1(norm(result)) && (randGlobalPhase || IS_AMP_0(result - ONE_CMPLX))) {
         SetPermutation(perm);
     }
 


### PR DESCRIPTION
This addresses systemic rounding issues. (The one unit test failure in Pennylane is in 'AerDevice', not 'QrackDevice', and therefore was not a product of this change.)