### PR TITLE
Fix Q# SWAP 2 qubit test

### DIFF
--- a/src/qstabilizer.cpp
+++ b/src/qstabilizer.cpp
@@ -633,9 +633,6 @@ bool QStabilizer::CanDecomposeDispose(const bitLenInt start, const bitLenInt len
                 return false;
             }
         }
-    }
-
-    for (i = 0; i < start; i++) {
         for (j = end; j < qubitCount; j++) {
             if (x[i][j] || z[i][j]) {
                 return false;
@@ -649,9 +646,6 @@ bool QStabilizer::CanDecomposeDispose(const bitLenInt start, const bitLenInt len
                 return false;
             }
         }
-    }
-
-    for (i = end; i < qubitCount; i++) {
         for (j = end; j < qubitCount; j++) {
             if (x[i][j] || z[i][j]) {
                 return false;

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1063,7 +1063,8 @@ real1_f QUnit::ProbBase(const bitLenInt& qubit)
         return prob;
     }
 
-    if (BLOCKED_SEPARATE(shard)) {
+    // TODO: It shouldn't be necessary to prevent separation of ALL Clifford shards.
+    if (shard.isClifford()) {
         return prob;
     }
 


### PR DESCRIPTION
It shouldn't be necessary to entirely avoid "shard" separation for Clifford sub-units, but this shunts a bug came across in Q# unit tests with QUnit.