### PR TITLE
No log normal test_stabilizer_* timing...

### DIFF
--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -684,85 +684,431 @@ TEST_CASE("test_stabilizer_t", "[supreme]")
     const int DimCount1Qb = 4;
     const int GateCountMultiQb = 4;
 
-    benchmarkLoop(
-        [&](QInterfacePtr qReg, bitLenInt n) {
-            int d;
-            bitLenInt i;
-            real1_f gateRand;
-            bitLenInt b1, b2;
+    benchmarkLoop([&](QInterfacePtr qReg, bitLenInt n) {
+        int d;
+        bitLenInt i;
+        real1_f gateRand;
+        bitLenInt b1, b2;
 
-            qReg->SetReactiveSeparate(true);
+        qReg->SetReactiveSeparate(true);
 
-            for (d = 0; d < benchmarkDepth; d++) {
-                for (i = 0; i < n; i++) {
-                    // "Phase" transforms:
-                    gateRand = DimCount1Qb * qReg->Rand();
+        for (d = 0; d < benchmarkDepth; d++) {
+            for (i = 0; i < n; i++) {
+                // "Phase" transforms:
+                gateRand = DimCount1Qb * qReg->Rand();
+                if (gateRand < ONE_R1) {
+                    qReg->H(i);
+                } else if (gateRand < (2 * ONE_R1)) {
+                    gateRand = 2 * qReg->Rand();
+                    if (gateRand < ONE_R1) {
+                        qReg->S(i);
+                    } else {
+                        qReg->IS(i);
+                    }
+                } else if (gateRand < (3 * ONE_R1)) {
+                    gateRand = 2 * qReg->Rand();
                     if (gateRand < ONE_R1) {
                         qReg->H(i);
-                    } else if (gateRand < (2 * ONE_R1)) {
-                        gateRand = 2 * qReg->Rand();
-                        if (gateRand < ONE_R1) {
-                            qReg->S(i);
-                        } else {
-                            qReg->IS(i);
-                        }
-                    } else if (gateRand < (3 * ONE_R1)) {
-                        gateRand = 2 * qReg->Rand();
-                        if (gateRand < ONE_R1) {
-                            qReg->H(i);
-                            qReg->S(i);
-                        } else {
-                            qReg->IS(i);
-                            qReg->H(i);
-                        }
-                    }
-                    // else - identity
-
-                    // "Position transforms:
-
-                    // Continuous Z root gates option:
-                    // gateRand = 2 * PI_R1 * qReg->Rand();
-                    // qReg->ApplySinglePhase(ONE_R1, std::polar(ONE_R1, (real1)gateRand), i);
-
-                    // Discrete Z root gates option:
-                    gateRand = 8 * qReg->Rand();
-                    if (gateRand < ONE_R1) {
-                        // Z^(1/4)
-                        qReg->T(i);
-                    } else if (gateRand < (2 * ONE_R1)) {
-                        // Z^(1/2)
                         qReg->S(i);
-                    } else if (gateRand < (3 * ONE_R1)) {
-                        // Z^(3/4)
-                        qReg->Z(i);
-                        qReg->IT(i);
-                    } else if (gateRand < (4 * ONE_R1)) {
-                        // Z
-                        qReg->Z(i);
-                    } else if (gateRand < (5 * ONE_R1)) {
-                        // Z^(-3/4)
-                        qReg->Z(i);
-                        qReg->T(i);
-                    } else if (gateRand < (6 * ONE_R1)) {
-                        // Z^(-1/2)
+                    } else {
                         qReg->IS(i);
-                    } else if (gateRand < (7 * ONE_R1)) {
-                        // Z^(-1/4)
-                        qReg->IT(i);
+                        qReg->H(i);
+                    }
+                }
+                // else - identity
+
+                // "Position transforms:
+
+                // Continuous Z root gates option:
+                // gateRand = 2 * PI_R1 * qReg->Rand();
+                // qReg->ApplySinglePhase(ONE_R1, std::polar(ONE_R1, (real1)gateRand), i);
+
+                // Discrete Z root gates option:
+                gateRand = 8 * qReg->Rand();
+                if (gateRand < ONE_R1) {
+                    // Z^(1/4)
+                    qReg->T(i);
+                } else if (gateRand < (2 * ONE_R1)) {
+                    // Z^(1/2)
+                    qReg->S(i);
+                } else if (gateRand < (3 * ONE_R1)) {
+                    // Z^(3/4)
+                    qReg->Z(i);
+                    qReg->IT(i);
+                } else if (gateRand < (4 * ONE_R1)) {
+                    // Z
+                    qReg->Z(i);
+                } else if (gateRand < (5 * ONE_R1)) {
+                    // Z^(-3/4)
+                    qReg->Z(i);
+                    qReg->T(i);
+                } else if (gateRand < (6 * ONE_R1)) {
+                    // Z^(-1/2)
+                    qReg->IS(i);
+                } else if (gateRand < (7 * ONE_R1)) {
+                    // Z^(-1/4)
+                    qReg->IT(i);
+                }
+                // else - identity
+            }
+
+            std::set<bitLenInt> unusedBits;
+            for (i = 0; i < n; i++) {
+                // In the past, "qReg->TrySeparate(i)" was also used, here, to attempt optimization. Be aware that
+                // the method can give performance advantages, under opportune conditions, but it does not, here.
+                unusedBits.insert(unusedBits.end(), i);
+            }
+
+            while (unusedBits.size() > 1) {
+                b1 = pickRandomBit(qReg, &unusedBits);
+                b2 = pickRandomBit(qReg, &unusedBits);
+
+                gateRand = GateCountMultiQb * qReg->Rand();
+
+                if (gateRand < ONE_R1) {
+                    gateRand = 4 * qReg->Rand();
+                    if (gateRand < (3 * ONE_R1)) {
+                        gateRand = 2 * qReg->Rand();
+                        if (gateRand < ONE_R1) {
+                            qReg->CNOT(b1, b2);
+                        } else {
+                            qReg->AntiCNOT(b1, b2);
+                        }
+                    } else {
+                        qReg->Swap(b1, b2);
+                    }
+                } else if (gateRand < (2 * ONE_R1)) {
+                    gateRand = 4 * qReg->Rand();
+                    if (gateRand < (3 * ONE_R1)) {
+                        gateRand = 2 * qReg->Rand();
+                        if (gateRand < ONE_R1) {
+                            qReg->CY(b1, b2);
+                        } else {
+                            qReg->AntiCY(b1, b2);
+                        }
+                    } else {
+                        qReg->Swap(b1, b2);
+                    }
+                } else if (gateRand < (3 * ONE_R1)) {
+                    gateRand = 2 * qReg->Rand();
+                    if (gateRand < ONE_R1) {
+                        qReg->CZ(b1, b2);
+                    } else {
+                        qReg->AntiCZ(b1, b2);
+                    }
+                }
+                // else - identity
+            }
+        }
+
+        qReg->MAll();
+    });
+}
+
+TEST_CASE("test_stabilizer_t_cc", "[supreme]")
+{
+    // Try with environment variable
+    // QRACK_QUNIT_SEPARABILITY_THRESHOLD=0.1464466
+    // for clamping of single bit states to Pauli basis axes.
+
+    std::cout << "(random circuit depth: " << benchmarkDepth << ")";
+
+    const int DimCount1Qb = 4;
+    const int DimCountMultiQb = 4;
+
+    benchmarkLoop([&](QInterfacePtr qReg, bitLenInt n) {
+        int d;
+        bitLenInt i;
+        real1_f gateRand;
+        bitLenInt b1, b2, b3;
+
+        qReg->SetReactiveSeparate(true);
+
+        for (d = 0; d < benchmarkDepth; d++) {
+            for (i = 0; i < n; i++) {
+                // "Phase" transforms:
+                gateRand = DimCount1Qb * qReg->Rand();
+                if (gateRand < ONE_R1) {
+                    qReg->H(i);
+                } else if (gateRand < (2 * ONE_R1)) {
+                    gateRand = 2 * qReg->Rand();
+                    if (gateRand < ONE_R1) {
+                        qReg->S(i);
+                    } else {
+                        qReg->IS(i);
+                    }
+                } else if (gateRand < (3 * ONE_R1)) {
+                    gateRand = 2 * qReg->Rand();
+                    if (gateRand < ONE_R1) {
+                        qReg->H(i);
+                        qReg->S(i);
+                    } else {
+                        qReg->IS(i);
+                        qReg->H(i);
+                    }
+                }
+                // else - identity
+
+                // "Position transforms:
+
+                // Continuous Z root gates option:
+                // gateRand = 2 * PI_R1 * qReg->Rand();
+                // qReg->ApplySinglePhase(ONE_R1, std::polar(ONE_R1, (real1)gateRand), i);
+
+                // Discrete Z root gates option:
+                gateRand = 8 * qReg->Rand();
+                if (gateRand < ONE_R1) {
+                    // Z^(1/4)
+                    qReg->T(i);
+                } else if (gateRand < (2 * ONE_R1)) {
+                    // Z^(1/2)
+                    qReg->S(i);
+                } else if (gateRand < (3 * ONE_R1)) {
+                    // Z^(3/4)
+                    qReg->Z(i);
+                    qReg->IT(i);
+                } else if (gateRand < (4 * ONE_R1)) {
+                    // Z
+                    qReg->Z(i);
+                } else if (gateRand < (5 * ONE_R1)) {
+                    // Z^(-3/4)
+                    qReg->Z(i);
+                    qReg->T(i);
+                } else if (gateRand < (6 * ONE_R1)) {
+                    // Z^(-1/2)
+                    qReg->IS(i);
+                } else if (gateRand < (7 * ONE_R1)) {
+                    // Z^(-1/4)
+                    qReg->IT(i);
+                }
+                // else - identity
+            }
+
+            std::set<bitLenInt> unusedBits;
+            for (i = 0; i < n; i++) {
+                unusedBits.insert(unusedBits.end(), i);
+            }
+
+            while (unusedBits.size() > 1) {
+                b1 = pickRandomBit(qReg, &unusedBits);
+                b2 = pickRandomBit(qReg, &unusedBits);
+
+                gateRand = 2 * qReg->Rand();
+
+                // TODO: Target "anti-" variants for optimization
+
+                if ((gateRand < ONE_R1) || !unusedBits.size()) {
+
+                    gateRand = DimCountMultiQb * qReg->Rand();
+
+                    if (gateRand < ONE_R1) {
+                        gateRand = 4 * qReg->Rand();
+                        if (gateRand < (3 * ONE_R1)) {
+                            gateRand = 2 * qReg->Rand();
+                            if (gateRand < ONE_R1) {
+                                qReg->CNOT(b1, b2);
+                            } else {
+                                qReg->AntiCNOT(b1, b2);
+                            }
+                        } else {
+                            qReg->Swap(b1, b2);
+                        }
+                    } else if (gateRand < (2 * ONE_R1)) {
+                        gateRand = 4 * qReg->Rand();
+                        if (gateRand < (3 * ONE_R1)) {
+                            gateRand = 2 * qReg->Rand();
+                            if (gateRand < ONE_R1) {
+                                qReg->CY(b1, b2);
+                            } else {
+                                qReg->AntiCY(b1, b2);
+                            }
+                        } else {
+                            qReg->Swap(b1, b2);
+                        }
+                    } else if (gateRand < (3 * ONE_R1)) {
+                        gateRand = 2 * qReg->Rand();
+                        if (gateRand < ONE_R1) {
+                            qReg->CZ(b1, b2);
+                        } else {
+                            qReg->AntiCZ(b1, b2);
+                        }
+                    }
+                    // else - identity
+                } else {
+                    b3 = pickRandomBit(qReg, &unusedBits);
+
+                    gateRand = DimCountMultiQb * qReg->Rand();
+
+                    if (gateRand < ONE_R1) {
+                        gateRand = 2 * qReg->Rand();
+                        if (gateRand < ONE_R1) {
+                            qReg->CCNOT(b1, b2, b3);
+                        } else {
+                            qReg->AntiCCNOT(b1, b2, b3);
+                        }
+                    } else if (gateRand < (2 * ONE_R1)) {
+                        gateRand = 2 * qReg->Rand();
+                        if (gateRand < ONE_R1) {
+                            qReg->CCY(b1, b2, b3);
+                        } else {
+                            qReg->AntiCCY(b1, b2, b3);
+                        }
+                    } else if (gateRand < (3 * ONE_R1)) {
+                        gateRand = 2 * qReg->Rand();
+                        if (gateRand < ONE_R1) {
+                            qReg->CCZ(b1, b2, b3);
+                        } else {
+                            qReg->AntiCCZ(b1, b2, b3);
+                        }
                     }
                     // else - identity
                 }
+            }
+        }
 
-                std::set<bitLenInt> unusedBits;
-                for (i = 0; i < n; i++) {
-                    // In the past, "qReg->TrySeparate(i)" was also used, here, to attempt optimization. Be aware that
-                    // the method can give performance advantages, under opportune conditions, but it does not, here.
-                    unusedBits.insert(unusedBits.end(), i);
+        qReg->MAll();
+    });
+}
+
+TEST_CASE("test_stabilizer_t_nn", "[supreme]")
+{
+    // Try with environment variable
+    // QRACK_QUNIT_SEPARABILITY_THRESHOLD=0.1464466
+    // for clamping of single bit states to Pauli basis axes.
+
+    std::cout << "(random circuit depth: " << benchmarkDepth << ")";
+
+    const int DimCount1Qb = 4;
+    const int GateCountMultiQb = 4;
+
+    benchmarkLoop([&](QInterfacePtr qReg, bitLenInt n) {
+        int d;
+        bitLenInt i;
+        real1_f gateRand;
+        bitLenInt b1, b2;
+        int row, col;
+        int tempRow, tempCol;
+        bitLenInt gate, tempGate;
+
+        // The test runs 2 bit gates according to a tiling sequence.
+        // The 1 bit indicates +/- column offset.
+        // The 2 bit indicates +/- row offset.
+        // This is the "ABCDCDAB" pattern, from the Cirq definition of the circuit in the supplemental materials to
+        // the paper.
+        std::list<bitLenInt> gateSequence = { 0, 3, 2, 1, 2, 1, 0, 3 };
+
+        // We factor the qubit count into two integers, as close to a perfect square as we can.
+        int colLen = std::sqrt(n);
+        while (((n / colLen) * colLen) != n) {
+            colLen--;
+        }
+        int rowLen = n / colLen;
+
+        qReg->SetReactiveSeparate(true);
+
+        for (d = 0; d < benchmarkDepth; d++) {
+            for (i = 0; i < n; i++) {
+                // "Phase" transforms:
+                gateRand = DimCount1Qb * qReg->Rand();
+                if (gateRand < ONE_R1) {
+                    qReg->H(i);
+                } else if (gateRand < (2 * ONE_R1)) {
+                    gateRand = 2 * qReg->Rand();
+                    if (gateRand < ONE_R1) {
+                        qReg->S(i);
+                    } else {
+                        qReg->IS(i);
+                    }
+                } else if (gateRand < (3 * ONE_R1)) {
+                    gateRand = 2 * qReg->Rand();
+                    if (gateRand < ONE_R1) {
+                        qReg->H(i);
+                        qReg->S(i);
+                    } else {
+                        qReg->IS(i);
+                        qReg->H(i);
+                    }
                 }
+                // else - identity
 
-                while (unusedBits.size() > 1) {
-                    b1 = pickRandomBit(qReg, &unusedBits);
-                    b2 = pickRandomBit(qReg, &unusedBits);
+                // "Position transforms:
+
+                // Continuous Z root gates option:
+                gateRand = 2 * PI_R1 * qReg->Rand();
+                qReg->ApplySinglePhase(ONE_R1, std::polar(ONE_R1, (real1)gateRand), i);
+
+                // Discrete Z root gates option:
+                /*
+                gateRand = 8 * qReg->Rand();
+                if (gateRand < ONE_R1) {
+                    // Z^(1/4)
+                    qReg->T(i);
+                } else if (gateRand < (2 * ONE_R1)) {
+                    // Z^(1/2)
+                    qReg->S(i);
+                } else if (gateRand < (3 * ONE_R1)) {
+                    // Z^(3/4)
+                    qReg->Z(i);
+                    qReg->IT(i);
+                } else if (gateRand < (4 * ONE_R1)) {
+                    // Z
+                    qReg->Z(i);
+                } else if (gateRand < (5 * ONE_R1)) {
+                    // Z^(-3/4)
+                    qReg->Z(i);
+                    qReg->T(i);
+                } else if (gateRand < (6 * ONE_R1)) {
+                    // Z^(-1/2)
+                    qReg->IS(i);
+                } else if (gateRand < (7 * ONE_R1)) {
+                    // Z^(-1/4)
+                    qReg->IT(i);
+                }
+                // else - identity
+                */
+            }
+
+            gate = gateSequence.front();
+            gateSequence.pop_front();
+            gateSequence.push_back(gate);
+
+            std::vector<bitLenInt> usedBits;
+
+            for (row = 0; row < rowLen; row++) {
+                for (col = 0; col < colLen; col++) {
+                    // The following pattern is isomorphic to a 45 degree bias on a rectangle, for couplers.
+                    // In this test, the boundaries of the rectangle have no couplers.
+                    // In a perfect square, in the interior bulk, one 2 bit gate is applied for every pair of bits,
+                    // (as many gates as 1/2 the number of bits). (Unless n is a perfect square, the "row length"
+                    // has to be factored into a rectangular shape, and "n" is sometimes prime or factors
+                    // awkwardly.)
+
+                    b1 = row * colLen + col;
+                    if (std::find(usedBits.begin(), usedBits.end(), b1) != usedBits.end()) {
+                        continue;
+                    }
+
+                    tempGate = (row & 1U) ? gate : (gate ^ 3U);
+
+                    tempRow = row;
+                    tempCol = col;
+
+                    tempRow += ((tempGate & 2U) ? 1 : -1);
+                    tempCol += (colLen == 1) ? 0 : ((tempGate & 1U) ? 1 : 0);
+
+                    b2 = tempRow * colLen + tempCol;
+
+                    if ((tempRow < 0) || (tempCol < 0) || (tempRow >= rowLen) || (tempCol >= colLen) ||
+                        (std::find(usedBits.begin(), usedBits.end(), b2) != usedBits.end())) {
+                        continue;
+                    }
+
+                    usedBits.push_back(b1);
+                    usedBits.push_back(b2);
+
+                    if ((qReg->Rand() * 2) >= ONE_R1) {
+                        std::swap(b1, b2);
+                    }
 
                     gateRand = GateCountMultiQb * qReg->Rand();
 
@@ -801,13 +1147,13 @@ TEST_CASE("test_stabilizer_t", "[supreme]")
                     // else - identity
                 }
             }
+        }
 
-            qReg->MAll();
-        },
-        false, false, testEngineType == QINTERFACE_QUNIT);
+        qReg->MAll();
+    });
 }
 
-TEST_CASE("test_stabilizer_t_cc", "[supreme]")
+TEST_CASE("test_stabilizer_t_cc_nn", "[supreme]")
 {
     // Try with environment variable
     // QRACK_QUNIT_SEPARABILITY_THRESHOLD=0.1464466
@@ -816,132 +1162,170 @@ TEST_CASE("test_stabilizer_t_cc", "[supreme]")
     std::cout << "(random circuit depth: " << benchmarkDepth << ")";
 
     const int DimCount1Qb = 4;
-    const int DimCountMultiQb = 4;
+    const int GateCountMultiQb = 4;
 
-    benchmarkLoop(
-        [&](QInterfacePtr qReg, bitLenInt n) {
-            int d;
-            bitLenInt i;
-            real1_f gateRand;
-            bitLenInt b1, b2, b3;
+    benchmarkLoop([&](QInterfacePtr qReg, bitLenInt n) {
+        int d;
+        bitLenInt i;
+        real1_f gateRand;
+        bitLenInt b1, b2, b3 = 0;
+        bool is3Qubit;
+        int row, col;
+        int tempRow, tempCol;
+        bitLenInt gate, tempGate;
 
-            qReg->SetReactiveSeparate(true);
+        // The test runs 2 bit gates according to a tiling sequence.
+        // The 1 bit indicates +/- column offset.
+        // The 2 bit indicates +/- row offset.
+        // This is the "ABCDCDAB" pattern, from the Cirq definition of the circuit in the supplemental materials to
+        // the paper.
+        std::list<bitLenInt> gateSequence = { 0, 3, 2, 1, 2, 1, 0, 3 };
 
-            for (d = 0; d < benchmarkDepth; d++) {
-                for (i = 0; i < n; i++) {
-                    // "Phase" transforms:
-                    gateRand = DimCount1Qb * qReg->Rand();
+        // We factor the qubit count into two integers, as close to a perfect square as we can.
+        int colLen = std::sqrt(n);
+        while (((n / colLen) * colLen) != n) {
+            colLen--;
+        }
+        int rowLen = n / colLen;
+
+        qReg->SetReactiveSeparate(true);
+
+        for (d = 0; d < benchmarkDepth; d++) {
+            for (i = 0; i < n; i++) {
+                // "Phase" transforms:
+                gateRand = DimCount1Qb * qReg->Rand();
+                if (gateRand < ONE_R1) {
+                    qReg->H(i);
+                } else if (gateRand < (2 * ONE_R1)) {
+                    gateRand = 2 * qReg->Rand();
+                    if (gateRand < ONE_R1) {
+                        qReg->S(i);
+                    } else {
+                        qReg->IS(i);
+                    }
+                } else if (gateRand < (3 * ONE_R1)) {
+                    gateRand = 2 * qReg->Rand();
                     if (gateRand < ONE_R1) {
                         qReg->H(i);
-                    } else if (gateRand < (2 * ONE_R1)) {
-                        gateRand = 2 * qReg->Rand();
-                        if (gateRand < ONE_R1) {
-                            qReg->S(i);
-                        } else {
-                            qReg->IS(i);
-                        }
-                    } else if (gateRand < (3 * ONE_R1)) {
-                        gateRand = 2 * qReg->Rand();
-                        if (gateRand < ONE_R1) {
-                            qReg->H(i);
-                            qReg->S(i);
-                        } else {
-                            qReg->IS(i);
-                            qReg->H(i);
-                        }
-                    }
-                    // else - identity
-
-                    // "Position transforms:
-
-                    // Continuous Z root gates option:
-                    // gateRand = 2 * PI_R1 * qReg->Rand();
-                    // qReg->ApplySinglePhase(ONE_R1, std::polar(ONE_R1, (real1)gateRand), i);
-
-                    // Discrete Z root gates option:
-                    gateRand = 8 * qReg->Rand();
-                    if (gateRand < ONE_R1) {
-                        // Z^(1/4)
-                        qReg->T(i);
-                    } else if (gateRand < (2 * ONE_R1)) {
-                        // Z^(1/2)
                         qReg->S(i);
-                    } else if (gateRand < (3 * ONE_R1)) {
-                        // Z^(3/4)
-                        qReg->Z(i);
-                        qReg->IT(i);
-                    } else if (gateRand < (4 * ONE_R1)) {
-                        // Z
-                        qReg->Z(i);
-                    } else if (gateRand < (5 * ONE_R1)) {
-                        // Z^(-3/4)
-                        qReg->Z(i);
-                        qReg->T(i);
-                    } else if (gateRand < (6 * ONE_R1)) {
-                        // Z^(-1/2)
-                        qReg->IS(i);
-                    } else if (gateRand < (7 * ONE_R1)) {
-                        // Z^(-1/4)
-                        qReg->IT(i);
-                    }
-                    // else - identity
-                }
-
-                std::set<bitLenInt> unusedBits;
-                for (i = 0; i < n; i++) {
-                    unusedBits.insert(unusedBits.end(), i);
-                }
-
-                while (unusedBits.size() > 1) {
-                    b1 = pickRandomBit(qReg, &unusedBits);
-                    b2 = pickRandomBit(qReg, &unusedBits);
-
-                    gateRand = 2 * qReg->Rand();
-
-                    // TODO: Target "anti-" variants for optimization
-
-                    if ((gateRand < ONE_R1) || !unusedBits.size()) {
-
-                        gateRand = DimCountMultiQb * qReg->Rand();
-
-                        if (gateRand < ONE_R1) {
-                            gateRand = 4 * qReg->Rand();
-                            if (gateRand < (3 * ONE_R1)) {
-                                gateRand = 2 * qReg->Rand();
-                                if (gateRand < ONE_R1) {
-                                    qReg->CNOT(b1, b2);
-                                } else {
-                                    qReg->AntiCNOT(b1, b2);
-                                }
-                            } else {
-                                qReg->Swap(b1, b2);
-                            }
-                        } else if (gateRand < (2 * ONE_R1)) {
-                            gateRand = 4 * qReg->Rand();
-                            if (gateRand < (3 * ONE_R1)) {
-                                gateRand = 2 * qReg->Rand();
-                                if (gateRand < ONE_R1) {
-                                    qReg->CY(b1, b2);
-                                } else {
-                                    qReg->AntiCY(b1, b2);
-                                }
-                            } else {
-                                qReg->Swap(b1, b2);
-                            }
-                        } else if (gateRand < (3 * ONE_R1)) {
-                            gateRand = 2 * qReg->Rand();
-                            if (gateRand < ONE_R1) {
-                                qReg->CZ(b1, b2);
-                            } else {
-                                qReg->AntiCZ(b1, b2);
-                            }
-                        }
-                        // else - identity
                     } else {
-                        b3 = pickRandomBit(qReg, &unusedBits);
+                        qReg->IS(i);
+                        qReg->H(i);
+                    }
+                }
+                // else - identity
 
-                        gateRand = DimCountMultiQb * qReg->Rand();
+                // "Position transforms:
 
+                // Continuous Z root gates option:
+                gateRand = 2 * PI_R1 * qReg->Rand();
+                qReg->ApplySinglePhase(ONE_R1, std::polar(ONE_R1, (real1)gateRand), i);
+
+                // Discrete Z root gates option:
+                /*
+                gateRand = 8 * qReg->Rand();
+                if (gateRand < ONE_R1) {
+                    // Z^(1/4)
+                    qReg->T(i);
+                } else if (gateRand < (2 * ONE_R1)) {
+                    // Z^(1/2)
+                    qReg->S(i);
+                } else if (gateRand < (3 * ONE_R1)) {
+                    // Z^(3/4)
+                    qReg->Z(i);
+                    qReg->IT(i);
+                } else if (gateRand < (4 * ONE_R1)) {
+                    // Z
+                    qReg->Z(i);
+                } else if (gateRand < (5 * ONE_R1)) {
+                    // Z^(-3/4)
+                    qReg->Z(i);
+                    qReg->T(i);
+                } else if (gateRand < (6 * ONE_R1)) {
+                    // Z^(-1/2)
+                    qReg->IS(i);
+                } else if (gateRand < (7 * ONE_R1)) {
+                    // Z^(-1/4)
+                    qReg->IT(i);
+                }
+                // else - identity
+                */
+            }
+
+            gate = gateSequence.front();
+            gateSequence.pop_front();
+            gateSequence.push_back(gate);
+
+            std::vector<bitLenInt> usedBits;
+
+            for (row = 0; row < rowLen; row++) {
+                for (col = 0; col < colLen; col++) {
+                    // The following pattern is isomorphic to a 45 degree bias on a rectangle, for couplers.
+                    // In this test, the boundaries of the rectangle have no couplers.
+                    // In a perfect square, in the interior bulk, one 2 bit gate is applied for every pair of bits,
+                    // (as many gates as 1/2 the number of bits). (Unless n is a perfect square, the "row length"
+                    // has to be factored into a rectangular shape, and "n" is sometimes prime or factors
+                    // awkwardly.)
+
+                    b1 = row * colLen + col;
+
+                    if (std::find(usedBits.begin(), usedBits.end(), b1) != usedBits.end()) {
+                        continue;
+                    }
+
+                    tempGate = (row & 1U) ? gate : (gate ^ 3U);
+
+                    tempRow = row;
+                    tempCol = col;
+
+                    tempRow += ((tempGate & 2U) ? 1 : -1);
+                    tempCol += (colLen == 1) ? 0 : ((tempGate & 1U) ? 1 : 0);
+
+                    b2 = tempRow * colLen + tempCol;
+
+                    if ((tempRow < 0) || (tempCol < 0) || (tempRow >= rowLen) || (tempCol >= colLen) ||
+                        (std::find(usedBits.begin(), usedBits.end(), b2) != usedBits.end())) {
+                        continue;
+                    }
+
+                    tempGate = tempGate ^ 3U;
+
+                    tempRow = row;
+                    tempCol = col;
+
+                    tempRow += ((tempGate & 2U) ? 1 : -1);
+                    tempCol += (colLen == 1) ? 0 : ((tempGate & 1U) ? 1 : 0);
+
+                    b3 = tempRow * colLen + tempCol;
+
+                    if ((tempRow < 0) || (tempCol < 0) || (tempRow >= rowLen) || (tempCol >= colLen) ||
+                        (std::find(usedBits.begin(), usedBits.end(), b3) != usedBits.end())) {
+                        is3Qubit = false;
+                    } else {
+                        is3Qubit = (b3 < b1) || ((qReg->Rand() * 2) >= ONE_R1);
+                    }
+
+                    usedBits.push_back(b1);
+                    usedBits.push_back(b2);
+                    if (is3Qubit) {
+                        usedBits.push_back(b3);
+                    }
+
+                    if ((qReg->Rand() * 2) >= ONE_R1) {
+                        std::swap(b1, b2);
+                    }
+                    if (is3Qubit) {
+                        if ((qReg->Rand() * 2) >= ONE_R1) {
+                            std::swap(b1, b3);
+                        }
+                        if ((qReg->Rand() * 2) >= ONE_R1) {
+                            std::swap(b2, b3);
+                        }
+                    }
+
+                    gateRand = GateCountMultiQb * qReg->Rand();
+
+                    if (is3Qubit) {
                         if (gateRand < ONE_R1) {
                             gateRand = 2 * qReg->Rand();
                             if (gateRand < ONE_R1) {
@@ -965,158 +1349,10 @@ TEST_CASE("test_stabilizer_t_cc", "[supreme]")
                             }
                         }
                         // else - identity
-                    }
-                }
-            }
 
-            qReg->MAll();
-        },
-        false, false, testEngineType == QINTERFACE_QUNIT);
-}
-
-TEST_CASE("test_stabilizer_t_nn", "[supreme]")
-{
-    // Try with environment variable
-    // QRACK_QUNIT_SEPARABILITY_THRESHOLD=0.1464466
-    // for clamping of single bit states to Pauli basis axes.
-
-    std::cout << "(random circuit depth: " << benchmarkDepth << ")";
-
-    const int DimCount1Qb = 4;
-    const int GateCountMultiQb = 4;
-
-    benchmarkLoop(
-        [&](QInterfacePtr qReg, bitLenInt n) {
-            int d;
-            bitLenInt i;
-            real1_f gateRand;
-            bitLenInt b1, b2;
-            int row, col;
-            int tempRow, tempCol;
-            bitLenInt gate, tempGate;
-
-            // The test runs 2 bit gates according to a tiling sequence.
-            // The 1 bit indicates +/- column offset.
-            // The 2 bit indicates +/- row offset.
-            // This is the "ABCDCDAB" pattern, from the Cirq definition of the circuit in the supplemental materials to
-            // the paper.
-            std::list<bitLenInt> gateSequence = { 0, 3, 2, 1, 2, 1, 0, 3 };
-
-            // We factor the qubit count into two integers, as close to a perfect square as we can.
-            int colLen = std::sqrt(n);
-            while (((n / colLen) * colLen) != n) {
-                colLen--;
-            }
-            int rowLen = n / colLen;
-
-            qReg->SetReactiveSeparate(true);
-
-            for (d = 0; d < benchmarkDepth; d++) {
-                for (i = 0; i < n; i++) {
-                    // "Phase" transforms:
-                    gateRand = DimCount1Qb * qReg->Rand();
-                    if (gateRand < ONE_R1) {
-                        qReg->H(i);
-                    } else if (gateRand < (2 * ONE_R1)) {
-                        gateRand = 2 * qReg->Rand();
-                        if (gateRand < ONE_R1) {
-                            qReg->S(i);
-                        } else {
-                            qReg->IS(i);
-                        }
-                    } else if (gateRand < (3 * ONE_R1)) {
-                        gateRand = 2 * qReg->Rand();
-                        if (gateRand < ONE_R1) {
-                            qReg->H(i);
-                            qReg->S(i);
-                        } else {
-                            qReg->IS(i);
-                            qReg->H(i);
-                        }
-                    }
-                    // else - identity
-
-                    // "Position transforms:
-
-                    // Continuous Z root gates option:
-                    gateRand = 2 * PI_R1 * qReg->Rand();
-                    qReg->ApplySinglePhase(ONE_R1, std::polar(ONE_R1, (real1)gateRand), i);
-
-                    // Discrete Z root gates option:
-                    /*
-                    gateRand = 8 * qReg->Rand();
-                    if (gateRand < ONE_R1) {
-                        // Z^(1/4)
-                        qReg->T(i);
-                    } else if (gateRand < (2 * ONE_R1)) {
-                        // Z^(1/2)
-                        qReg->S(i);
-                    } else if (gateRand < (3 * ONE_R1)) {
-                        // Z^(3/4)
-                        qReg->Z(i);
-                        qReg->IT(i);
-                    } else if (gateRand < (4 * ONE_R1)) {
-                        // Z
-                        qReg->Z(i);
-                    } else if (gateRand < (5 * ONE_R1)) {
-                        // Z^(-3/4)
-                        qReg->Z(i);
-                        qReg->T(i);
-                    } else if (gateRand < (6 * ONE_R1)) {
-                        // Z^(-1/2)
-                        qReg->IS(i);
-                    } else if (gateRand < (7 * ONE_R1)) {
-                        // Z^(-1/4)
-                        qReg->IT(i);
-                    }
-                    // else - identity
-                    */
-                }
-
-                gate = gateSequence.front();
-                gateSequence.pop_front();
-                gateSequence.push_back(gate);
-
-                std::vector<bitLenInt> usedBits;
-
-                for (row = 0; row < rowLen; row++) {
-                    for (col = 0; col < colLen; col++) {
-                        // The following pattern is isomorphic to a 45 degree bias on a rectangle, for couplers.
-                        // In this test, the boundaries of the rectangle have no couplers.
-                        // In a perfect square, in the interior bulk, one 2 bit gate is applied for every pair of bits,
-                        // (as many gates as 1/2 the number of bits). (Unless n is a perfect square, the "row length"
-                        // has to be factored into a rectangular shape, and "n" is sometimes prime or factors
-                        // awkwardly.)
-
-                        b1 = row * colLen + col;
-                        if (std::find(usedBits.begin(), usedBits.end(), b1) != usedBits.end()) {
-                            continue;
-                        }
-
-                        tempGate = (row & 1U) ? gate : (gate ^ 3U);
-
-                        tempRow = row;
-                        tempCol = col;
-
-                        tempRow += ((tempGate & 2U) ? 1 : -1);
-                        tempCol += (colLen == 1) ? 0 : ((tempGate & 1U) ? 1 : 0);
-
-                        b2 = tempRow * colLen + tempCol;
-
-                        if ((tempRow < 0) || (tempCol < 0) || (tempRow >= rowLen) || (tempCol >= colLen) ||
-                            (std::find(usedBits.begin(), usedBits.end(), b2) != usedBits.end())) {
-                            continue;
-                        }
-
-                        usedBits.push_back(b1);
-                        usedBits.push_back(b2);
-
-                        if ((qReg->Rand() * 2) >= ONE_R1) {
-                            std::swap(b1, b2);
-                        }
-
-                        gateRand = GateCountMultiQb * qReg->Rand();
-
+                        // std::cout << "(b1, b2, b3) = (" << (int)b1 << ", " << (int)b2 << ", " << (int)b3 << ")"
+                        //           << std::endl;
+                    } else {
                         if (gateRand < ONE_R1) {
                             gateRand = 4 * qReg->Rand();
                             if (gateRand < (3 * ONE_R1)) {
@@ -1150,259 +1386,15 @@ TEST_CASE("test_stabilizer_t_nn", "[supreme]")
                             }
                         }
                         // else - identity
+
+                        // std::cout << "(b1, b2) = (" << (int)b1 << ", " << (int)b2 << ")" << std::endl;
                     }
                 }
             }
+        }
 
-            qReg->MAll();
-        },
-        false, false, testEngineType == QINTERFACE_QUNIT);
-}
-
-TEST_CASE("test_stabilizer_t_cc_nn", "[supreme]")
-{
-    // Try with environment variable
-    // QRACK_QUNIT_SEPARABILITY_THRESHOLD=0.1464466
-    // for clamping of single bit states to Pauli basis axes.
-
-    std::cout << "(random circuit depth: " << benchmarkDepth << ")";
-
-    const int DimCount1Qb = 4;
-    const int GateCountMultiQb = 4;
-
-    benchmarkLoop(
-        [&](QInterfacePtr qReg, bitLenInt n) {
-            int d;
-            bitLenInt i;
-            real1_f gateRand;
-            bitLenInt b1, b2, b3 = 0;
-            bool is3Qubit;
-            int row, col;
-            int tempRow, tempCol;
-            bitLenInt gate, tempGate;
-
-            // The test runs 2 bit gates according to a tiling sequence.
-            // The 1 bit indicates +/- column offset.
-            // The 2 bit indicates +/- row offset.
-            // This is the "ABCDCDAB" pattern, from the Cirq definition of the circuit in the supplemental materials to
-            // the paper.
-            std::list<bitLenInt> gateSequence = { 0, 3, 2, 1, 2, 1, 0, 3 };
-
-            // We factor the qubit count into two integers, as close to a perfect square as we can.
-            int colLen = std::sqrt(n);
-            while (((n / colLen) * colLen) != n) {
-                colLen--;
-            }
-            int rowLen = n / colLen;
-
-            qReg->SetReactiveSeparate(true);
-
-            for (d = 0; d < benchmarkDepth; d++) {
-                for (i = 0; i < n; i++) {
-                    // "Phase" transforms:
-                    gateRand = DimCount1Qb * qReg->Rand();
-                    if (gateRand < ONE_R1) {
-                        qReg->H(i);
-                    } else if (gateRand < (2 * ONE_R1)) {
-                        gateRand = 2 * qReg->Rand();
-                        if (gateRand < ONE_R1) {
-                            qReg->S(i);
-                        } else {
-                            qReg->IS(i);
-                        }
-                    } else if (gateRand < (3 * ONE_R1)) {
-                        gateRand = 2 * qReg->Rand();
-                        if (gateRand < ONE_R1) {
-                            qReg->H(i);
-                            qReg->S(i);
-                        } else {
-                            qReg->IS(i);
-                            qReg->H(i);
-                        }
-                    }
-                    // else - identity
-
-                    // "Position transforms:
-
-                    // Continuous Z root gates option:
-                    gateRand = 2 * PI_R1 * qReg->Rand();
-                    qReg->ApplySinglePhase(ONE_R1, std::polar(ONE_R1, (real1)gateRand), i);
-
-                    // Discrete Z root gates option:
-                    /*
-                    gateRand = 8 * qReg->Rand();
-                    if (gateRand < ONE_R1) {
-                        // Z^(1/4)
-                        qReg->T(i);
-                    } else if (gateRand < (2 * ONE_R1)) {
-                        // Z^(1/2)
-                        qReg->S(i);
-                    } else if (gateRand < (3 * ONE_R1)) {
-                        // Z^(3/4)
-                        qReg->Z(i);
-                        qReg->IT(i);
-                    } else if (gateRand < (4 * ONE_R1)) {
-                        // Z
-                        qReg->Z(i);
-                    } else if (gateRand < (5 * ONE_R1)) {
-                        // Z^(-3/4)
-                        qReg->Z(i);
-                        qReg->T(i);
-                    } else if (gateRand < (6 * ONE_R1)) {
-                        // Z^(-1/2)
-                        qReg->IS(i);
-                    } else if (gateRand < (7 * ONE_R1)) {
-                        // Z^(-1/4)
-                        qReg->IT(i);
-                    }
-                    // else - identity
-                    */
-                }
-
-                gate = gateSequence.front();
-                gateSequence.pop_front();
-                gateSequence.push_back(gate);
-
-                std::vector<bitLenInt> usedBits;
-
-                for (row = 0; row < rowLen; row++) {
-                    for (col = 0; col < colLen; col++) {
-                        // The following pattern is isomorphic to a 45 degree bias on a rectangle, for couplers.
-                        // In this test, the boundaries of the rectangle have no couplers.
-                        // In a perfect square, in the interior bulk, one 2 bit gate is applied for every pair of bits,
-                        // (as many gates as 1/2 the number of bits). (Unless n is a perfect square, the "row length"
-                        // has to be factored into a rectangular shape, and "n" is sometimes prime or factors
-                        // awkwardly.)
-
-                        b1 = row * colLen + col;
-
-                        if (std::find(usedBits.begin(), usedBits.end(), b1) != usedBits.end()) {
-                            continue;
-                        }
-
-                        tempGate = (row & 1U) ? gate : (gate ^ 3U);
-
-                        tempRow = row;
-                        tempCol = col;
-
-                        tempRow += ((tempGate & 2U) ? 1 : -1);
-                        tempCol += (colLen == 1) ? 0 : ((tempGate & 1U) ? 1 : 0);
-
-                        b2 = tempRow * colLen + tempCol;
-
-                        if ((tempRow < 0) || (tempCol < 0) || (tempRow >= rowLen) || (tempCol >= colLen) ||
-                            (std::find(usedBits.begin(), usedBits.end(), b2) != usedBits.end())) {
-                            continue;
-                        }
-
-                        tempGate = tempGate ^ 3U;
-
-                        tempRow = row;
-                        tempCol = col;
-
-                        tempRow += ((tempGate & 2U) ? 1 : -1);
-                        tempCol += (colLen == 1) ? 0 : ((tempGate & 1U) ? 1 : 0);
-
-                        b3 = tempRow * colLen + tempCol;
-
-                        if ((tempRow < 0) || (tempCol < 0) || (tempRow >= rowLen) || (tempCol >= colLen) ||
-                            (std::find(usedBits.begin(), usedBits.end(), b3) != usedBits.end())) {
-                            is3Qubit = false;
-                        } else {
-                            is3Qubit = (b3 < b1) || ((qReg->Rand() * 2) >= ONE_R1);
-                        }
-
-                        usedBits.push_back(b1);
-                        usedBits.push_back(b2);
-                        if (is3Qubit) {
-                            usedBits.push_back(b3);
-                        }
-
-                        if ((qReg->Rand() * 2) >= ONE_R1) {
-                            std::swap(b1, b2);
-                        }
-                        if (is3Qubit) {
-                            if ((qReg->Rand() * 2) >= ONE_R1) {
-                                std::swap(b1, b3);
-                            }
-                            if ((qReg->Rand() * 2) >= ONE_R1) {
-                                std::swap(b2, b3);
-                            }
-                        }
-
-                        gateRand = GateCountMultiQb * qReg->Rand();
-
-                        if (is3Qubit) {
-                            if (gateRand < ONE_R1) {
-                                gateRand = 2 * qReg->Rand();
-                                if (gateRand < ONE_R1) {
-                                    qReg->CCNOT(b1, b2, b3);
-                                } else {
-                                    qReg->AntiCCNOT(b1, b2, b3);
-                                }
-                            } else if (gateRand < (2 * ONE_R1)) {
-                                gateRand = 2 * qReg->Rand();
-                                if (gateRand < ONE_R1) {
-                                    qReg->CCY(b1, b2, b3);
-                                } else {
-                                    qReg->AntiCCY(b1, b2, b3);
-                                }
-                            } else if (gateRand < (3 * ONE_R1)) {
-                                gateRand = 2 * qReg->Rand();
-                                if (gateRand < ONE_R1) {
-                                    qReg->CCZ(b1, b2, b3);
-                                } else {
-                                    qReg->AntiCCZ(b1, b2, b3);
-                                }
-                            }
-                            // else - identity
-
-                            // std::cout << "(b1, b2, b3) = (" << (int)b1 << ", " << (int)b2 << ", " << (int)b3 << ")"
-                            //           << std::endl;
-                        } else {
-                            if (gateRand < ONE_R1) {
-                                gateRand = 4 * qReg->Rand();
-                                if (gateRand < (3 * ONE_R1)) {
-                                    gateRand = 2 * qReg->Rand();
-                                    if (gateRand < ONE_R1) {
-                                        qReg->CNOT(b1, b2);
-                                    } else {
-                                        qReg->AntiCNOT(b1, b2);
-                                    }
-                                } else {
-                                    qReg->Swap(b1, b2);
-                                }
-                            } else if (gateRand < (2 * ONE_R1)) {
-                                gateRand = 4 * qReg->Rand();
-                                if (gateRand < (3 * ONE_R1)) {
-                                    gateRand = 2 * qReg->Rand();
-                                    if (gateRand < ONE_R1) {
-                                        qReg->CY(b1, b2);
-                                    } else {
-                                        qReg->AntiCY(b1, b2);
-                                    }
-                                } else {
-                                    qReg->Swap(b1, b2);
-                                }
-                            } else if (gateRand < (3 * ONE_R1)) {
-                                gateRand = 2 * qReg->Rand();
-                                if (gateRand < ONE_R1) {
-                                    qReg->CZ(b1, b2);
-                                } else {
-                                    qReg->AntiCZ(b1, b2);
-                                }
-                            }
-                            // else - identity
-
-                            // std::cout << "(b1, b2) = (" << (int)b1 << ", " << (int)b2 << ")" << std::endl;
-                        }
-                    }
-                }
-            }
-
-            qReg->MAll();
-        },
-        false, false, testEngineType == QINTERFACE_QUNIT);
+        qReg->MAll();
+    });
 }
 
 TEST_CASE("test_universal_circuit_continuous", "[supreme]")


### PR DESCRIPTION
…(and turn on random permutation init)

Log normal statistics are not appropriate in the `test_stabilizer_*` tests. I should assess the tests for which statistical distributions are still Gaussian under log normal statistics.