### PR TITLE
TrySeparate(a) continuous basis change optimization

### DIFF
--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -756,8 +756,7 @@ bool QUnit::TrySeparate(bitLenInt qubit)
 
         willSeparate |= (abs(prob) < (SQRT1_2_R1 / 2)) && ((ONE_R1 / 2 - abs(prob)) <= separabilityThreshold);
 
-        if ((i == 0) && shard.unit && !willSeparate && (abs(prob) > separabilityThreshold) &&
-            !shard.unit->isClifford()) {
+        if (shard.unit && !willSeparate && (abs(prob) > separabilityThreshold) && !shard.unit->isClifford()) {
             // Let's assume bit is separable, but not at 0 or 1 probability in the current basis.
             // If the qubit is separable, call the current basis "Pauli Z".
             // If QUnit basis transformation is opportune, then shard Pauli Z basis is an RY(phi, qubit) gate from

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -21,8 +21,6 @@
 // See LICENSE.md in the project root or https://www.gnu.org/licenses/lgpl-3.0.en.html
 // for details.
 
-#include <iostream>
-
 #include <ctime>
 #include <initializer_list>
 #include <map>
@@ -786,37 +784,7 @@ bool QUnit::TrySeparate(bitLenInt qubit)
                 return true;
             }
 
-            if (abs(prob) > separabilityThreshold) {
-                // The test failed. We reverse the rotation after the test.
-                shard.unit->RY(-phi, shard.mapped);
-                shard.MakeDirty();
-
-                freezeTrySeparate = false;
-                return false;
-            }
-
-            // Otherwise, the test succeeded, and we know the basis.
-            shard.unit->S(shard.mapped);
-            shard.MakeDirty();
-            ProbBase(qubit);
-
-            if (!shard.unit) {
-                shard.amp1 = -I_CMPLX * shard.amp1;
-
-                complex tempAmp1 = sine * shard.amp0 + cosine * shard.amp1;
-                shard.amp0 = cosine * shard.amp0 - sine * shard.amp1;
-                shard.amp1 = tempAmp1;
-                if (doNormalize) {
-                    shard.ClampAmps(amplitudeFloor);
-                }
-
-                freezeTrySeparate = false;
-                return true;
-            }
-
-            // We revert if rounding went wrong.
-
-            shard.unit->S(shard.mapped);
+            // The test failed. We reverse the rotation after the test.
             shard.unit->RY(-phi, shard.mapped);
             shard.MakeDirty();
 


### PR DESCRIPTION
This occasionally separates a single qubit that is not in an X/Y/Z basis eigenstate, to start.