### PR TITLE
RX and RY test for separability

### DIFF
--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -704,6 +704,20 @@ public:
     }
 
     /**
+     * "Azimuth, Inclination" (RY-RZ-RY)
+     *
+     * Sets the azimuth and inclination from Z-X-Y basis probability measurements.
+     */
+    virtual void AI(bitLenInt target, real1_f azimuth, real1_f inclination);
+
+    /**
+     * Invert "Azimuth, Inclination" (RY-RZ-RY)
+     *
+     * (Inverse of) sets the azimuth and inclination from Z-X-Y basis probability measurements.
+     */
+    virtual void IAI(bitLenInt target, real1_f azimuth, real1_f inclination);
+
+    /**
      * Controlled general unitary gate
      *
      * Applies a controlled gate guaranteed to be unitary, from three angles, as commonly defined, spanning all possible

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -1205,6 +1205,20 @@ public:
     virtual void CRY(real1_f radians, bitLenInt control, bitLenInt target);
 
     /**
+     * "Yaw, pitch, roll", y-x-z
+     *
+     * This is nonstandard helper gate for state preparation.
+     */
+    virtual void YPR(real1_f theta, real1_f phi, real1_f lambda, bitLenInt qubit);
+
+    /**
+     * Inverse "Yaw, pitch, roll"
+     *
+     * This is nonstandard helper gate for state preparation.
+     */
+    virtual void IYPR(real1_f theta, real1_f phi, real1_f lambda, bitLenInt qubit);
+
+    /**
      * Controlled dyadic fraction y axis rotation gate
      *
      * If "control" is set to 1, rotates as \f$ \exp\left(i*{\pi * numerator} / 2^{denomPower}\right) \f$ around Pauli Y

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -1205,18 +1205,18 @@ public:
     virtual void CRY(real1_f radians, bitLenInt control, bitLenInt target);
 
     /**
-     * "Yaw, pitch, roll", (y-z-x)
+     * "Yaw, pitch", (RY-RZ)
      *
-     * Rotates Z into X according to theta, then X into Y according to phi, then Y into Z according to lambda.
+     * Rotates Z_0 into X_0 according to theta, then X_0 into Y_0 according to phi.
      */
-    virtual void YPR(real1_f theta, real1_f phi, real1_f lambda, bitLenInt qubit);
+    virtual void YP(real1_f theta, real1_f phi, bitLenInt qubit);
 
     /**
-     * Inverse "Yaw, pitch, roll"
+     * Inverse "Yaw, pitch"
      *
-     * Inverts YPR for exact same arguments.
+     * Inverts YP for exact same arguments.
      */
-    virtual void IYPR(real1_f theta, real1_f phi, real1_f lambda, bitLenInt qubit);
+    virtual void IYP(real1_f theta, real1_f phi, bitLenInt qubit);
 
     /**
      * Controlled dyadic fraction y axis rotation gate

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -694,6 +694,16 @@ public:
     virtual void U2(bitLenInt target, real1_f phi, real1_f lambda) { U(target, M_PI / 2, phi, lambda); }
 
     /**
+     * Inverse 2-parameter unitary gate
+     *
+     * Applies the inverse of U2
+     */
+    virtual void IU2(bitLenInt target, real1_f phi, real1_f lambda)
+    {
+        U(target, M_PI / 2, -lambda - PI_R1, -phi + PI_R1);
+    }
+
+    /**
      * Controlled general unitary gate
      *
      * Applies a controlled gate guaranteed to be unitary, from three angles, as commonly defined, spanning all possible
@@ -1203,20 +1213,6 @@ public:
      * Pauli Y axis.
      */
     virtual void CRY(real1_f radians, bitLenInt control, bitLenInt target);
-
-    /**
-     * "Yaw, pitch", (RY-RZ)
-     *
-     * Rotates Z_0 into X_0 according to theta, then X_0 into Y_0 according to phi.
-     */
-    virtual void YP(real1_f azimuth, real1_f inclination, bitLenInt qubit);
-
-    /**
-     * Inverse "Yaw, pitch"
-     *
-     * Inverts YP for exact same arguments.
-     */
-    virtual void IYP(real1_f azimuth, real1_f inclination, bitLenInt qubit);
 
     /**
      * Controlled dyadic fraction y axis rotation gate

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -1205,16 +1205,16 @@ public:
     virtual void CRY(real1_f radians, bitLenInt control, bitLenInt target);
 
     /**
-     * "Yaw, pitch, roll", x-y-z
+     * "Yaw, pitch, roll", (y-z-x)
      *
-     * This is nonstandard helper gate for state preparation.
+     * Rotates Z into X according to theta, then X into Y according to phi, then Y into Z according to lambda.
      */
     virtual void YPR(real1_f theta, real1_f phi, real1_f lambda, bitLenInt qubit);
 
     /**
      * Inverse "Yaw, pitch, roll"
      *
-     * This is nonstandard helper gate for state preparation.
+     * Inverts YPR for exact same arguments.
      */
     virtual void IYPR(real1_f theta, real1_f phi, real1_f lambda, bitLenInt qubit);
 

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -1205,7 +1205,7 @@ public:
     virtual void CRY(real1_f radians, bitLenInt control, bitLenInt target);
 
     /**
-     * "Yaw, pitch, roll", y-x-z
+     * "Yaw, pitch, roll", x-y-z
      *
      * This is nonstandard helper gate for state preparation.
      */

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -1209,14 +1209,14 @@ public:
      *
      * Rotates Z_0 into X_0 according to theta, then X_0 into Y_0 according to phi.
      */
-    virtual void YP(real1_f theta, real1_f phi, bitLenInt qubit);
+    virtual void YP(real1_f azimuth, real1_f inclination, bitLenInt qubit);
 
     /**
      * Inverse "Yaw, pitch"
      *
      * Inverts YP for exact same arguments.
      */
-    virtual void IYP(real1_f theta, real1_f phi, bitLenInt qubit);
+    virtual void IYP(real1_f azimuth, real1_f inclination, bitLenInt qubit);
 
     /**
      * Controlled dyadic fraction y axis rotation gate

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -312,6 +312,8 @@ protected:
     virtual void ZBase(const bitLenInt& target);
     virtual real1_f ProbBase(const bitLenInt& qubit);
 
+    virtual bool TrySeparatePure(bitLenInt qubit);
+
     typedef void (QInterface::*INCxFn)(bitCapInt, bitLenInt, bitLenInt, bitLenInt);
     typedef void (QInterface::*INCxxFn)(bitCapInt, bitLenInt, bitLenInt, bitLenInt, bitLenInt);
     typedef void (QInterface::*CMULFn)(bitCapInt toMod, bitLenInt start, bitLenInt carryStart, bitLenInt length,

--- a/src/qinterface/gates.cpp
+++ b/src/qinterface/gates.cpp
@@ -89,29 +89,6 @@ void QInterface::ApplyAntiControlledSingleInvert(const bitLenInt* controls, cons
     ApplyAntiControlledSingleBit(controls, controlLen, target, mtrx);
 }
 
-/// General unitary gate
-void QInterface::U(bitLenInt target, real1_f theta, real1_f phi, real1_f lambda)
-{
-    real1 cos0 = (real1)cos(theta / 2);
-    real1 sin0 = (real1)sin(theta / 2);
-    const complex uGate[4] = { complex(cos0, ZERO_R1), sin0 * complex((real1)(-cos(lambda)), (real1)(-sin(lambda))),
-        sin0 * complex((real1)cos(phi), (real1)sin(phi)),
-        cos0 * complex((real1)cos(phi + lambda), (real1)sin(phi + lambda)) };
-    ApplySingleBit(uGate, target);
-}
-
-/// Controlled general unitary gate
-void QInterface::CU(
-    bitLenInt* controls, bitLenInt controlLen, bitLenInt target, real1_f theta, real1_f phi, real1_f lambda)
-{
-    real1 cos0 = (real1)cos(theta / 2);
-    real1 sin0 = (real1)sin(theta / 2);
-    const complex uGate[4] = { complex(cos0, ZERO_R1), sin0 * complex((real1)(-cos(lambda)), (real1)(-sin(lambda))),
-        sin0 * complex((real1)cos(phi), (real1)sin(phi)),
-        cos0 * complex((real1)cos(phi + lambda), (real1)sin(phi + lambda)) };
-    ApplyControlledSingleBit(controls, controlLen, target, uGate);
-}
-
 /// Apply 1/(2^N) phase rotation
 void QInterface::PhaseRootN(bitLenInt n, bitLenInt qubit)
 {

--- a/src/qinterface/qinterface.cpp
+++ b/src/qinterface/qinterface.cpp
@@ -404,22 +404,6 @@ void QInterface::CRZDyad(int numerator, int denomPower, bitLenInt control, bitLe
 /// e^(i*(M_PI * numerator) / denominator) around Pauli z axis
 REG_GATE_C1_1D(CRZDyad);
 
-/// Apply general unitary gate to each bit in "length," starting from bit index "start"
-void QInterface::U(bitLenInt start, bitLenInt length, real1_f theta, real1_f phi, real1_f lambda)
-{
-    for (bitLenInt bit = 0; bit < length; bit++) {
-        U(start + bit, theta, phi, lambda);
-    }
-}
-
-/// Apply 2-parameter unitary gate to each bit in "length," starting from bit index "start"
-void QInterface::U2(bitLenInt start, bitLenInt length, real1_f phi, real1_f lambda)
-{
-    for (bitLenInt bit = 0; bit < length; bit++) {
-        U2(start + bit, phi, lambda);
-    }
-}
-
 /// Apply "PhaseRootN" gate (1/(2^N) phase rotation) to each bit in "length", starting from bit index "start"
 void QInterface::PhaseRootN(bitLenInt n, bitLenInt start, bitLenInt length)
 {

--- a/src/qinterface/rotational.cpp
+++ b/src/qinterface/rotational.cpp
@@ -80,6 +80,54 @@ void QInterface::CU(
     ApplyControlledSingleBit(controls, controlLen, target, uGate);
 }
 
+/// "Azimuth, Inclination"
+void QInterface::AI(bitLenInt target, real1_f azimuth, real1_f inclination)
+{
+    real1 cosine = (real1)cos(azimuth / 2);
+    real1 sine = (real1)sin(azimuth / 2);
+    complex pauliRY[4] = { cosine, -sine, sine, cosine };
+
+    cosine = SQRT1_2_R1;
+    sine = SQRT1_2_R1;
+    complex pauliRZ[4] = { complex(cosine, -sine), ZERO_CMPLX, ZERO_CMPLX, complex(cosine, sine) };
+
+    cosine = (real1)cos(inclination / 2);
+    sine = (real1)sin(inclination / 2);
+    complex pauliRY2[4] = { cosine, -sine, sine, cosine };
+
+    complex mtrx[4];
+    complex tMtrx[4];
+
+    mul2x2(pauliRZ, pauliRY, tMtrx);
+    mul2x2(pauliRY2, tMtrx, mtrx);
+
+    ApplySingleBit(mtrx, target);
+}
+
+/// Inverse "Azimuth, Inclination"
+void QInterface::IAI(bitLenInt target, real1_f azimuth, real1_f inclination)
+{
+    real1 cosine = (real1)cos(-inclination / 2);
+    real1 sine = (real1)sin(-inclination / 2);
+    complex pauliRY[4] = { cosine, -sine, sine, cosine };
+
+    cosine = SQRT1_2_R1;
+    sine = -SQRT1_2_R1;
+    complex pauliRZ[4] = { complex(cosine, -sine), ZERO_CMPLX, ZERO_CMPLX, complex(cosine, sine) };
+
+    cosine = (real1)cos(-azimuth / 2);
+    sine = (real1)sin(-azimuth / 2);
+    complex pauliRY2[4] = { cosine, -sine, sine, cosine };
+
+    complex mtrx[4];
+    complex tMtrx[4];
+
+    mul2x2(pauliRZ, pauliRY, tMtrx);
+    mul2x2(pauliRY2, tMtrx, mtrx);
+
+    ApplySingleBit(mtrx, target);
+}
+
 /// Apply 2-parameter unitary gate to each bit in "length," starting from bit index "start"
 void QInterface::U2(bitLenInt start, bitLenInt length, real1_f phi, real1_f lambda)
 {

--- a/src/qinterface/rotational.cpp
+++ b/src/qinterface/rotational.cpp
@@ -49,8 +49,8 @@ void QInterface::RZ(real1_f radians, bitLenInt qubit)
     ApplySinglePhase(complex(cosine, -sine), complex(cosine, sine), qubit);
 }
 
-/// "Yaw, pitch, roll", (y-z-x)
-void QInterface::YPR(real1_f theta, real1_f phi, real1_f lambda, bitLenInt qubit)
+/// "Yaw, pitch", (RY-RZ)
+void QInterface::YP(real1_f theta, real1_f phi, bitLenInt qubit)
 {
     real1 cosine = (real1)cos(theta / 2);
     real1 sine = (real1)sin(theta / 2);
@@ -60,22 +60,14 @@ void QInterface::YPR(real1_f theta, real1_f phi, real1_f lambda, bitLenInt qubit
     sine = (real1)sin(phi / 2);
     complex pauliRZ[4] = { complex(cosine, -sine), ZERO_CMPLX, ZERO_CMPLX, complex(cosine, sine) };
 
-    cosine = (real1)cos(lambda / 2);
-    sine = (real1)sin(lambda / 2);
-    complex pauliRX[4] = { complex(cosine, ZERO_R1), complex(ZERO_R1, -sine), complex(ZERO_R1, -sine),
-        complex(cosine, ZERO_R1) };
-
     complex mtrx[4];
-    complex mtrx2[4];
-
     mul2x2(pauliRZ, pauliRY, mtrx);
-    mul2x2(pauliRX, mtrx, mtrx2);
 
-    ApplySingleBit(mtrx2, qubit);
+    ApplySingleBit(mtrx, qubit);
 }
 
-/// Inverse "Yaw, pitch, roll"
-void QInterface::IYPR(real1_f theta, real1_f phi, real1_f lambda, bitLenInt qubit)
+/// Inverse "Yaw, pitch"
+void QInterface::IYP(real1_f theta, real1_f phi, bitLenInt qubit)
 {
     real1 cosine = (real1)cos(-theta / 2);
     real1 sine = (real1)sin(-theta / 2);
@@ -85,18 +77,10 @@ void QInterface::IYPR(real1_f theta, real1_f phi, real1_f lambda, bitLenInt qubi
     sine = (real1)sin(-phi / 2);
     complex pauliRZ[4] = { complex(cosine, -sine), ZERO_CMPLX, ZERO_CMPLX, complex(cosine, sine) };
 
-    cosine = (real1)cos(-lambda / 2);
-    sine = (real1)sin(-lambda / 2);
-    complex pauliRX[4] = { complex(cosine, ZERO_R1), complex(ZERO_R1, -sine), complex(ZERO_R1, -sine),
-        complex(cosine, ZERO_R1) };
-
     complex mtrx[4];
-    complex mtrx2[4];
+    mul2x2(pauliRY, pauliRZ, mtrx);
 
-    mul2x2(pauliRZ, pauliRX, mtrx);
-    mul2x2(pauliRY, mtrx, mtrx2);
-
-    ApplySingleBit(mtrx2, qubit);
+    ApplySingleBit(mtrx, qubit);
 }
 
 /// Uniformly controlled y axis rotation gate - Rotates as e^(-i*\theta_k/2) around Pauli y axis for each permutation

--- a/src/qinterface/rotational.cpp
+++ b/src/qinterface/rotational.cpp
@@ -50,14 +50,14 @@ void QInterface::RZ(real1_f radians, bitLenInt qubit)
 }
 
 /// "Yaw, pitch", (RY-RZ)
-void QInterface::YP(real1_f theta, real1_f phi, bitLenInt qubit)
+void QInterface::YP(real1_f azimuth, real1_f inclination, bitLenInt qubit)
 {
-    real1 cosine = (real1)cos(theta / 2);
-    real1 sine = (real1)sin(theta / 2);
+    real1 cosine = (real1)cos(azimuth / 2);
+    real1 sine = (real1)sin(azimuth / 2);
     complex pauliRY[4] = { cosine, -sine, sine, cosine };
 
-    cosine = (real1)cos(phi / 2);
-    sine = (real1)sin(phi / 2);
+    cosine = (real1)cos(inclination / 2);
+    sine = (real1)sin(inclination / 2);
     complex pauliRZ[4] = { complex(cosine, -sine), ZERO_CMPLX, ZERO_CMPLX, complex(cosine, sine) };
 
     complex mtrx[4];
@@ -67,14 +67,14 @@ void QInterface::YP(real1_f theta, real1_f phi, bitLenInt qubit)
 }
 
 /// Inverse "Yaw, pitch"
-void QInterface::IYP(real1_f theta, real1_f phi, bitLenInt qubit)
+void QInterface::IYP(real1_f azimuth, real1_f inclination, bitLenInt qubit)
 {
-    real1 cosine = (real1)cos(-theta / 2);
-    real1 sine = (real1)sin(-theta / 2);
+    real1 cosine = (real1)cos(-azimuth / 2);
+    real1 sine = (real1)sin(-azimuth / 2);
     complex pauliRY[4] = { cosine, -sine, sine, cosine };
 
-    cosine = (real1)cos(-phi / 2);
-    sine = (real1)sin(-phi / 2);
+    cosine = (real1)cos(-inclination / 2);
+    sine = (real1)sin(-inclination / 2);
     complex pauliRZ[4] = { complex(cosine, -sine), ZERO_CMPLX, ZERO_CMPLX, complex(cosine, sine) };
 
     complex mtrx[4];

--- a/src/qinterface/rotational.cpp
+++ b/src/qinterface/rotational.cpp
@@ -49,17 +49,17 @@ void QInterface::RZ(real1_f radians, bitLenInt qubit)
     ApplySinglePhase(complex(cosine, -sine), complex(cosine, sine), qubit);
 }
 
-/// "Yaw, pitch, roll", y-x-z
+/// "Yaw, pitch, roll", x-y-z
 void QInterface::YPR(real1_f theta, real1_f phi, real1_f lambda, bitLenInt qubit)
 {
     real1 cosine = (real1)cos(theta / 2);
     real1 sine = (real1)sin(theta / 2);
-    complex pauliRY[4] = { cosine, -sine, sine, cosine };
+    complex pauliRX[4] = { complex(cosine, ZERO_R1), complex(ZERO_R1, -sine), complex(ZERO_R1, -sine),
+        complex(cosine, ZERO_R1) };
 
     cosine = (real1)cos(phi / 2);
     sine = (real1)sin(phi / 2);
-    complex pauliRX[4] = { complex(cosine, ZERO_R1), complex(ZERO_R1, -sine), complex(ZERO_R1, -sine),
-        complex(cosine, ZERO_R1) };
+    complex pauliRY[4] = { cosine, -sine, sine, cosine };
 
     cosine = (real1)cos(lambda / 2);
     sine = (real1)sin(lambda / 2);
@@ -68,8 +68,8 @@ void QInterface::YPR(real1_f theta, real1_f phi, real1_f lambda, bitLenInt qubit
     complex mtrx[4];
     complex mtrx2[4];
 
-    mul2x2(pauliRX, pauliRZ, mtrx);
-    mul2x2(pauliRY, mtrx, mtrx2);
+    mul2x2(pauliRY, pauliRX, mtrx);
+    mul2x2(pauliRZ, mtrx, mtrx2);
 
     ApplySingleBit(mtrx2, qubit);
 }
@@ -79,12 +79,12 @@ void QInterface::IYPR(real1_f theta, real1_f phi, real1_f lambda, bitLenInt qubi
 {
     real1 cosine = (real1)cos(-theta / 2);
     real1 sine = (real1)sin(-theta / 2);
-    complex pauliRY[4] = { cosine, -sine, sine, cosine };
+    complex pauliRX[4] = { complex(cosine, ZERO_R1), complex(ZERO_R1, -sine), complex(ZERO_R1, -sine),
+        complex(cosine, ZERO_R1) };
 
     cosine = (real1)cos(-phi / 2);
     sine = (real1)sin(-phi / 2);
-    complex pauliRX[4] = { complex(cosine, ZERO_R1), complex(ZERO_R1, -sine), complex(ZERO_R1, -sine),
-        complex(cosine, ZERO_R1) };
+    complex pauliRY[4] = { cosine, -sine, sine, cosine };
 
     cosine = (real1)cos(-lambda / 2);
     sine = (real1)sin(-lambda / 2);
@@ -93,8 +93,8 @@ void QInterface::IYPR(real1_f theta, real1_f phi, real1_f lambda, bitLenInt qubi
     complex mtrx[4];
     complex mtrx2[4];
 
-    mul2x2(pauliRX, pauliRY, mtrx);
-    mul2x2(pauliRZ, mtrx, mtrx2);
+    mul2x2(pauliRY, pauliRZ, mtrx);
+    mul2x2(pauliRX, mtrx, mtrx2);
 
     ApplySingleBit(mtrx2, qubit);
 }

--- a/src/qinterface/rotational.cpp
+++ b/src/qinterface/rotational.cpp
@@ -49,27 +49,27 @@ void QInterface::RZ(real1_f radians, bitLenInt qubit)
     ApplySinglePhase(complex(cosine, -sine), complex(cosine, sine), qubit);
 }
 
-/// "Yaw, pitch, roll", x-y-z
+/// "Yaw, pitch, roll", (y-z-x)
 void QInterface::YPR(real1_f theta, real1_f phi, real1_f lambda, bitLenInt qubit)
 {
     real1 cosine = (real1)cos(theta / 2);
     real1 sine = (real1)sin(theta / 2);
-    complex pauliRX[4] = { complex(cosine, ZERO_R1), complex(ZERO_R1, -sine), complex(ZERO_R1, -sine),
-        complex(cosine, ZERO_R1) };
+    complex pauliRY[4] = { cosine, -sine, sine, cosine };
 
     cosine = (real1)cos(phi / 2);
     sine = (real1)sin(phi / 2);
-    complex pauliRY[4] = { cosine, -sine, sine, cosine };
+    complex pauliRZ[4] = { complex(cosine, -sine), ZERO_CMPLX, ZERO_CMPLX, complex(cosine, sine) };
 
     cosine = (real1)cos(lambda / 2);
     sine = (real1)sin(lambda / 2);
-    complex pauliRZ[4] = { complex(cosine, -sine), ZERO_CMPLX, ZERO_CMPLX, complex(cosine, sine) };
+    complex pauliRX[4] = { complex(cosine, ZERO_R1), complex(ZERO_R1, -sine), complex(ZERO_R1, -sine),
+        complex(cosine, ZERO_R1) };
 
     complex mtrx[4];
     complex mtrx2[4];
 
-    mul2x2(pauliRY, pauliRX, mtrx);
-    mul2x2(pauliRZ, mtrx, mtrx2);
+    mul2x2(pauliRZ, pauliRY, mtrx);
+    mul2x2(pauliRX, mtrx, mtrx2);
 
     ApplySingleBit(mtrx2, qubit);
 }
@@ -79,22 +79,22 @@ void QInterface::IYPR(real1_f theta, real1_f phi, real1_f lambda, bitLenInt qubi
 {
     real1 cosine = (real1)cos(-theta / 2);
     real1 sine = (real1)sin(-theta / 2);
-    complex pauliRX[4] = { complex(cosine, ZERO_R1), complex(ZERO_R1, -sine), complex(ZERO_R1, -sine),
-        complex(cosine, ZERO_R1) };
+    complex pauliRY[4] = { cosine, -sine, sine, cosine };
 
     cosine = (real1)cos(-phi / 2);
     sine = (real1)sin(-phi / 2);
-    complex pauliRY[4] = { cosine, -sine, sine, cosine };
+    complex pauliRZ[4] = { complex(cosine, -sine), ZERO_CMPLX, ZERO_CMPLX, complex(cosine, sine) };
 
     cosine = (real1)cos(-lambda / 2);
     sine = (real1)sin(-lambda / 2);
-    complex pauliRZ[4] = { complex(cosine, -sine), ZERO_CMPLX, ZERO_CMPLX, complex(cosine, sine) };
+    complex pauliRX[4] = { complex(cosine, ZERO_R1), complex(ZERO_R1, -sine), complex(ZERO_R1, -sine),
+        complex(cosine, ZERO_R1) };
 
     complex mtrx[4];
     complex mtrx2[4];
 
-    mul2x2(pauliRY, pauliRZ, mtrx);
-    mul2x2(pauliRX, mtrx, mtrx2);
+    mul2x2(pauliRZ, pauliRX, mtrx);
+    mul2x2(pauliRY, mtrx, mtrx2);
 
     ApplySingleBit(mtrx2, qubit);
 }

--- a/src/qinterface/rotational.cpp
+++ b/src/qinterface/rotational.cpp
@@ -37,8 +37,7 @@ void QInterface::RY(real1_f radians, bitLenInt qubit)
 {
     real1 cosine = (real1)cos(radians / 2);
     real1 sine = (real1)sin(radians / 2);
-    complex pauliRY[4] = { complex(cosine, ZERO_R1), complex(-sine, ZERO_R1), complex(sine, ZERO_R1),
-        complex(cosine, ZERO_R1) };
+    complex pauliRY[4] = { cosine, -sine, sine, cosine };
     ApplySingleBit(pauliRY, qubit);
 }
 
@@ -48,6 +47,56 @@ void QInterface::RZ(real1_f radians, bitLenInt qubit)
     real1 cosine = (real1)cos(radians / 2);
     real1 sine = (real1)sin(radians / 2);
     ApplySinglePhase(complex(cosine, -sine), complex(cosine, sine), qubit);
+}
+
+/// "Yaw, pitch, roll", y-x-z
+void QInterface::YPR(real1_f theta, real1_f phi, real1_f lambda, bitLenInt qubit)
+{
+    real1 cosine = (real1)cos(theta / 2);
+    real1 sine = (real1)sin(theta / 2);
+    complex pauliRY[4] = { cosine, -sine, sine, cosine };
+
+    cosine = (real1)cos(phi / 2);
+    sine = (real1)sin(phi / 2);
+    complex pauliRX[4] = { complex(cosine, ZERO_R1), complex(ZERO_R1, -sine), complex(ZERO_R1, -sine),
+        complex(cosine, ZERO_R1) };
+
+    cosine = (real1)cos(lambda / 2);
+    sine = (real1)sin(lambda / 2);
+    complex pauliRZ[4] = { complex(cosine, -sine), ZERO_CMPLX, ZERO_CMPLX, complex(cosine, sine) };
+
+    complex mtrx[4];
+    complex mtrx2[4];
+
+    mul2x2(pauliRX, pauliRZ, mtrx);
+    mul2x2(pauliRY, mtrx, mtrx2);
+
+    ApplySingleBit(mtrx2, qubit);
+}
+
+/// Inverse "Yaw, pitch, roll"
+void QInterface::IYPR(real1_f theta, real1_f phi, real1_f lambda, bitLenInt qubit)
+{
+    real1 cosine = (real1)cos(-theta / 2);
+    real1 sine = (real1)sin(-theta / 2);
+    complex pauliRY[4] = { cosine, -sine, sine, cosine };
+
+    cosine = (real1)cos(-phi / 2);
+    sine = (real1)sin(-phi / 2);
+    complex pauliRX[4] = { complex(cosine, ZERO_R1), complex(ZERO_R1, -sine), complex(ZERO_R1, -sine),
+        complex(cosine, ZERO_R1) };
+
+    cosine = (real1)cos(-lambda / 2);
+    sine = (real1)sin(-lambda / 2);
+    complex pauliRZ[4] = { complex(cosine, -sine), ZERO_CMPLX, ZERO_CMPLX, complex(cosine, sine) };
+
+    complex mtrx[4];
+    complex mtrx2[4];
+
+    mul2x2(pauliRX, pauliRY, mtrx);
+    mul2x2(pauliRZ, mtrx, mtrx2);
+
+    ApplySingleBit(mtrx2, qubit);
 }
 
 /// Uniformly controlled y axis rotation gate - Rotates as e^(-i*\theta_k/2) around Pauli y axis for each permutation

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -757,6 +757,7 @@ bool QUnit::TrySeparatePure(bitLenInt qubit)
     }
 
     shard.unit->ApplySingleBit(mtrx, shard.mapped);
+    shard.MakeDirty();
 
     // If length of vector is 0.5, this is a pure state.
     if (abs((ONE_R1 / 2) - sqrt((probX * probX) + (probY * probY) + (probZ * probZ))) > separabilityThreshold) {
@@ -765,18 +766,14 @@ bool QUnit::TrySeparatePure(bitLenInt qubit)
         return false;
     }
 
-    if (abs(probZ) > (ONE_R1 / 2)) {
-        probZ = (probZ < ZERO_R1) ? -(ONE_R1 / 2) : (ONE_R1 / 2);
-    }
-    if (abs(probX) > (ONE_R1 / 2)) {
-        probX = (probX < ZERO_R1) ? -(ONE_R1 / 2) : (ONE_R1 / 2);
-    }
-    if (abs(probY) > (ONE_R1 / 2)) {
-        probY = (probZ < ZERO_R1) ? -(ONE_R1 / 2) : (ONE_R1 / 2);
-    }
-
     real1_f azimuth = acos(2 * probZ);
+    if (std::isnan(azimuth) || std::isinf(azimuth)) {
+        azimuth = ZERO_R1;
+    }
     real1_f inclination = atan2(2 * probY, 2 * probX);
+    if (std::isnan(inclination) || std::isinf(inclination)) {
+        inclination = ZERO_R1;
+    }
 
     // YP with these yaw and pitch should prepare the state from |0>.
     // Therefore, inverse YP with the same parameters should deconstruct this state to |0>.

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -749,7 +749,7 @@ bool QUnit::TrySeparate(bitLenInt qubit)
     real1_f probY = ZERO_R1;
     real1_f probZ = ZERO_R1;
 
-    if (!shard.isClifford()) {
+    if (!shard.isClifford() && (separabilityThreshold < ((ONE_R1 - SQRT1_2_R1) / 2))) {
         // Let's assume bit is separable, but not at 0 or 1 probability in the current basis.
 
         probZ = 2 * (shard.unit->Prob(shard.mapped) - (ONE_R1 / 2));
@@ -859,8 +859,6 @@ bool QUnit::TrySeparate(bitLenInt qubit)
     for (bitLenInt i = 0; i < 3; i++) {
         prob = ProbBase(qubit) - ONE_R1 / 2;
 
-        willSeparate |= (abs(prob) < (SQRT1_2_R1 / 2)) && ((ONE_R1 / 2 - abs(prob)) <= separabilityThreshold);
-
         if (!shard.isPauliX && !shard.isPauliY) {
             probZ = prob;
         } else if (shard.isPauliX) {
@@ -870,6 +868,7 @@ bool QUnit::TrySeparate(bitLenInt qubit)
         }
 
         didSeparate = !shard.unit;
+        willSeparate |= (abs(prob) < (SQRT1_2_R1 / 2)) && ((ONE_R1 / 2 - abs(prob)) <= separabilityThreshold);
 
         if (i >= 2) {
             continue;

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -807,7 +807,18 @@ bool QUnit::TrySeparate(bitLenInt qubit)
         }
 
         real1_f yaw = acos(probZ);
+
+        if (isnan(yaw) || isinf(yaw)) {
+            freezeTrySeparate = false;
+            return false;
+        }
+
         real1_f pitch = atan2(probY, probX);
+
+        if (isnan(pitch) || isinf(pitch)) {
+            freezeTrySeparate = false;
+            return false;
+        }
 
         shard.unit->IYPR(yaw, pitch, 0, shard.mapped);
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -785,8 +785,9 @@ bool QUnit::TrySeparate(bitLenInt qubit)
         // shard.unit->RZ(-PI_R1 / 2, shard.mapped);
         // shard.unit->RY(-PI_R1 / 2, shard.mapped);
 
-        complex mtrx[4] = { complex(ONE_R1 / 2, ONE_R1 / 2), complex(ONE_R1 / 2, ONE_R1 / 2),
-            complex(-ONE_R1 / 2, ONE_R1 / 2), complex(ONE_R1 / 2, -ONE_R1 / 2) };
+        complex mtrx[4] = { complex((real1)(ONE_R1 / 2), (real1)(ONE_R1 / 2)),
+            complex((real1)(ONE_R1 / 2), (real1)(ONE_R1 / 2)), complex((real1)(-ONE_R1 / 2), (real1)(ONE_R1 / 2)),
+            complex((real1)(ONE_R1 / 2), (real1)(-ONE_R1 / 2)) };
 
         if ((ONE_R1 - abs(probY)) <= separabilityThreshold) {
             SeparateBit(probY > ZERO_R1, qubit);
@@ -807,14 +808,12 @@ bool QUnit::TrySeparate(bitLenInt qubit)
         }
 
         real1_f yaw = acos(probZ);
-
         if (isnan(yaw) || isinf(yaw)) {
             freezeTrySeparate = false;
             return false;
         }
 
         real1_f pitch = atan2(probY, probX);
-
         if (isnan(pitch) || isinf(pitch)) {
             freezeTrySeparate = false;
             return false;

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -808,12 +808,12 @@ bool QUnit::TrySeparate(bitLenInt qubit)
         }
 
         real1_f yaw = acos(probZ);
-        if (isnan(yaw) || isinf(yaw)) {
+        if (std::isnan(yaw) || std::isinf(yaw)) {
             yaw = ZERO_R1;
         }
 
         real1_f pitch = atan2(probY, probX);
-        if (isnan(pitch) || isinf(pitch)) {
+        if (std::isnan(pitch) || std::isinf(pitch)) {
             pitch = ZERO_R1;
         }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -809,14 +809,12 @@ bool QUnit::TrySeparate(bitLenInt qubit)
 
         real1_f yaw = acos(probZ);
         if (isnan(yaw) || isinf(yaw)) {
-            freezeTrySeparate = false;
-            return false;
+            yaw = ZERO_R1;
         }
 
         real1_f pitch = atan2(probY, probX);
         if (isnan(pitch) || isinf(pitch)) {
-            freezeTrySeparate = false;
-            return false;
+            pitch = ZERO_R1;
         }
 
         shard.unit->IYPR(yaw, pitch, 0, shard.mapped);

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -768,8 +768,8 @@ bool QUnit::TrySeparate(bitLenInt qubit)
             return false;
         }
 
-        real1_f yaw = asin(2 * probY);
-        real1_f pitch = asin(2 * probX);
+        real1_f yaw = asin(2 * probZ);
+        real1_f pitch = !probX ? (PI_R1 / 2) : acos(probY / probX);
 
         shard.unit->IYPR(yaw, pitch, 0, shard.mapped);
         shard.MakeDirty();
@@ -785,14 +785,13 @@ bool QUnit::TrySeparate(bitLenInt qubit)
 
         real1 cosine = (real1)cos(yaw / 2);
         real1 sine = (real1)sin(yaw / 2);
-        complex pauliRX[4] = { complex(cosine, ZERO_R1), complex(ZERO_R1, -sine), complex(ZERO_R1, -sine),
-            complex(cosine, ZERO_R1) };
+        complex pauliRY[4] = { cosine, -sine, sine, cosine };
 
         cosine = (real1)cos(pitch / 2);
         sine = (real1)sin(pitch / 2);
-        complex pauliRY[4] = { cosine, -sine, sine, cosine };
+        complex pauliRZ[4] = { complex(cosine, -sine), ZERO_CMPLX, ZERO_CMPLX, complex(cosine, sine) };
 
-        mul2x2(pauliRY, pauliRX, mtrx);
+        mul2x2(pauliRZ, pauliRY, mtrx);
 
         complex tempAmp1 = mtrx[2] * shard.amp0 + mtrx[3] * shard.amp1;
         shard.amp0 = mtrx[0] * shard.amp0 + mtrx[1] * shard.amp1;

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -853,7 +853,7 @@ bool QUnit::TrySeparate(bitLenInt qubit)
         return false;
     }
 
-    if (!shard.unit->isClifford() && (separabilityThreshold < ((ONE_R1 - SQRT1_2_R1) / 2))) {
+    if (!shard.isClifford() && (separabilityThreshold < ((ONE_R1 - SQRT1_2_R1) / 2))) {
         return TrySeparatePure(qubit);
     }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -771,7 +771,7 @@ bool QUnit::TrySeparatePure(bitLenInt qubit)
         probZ = (probZ < ZERO_R1) ? -(ONE_R1 / 2) : (ONE_R1 / 2);
         yaw = ZERO_R1;
     } else {
-        yaw = acos(-2 * probZ);
+        yaw = acos(probZ);
     }
 
     if (abs(probX) > (ONE_R1 / 2)) {
@@ -784,7 +784,7 @@ bool QUnit::TrySeparatePure(bitLenInt qubit)
     if (!probX && !probY) {
         pitch = ZERO_R1;
     } else {
-        pitch = atan2(-2 * probY, -2 * probX);
+        pitch = atan2(probY, probX);
     }
 
     // YP with these yaw and pitch should prepare the state from |0>.

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -707,7 +707,7 @@ bool QUnit::TrySeparatePure(bitLenInt qubit)
     // Let's assume bit is separable, but not necessarily at 0 or 1 probability in the current basis.
     freezeTrySeparate = true;
 
-    real1_f probZ = ProbBase(qubit) - (ONE_R1 / 2);
+    real1_f probZ = (ONE_R1 / 2) - ProbBase(qubit);
 
     if (!shard.unit) {
         // Z eigenstate
@@ -715,10 +715,10 @@ bool QUnit::TrySeparatePure(bitLenInt qubit)
         return true;
     }
 
-    // Takes |0> to |+>
+    // Takes Z_0 to X_0
     shard.unit->RY(PI_R1 / 2, shard.mapped);
     shard.MakeDirty();
-    real1_f probX = ProbBase(qubit) - (ONE_R1 / 2);
+    real1_f probX = (ONE_R1 / 2) - ProbBase(qubit);
 
     if (!shard.unit) {
         // X eigenstate
@@ -733,10 +733,10 @@ bool QUnit::TrySeparatePure(bitLenInt qubit)
         return true;
     }
 
-    // Takes |+> to Y+
+    // Takes X_0 to Y_0
     shard.unit->RZ(PI_R1 / 2, shard.mapped);
     shard.MakeDirty();
-    real1_f probY = ProbBase(qubit) - (ONE_R1 / 2);
+    real1_f probY = (ONE_R1 / 2) - ProbBase(qubit);
 
     // Equivalent to this:
     // shard.unit->RZ(-PI_R1 / 2, shard.mapped);
@@ -765,15 +765,9 @@ bool QUnit::TrySeparatePure(bitLenInt qubit)
         return false;
     }
 
-    real1_f yaw, pitch;
-
     if (abs(probZ) > (ONE_R1 / 2)) {
         probZ = (probZ < ZERO_R1) ? -(ONE_R1 / 2) : (ONE_R1 / 2);
-        yaw = ZERO_R1;
-    } else {
-        yaw = acos(probZ);
     }
-
     if (abs(probX) > (ONE_R1 / 2)) {
         probX = (probX < ZERO_R1) ? -(ONE_R1 / 2) : (ONE_R1 / 2);
     }
@@ -781,11 +775,8 @@ bool QUnit::TrySeparatePure(bitLenInt qubit)
         probY = (probZ < ZERO_R1) ? -(ONE_R1 / 2) : (ONE_R1 / 2);
     }
 
-    if (!probX && !probY) {
-        pitch = ZERO_R1;
-    } else {
-        pitch = atan2(probY, probX);
-    }
+    real1_f yaw = acos(2 * probZ);
+    real1_f pitch = atan2(2 * probY, 2 * probX);
 
     // YP with these yaw and pitch should prepare the state from |0>.
     // Therefore, inverse YP with the same parameters should deconstruct this state to |0>.

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -707,21 +707,24 @@ bool QUnit::TrySeparatePure(bitLenInt qubit)
     // Let's assume bit is separable, but not necessarily at 0 or 1 probability in the current basis.
     freezeTrySeparate = true;
 
-    real1_f probZ = (ONE_R1 / 2) - ProbBase(qubit);
+    real1_f probZ = (ONE_R1 / 2) - shard.unit->Prob(shard.mapped);
 
-    if (!shard.unit) {
+    if (((ONE_R1 / 2) - abs(probZ)) <= separabilityThreshold) {
         // Z eigenstate
+        SeparateBit(probZ < ZERO_R1, qubit);
+
         freezeTrySeparate = false;
         return true;
     }
 
     // Takes Z_0 to X_0
     shard.unit->H(shard.mapped);
-    shard.MakeDirty();
-    real1_f probX = (ONE_R1 / 2) - ProbBase(qubit);
+    real1_f probX = (ONE_R1 / 2) - shard.unit->Prob(shard.mapped);
 
-    if (!shard.unit) {
+    if (((ONE_R1 / 2) - abs(probX)) <= separabilityThreshold) {
         // X eigenstate
+        SeparateBit(probX < ZERO_R1, qubit);
+
         freezeBasisH = true;
         H(qubit);
         freezeBasisH = false;
@@ -732,7 +735,6 @@ bool QUnit::TrySeparatePure(bitLenInt qubit)
 
     // Takes X_0 to Y_0
     shard.unit->S(shard.mapped);
-    shard.MakeDirty();
     real1_f probY = (ONE_R1 / 2) - ProbBase(qubit);
 
     // Equivalent to this:
@@ -741,8 +743,10 @@ bool QUnit::TrySeparatePure(bitLenInt qubit)
 
     complex mtrx[4] = { SQRT1_2_R1, -SQRT1_2_R1 * I_CMPLX, SQRT1_2_R1, SQRT1_2_R1 * I_CMPLX };
 
-    if (!shard.unit) {
+    if (((ONE_R1 / 2) - abs(probY)) <= separabilityThreshold) {
         // Y eigenstate
+        SeparateBit(probY < ZERO_R1, qubit);
+
         complex tempAmp1 = mtrx[2] * shard.amp0 + mtrx[3] * shard.amp1;
         shard.amp0 = mtrx[0] * shard.amp0 + mtrx[1] * shard.amp1;
         shard.amp1 = tempAmp1;
@@ -752,7 +756,6 @@ bool QUnit::TrySeparatePure(bitLenInt qubit)
     }
 
     shard.unit->ApplySingleBit(mtrx, shard.mapped);
-    shard.MakeDirty();
 
     // If length of vector is 0.5, this is a pure state.
     if (abs((ONE_R1 / 2) - sqrt((probX * probX) + (probY * probY) + (probZ * probZ))) > separabilityThreshold) {

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -738,7 +738,7 @@ bool QUnit::TrySeparate(bitLenInt qubit)
         return true;
     }
 
-    if (freezeTrySeparate) {
+    if (freezeTrySeparate || BLOCKED_SEPARATE(shard)) {
         return false;
     }
 
@@ -817,6 +817,11 @@ bool QUnit::TrySeparate(bitLenInt qubit)
             pitch = ZERO_R1;
         }
 
+        if ((abs(yaw) <= REAL1_EPSILON) && (abs(pitch) <= REAL1_EPSILON)) {
+            freezeTrySeparate = false;
+            return false;
+        }
+
         shard.unit->IYPR(yaw, pitch, 0, shard.mapped);
 
         prob = 2 * (shard.unit->Prob(shard.mapped) - (ONE_R1 / 2));
@@ -846,11 +851,6 @@ bool QUnit::TrySeparate(bitLenInt qubit)
 
         freezeTrySeparate = false;
         return true;
-    }
-
-    if (BLOCKED_SEPARATE(shard)) {
-        freezeTrySeparate = false;
-        return false;
     }
 
     bool didSeparate;


### PR DESCRIPTION
Single separable bits do tend to stay in RX and RY directions, it turns out. To an extent, this is an artifact of benchmark gate sets, but those gate sets should at least have very uniform coverage on the single qubit subspaces within them.