### PR TITLE
Correct and restore AI/IAI

### DIFF
--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -704,6 +704,20 @@ public:
     }
 
     /**
+     * "Azimuth, Inclination" (RY-RZ)
+     *
+     * Sets the azimuth and inclination from Z-X-Y basis probability measurements.
+     */
+    virtual void AI(bitLenInt target, real1_f azimuth, real1_f inclination);
+
+    /**
+     * Invert "Azimuth, Inclination" (RY-RZ)
+     *
+     * (Inverse of) sets the azimuth and inclination from Z-X-Y basis probability measurements.
+     */
+    virtual void IAI(bitLenInt target, real1_f azimuth, real1_f inclination);
+
+    /**
      * Controlled general unitary gate
      *
      * Applies a controlled gate guaranteed to be unitary, from three angles, as commonly defined, spanning all possible

--- a/src/qinterface/rotational.cpp
+++ b/src/qinterface/rotational.cpp
@@ -88,6 +88,40 @@ void QInterface::U2(bitLenInt start, bitLenInt length, real1_f phi, real1_f lamb
     }
 }
 
+/// "Azimuth, Inclination"
+void QInterface::AI(bitLenInt target, real1_f azimuth, real1_f inclination)
+{
+    real1 cosine = (real1)cos(azimuth / 2);
+    real1 sine = (real1)sin(azimuth / 2);
+    complex pauliRY[4] = { cosine, -sine, sine, cosine };
+
+    cosine = (real1)cos(inclination / 2);
+    sine = (real1)sin(inclination / 2);
+    complex pauliRZ[4] = { complex(cosine, -sine), ZERO_CMPLX, ZERO_CMPLX, complex(cosine, sine) };
+
+    complex mtrx[4];
+    mul2x2(pauliRZ, pauliRY, mtrx);
+
+    ApplySingleBit(mtrx, target);
+}
+
+/// Inverse "Azimuth, Inclination"
+void QInterface::IAI(bitLenInt target, real1_f azimuth, real1_f inclination)
+{
+    real1 cosine = (real1)cos(-inclination / 2);
+    real1 sine = (real1)sin(-inclination / 2);
+    complex pauliRZ[4] = { complex(cosine, -sine), ZERO_CMPLX, ZERO_CMPLX, complex(cosine, sine) };
+
+    cosine = (real1)cos(azimuth / 2);
+    sine = (real1)sin(azimuth / 2);
+    complex pauliRY[4] = { cosine, -sine, sine, cosine };
+
+    complex mtrx[4];
+    mul2x2(pauliRY, pauliRZ, mtrx);
+
+    ApplySingleBit(mtrx, target);
+}
+
 /// Uniformly controlled y axis rotation gate - Rotates as e^(-i*\theta_k/2) around Pauli y axis for each permutation
 /// "k" of the control bits.
 void QInterface::UniformlyControlledRY(


### PR DESCRIPTION
These azimuth/inclination gates are useful to me, and I'd like to continue to experiment with them. Given probability from Z/X/Y basis measurements, azimuth should equal `acos(2 * probZ)`and inclination should equal `atan(2 * probY, 2 * probX)`. Per more common conventions for spherical to Cartesian coordinate conversion, as per the [Wikipedia articles](https://en.wikipedia.org/wiki/Spherical_coordinate_system), this should be an intuitive way to think of (de-)constructing states from Pauli Z/X/Y basis probability expectation.