### PR TITLE
Re-enable QEngineOCL ZeroAmplitudes() in UpdateRunningNorm()

### DIFF
--- a/include/qengine_cpu.hpp
+++ b/include/qengine_cpu.hpp
@@ -178,6 +178,11 @@ public:
             return;
         }
 
+        if (!stateVec) {
+            ResetStateVec(AllocStateVec(maxQPower));
+            stateVec->clear();
+        }
+
         complex* sv;
         if (isSparse) {
             sv = new complex[(bitCapIntOcl)maxQPower];

--- a/include/qengine_opencl.hpp
+++ b/include/qengine_opencl.hpp
@@ -241,6 +241,10 @@ public:
             return;
         }
 
+        if (!stateBuffer) {
+            ReinitBuffer();
+        }
+
         LockSync(CL_MAP_WRITE);
         src->GetQuantumState(stateVec);
         UnlockSync();

--- a/src/common/dispatchqueue.cpp
+++ b/src/common/dispatchqueue.cpp
@@ -66,9 +66,8 @@ void DispatchQueue::dump()
 
     std::queue<fp_t> empty;
     std::swap(q_, empty);
-    isFinished_ = true;
     lock.unlock();
-    cvFinished_.notify_all();
+    finish();
 }
 
 void DispatchQueue::dispatch(const fp_t& op)

--- a/src/common/dispatchqueue.cpp
+++ b/src/common/dispatchqueue.cpp
@@ -66,8 +66,9 @@ void DispatchQueue::dump()
 
     std::queue<fp_t> empty;
     std::swap(q_, empty);
+    isFinished_ = true;
     lock.unlock();
-    finish();
+    cvFinished_.notify_all();
 }
 
 void DispatchQueue::dispatch(const fp_t& op)

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -2666,10 +2666,9 @@ void QEngineOCL::UpdateRunningNorm(real1_f norm_thresh)
 
     WAIT_REAL1_SUM(*nrmBuffer, ngc / ngs, nrmArray, &runningNorm);
 
-    // TODO: Why doesn't this work, with QPager?
-    // if (runningNorm <= amplitudeFloor) {
-    //     ZeroAmplitudes();
-    // }
+    if (runningNorm <= amplitudeFloor) {
+        ZeroAmplitudes();
+    }
 }
 
 complex* QEngineOCL::AllocStateVec(bitCapInt elemCount, bool doForceAlloc)

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -2666,9 +2666,10 @@ void QEngineOCL::UpdateRunningNorm(real1_f norm_thresh)
 
     WAIT_REAL1_SUM(*nrmBuffer, ngc / ngs, nrmArray, &runningNorm);
 
-    if (runningNorm <= amplitudeFloor) {
-        ZeroAmplitudes();
-    }
+    // TODO: Why doesn't this work, with QPager?
+    // if (runningNorm <= amplitudeFloor) {
+    //     ZeroAmplitudes();
+    // }
 }
 
 complex* QEngineOCL::AllocStateVec(bitCapInt elemCount, bool doForceAlloc)

--- a/src/qengine/state.cpp
+++ b/src/qengine/state.cpp
@@ -1475,9 +1475,9 @@ void QEngineCPU::UpdateRunningNorm(real1_f norm_thresh)
     runningNorm = par_norm(maxQPower, stateVec, norm_thresh);
 
     // TODO: Why doesn't this work, with QPager?
-    // if (runningNorm <= amplitudeFloor) {
-    //     ZeroAmplitudes();
-    // }
+    if (runningNorm <= amplitudeFloor) {
+        ZeroAmplitudes();
+    }
 }
 
 StateVectorPtr QEngineCPU::AllocStateVec(bitCapInt elemCount)

--- a/src/qengine/state.cpp
+++ b/src/qengine/state.cpp
@@ -1474,7 +1474,6 @@ void QEngineCPU::UpdateRunningNorm(real1_f norm_thresh)
     }
     runningNorm = par_norm(maxQPower, stateVec, norm_thresh);
 
-    // TODO: Why doesn't this work, with QPager?
     if (runningNorm <= amplitudeFloor) {
         ZeroAmplitudes();
     }


### PR DESCRIPTION
I'm trying to restore the `ZeroAmplitudes()` optimization in `UpdateRunningNorm()`. It looks like it might be safe to put the call back in `QEngineOCL`, but not `QEngineCPU`, yet.