### PR TITLE
Call ZeroAmplitudes() as opportune for Compose()

### DIFF
--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -1115,6 +1115,7 @@ void QEngineOCL::Compose(OCLAPI apiCall, bitCapIntOcl* bciArgs, QEngineOCLPtr to
 {
     if (!stateBuffer || !toCopy->stateBuffer) {
         // Compose will have a wider but 0 stateVec
+        ZeroAmplitudes();
         SetQubitCount(qubitCount + toCopy->qubitCount);
         return;
     }

--- a/src/qengine/state.cpp
+++ b/src/qengine/state.cpp
@@ -673,6 +673,7 @@ bitLenInt QEngineCPU::Compose(QEngineCPUPtr toCopy)
 
     if (!stateVec || !toCopy->stateVec) {
         // Compose will have a wider but 0 stateVec
+        ZeroAmplitudes();
         SetQubitCount(nQubitCount);
         return result;
     }
@@ -722,6 +723,7 @@ bitLenInt QEngineCPU::Compose(QEngineCPUPtr toCopy, bitLenInt start)
 
     if (!stateVec || !toCopy->stateVec) {
         // Compose will have a wider but 0 stateVec
+        ZeroAmplitudes();
         SetQubitCount(nQubitCount);
         return start;
     }


### PR DESCRIPTION
When `QEngine` types are used as `QPager` "pages," they might compose with another page that has 0 overall probability within it. If so, we know the `Compose()` operation will lead to a product state with 0 total internal probability represented, and we can deallocate the RAM for this page.