### PR TITLE
"Litmus test" for brute force TryDecompose()

### DIFF
--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -42,6 +42,7 @@ protected:
     bool canSuppressPaging;
     bitLenInt thresholdQubits;
     bitLenInt pagingThresholdQubits;
+    bitLenInt maxShardQubits;
     real1_f separabilityThreshold;
     std::vector<int> deviceIDs;
 

--- a/src/qinterface/qinterface.cpp
+++ b/src/qinterface/qinterface.cpp
@@ -806,11 +806,24 @@ bool QInterface::TryDecompose(bitLenInt start, QInterfacePtr dest, real1_f error
     unitCopy->Decompose(start, dest);
     unitCopy->Compose(dest, start);
 
-    bool didSeparate = ApproxCompare(unitCopy, error_tol);
+    real1_f diff = SumSqrDiff(unitCopy);
+    bool didSeparate = diff <= error_tol;
 
     if (didSeparate) {
         // The subsystem is separable.
         Dispose(start, dest->GetQubitCount());
+
+        if (diff > REAL1_EPSILON) {
+            UpdateRunningNorm();
+            if (!doNormalize) {
+                NormalizeState();
+            }
+
+            dest->UpdateRunningNorm();
+            if (!dest->doNormalize) {
+                dest->NormalizeState();
+            }
+        }
     }
 
     return didSeparate;

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -846,13 +846,14 @@ bool QUnit::TrySeparate(bitLenInt qubit)
         return false;
     }
 
-    if (shard.unit->isClifford(shard.mapped) || (shard.unit->GetQubitCount() >= maxShardQubits)) {
+    if (shard.unit->isClifford(shard.mapped) || (maxShardQubits < 2U) ||
+        (shard.unit->GetQubitCount() > (maxShardQubits - 2U))) {
         return TrySeparateClifford(qubit);
     }
 
     bitLenInt mapped = shard.mapped;
     QInterfacePtr oUnit = shard.unit;
-    QInterfacePtr nUnit = MakeEngine(1, 0);
+    QInterfacePtr nUnit = MakeEngine(1U, 0U);
     if (oUnit->TryDecompose(mapped, nUnit, separabilityThreshold)) {
         for (bitLenInt i = 0; i < qubitCount; i++) {
             if ((shards[i].unit == oUnit) && (shards[i].mapped > mapped)) {


### PR DESCRIPTION
In `QUnit` internals, `TryDecompose()` should catch all cases of separable single qubits that Clifford basis checks miss. However, this check is extremely expensive, compared to Clifford basis checks only. However, simulated experimental probing suggests that, on the unit circle, under arbitrary rotation of a separable pure state, the root-mean-square of probability vector length along 3 orthogonal axes (as calculated herein) is never less than 1/2.