### PR TITLE
Optimize SumSqrDiff()

### DIFF
--- a/include/qstabilizerhybrid.hpp
+++ b/include/qstabilizerhybrid.hpp
@@ -1037,7 +1037,7 @@ public:
         // If the qubit counts are unequal, these can't be approximately equal objects.
         if (qubitCount != toCompare->qubitCount) {
             // Max square difference:
-            return 4.0f;
+            return ONE_R1;
         }
 
         SwitchToEngine();

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -42,7 +42,6 @@ protected:
     bool canSuppressPaging;
     bitLenInt thresholdQubits;
     bitLenInt pagingThresholdQubits;
-    bitLenInt maxShardQubits;
     real1_f separabilityThreshold;
     std::vector<int> deviceIDs;
 

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -2545,12 +2545,12 @@ real1_f QEngineOCL::SumSqrDiff(QEngineOCLPtr toCompare)
 
     if (!stateBuffer) {
         toCompare->UpdateRunningNorm();
-        return toCompare->runningNorm * toCompare->runningNorm;
+        return toCompare->runningNorm;
     }
 
     if (!toCompare->stateBuffer) {
         UpdateRunningNorm();
-        return runningNorm * runningNorm;
+        return runningNorm;
     }
 
     toCompare->Finish();

--- a/src/qengine/state.cpp
+++ b/src/qengine/state.cpp
@@ -1305,7 +1305,7 @@ real1_f QEngineCPU::SumSqrDiff(QEngineCPUPtr toCompare)
     // If the qubit counts are unequal, these can't be approximately equal objects.
     if (qubitCount != toCompare->qubitCount) {
         // Max square difference:
-        return 4.0f;
+        return ONE_R1;
     }
 
     // Make sure both engines are normalized

--- a/src/qengine/state.cpp
+++ b/src/qengine/state.cpp
@@ -1325,12 +1325,12 @@ real1_f QEngineCPU::SumSqrDiff(QEngineCPUPtr toCompare)
 
     if (!stateVec) {
         toCompare->UpdateRunningNorm();
-        return toCompare->runningNorm * toCompare->runningNorm;
+        return toCompare->runningNorm;
     }
 
     if (!toCompare->stateVec) {
         UpdateRunningNorm();
-        return runningNorm * runningNorm;
+        return runningNorm;
     }
 
     stateVec->isReadLocked = false;

--- a/src/qinterface/qinterface.cpp
+++ b/src/qinterface/qinterface.cpp
@@ -806,24 +806,11 @@ bool QInterface::TryDecompose(bitLenInt start, QInterfacePtr dest, real1_f error
     unitCopy->Decompose(start, dest);
     unitCopy->Compose(dest, start);
 
-    real1_f diff = SumSqrDiff(unitCopy);
-    bool didSeparate = diff <= error_tol;
+    bool didSeparate = ApproxCompare(unitCopy, error_tol);
 
     if (didSeparate) {
         // The subsystem is separable.
         Dispose(start, dest->GetQubitCount());
-
-        if (diff > REAL1_EPSILON) {
-            UpdateRunningNorm();
-            if (!doNormalize) {
-                NormalizeState();
-            }
-
-            dest->UpdateRunningNorm();
-            if (!dest->doNormalize) {
-                dest->NormalizeState();
-            }
-        }
     }
 
     return didSeparate;

--- a/src/qpager.cpp
+++ b/src/qpager.cpp
@@ -1433,7 +1433,7 @@ real1_f QPager::SumSqrDiff(QPagerPtr toCompare)
     // If the qubit counts are unequal, these can't be approximately equal objects.
     if (qubitCount != toCompare->qubitCount) {
         // Max square difference:
-        return 4.0f;
+        return ONE_R1;
     }
 
     bitCapIntOcl i;

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -4429,7 +4429,7 @@ real1_f QUnit::SumSqrDiff(QUnitPtr toCompare)
     // If the qubit counts are unequal, these can't be approximately equal objects.
     if (qubitCount != toCompare->qubitCount) {
         // Max square difference:
-        return 4.0f;
+        return ONE_R1;
     }
 
     if (qubitCount == 1U) {
@@ -4460,7 +4460,7 @@ real1_f QUnit::SumSqrDiff(QUnitPtr toCompare)
         }
 
         // Necessarily max difference:
-        return 4.0f;
+        return ONE_R1;
     }
 
     QUnitPtr thisCopyShared, thatCopyShared;

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -78,7 +78,6 @@ QUnit::QUnit(QInterfaceEngine eng, QInterfaceEngine subEng, bitLenInt qBitCount,
     , isReactiveSeparate(false)
     , thresholdQubits(qubitThreshold)
     , pagingThresholdQubits(21)
-    , maxShardQubits(-1)
     , separabilityThreshold(sep_thresh)
     , deviceIDs(devList)
 {
@@ -88,10 +87,6 @@ QUnit::QUnit(QInterfaceEngine eng, QInterfaceEngine subEng, bitLenInt qBitCount,
 
     if (getenv("QRACK_QUNIT_SEPARABILITY_THRESHOLD")) {
         separabilityThreshold = (real1_f)std::stof(std::string(getenv("QRACK_QUNIT_SEPARABILITY_THRESHOLD")));
-    }
-
-    if (getenv("QRACK_MAX_PAGING_QB")) {
-        maxShardQubits = (bitLenInt)std::stoi(std::string(getenv("QRACK_MAX_PAGING_QB")));
     }
 
     if ((engine == QINTERFACE_QUNIT) || (engine == QINTERFACE_QUNIT_MULTI)) {
@@ -736,16 +731,16 @@ bool QUnit::TrySeparateClifford(bitLenInt qubit)
         }
 
         didSeparate = !shard.unit;
-
-        if (didSeparate) {
-            freezeTrySeparate = false;
-            return true;
-        }
-
         willSeparate |= (abs(prob) < (SQRT1_2_R1 / 2)) && ((ONE_R1 / 2 - abs(prob)) <= separabilityThreshold);
 
         if (i >= 2) {
             continue;
+        }
+
+        // If this is 0.5, it wasn't this basis, but it's worth checking the next basis.
+        if (didSeparate || (abs(prob) > separabilityThreshold)) {
+            freezeTrySeparate = false;
+            return didSeparate;
         }
 
         if (!shard.isPauliX && !shard.isPauliY) {
@@ -757,27 +752,11 @@ bool QUnit::TrySeparateClifford(bitLenInt qubit)
         }
     }
 
-    probZ = 2 * probZ;
-    probX = 2 * probX;
-    probY = 2 * probY;
-
-    prob = sqrt(probZ * probZ + probX * probX + probY * probY);
-
-    // Without calculating the reduced density matrix, experimental test suggests that, under arbitrary rotation of a
-    // separable pure state, this value will never be lower than 1/2.
-    if ((shard.unit->GetQubitCount() < maxShardQubits) && (prob >= ((ONE_R1 / 2) - separabilityThreshold))) {
-        bitLenInt q[1] = { qubit };
-        if (TrySeparate(q, 1U, separabilityThreshold)) {
-            freezeTrySeparate = false;
-            return true;
-        }
-    }
-
     probZ = abs(probZ);
     probX = abs(probX);
     probY = abs(probY);
 
-    if (!willSeparate) {
+    if (didSeparate || !willSeparate) {
         if (isReactiveSeparate && (separabilityThreshold > FP_NORM_EPSILON)) {
             // Convert back to the basis with the highest projection:
             if ((probZ >= probY) && (probZ >= probX)) {


### PR DESCRIPTION
Not only will this make `SumSqrDiff()` faster, but it bases the return value upon the square norm of the inner product between compared states, such that _all_ representations that are equivalent in the expectation values of all Hermitian operators will be recognized as the same state, when compared.