### PR TITLE
'Litmus test' for brute-force TrySeparate(a)

### DIFF
--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -42,6 +42,7 @@ protected:
     bool canSuppressPaging;
     bitLenInt thresholdQubits;
     bitLenInt pagingThresholdQubits;
+    bitLenInt maxShardQubits;
     real1_f separabilityThreshold;
     std::vector<int> deviceIDs;
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -78,6 +78,7 @@ QUnit::QUnit(QInterfaceEngine eng, QInterfaceEngine subEng, bitLenInt qBitCount,
     , isReactiveSeparate(false)
     , thresholdQubits(qubitThreshold)
     , pagingThresholdQubits(21)
+    , maxShardQubits(-1)
     , separabilityThreshold(sep_thresh)
     , deviceIDs(devList)
 {
@@ -87,6 +88,10 @@ QUnit::QUnit(QInterfaceEngine eng, QInterfaceEngine subEng, bitLenInt qBitCount,
 
     if (getenv("QRACK_QUNIT_SEPARABILITY_THRESHOLD")) {
         separabilityThreshold = (real1_f)std::stof(std::string(getenv("QRACK_QUNIT_SEPARABILITY_THRESHOLD")));
+    }
+
+    if (getenv("QRACK_MAX_PAGING_QB")) {
+        maxShardQubits = (bitLenInt)std::stoi(std::string(getenv("QRACK_MAX_PAGING_QB")));
     }
 
     if ((engine == QINTERFACE_QUNIT) || (engine == QINTERFACE_QUNIT_MULTI)) {
@@ -731,16 +736,16 @@ bool QUnit::TrySeparateClifford(bitLenInt qubit)
         }
 
         didSeparate = !shard.unit;
+
+        if (didSeparate) {
+            freezeTrySeparate = false;
+            return true;
+        }
+
         willSeparate |= (abs(prob) < (SQRT1_2_R1 / 2)) && ((ONE_R1 / 2 - abs(prob)) <= separabilityThreshold);
 
         if (i >= 2) {
             continue;
-        }
-
-        // If this is 0.5, it wasn't this basis, but it's worth checking the next basis.
-        if (didSeparate || (abs(prob) > separabilityThreshold)) {
-            freezeTrySeparate = false;
-            return didSeparate;
         }
 
         if (!shard.isPauliX && !shard.isPauliY) {
@@ -752,11 +757,27 @@ bool QUnit::TrySeparateClifford(bitLenInt qubit)
         }
     }
 
+    probZ = 2 * probZ;
+    probX = 2 * probX;
+    probY = 2 * probY;
+
+    prob = sqrt(probZ * probZ + probX * probX + probY * probY);
+
+    // Without calculating the reduced density matrix, experimental test suggests that, under arbitrary rotation of a
+    // separable pure state, this value will never be lower than 1/2.
+    if ((shard.unit->GetQubitCount() < maxShardQubits) && (prob >= ((ONE_R1 / 2) - separabilityThreshold))) {
+        bitLenInt q[1] = { qubit };
+        if (TrySeparate(q, 1U, separabilityThreshold)) {
+            freezeTrySeparate = false;
+            return true;
+        }
+    }
+
     probZ = abs(probZ);
     probX = abs(probX);
     probY = abs(probY);
 
-    if (didSeparate || !willSeparate) {
+    if (!willSeparate) {
         if (isReactiveSeparate && (separabilityThreshold > FP_NORM_EPSILON)) {
             // Convert back to the basis with the highest projection:
             if ((probZ >= probY) && (probZ >= probX)) {


### PR DESCRIPTION
With the rapid changes, today, this revert might turn out to be more universal in practicality (but slightly slower) after all. I'm still testing.