### PR TITLE
ZeroPhaseFlip shunt no longer necessary

### DIFF
--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1743,14 +1743,6 @@ void QUnit::ZeroPhaseFlip(bitLenInt start, bitLenInt length)
         return;
     }
 
-    if ((engine == QINTERFACE_QPAGER) || (subEngine == QINTERFACE_QPAGER)) {
-        // TODO: Case below this should work for QPager, but doesn't
-        EntangleRange(start, length);
-        shards[start].unit->ZeroPhaseFlip(shards[start].mapped, length);
-        DirtyShardRange(start, length);
-        return;
-    }
-
     QInterface::ZeroPhaseFlip(start, length);
 }
 


### PR DESCRIPTION
In the early days of `QPager`, the (better) default implementation here didn't work, but this has been corrected, at some point over the course of months of cumulative development.