### PR TITLE
Global max allocation guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,9 @@ QEngineCPU and QHybrid batch work items in groups of 2^`PSTRIDEPOW` before dispa
 
 `-DENABLE_QUNIT_CPU_PARALLEL=OFF` disables asynchronous dispatch of QStabilizerHybrid and low width QEngineCPU/QHybrid gates with `std::future`. This option is on by default. Typically, QUnit stays safely under maximum thread count limits, but situations arise where async CPU simulation causes QUnit to dispatch too many CPU threads for the operating system. This build option can also reduce overall thread usage when Qrack user code operates in a multi-threaded or multi-shell environment. (Linux thread count limits might be smaller than Windows.)
 
+## Maximum allocation guard
+Set the maximum allowed allocation (in MB) for the global pool of state vectors with `QRACK_MAX_ALLOC_MB`. This does not include other heap usage, besides state vector allocations, and it currently does not account for out-of-place single duplication of any state vector.
+
 ## Approximation options
 `QUnit` can optionally round qubit subsystems proactively or on-demand to the nearest Pauli and Bell basis eigenstates according to the `QRACK_QUNIT_SEPARABILITY_THRESHOLD=[0.0 - 0.5]` environment variable, with a value between `0.0` and `0.5`. If a probability check under Pauli or Bell basis rotation brings a single qubit probability within parameter range of any X/Y/Z basis eigenstate, (distance from closer of 0.0 or 1.0,) then the subsystem will be rounded to that state. If the environment variable is set high enough that poles overlap, (greater than `(1-1/sqrt(2))/2`, approximately `0.1464466`,) then `QUnit` will cycle through X/Y/Z Pauli bases to find the best match to a mixed or pure state.
 

--- a/include/common/oclengine.hpp
+++ b/include/common/oclengine.hpp
@@ -285,11 +285,36 @@ public:
         return std::string(getenv("HOME") ? getenv("HOME") : "") + "/.qrack/";
 #endif
     }
+    size_t GetMaxActiveAllocSize() { return maxActiveAllocSize; }
+    size_t GetActiveAllocSize() { return activeAllocSize; }
+    void AddToActiveAllocSize(size_t size)
+    {
+        std::lock_guard<std::mutex> lock(allocMutex);
+        activeAllocSize += size;
+
+        if ((maxActiveAllocSize > 0) && (maxActiveAllocSize < activeAllocSize)) {
+            throw std::bad_alloc();
+        }
+    }
+    void SubtractFromActiveAllocSize(size_t size)
+    {
+        std::lock_guard<std::mutex> lock(allocMutex);
+        activeAllocSize -= size;
+    }
+    void ResetActiveAllocSize()
+    {
+        std::lock_guard<std::mutex> lock(allocMutex);
+        // User code should catch std::bad_alloc and reset:
+        activeAllocSize = 0;
+    }
 
 private:
     static const std::vector<OCLKernelHandle> kernelHandles;
     static const std::string binary_file_prefix;
     static const std::string binary_file_ext;
+    int64_t activeAllocSize;
+    int64_t maxActiveAllocSize;
+    std::mutex allocMutex;
     std::vector<DeviceContextPtr> all_device_contexts;
     DeviceContextPtr default_device_context;
 

--- a/include/common/oclengine.hpp
+++ b/include/common/oclengine.hpp
@@ -299,7 +299,11 @@ public:
     void SubtractFromActiveAllocSize(size_t size)
     {
         std::lock_guard<std::mutex> lock(allocMutex);
-        activeAllocSize -= size;
+        if (size < activeAllocSize) {
+            activeAllocSize -= size;
+        } else {
+            activeAllocSize = 0;
+        }
     }
     void ResetActiveAllocSize()
     {
@@ -312,8 +316,8 @@ private:
     static const std::vector<OCLKernelHandle> kernelHandles;
     static const std::string binary_file_prefix;
     static const std::string binary_file_ext;
-    int64_t activeAllocSize;
-    int64_t maxActiveAllocSize;
+    size_t activeAllocSize;
+    size_t maxActiveAllocSize;
     std::mutex allocMutex;
     std::vector<DeviceContextPtr> all_device_contexts;
     DeviceContextPtr default_device_context;

--- a/include/qengine_opencl.hpp
+++ b/include/qengine_opencl.hpp
@@ -200,6 +200,8 @@ public:
         runningNorm = ZERO_R1;
         ResetStateBuffer(NULL);
         FreeStateVec();
+
+        OCLEngine::Instance()->SubtractFromActiveAllocSize(sizeof(complex) * maxQPower);
     }
 
     virtual void SetQubitCount(bitLenInt qb)

--- a/src/common/oclengine.cpp
+++ b/src/common/oclengine.cpp
@@ -395,8 +395,12 @@ void OCLEngine::InitOCL(bool buildFromSource, bool saveBinaries, std::string hom
 }
 
 OCLEngine::OCLEngine()
+    : activeAllocSize(0)
+    , maxActiveAllocSize(0)
 {
-    // Intentionally left blank;
+    if (getenv("QRACK_MAX_ALLOC_MB")) {
+        maxActiveAllocSize = 1024 * 1024 * (size_t)std::stoi(std::string(getenv("QRACK_MAX_ALLOC_MB")));
+    }
 }
 OCLEngine* OCLEngine::m_pInstance = NULL;
 OCLEngine* OCLEngine::Instance()

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -1250,7 +1250,7 @@ void QEngineOCL::DecomposeDispose(bitLenInt start, bitLenInt length, QEngineOCLP
             stateVec = NULL;
         }
         // This will be cleared by the destructor:
-        OCLEngine::Instance()->SubtractFromActiveAllocSize(sizeof(complex) * pow2Ocl(length) - 2U);
+        OCLEngine::Instance()->SubtractFromActiveAllocSize(sizeof(complex) * pow2Ocl(qubitCount) - 2U);
         ResetStateVec(AllocStateVec(2));
         stateBuffer = MakeStateVecBuffer(stateVec);
         SetQubitCount(1);
@@ -1386,6 +1386,7 @@ void QEngineOCL::Dispose(bitLenInt start, bitLenInt length, bitCapInt disposedPe
         // This will be cleared by the destructor:
         ResetStateVec(AllocStateVec(2));
         stateBuffer = MakeStateVecBuffer(stateVec);
+        OCLEngine::Instance()->SubtractFromActiveAllocSize(sizeof(complex) * pow2Ocl(qubitCount) - 2U);
         SetQubitCount(1);
         return;
     }
@@ -1399,6 +1400,7 @@ void QEngineOCL::Dispose(bitLenInt start, bitLenInt length, bitCapInt disposedPe
 
     bitLenInt nLength = qubitCount - length;
     bitCapIntOcl remainderPower = pow2Ocl(nLength);
+    size_t sizeDiff = sizeof(complex) * (maxQPower - remainderPower);
     bitCapIntOcl skipMask = pow2Ocl(start) - ONE_BCI;
     bitCapIntOcl disposedRes = (bitCapIntOcl)disposedPerm << (bitCapIntOcl)start;
 
@@ -1418,6 +1420,8 @@ void QEngineOCL::Dispose(bitLenInt start, bitLenInt length, bitCapInt disposedPe
 
     ResetStateVec(nStateVec);
     ResetStateBuffer(nStateBuffer);
+
+    OCLEngine::Instance()->SubtractFromActiveAllocSize(sizeDiff);
 }
 
 real1_f QEngineOCL::Probx(OCLAPI api_call, bitCapIntOcl* bciArgs)

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -93,6 +93,7 @@ void benchmarkLoopVariable(std::function<void(QInterfacePtr, bitLenInt)> fn, bit
     if (getenv("QRACK_MAX_PAGING_QB")) {
         qbTryThreshold = (bitLenInt)std::stoi(std::string(getenv("QRACK_MAX_PAGING_QB")));
     }
+#if ENABLE_OPENCL
     size_t maxAllocSize = OCLEngine::Instance()->GetMaxActiveAllocSize();
     if (maxAllocSize > 0) {
         bitLenInt maxQubits = log2(maxAllocSize / sizeof(complex));
@@ -100,6 +101,7 @@ void benchmarkLoopVariable(std::function<void(QInterfacePtr, bitLenInt)> fn, bit
             qbTryThreshold = maxQubits;
         }
     }
+#endif
 
     int sampleFailureCount;
 

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -95,7 +95,7 @@ void benchmarkLoopVariable(std::function<void(QInterfacePtr, bitLenInt)> fn, bit
     }
     size_t maxAllocSize = OCLEngine::Instance()->GetMaxActiveAllocSize();
     if (maxAllocSize > 0) {
-        bitLenInt maxQubits = log2(maxAllocSize);
+        bitLenInt maxQubits = log2(maxAllocSize / sizeof(complex));
         if (maxQubits < qbTryThreshold) {
             qbTryThreshold = maxQubits;
         }

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -96,7 +96,7 @@ void benchmarkLoopVariable(std::function<void(QInterfacePtr, bitLenInt)> fn, bit
 #if ENABLE_OPENCL
     size_t maxAllocSize = OCLEngine::Instance()->GetMaxActiveAllocSize();
     if (maxAllocSize > 0) {
-        bitLenInt maxQubits = log2(maxAllocSize / sizeof(complex));
+        bitLenInt maxQubits = log2(maxAllocSize / sizeof(complex)) - 1U;
         if (maxQubits < qbTryThreshold) {
             qbTryThreshold = maxQubits;
         }
@@ -161,7 +161,9 @@ void benchmarkLoopVariable(std::function<void(QInterfacePtr, bitLenInt)> fn, bit
                     isTrialSuccessful = true;
                 } catch (const std::exception& e) {
                     qftReg = NULL;
+#if ENABLE_OPENCL
                     OCLEngine::Instance()->ResetActiveAllocSize();
+#endif
                     sampleFailureCount++;
                     isTrialSuccessful = false;
                 }

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -93,6 +93,13 @@ void benchmarkLoopVariable(std::function<void(QInterfacePtr, bitLenInt)> fn, bit
     if (getenv("QRACK_MAX_PAGING_QB")) {
         qbTryThreshold = (bitLenInt)std::stoi(std::string(getenv("QRACK_MAX_PAGING_QB")));
     }
+    size_t maxAllocSize = OCLEngine::Instance()->GetMaxActiveAllocSize();
+    if (maxAllocSize > 0) {
+        bitLenInt maxQubits = log2(maxAllocSize);
+        if (maxQubits < qbTryThreshold) {
+            qbTryThreshold = maxQubits;
+        }
+    }
 
     int sampleFailureCount;
 
@@ -152,7 +159,8 @@ void benchmarkLoopVariable(std::function<void(QInterfacePtr, bitLenInt)> fn, bit
                 try {
                     fn(qftReg, numBits);
                     isTrialSuccessful = true;
-                } catch (const std::invalid_argument& e) {
+                } catch (const std::exception& e) {
+                    OCLEngine::Instance()->ResetActiveAllocSize();
                     sampleFailureCount++;
                     isTrialSuccessful = false;
                 }


### PR DESCRIPTION
This adds a global maximum allocation guard to `OCLEngine()`, with the ability to reset it after exceptions.