### PR TITLE
Fix mem leak on throw std::bad_alloc()

### DIFF
--- a/include/common/oclengine.hpp
+++ b/include/common/oclengine.hpp
@@ -287,24 +287,21 @@ public:
     }
     size_t GetMaxActiveAllocSize() { return maxActiveAllocSize; }
     size_t GetActiveAllocSize() { return activeAllocSize; }
-    void AddToActiveAllocSize(size_t size)
+    size_t AddToActiveAllocSize(size_t size)
     {
         if (size == 0) {
-            return;
+            return activeAllocSize;
         }
 
         std::lock_guard<std::mutex> lock(allocMutex);
         activeAllocSize += size;
 
-        if ((maxActiveAllocSize > 0) && (maxActiveAllocSize < activeAllocSize)) {
-            activeAllocSize -= size;
-            throw std::bad_alloc();
-        }
+        return activeAllocSize;
     }
-    void SubtractFromActiveAllocSize(size_t size)
+    size_t SubtractFromActiveAllocSize(size_t size)
     {
         if (size == 0) {
-            return;
+            return activeAllocSize;
         }
 
         std::lock_guard<std::mutex> lock(allocMutex);
@@ -313,6 +310,7 @@ public:
         } else {
             activeAllocSize = 0;
         }
+        return activeAllocSize;
     }
     void ResetActiveAllocSize()
     {

--- a/include/qengine_opencl.hpp
+++ b/include/qengine_opencl.hpp
@@ -150,7 +150,7 @@ protected:
     BufferPtr nrmBuffer;
     BufferPtr powersBuffer;
     std::vector<PoolItemPtr> poolItems;
-    std::unique_ptr<real1[]> nrmArray;
+    real1* nrmArray;
     size_t nrmGroupCount;
     size_t nrmGroupSize;
     size_t maxWorkItems;
@@ -199,9 +199,15 @@ public:
 
         powersBuffer = NULL;
         if (nrmArray) {
-            nrmArray.reset();
+            FreeAligned(nrmArray);
+            nrmArray = NULL;
         }
-        SubtractAlloc(sizeof(bitCapIntOcl) * pow2Ocl(QBCAPPOW) + sizeof(real1) * nrmGroupCount / nrmGroupSize);
+
+        size_t sizeDiff = sizeof(bitCapIntOcl) * pow2Ocl(QBCAPPOW);
+        sizeDiff += ((sizeof(real1) * nrmGroupCount / nrmGroupSize) < QRACK_ALIGN_SIZE)
+            ? QRACK_ALIGN_SIZE
+            : (sizeof(real1) * nrmGroupCount / nrmGroupSize);
+        SubtractAlloc(sizeDiff);
     }
 
     virtual void ZeroAmplitudes()

--- a/include/qengine_opencl.hpp
+++ b/include/qengine_opencl.hpp
@@ -198,7 +198,9 @@ public:
         ZeroAmplitudes();
 
         powersBuffer = NULL;
-        nrmArray.reset();
+        if (nrmArray) {
+            nrmArray.reset();
+        }
         SubtractAlloc(sizeof(bitCapIntOcl) * pow2Ocl(QBCAPPOW) + sizeof(real1) * nrmGroupCount / nrmGroupSize);
     }
 

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -621,7 +621,7 @@ void QEngineOCL::CArithmeticCall(OCLAPI api_call, bitCapIntOcl (&bciArgs)[BCI_AR
 {
     CHECK_ZERO_SKIP();
 
-    size_t sizeDiff = sizeof(complex) * maxQPower;
+    size_t sizeDiff = sizeof(complex) * maxQPowerOcl;
     if (controlLen) {
         sizeDiff += sizeof(bitCapIntOcl) * controlLen;
     }
@@ -1445,8 +1445,7 @@ void QEngineOCL::Dispose(bitLenInt start, bitLenInt length, bitCapInt disposedPe
 
     bitLenInt nLength = qubitCount - length;
     bitCapIntOcl remainderPower = pow2Ocl(nLength);
-    AddAlloc(sizeof(complex) * remainderPower);
-    size_t sizeDiff = sizeof(complex) * maxQPower;
+    size_t sizeDiff = sizeof(complex) * maxQPowerOcl;
     bitCapIntOcl skipMask = pow2Ocl(start) - ONE_BCI;
     bitCapIntOcl disposedRes = (bitCapIntOcl)disposedPerm << (bitCapIntOcl)start;
 

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -512,7 +512,7 @@ void QEngineOCL::SetDevice(const int& dID, const bool& forceReInit)
         nrmBuffer = NULL;
         FreeAligned(nrmArray);
         nrmArray = NULL;
-        OCLEngine::Instance()->SubtractFromActiveAllocSize(oldNrmVecAlignSize);
+        SubtractAlloc(oldNrmVecAlignSize);
     }
 
     if (!didInit || doResize) {

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -427,6 +427,7 @@ real1_f QEngineOCL::ProbAll(bitCapInt fullRegister)
 void QEngineOCL::SetDevice(const int& dID, const bool& forceReInit)
 {
     if (!(OCLEngine::Instance()->GetDeviceCount())) {
+        FreeAll();
         throw std::runtime_error("Tried to initialize QEngineOCL, but no available OpenCL devices.");
     }
 
@@ -491,6 +492,7 @@ void QEngineOCL::SetDevice(const int& dID, const bool& forceReInit)
     size_t stateVecSize = maxQPowerOcl * sizeof(complex);
     // Device RAM should be large enough for 2 times the size of the stateVec, plus some excess.
     if (stateVecSize > maxAlloc) {
+        FreeAll();
         throw "Error: State vector exceeds device maximum OpenCL allocation";
     } else if (useHostRam || ((OclMemDenom * stateVecSize) > maxMem)) {
         usingHostRam = true;
@@ -892,6 +894,7 @@ void QEngineOCL::Apply2x2(bitCapInt offset1, bitCapInt offset2, const complex* m
         api_call = OCL_API_APPLY2X2_DOUBLE_WIDE;
         break;
     default:
+        FreeAll();
         throw("Invalid APPLY2X2 kernel selected!");
     }
 
@@ -1159,6 +1162,7 @@ void QEngineOCL::Compose(OCLAPI apiCall, bitCapIntOcl* bciArgs, QEngineOCLPtr to
     size_t nStateVecSize = nMaxQPower * sizeof(complex);
     maxAlloc = device_context->device.getInfo<CL_DEVICE_MAX_MEM_ALLOC_SIZE>();
     if (nStateVecSize > maxAlloc) {
+        FreeAll();
         throw "Error: State vector exceeds device maximum OpenCL allocation";
     }
 
@@ -1959,6 +1963,7 @@ void QEngineOCL::INTBCD(OCLAPI api_call, bitCapIntOcl toMod, const bitLenInt sta
 
     bitCapIntOcl nibbleCount = length / 4;
     if (nibbleCount * 4 != length) {
+        FreeAll();
         throw std::invalid_argument("BCD word bit length must be a multiple of 4.");
     }
 
@@ -1992,6 +1997,7 @@ void QEngineOCL::INTBCDC(
 
     bitCapIntOcl nibbleCount = length / 4;
     if (nibbleCount * 4 != length) {
+        FreeAll();
         throw std::invalid_argument("BCD word bit length must be a multiple of 4.");
     }
 
@@ -2040,7 +2046,8 @@ void QEngineOCL::MUL(bitCapInt toMul, bitLenInt inOutStart, bitLenInt carryStart
 void QEngineOCL::DIV(bitCapInt toDiv, bitLenInt inOutStart, bitLenInt carryStart, bitLenInt length)
 {
     if (toDiv == 0) {
-        throw "DIV by zero";
+        FreeAll();
+        throw std::runtime_error("DIV by zero");
     }
 
     MULx(OCL_API_DIV, (bitCapIntOcl)toDiv, inOutStart, carryStart, length);
@@ -2144,7 +2151,8 @@ void QEngineOCL::CDIV(bitCapInt toDiv, bitLenInt inOutStart, bitLenInt carryStar
     }
 
     if (toDiv == 0) {
-        throw "DIV by zero";
+        FreeAll();
+        throw std::runtime_error("DIV by zero");
     }
 
     if (toDiv == 1) {

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -556,7 +556,6 @@ void QEngineOCL::SetDevice(const int& dID, const bool& forceReInit)
 
     AddAlloc(sizeof(bitCapIntOcl) * pow2Ocl(QBCAPPOW));
     powersBuffer = std::make_shared<cl::Buffer>(context, CL_MEM_READ_ONLY, sizeof(bitCapIntOcl) * pow2Ocl(QBCAPPOW));
-    AddAlloc(sizeof(bitCapIntOcl) * pow2Ocl(QBCAPPOW));
 }
 
 real1_f QEngineOCL::ParSum(real1* toSum, bitCapIntOcl maxI)

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -516,6 +516,7 @@ void QEngineOCL::SetDevice(const int& dID, const bool& forceReInit)
     }
 
     if (!didInit || doResize) {
+        AddAlloc(nrmVecAlignSize);
 #if defined(__APPLE__)
         posix_memalign((void**)&nrmArray, QRACK_ALIGN_SIZE, nrmVecAlignSize);
 #elif defined(_WIN32) && !defined(__CYGWIN__)
@@ -524,7 +525,6 @@ void QEngineOCL::SetDevice(const int& dID, const bool& forceReInit)
         nrmArray = (real1*)aligned_alloc(QRACK_ALIGN_SIZE, nrmVecAlignSize);
 #endif
         nrmBuffer = std::make_shared<cl::Buffer>(context, CL_MEM_READ_WRITE, nrmVecAlignSize);
-        AddAlloc(nrmVecAlignSize);
     }
 
     // create buffers on device (allocate space on GPU)

--- a/src/qengine/qengine.cpp
+++ b/src/qengine/qengine.cpp
@@ -80,13 +80,13 @@ bitCapInt QEngine::ForceM(const bitLenInt* bits, const bitLenInt& length, const 
 
     complex phase = GetNonunitaryPhase();
 
-    bitCapInt* qPowers = new bitCapInt[length];
+    std::unique_ptr<bitCapInt[]> qPowers(new bitCapInt[length]);
     bitCapInt regMask = 0;
     for (i = 0; i < length; i++) {
-        qPowers[i] = pow2(bits[i]);
-        regMask |= qPowers[i];
+        qPowers.get()[i] = pow2(bits[i]);
+        regMask |= qPowers.get()[i];
     }
-    std::sort(qPowers, qPowers + length);
+    std::sort(qPowers.get(), qPowers.get() + length);
 
     bitCapIntOcl lengthPower = pow2Ocl(length);
     real1 nrmlzr = ONE_R1;
@@ -110,9 +110,9 @@ bitCapInt QEngine::ForceM(const bitLenInt* bits, const bitLenInt& length, const 
     }
 
     real1_f prob = Rand();
-    real1* probArray = new real1[lengthPower]();
+    std::unique_ptr<real1[]> probArray(new real1[lengthPower]());
 
-    ProbMaskAll(regMask, probArray);
+    ProbMaskAll(regMask, probArray.get());
 
     lcv = 0;
     real1 lowerProb = ZERO_R1;
@@ -141,17 +141,17 @@ bitCapInt QEngine::ForceM(const bitLenInt* bits, const bitLenInt& length, const 
         nrmlzr = probArray[lcv];
     }
 
-    delete[] probArray;
+    probArray.reset();
 
     i = 0;
     for (bitLenInt p = 0; p < length; p++) {
         if (pow2(p) & result) {
-            i |= (bitCapIntOcl)qPowers[p];
+            i |= (bitCapIntOcl)qPowers.get()[p];
         }
     }
     result = i;
 
-    delete[] qPowers;
+    qPowers.reset();
 
     nrm = phase / (real1)(std::sqrt(nrmlzr));
 
@@ -228,16 +228,15 @@ void QEngine::CSwap(
     const complex pauliX[4] = { complex(ZERO_R1, ZERO_R1), complex(ONE_R1, ZERO_R1), complex(ONE_R1, ZERO_R1),
         complex(ZERO_R1, ZERO_R1) };
     bitCapInt skipMask = 0;
-    bitCapInt* qPowersSorted = new bitCapInt[controlLen + 2];
+    std::unique_ptr<bitCapInt[]> qPowersSorted(new bitCapInt[controlLen + 2]);
     for (bitLenInt i = 0; i < controlLen; i++) {
-        qPowersSorted[i] = pow2(controls[i]);
-        skipMask |= qPowersSorted[i];
+        qPowersSorted.get()[i] = pow2(controls[i]);
+        skipMask |= qPowersSorted.get()[i];
     }
     qPowersSorted[controlLen] = pow2(qubit1);
     qPowersSorted[controlLen + 1] = pow2(qubit2);
-    std::sort(qPowersSorted, qPowersSorted + controlLen + 2);
-    Apply2x2(skipMask | pow2(qubit1), skipMask | pow2(qubit2), pauliX, 2 + controlLen, qPowersSorted, false);
-    delete[] qPowersSorted;
+    std::sort(qPowersSorted.get(), qPowersSorted.get() + controlLen + 2);
+    Apply2x2(skipMask | pow2(qubit1), skipMask | pow2(qubit2), pauliX, 2 + controlLen, qPowersSorted.get(), false);
 }
 
 void QEngine::AntiCSwap(
@@ -249,15 +248,14 @@ void QEngine::AntiCSwap(
 
     const complex pauliX[4] = { complex(ZERO_R1, ZERO_R1), complex(ONE_R1, ZERO_R1), complex(ONE_R1, ZERO_R1),
         complex(ZERO_R1, ZERO_R1) };
-    bitCapInt* qPowersSorted = new bitCapInt[controlLen + 2];
+    std::unique_ptr<bitCapInt[]> qPowersSorted(new bitCapInt[controlLen + 2]);
     for (bitLenInt i = 0; i < controlLen; i++) {
-        qPowersSorted[i] = pow2(controls[i]);
+        qPowersSorted.get()[i] = pow2(controls[i]);
     }
-    qPowersSorted[controlLen] = pow2(qubit1);
-    qPowersSorted[controlLen + 1] = pow2(qubit2);
-    std::sort(qPowersSorted, qPowersSorted + controlLen + 2);
-    Apply2x2(pow2(qubit1), pow2(qubit2), pauliX, 2 + controlLen, qPowersSorted, false);
-    delete[] qPowersSorted;
+    qPowersSorted.get()[controlLen] = pow2(qubit1);
+    qPowersSorted.get()[controlLen + 1] = pow2(qubit2);
+    std::sort(qPowersSorted.get(), qPowersSorted.get() + controlLen + 2);
+    Apply2x2(pow2(qubit1), pow2(qubit2), pauliX, 2 + controlLen, qPowersSorted.get(), false);
 }
 
 void QEngine::CSqrtSwap(
@@ -270,16 +268,15 @@ void QEngine::CSqrtSwap(
     const complex sqrtX[4] = { complex(ONE_R1, ONE_R1) / (real1)2.0f, complex(ONE_R1, -ONE_R1) / (real1)2.0f,
         complex(ONE_R1, -ONE_R1) / (real1)2.0f, complex(ONE_R1, ONE_R1) / (real1)2.0f };
     bitCapInt skipMask = 0;
-    bitCapInt* qPowersSorted = new bitCapInt[controlLen + 2];
+    std::unique_ptr<bitCapInt[]> qPowersSorted(new bitCapInt[controlLen + 2]);
     for (bitLenInt i = 0; i < controlLen; i++) {
-        qPowersSorted[i] = pow2(controls[i]);
-        skipMask |= qPowersSorted[i];
+        qPowersSorted.get()[i] = pow2(controls[i]);
+        skipMask |= qPowersSorted.get()[i];
     }
-    qPowersSorted[controlLen] = pow2(qubit1);
-    qPowersSorted[controlLen + 1] = pow2(qubit2);
-    std::sort(qPowersSorted, qPowersSorted + controlLen + 2);
-    Apply2x2(skipMask | pow2(qubit1), skipMask | pow2(qubit2), sqrtX, 2 + controlLen, qPowersSorted, false);
-    delete[] qPowersSorted;
+    qPowersSorted.get()[controlLen] = pow2(qubit1);
+    qPowersSorted.get()[controlLen + 1] = pow2(qubit2);
+    std::sort(qPowersSorted.get(), qPowersSorted.get() + controlLen + 2);
+    Apply2x2(skipMask | pow2(qubit1), skipMask | pow2(qubit2), sqrtX, 2 + controlLen, qPowersSorted.get(), false);
 }
 
 void QEngine::AntiCSqrtSwap(
@@ -291,15 +288,14 @@ void QEngine::AntiCSqrtSwap(
 
     const complex sqrtX[4] = { complex(ONE_R1, ONE_R1) / (real1)2.0f, complex(ONE_R1, -ONE_R1) / (real1)2.0f,
         complex(ONE_R1, -ONE_R1) / (real1)2.0f, complex(ONE_R1, ONE_R1) / (real1)2.0f };
-    bitCapInt* qPowersSorted = new bitCapInt[controlLen + 2];
+    std::unique_ptr<bitCapInt[]> qPowersSorted(new bitCapInt[controlLen + 2]);
     for (bitLenInt i = 0; i < controlLen; i++) {
-        qPowersSorted[i] = pow2(controls[i]);
+        qPowersSorted.get()[i] = pow2(controls[i]);
     }
-    qPowersSorted[controlLen] = pow2(qubit1);
-    qPowersSorted[controlLen + 1] = pow2(qubit2);
-    std::sort(qPowersSorted, qPowersSorted + controlLen + 2);
-    Apply2x2(pow2(qubit1), pow2(qubit2), sqrtX, 2 + controlLen, qPowersSorted, false);
-    delete[] qPowersSorted;
+    qPowersSorted.get()[controlLen] = pow2(qubit1);
+    qPowersSorted.get()[controlLen + 1] = pow2(qubit2);
+    std::sort(qPowersSorted.get(), qPowersSorted.get() + controlLen + 2);
+    Apply2x2(pow2(qubit1), pow2(qubit2), sqrtX, 2 + controlLen, qPowersSorted.get(), false);
 }
 
 void QEngine::CISqrtSwap(
@@ -312,16 +308,15 @@ void QEngine::CISqrtSwap(
     const complex iSqrtX[4] = { complex(ONE_R1, -ONE_R1) / (real1)2.0f, complex(ONE_R1, ONE_R1) / (real1)2.0f,
         complex(ONE_R1, ONE_R1) / (real1)2.0f, complex(ONE_R1, -ONE_R1) / (real1)2.0f };
     bitCapInt skipMask = 0;
-    bitCapInt* qPowersSorted = new bitCapInt[controlLen + 2];
+    std::unique_ptr<bitCapInt[]> qPowersSorted(new bitCapInt[controlLen + 2]);
     for (bitLenInt i = 0; i < controlLen; i++) {
-        qPowersSorted[i] = pow2(controls[i]);
-        skipMask |= qPowersSorted[i];
+        qPowersSorted.get()[i] = pow2(controls[i]);
+        skipMask |= qPowersSorted.get()[i];
     }
-    qPowersSorted[controlLen] = pow2(qubit1);
-    qPowersSorted[controlLen + 1] = pow2(qubit2);
-    std::sort(qPowersSorted, qPowersSorted + controlLen + 2);
-    Apply2x2(skipMask | pow2(qubit1), skipMask | pow2(qubit2), iSqrtX, 2 + controlLen, qPowersSorted, false);
-    delete[] qPowersSorted;
+    qPowersSorted.get()[controlLen] = pow2(qubit1);
+    qPowersSorted.get()[controlLen + 1] = pow2(qubit2);
+    std::sort(qPowersSorted.get(), qPowersSorted.get() + controlLen + 2);
+    Apply2x2(skipMask | pow2(qubit1), skipMask | pow2(qubit2), iSqrtX, 2 + controlLen, qPowersSorted.get(), false);
 }
 
 void QEngine::AntiCISqrtSwap(
@@ -333,48 +328,45 @@ void QEngine::AntiCISqrtSwap(
 
     const complex iSqrtX[4] = { complex(ONE_R1, -ONE_R1) / (real1)2.0f, complex(ONE_R1, ONE_R1) / (real1)2.0f,
         complex(ONE_R1, ONE_R1) / (real1)2.0f, complex(ONE_R1, -ONE_R1) / (real1)2.0f };
-    bitCapInt* qPowersSorted = new bitCapInt[controlLen + 2];
+    std::unique_ptr<bitCapInt[]> qPowersSorted(new bitCapInt[controlLen + 2]);
     for (bitLenInt i = 0; i < controlLen; i++) {
-        qPowersSorted[i] = pow2(controls[i]);
+        qPowersSorted.get()[i] = pow2(controls[i]);
     }
-    qPowersSorted[controlLen] = pow2(qubit1);
-    qPowersSorted[controlLen + 1] = pow2(qubit2);
-    std::sort(qPowersSorted, qPowersSorted + controlLen + 2);
-    Apply2x2(pow2(qubit1), pow2(qubit2), iSqrtX, 2 + controlLen, qPowersSorted, false);
-    delete[] qPowersSorted;
+    qPowersSorted.get()[controlLen] = pow2(qubit1);
+    qPowersSorted.get()[controlLen + 1] = pow2(qubit2);
+    std::sort(qPowersSorted.get(), qPowersSorted.get() + controlLen + 2);
+    Apply2x2(pow2(qubit1), pow2(qubit2), iSqrtX, 2 + controlLen, qPowersSorted.get(), false);
 }
 
 void QEngine::ApplyControlled2x2(
     const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& target, const complex* mtrx)
 {
-    bitCapInt* qPowersSorted = new bitCapInt[controlLen + 1U];
+    std::unique_ptr<bitCapInt[]> qPowersSorted(new bitCapInt[controlLen + 1U]);
     bitCapInt targetMask = pow2Ocl(target);
     bitCapInt fullMask = 0U;
     bitCapInt controlMask;
     for (bitLenInt i = 0U; i < controlLen; i++) {
-        qPowersSorted[i] = pow2(controls[i]);
-        fullMask |= qPowersSorted[i];
+        qPowersSorted.get()[i] = pow2(controls[i]);
+        fullMask |= qPowersSorted.get()[i];
     }
     controlMask = fullMask;
-    qPowersSorted[controlLen] = targetMask;
+    qPowersSorted.get()[controlLen] = targetMask;
     fullMask |= targetMask;
-    std::sort(qPowersSorted, qPowersSorted + controlLen + 1U);
-    Apply2x2(controlMask, fullMask, mtrx, controlLen + 1U, qPowersSorted, false);
-    delete[] qPowersSorted;
+    std::sort(qPowersSorted.get(), qPowersSorted.get() + controlLen + 1U);
+    Apply2x2(controlMask, fullMask, mtrx, controlLen + 1U, qPowersSorted.get(), false);
 }
 
 void QEngine::ApplyAntiControlled2x2(
     const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& target, const complex* mtrx)
 {
-    bitCapInt* qPowersSorted = new bitCapInt[controlLen + 1U];
+    std::unique_ptr<bitCapInt[]> qPowersSorted(new bitCapInt[controlLen + 1U]);
     bitCapInt targetMask = pow2Ocl(target);
     for (bitLenInt i = 0U; i < controlLen; i++) {
-        qPowersSorted[i] = pow2(controls[i]);
+        qPowersSorted.get()[i] = pow2(controls[i]);
     }
-    qPowersSorted[controlLen] = targetMask;
-    std::sort(qPowersSorted, qPowersSorted + controlLen + 1U);
-    Apply2x2(0, targetMask, mtrx, controlLen + 1U, qPowersSorted, false);
-    delete[] qPowersSorted;
+    qPowersSorted.get()[controlLen] = targetMask;
+    std::sort(qPowersSorted.get(), qPowersSorted.get() + controlLen + 1U);
+    Apply2x2(0, targetMask, mtrx, controlLen + 1U, qPowersSorted.get(), false);
 }
 
 /// Swap values of two bits in register
@@ -497,8 +489,8 @@ bitCapInt QEngine::ForceMReg(bitLenInt start, bitLenInt length, bitCapInt result
         nrmlzr = ProbMask(regMask, result << (bitCapIntOcl)start);
     } else {
         bitCapIntOcl lcv = 0;
-        real1* probArray = new real1[lengthPower]();
-        ProbRegAll(start, length, probArray);
+        std::unique_ptr<real1[]> probArray(new real1[lengthPower]());
+        ProbRegAll(start, length, probArray.get());
 
         real1_f prob = Rand();
         real1_f lowerProb = ZERO_R1;
@@ -511,9 +503,9 @@ bitCapInt QEngine::ForceMReg(bitLenInt start, bitLenInt length, bitCapInt result
          * vector.
          */
         while ((lowerProb < prob) && (lcv < lengthPower)) {
-            lowerProb += probArray[lcv];
-            if (largestProb <= probArray[lcv]) {
-                largestProb = probArray[lcv];
+            lowerProb += probArray.get()[lcv];
+            if (largestProb <= probArray.get()[lcv]) {
+                largestProb = probArray.get()[lcv];
                 nrmlzr = largestProb;
                 result = lcv;
             }
@@ -522,10 +514,10 @@ bitCapInt QEngine::ForceMReg(bitLenInt start, bitLenInt length, bitCapInt result
         if (lcv < lengthPower) {
             lcv--;
             result = lcv;
-            nrmlzr = probArray[lcv];
+            nrmlzr = probArray.get()[lcv];
         }
 
-        delete[] probArray;
+        probArray.reset();
     }
 
     bitCapInt resultPtr = result << (bitCapIntOcl)start;

--- a/src/qinterface/arithmetic.cpp
+++ b/src/qinterface/arithmetic.cpp
@@ -84,7 +84,8 @@ void QInterface::CFullAdd(bitLenInt* controlBits, bitLenInt controlLen, bitLenIn
     bitLenInt carryInSumOut, bitLenInt carryOut)
 {
     // See https://quantumcomputing.stackexchange.com/questions/1654/how-do-i-add-11-using-a-quantum-computer
-    bitLenInt* cBits = new bitLenInt[controlLen + 2];
+    std::unique_ptr<bitLenInt[]> cBitsU(new bitLenInt[controlLen + 2]);
+    bitLenInt* cBits = cBitsU.get();
     std::copy(controlBits, controlBits + controlLen, cBits);
 
     // Assume outputBit is in 0 state.
@@ -103,8 +104,6 @@ void QInterface::CFullAdd(bitLenInt* controlBits, bitLenInt controlLen, bitLenIn
 
     cBits[controlLen] = inputBit1;
     ApplyControlledSingleInvert(cBits, controlLen + 1, inputBit2, complex(ONE_R1, ZERO_R1), complex(ONE_R1, ZERO_R1));
-
-    delete[] cBits;
 }
 
 /// Inverse of FullAdd
@@ -115,7 +114,8 @@ void QInterface::CIFullAdd(bitLenInt* controlBits, bitLenInt controlLen, bitLenI
     // Quantum computing is reversible! Simply perform the inverse operations in reverse order!
     // (CNOT and CCNOT are self-inverse.)
 
-    bitLenInt* cBits = new bitLenInt[controlLen + 2];
+    std::unique_ptr<bitLenInt[]> cBitsU(new bitLenInt[controlLen + 2]);
+    bitLenInt* cBits = cBitsU.get();
     std::copy(controlBits, controlBits + controlLen, cBits);
 
     // Assume outputBit is in 0 state.
@@ -133,8 +133,6 @@ void QInterface::CIFullAdd(bitLenInt* controlBits, bitLenInt controlLen, bitLenI
     ApplyControlledSingleInvert(cBits, controlLen + 1, inputBit2, complex(ONE_R1, ZERO_R1), complex(ONE_R1, ZERO_R1));
     cBits[controlLen + 1] = inputBit2;
     ApplyControlledSingleInvert(cBits, controlLen + 2, carryOut, complex(ONE_R1, ZERO_R1), complex(ONE_R1, ZERO_R1));
-
-    delete[] cBits;
 }
 
 void QInterface::ADC(bitLenInt input1, bitLenInt input2, bitLenInt output, bitLenInt length, bitLenInt carry)

--- a/src/qinterface/rotational.cpp
+++ b/src/qinterface/rotational.cpp
@@ -94,7 +94,7 @@ void QInterface::UniformlyControlledRY(
     const bitLenInt* controls, const bitLenInt& controlLen, bitLenInt qubitIndex, const real1* angles)
 {
     bitCapIntOcl permCount = pow2Ocl(controlLen);
-    complex* pauliRYs = new complex[4U * (bitCapIntOcl)permCount];
+    std::unique_ptr<complex[]> pauliRYs(new complex[4U * (bitCapIntOcl)permCount]);
 
     real1 cosine, sine;
     for (bitCapIntOcl i = 0; i < permCount; i++) {
@@ -107,9 +107,7 @@ void QInterface::UniformlyControlledRY(
         pauliRYs[3U + 4U * i] = complex(cosine, ZERO_R1);
     }
 
-    UniformlyControlledSingleBit(controls, controlLen, qubitIndex, pauliRYs);
-
-    delete[] pauliRYs;
+    UniformlyControlledSingleBit(controls, controlLen, qubitIndex, pauliRYs.get());
 }
 
 /// Uniformly controlled z axis rotation gate - Rotates as e^(-i*\theta_k/2) around Pauli z axis for each permutation
@@ -118,7 +116,7 @@ void QInterface::UniformlyControlledRZ(
     const bitLenInt* controls, const bitLenInt& controlLen, bitLenInt qubitIndex, const real1* angles)
 {
     bitCapIntOcl permCount = pow2Ocl(controlLen);
-    complex* pauliRZs = new complex[4U * (bitCapIntOcl)permCount];
+    std::unique_ptr<complex[]> pauliRZs(new complex[4U * (bitCapIntOcl)permCount]);
 
     real1 cosine, sine;
     for (bitCapIntOcl i = 0; i < permCount; i++) {
@@ -131,9 +129,7 @@ void QInterface::UniformlyControlledRZ(
         pauliRZs[3U + 4U * i] = complex(cosine, sine);
     }
 
-    UniformlyControlledSingleBit(controls, controlLen, qubitIndex, pauliRZs);
-
-    delete[] pauliRZs;
+    UniformlyControlledSingleBit(controls, controlLen, qubitIndex, pauliRZs.get());
 }
 
 /// Exponentiate identity operator

--- a/src/qstabilizerhybrid.cpp
+++ b/src/qstabilizerhybrid.cpp
@@ -97,11 +97,10 @@ QInterfacePtr QStabilizerHybrid::Clone()
             c->shardsEigenZ[i] = shardsEigenZ[i];
         }
     } else {
-        complex* stateVec = new complex[(bitCapIntOcl)maxQPower];
-        engine->GetQuantumState(stateVec);
+        std::unique_ptr<complex[]> stateVec(new complex[(bitCapIntOcl)maxQPower]);
+        engine->GetQuantumState(stateVec.get());
         c->SwitchToEngine();
-        c->engine->SetQuantumState(stateVec);
-        delete[] stateVec;
+        c->engine->SetQuantumState(stateVec.get());
     }
 
     return c;
@@ -450,12 +449,11 @@ void QStabilizerHybrid::GetProbs(real1* outputProbs)
     FlushBuffers();
 
     if (stabilizer) {
-        complex* stateVec = new complex[(bitCapIntOcl)maxQPower];
-        stabilizer->GetQuantumState(stateVec);
+        std::unique_ptr<complex[]> stateVec(new complex[(bitCapIntOcl)maxQPower]);
+        stabilizer->GetQuantumState(stateVec.get());
         for (bitCapIntOcl i = 0; i < maxQPower; i++) {
-            outputProbs[i] = norm(stateVec[i]);
+            outputProbs[i] = norm(stateVec.get()[i]);
         }
-        delete[] stateVec;
     } else {
         engine->GetProbs(outputProbs);
     }


### PR DESCRIPTION
This has been a problem, with the recent work on allocation guards. When exceeding allocation limits, we now throw in `QEngineOCL`, _after_ de-allocating all heap resources.