### PR TITLE
QStabilizerHybrid refactor - cut redundant code

### DIFF
--- a/include/qstabilizerhybrid.hpp
+++ b/include/qstabilizerhybrid.hpp
@@ -422,8 +422,8 @@ public:
                     return norm(shard->gate[2]);
                 }
 
-                // Otherwise, state is entangled and locally appears maximally mixed.
-                return ONE_R1 / 2;
+                SwitchToEngine();
+                return engine->Prob(qubitIndex);
             }
         }
 
@@ -431,7 +431,8 @@ public:
             return (isCachedInvert != stabilizer->M(qubitIndex)) ? ONE_R1 : ZERO_R1;
         }
 
-        return ONE_R1 / 2;
+        SwitchToEngine();
+        return engine->Prob(qubitIndex);
     }
 
     virtual void Swap(bitLenInt qubit1, bitLenInt qubit2)

--- a/src/qstabilizer.cpp
+++ b/src/qstabilizer.cpp
@@ -401,7 +401,6 @@ void QStabilizer::GetQuantumState(QInterfacePtr eng)
     }
 
     eng->UpdateRunningNorm();
-    eng->NormalizeState();
 }
 
 /// Get all probabilities corresponding to ket notation

--- a/src/qstabilizerhybrid.cpp
+++ b/src/qstabilizerhybrid.cpp
@@ -29,7 +29,6 @@ QStabilizerHybrid::QStabilizerHybrid(QInterfaceEngine eng, QInterfaceEngine subE
     , subEngineType(subEng)
     , engine(NULL)
     , shards(qubitCount)
-    , shardsEigenZ(qubitCount)
     , devID(deviceId)
     , phaseFactor(phaseFac)
     , doNormalize(doNorm)
@@ -88,36 +87,28 @@ QStabilizerShardPtr QStabilizerHybrid::CacheEigenState(const bitLenInt& target, 
     // If in PauliX or PauliY basis, compose gate with conversion from/to PauliZ basis.
     if (!skipZ && stabilizer->IsSeparableZ(target)) {
         // Z eigenstate
-        shardsEigenZ[target] = true;
-
         complex mtrx[4] = { ONE_CMPLX, ZERO_CMPLX, ZERO_CMPLX, ONE_CMPLX };
         toRet = std::make_shared<QStabilizerShard>(mtrx);
-
+        toRet->isEigenZ = true;
     } else if (stabilizer->IsSeparableX(target)) {
         // X eigenstate
-        shardsEigenZ[target] = true;
-
         stabilizer->H(target);
 
         complex mtrx[4] = { complex(SQRT1_2_R1, ZERO_R1), complex(SQRT1_2_R1, ZERO_R1), complex(SQRT1_2_R1, ZERO_R1),
             complex(-SQRT1_2_R1, ZERO_R1) };
         toRet = std::make_shared<QStabilizerShard>(mtrx);
-
+        toRet->isEigenZ = true;
     } else if (stabilizer->IsSeparableY(target)) {
         // Y eigenstate
-        shardsEigenZ[target] = true;
-
         stabilizer->IS(target);
         stabilizer->H(target);
 
         complex mtrx[4] = { complex(SQRT1_2_R1, ZERO_R1), complex(SQRT1_2_R1, ZERO_R1), complex(ZERO_R1, SQRT1_2_R1),
             complex(ZERO_R1, -SQRT1_2_R1) };
         toRet = std::make_shared<QStabilizerShard>(mtrx);
-
+        toRet->isEigenZ = true;
     } else {
         // Not a single qubit eigenstate
-        shardsEigenZ[target] = false;
-
         complex mtrx[4] = { ONE_CMPLX, ZERO_CMPLX, ZERO_CMPLX, ONE_CMPLX };
         toRet = std::make_shared<QStabilizerShard>(mtrx);
     }
@@ -140,7 +131,6 @@ QInterfacePtr QStabilizerHybrid::Clone()
             if (shards[i]) {
                 c->shards[i] = std::make_shared<QStabilizerShard>(shards[i]->gate);
             }
-            c->shardsEigenZ[i] = shardsEigenZ[i];
         }
     } else {
         // Clone and set engine directly.
@@ -163,150 +153,6 @@ void QStabilizerHybrid::SwitchToEngine()
     FlushBuffers();
 }
 
-void QStabilizerHybrid::CCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target)
-{
-    if (stabilizer) {
-        real1_f prob = Prob(control1);
-        if (prob == ZERO_R1) {
-            return;
-        }
-        if (prob == ONE_R1) {
-            CNOT(control2, target);
-            return;
-        }
-
-        prob = Prob(control2);
-        if (prob == ZERO_R1) {
-            return;
-        }
-        if (prob == ONE_R1) {
-            CNOT(control1, target);
-            return;
-        }
-
-        SwitchToEngine();
-    }
-
-    engine->CCNOT(control1, control2, target);
-}
-
-void QStabilizerHybrid::CH(bitLenInt control, bitLenInt target)
-{
-    if (stabilizer) {
-        real1_f prob = Prob(control);
-        if (prob == ZERO_R1) {
-            return;
-        }
-        if (prob == ONE_R1) {
-            H(target);
-            return;
-        }
-
-        SwitchToEngine();
-    }
-
-    engine->CH(control, target);
-}
-
-void QStabilizerHybrid::CS(bitLenInt control, bitLenInt target)
-{
-    if (stabilizer) {
-        real1_f prob = Prob(control);
-        if (prob == ZERO_R1) {
-            return;
-        }
-        if (prob == ONE_R1) {
-            S(target);
-            return;
-        }
-
-        SwitchToEngine();
-    }
-
-    engine->CS(control, target);
-}
-
-void QStabilizerHybrid::CIS(bitLenInt control, bitLenInt target)
-{
-    if (stabilizer) {
-        real1_f prob = Prob(control);
-        if (prob == ZERO_R1) {
-            return;
-        }
-        if (prob == ONE_R1) {
-            IS(target);
-            return;
-        }
-
-        SwitchToEngine();
-    }
-
-    engine->CIS(control, target);
-}
-
-void QStabilizerHybrid::CCZ(bitLenInt control1, bitLenInt control2, bitLenInt target)
-{
-    if (stabilizer) {
-        real1_f prob = Prob(control1);
-        if (prob == ZERO_R1) {
-            return;
-        }
-        if (prob == ONE_R1) {
-            CZ(control2, target);
-            return;
-        }
-
-        prob = Prob(control2);
-        if (prob == ZERO_R1) {
-            return;
-        }
-        if (prob == ONE_R1) {
-            CZ(control1, target);
-            return;
-        }
-
-        prob = Prob(target);
-        if (prob == ZERO_R1) {
-            return;
-        }
-        if (prob == ONE_R1) {
-            CZ(control1, control2);
-            return;
-        }
-
-        SwitchToEngine();
-    }
-
-    engine->CCZ(control1, control2, target);
-}
-
-void QStabilizerHybrid::CCY(bitLenInt control1, bitLenInt control2, bitLenInt target)
-{
-    if (stabilizer) {
-        real1_f prob = Prob(control1);
-        if (prob == ZERO_R1) {
-            return;
-        }
-        if (prob == ONE_R1) {
-            CY(control2, target);
-            return;
-        }
-
-        prob = Prob(control2);
-        if (prob == ZERO_R1) {
-            return;
-        }
-        if (prob == ONE_R1) {
-            CY(control1, target);
-            return;
-        }
-
-        SwitchToEngine();
-    }
-
-    engine->CCY(control1, control2, target);
-}
-
 void QStabilizerHybrid::Decompose(bitLenInt start, QStabilizerHybridPtr dest)
 {
     bitLenInt length = dest->qubitCount;
@@ -318,7 +164,6 @@ void QStabilizerHybrid::Decompose(bitLenInt start, QStabilizerHybridPtr dest)
         engine = NULL;
 
         dest->shards = shards;
-        dest->shardsEigenZ = shardsEigenZ;
         DumpBuffers();
 
         SetQubitCount(1);
@@ -341,8 +186,6 @@ void QStabilizerHybrid::Decompose(bitLenInt start, QStabilizerHybridPtr dest)
     stabilizer->Decompose(start, dest->stabilizer);
     std::copy(shards.begin() + start, shards.begin() + start + length, dest->shards.begin());
     shards.erase(shards.begin() + start, shards.begin() + start + length);
-    std::copy(shardsEigenZ.begin() + start, shardsEigenZ.begin() + start + length, dest->shardsEigenZ.begin());
-    shardsEigenZ.erase(shardsEigenZ.begin() + start, shardsEigenZ.begin() + start + length);
     SetQubitCount(qubitCount - length);
 }
 
@@ -370,7 +213,6 @@ void QStabilizerHybrid::Dispose(bitLenInt start, bitLenInt length)
     }
 
     shards.erase(shards.begin() + start, shards.begin() + start + length);
-    shardsEigenZ.erase(shardsEigenZ.begin() + start, shardsEigenZ.begin() + start + length);
     SetQubitCount(qubitCount - length);
 }
 
@@ -398,7 +240,6 @@ void QStabilizerHybrid::Dispose(bitLenInt start, bitLenInt length, bitCapInt dis
     }
 
     shards.erase(shards.begin() + start, shards.begin() + start + length);
-    shardsEigenZ.erase(shardsEigenZ.begin() + start, shardsEigenZ.begin() + start + length);
     SetQubitCount(qubitCount - length);
 }
 
@@ -908,7 +749,7 @@ bitCapInt QStabilizerHybrid::MAll()
                 } else if (shard->IsPhase()) {
                     shards[i] = NULL;
                 } else {
-                    if (shardsEigenZ[i]) {
+                    if (shards[i]->isEigenZ) {
                         CollapseSeparableShard(i);
                     } else {
                         FlushBuffers();


### PR DESCRIPTION
All `void` return gate methods in `QStabilizerHybrid` that are not `QInterface` trunk can now be cut without loss of performance, hypothetically.

Since we have "shards" for single qubits already in `QStabilizerHybrid`, rather than store a corresponding `shardsEigenZ` vector alongside to complement, just store this `bool` on the shards themselves. This must always be appropriately set, whenever we call `make_shared<QStabilizerShard>()`.

I am unit testing locally before merging, including with Qiskit. I will deal with "Travis-ocalypse" this weekend.