### PR TITLE
Qiskit debug

### DIFF
--- a/include/qstabilizer.hpp
+++ b/include/qstabilizer.hpp
@@ -94,18 +94,19 @@ public:
     QStabilizer(
         const bitLenInt& n, const bitCapInt& perm = 0, bool useHardwareRNG = true, qrack_rand_gen_ptr rgp = nullptr);
 
-    QStabilizer(QStabilizer& s)
+    QStabilizerPtr Clone()
     {
-        s.Finish();
+        Finish();
 
-        qubitCount = s.qubitCount;
-        x = s.x;
-        z = s.z;
-        r = s.r;
-        randomSeed = s.randomSeed;
-        rand_generator = s.rand_generator;
-        rand_distribution = s.rand_distribution;
-        hardware_rand_generator = s.hardware_rand_generator;
+        QStabilizerPtr clone =
+            std::make_shared<QStabilizer>(qubitCount, 0, hardware_rand_generator != NULL, rand_generator);
+
+        clone->x = x;
+        clone->z = z;
+        clone->r = r;
+        clone->SetRandomSeed(randomSeed);
+
+        return clone;
     }
 
     virtual ~QStabilizer() { Dump(); }

--- a/include/qstabilizer.hpp
+++ b/include/qstabilizer.hpp
@@ -96,15 +96,17 @@ public:
 
     QStabilizerPtr Clone()
     {
-        Finish();
-
         QStabilizerPtr clone =
             std::make_shared<QStabilizer>(qubitCount, 0, hardware_rand_generator != NULL, rand_generator);
+
+        clone->Finish();
+        Finish();
+
+        clone->SetRandomSeed(randomSeed);
 
         clone->x = x;
         clone->z = z;
         clone->r = r;
-        clone->SetRandomSeed(randomSeed);
 
         return clone;
     }

--- a/src/qstabilizer.cpp
+++ b/src/qstabilizer.cpp
@@ -100,8 +100,8 @@ void QStabilizer::rowcopy(const bitLenInt& i, const bitLenInt& k)
         return;
     }
 
-    std::copy(x[k].begin(), x[k].end(), x[i].begin());
-    std::copy(z[k].begin(), z[k].end(), z[i].begin());
+    x[i] = x[k];
+    z[i] = z[k];
     r[i] = r[k];
 }
 

--- a/src/qstabilizerhybrid.cpp
+++ b/src/qstabilizerhybrid.cpp
@@ -132,16 +132,16 @@ void QStabilizerHybrid::CacheEigenstate(const bitLenInt& target)
 
 QInterfacePtr QStabilizerHybrid::Clone()
 {
-    Finish();
-
     QStabilizerHybridPtr c =
         std::dynamic_pointer_cast<QStabilizerHybrid>(CreateQuantumInterface(QINTERFACE_STABILIZER_HYBRID, engineType,
             subEngineType, qubitCount, 0, rand_generator, phaseFactor, doNormalize, randGlobalPhase, useHostRam, devID,
             useRDRAND, isSparse, (real1_f)amplitudeFloor, std::vector<int>{}, thresholdQubits, separabilityThreshold));
 
+    c->Finish();
+
     if (stabilizer) {
-        c->stabilizer = std::make_shared<QStabilizer>(*stabilizer);
-        for (bitLenInt i = 0; i < shards.size(); i++) {
+        c->stabilizer = stabilizer->Clone();
+        for (bitLenInt i = 0; i < qubitCount; i++) {
             if (shards[i]) {
                 c->shards[i] = std::make_shared<QStabilizerShard>(shards[i]->gate);
             }

--- a/src/qstabilizerhybrid.cpp
+++ b/src/qstabilizerhybrid.cpp
@@ -137,9 +137,11 @@ QInterfacePtr QStabilizerHybrid::Clone()
             subEngineType, qubitCount, 0, rand_generator, phaseFactor, doNormalize, randGlobalPhase, useHostRam, devID,
             useRDRAND, isSparse, (real1_f)amplitudeFloor, std::vector<int>{}, thresholdQubits, separabilityThreshold));
 
+    Finish();
     c->Finish();
 
     if (stabilizer) {
+        c->engine = NULL;
         c->stabilizer = stabilizer->Clone();
         for (bitLenInt i = 0; i < qubitCount; i++) {
             if (shards[i]) {

--- a/src/qstabilizerhybrid.cpp
+++ b/src/qstabilizerhybrid.cpp
@@ -137,6 +137,9 @@ QInterfacePtr QStabilizerHybrid::Clone()
             subEngineType, qubitCount, 0, rand_generator, phaseFactor, doNormalize, randGlobalPhase, useHostRam, devID,
             useRDRAND, isSparse, (real1_f)amplitudeFloor, std::vector<int>{}, thresholdQubits, separabilityThreshold));
 
+    // TODO: Remove.
+    SwitchToEngine();
+
     Finish();
     c->Finish();
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -4503,8 +4503,12 @@ QInterfacePtr QUnit::Clone()
         RevertBasis2Qb(i);
     }
 
-    QUnitPtr copyPtr = std::make_shared<QUnit>(
-        engine, subEngine, qubitCount, 0, rand_generator, ONE_CMPLX, doNormalize, randGlobalPhase, useHostRam);
+    QUnitPtr copyPtr = std::make_shared<QUnit>(engine, subEngine, qubitCount, 0, rand_generator, phaseFactor,
+        doNormalize, randGlobalPhase, useHostRam, devID, useRDRAND, isSparse, (real1_f)amplitudeFloor, deviceIDs,
+        thresholdQubits, separabilityThreshold);
+
+    Finish();
+    copyPtr->Finish();
 
     return CloneBody(copyPtr);
 }

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -4501,7 +4501,6 @@ QInterfacePtr QUnit::Clone()
     // TODO: Copy buffers instead of flushing?
     for (bitLenInt i = 0; i < qubitCount; i++) {
         RevertBasis2Qb(i);
-        EndEmulation(i);
     }
 
     QUnitPtr copyPtr = std::make_shared<QUnit>(
@@ -4512,21 +4511,19 @@ QInterfacePtr QUnit::Clone()
 
 QInterfacePtr QUnit::CloneBody(QUnitPtr copyPtr)
 {
-    std::vector<QInterfacePtr> shardEngines;
-    std::vector<QInterfacePtr> dupeEngines;
-    std::vector<QInterfacePtr>::iterator origEngine;
-    bitLenInt engineIndex;
+    std::map<QInterfacePtr, QInterfacePtr> dupeEngines;
     for (bitLenInt i = 0; i < qubitCount; i++) {
-        if (find(shardEngines.begin(), shardEngines.end(), shards[i].unit) == shardEngines.end()) {
-            shardEngines.push_back(shards[i].unit);
-            dupeEngines.push_back(shards[i].unit->Clone());
+        copyPtr->shards[i] = QEngineShard(shards[i]);
+
+        if (!shards[i].unit) {
+            continue;
         }
 
-        origEngine = find(shardEngines.begin(), shardEngines.end(), shards[i].unit);
-        engineIndex = origEngine - shardEngines.begin();
+        if (dupeEngines.find(shards[i].unit) == dupeEngines.end()) {
+            dupeEngines[shards[i].unit] = shards[i].unit->Clone();
+        }
 
-        copyPtr->shards[i] = QEngineShard(shards[i]);
-        copyPtr->shards[i].unit = dupeEngines[engineIndex];
+        copyPtr->shards[i].unit = dupeEngines[shards[i].unit];
     }
 
     return copyPtr;

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -4515,19 +4515,21 @@ QInterfacePtr QUnit::Clone()
 
 QInterfacePtr QUnit::CloneBody(QUnitPtr copyPtr)
 {
+    QInterfacePtr unit;
     std::map<QInterfacePtr, QInterfacePtr> dupeEngines;
     for (bitLenInt i = 0; i < qubitCount; i++) {
         copyPtr->shards[i] = QEngineShard(shards[i]);
 
-        if (!shards[i].unit) {
+        unit = shards[i].unit;
+        if (!unit) {
             continue;
         }
 
-        if (dupeEngines.find(shards[i].unit) == dupeEngines.end()) {
-            dupeEngines[shards[i].unit] = shards[i].unit->Clone();
+        if (dupeEngines.find(unit) == dupeEngines.end()) {
+            dupeEngines[unit] = unit->Clone();
         }
 
-        copyPtr->shards[i].unit = dupeEngines[shards[i].unit];
+        copyPtr->shards[i].unit = dupeEngines[unit];
     }
 
     return copyPtr;

--- a/src/qunitmulti.cpp
+++ b/src/qunitmulti.cpp
@@ -225,11 +225,14 @@ QInterfacePtr QUnitMulti::Clone()
     // TODO: Copy buffers instead of flushing?
     for (bitLenInt i = 0; i < qubitCount; i++) {
         RevertBasis2Qb(i);
-        EndEmulation(i);
     }
 
-    QUnitMultiPtr copyPtr = std::make_shared<QUnitMulti>(
-        qubitCount, 0, rand_generator, complex(ONE_R1, ZERO_R1), doNormalize, randGlobalPhase, useHostRam);
+    QUnitMultiPtr copyPtr = std::make_shared<QUnitMulti>(engine, subEngine, qubitCount, 0, rand_generator, phaseFactor,
+        doNormalize, randGlobalPhase, useHostRam, devID, useRDRAND, isSparse, (real1_f)amplitudeFloor, deviceIDs,
+        thresholdQubits, separabilityThreshold);
+
+    Finish();
+    copyPtr->Finish();
 
     return CloneBody(copyPtr);
 }

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -4680,7 +4680,6 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_universal_set")
     REQUIRE_THAT(qftReg, HasProbability(0, 20, 3));
 }
 
-#if 0
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_teleport")
 {
     qftReg = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 3, 0);
@@ -4707,7 +4706,6 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_teleport")
         REQUIRE(!suffix->M(2));
     }
 }
-#endif
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_h_cnot_rand")
 {

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -4680,31 +4680,34 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_universal_set")
     REQUIRE_THAT(qftReg, HasProbability(0, 20, 3));
 }
 
+#if 0
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_teleport")
 {
     qftReg = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 3, 0);
 
+    qftReg->SetPermutation(0);
+
+    qftReg->H(1);
+    qftReg->CNOT(1, 2);
+    qftReg->CNOT(0, 1);
+    qftReg->H(0);
+
     for (int i = 0; i < 10; i++) {
-        qftReg->SetPermutation(0);
-
-        qftReg->H(1);
-        qftReg->CNOT(1, 2);
-        qftReg->CNOT(0, 1);
-        qftReg->H(0);
-
-        bool c0 = qftReg->M(0);
-        bool c1 = qftReg->M(1);
+        QInterfacePtr suffix = qftReg->Clone();
+        bool c0 = suffix->M(0);
+        bool c1 = suffix->M(1);
 
         if (c0) {
-            qftReg->Z(2);
+            suffix->Z(2);
         }
         if (c1) {
-            qftReg->X(2);
+            suffix->X(2);
         }
 
-        REQUIRE(!qftReg->M(2));
+        REQUIRE(!suffix->M(2));
     }
 }
+#endif
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_h_cnot_rand")
 {


### PR DESCRIPTION
I've been poking this for hours, and I have no idea why the current implementation of `QStabilizerHybrid::Clone()` doesn't seem to work when copying a `QStabilizer` pointer. However, I will open an issue to track this, and it shouldn't make any significant difference to performance, since this case is invoked in Qiskit only immediately before a non-unitary gate, as in the unit test.