### PR TITLE
LGTM refactor

### DIFF
--- a/include/hamiltonian.hpp
+++ b/include/hamiltonian.hpp
@@ -95,7 +95,7 @@ struct UniformHamiltonianOp : HamiltonianOp {
         uniform = true;
     }
 
-    UniformHamiltonianOp(const _QrackTimeEvolveOpHeader &teoh, double* mtrx)
+    UniformHamiltonianOp(const _QrackTimeEvolveOpHeader& teoh, double* mtrx)
         : HamiltonianOp()
     {
         targetBit = (bitLenInt)(teoh.target);

--- a/include/hamiltonian.hpp
+++ b/include/hamiltonian.hpp
@@ -95,7 +95,7 @@ struct UniformHamiltonianOp : HamiltonianOp {
         uniform = true;
     }
 
-    UniformHamiltonianOp(const _QrackTimeEvolveOpHeader& teoh, double* mtrx)
+    UniformHamiltonianOp(const _QrackTimeEvolveOpHeader &teoh, double* mtrx)
         : HamiltonianOp()
     {
         targetBit = (bitLenInt)(teoh.target);

--- a/src/qunitmulti.cpp
+++ b/src/qunitmulti.cpp
@@ -40,7 +40,7 @@ QUnitMulti::QUnitMulti(QInterfaceEngine eng, QInterfaceEngine subEng, bitLenInt 
     if (devList.size() == 0) {
         defaultDeviceID = (deviceID == -1) ? OCLEngine::Instance()->GetDefaultDeviceID() : deviceID;
 
-        for (unsigned int i = 0; i < deviceContext.size(); i++) {
+        for (size_t i = 0; i < deviceContext.size(); i++) {
             DeviceInfo deviceInfo;
             deviceInfo.id = i;
             deviceList.push_back(deviceInfo);
@@ -50,14 +50,14 @@ QUnitMulti::QUnitMulti(QInterfaceEngine eng, QInterfaceEngine subEng, bitLenInt 
     } else {
         defaultDeviceID = devList[0];
 
-        for (unsigned int i = 0; i < devList.size(); i++) {
+        for (size_t i = 0; i < devList.size(); i++) {
             DeviceInfo deviceInfo;
             deviceInfo.id = devList[i];
             deviceList.push_back(deviceInfo);
         }
     }
 
-    for (unsigned int i = 0; i < deviceList.size(); i++) {
+    for (size_t i = 0; i < deviceList.size(); i++) {
         deviceList[i].maxSize = deviceContext[deviceList[i].id]->device.getInfo<CL_DEVICE_MAX_MEM_ALLOC_SIZE>();
     }
 
@@ -111,7 +111,7 @@ void QUnitMulti::RedistributeQEngines()
     std::fill(devSizes.begin(), devSizes.end(), 0U);
     bitCapInt sz;
     bitLenInt devID, devIndex;
-    unsigned int i, j;
+    size_t i, j;
 
     for (i = 0; i < qinfos.size(); i++) {
         // If the engine adds negligible load, we can let any given unit keep its


### PR DESCRIPTION
The fact that the last LGTM error wasn't fixed by #854 doesn't make sense, given the suggestion notes from them. I'm testing if LGTM was tripped up on the degenerate syntax, of `const type& x` as opposed to `const type &x`.