### PR TITLE
Unity debugging/improvement

### DIFF
--- a/include/pinvoke_api.hpp
+++ b/include/pinvoke_api.hpp
@@ -115,8 +115,6 @@ MICROSOFT_QUANTUM_DECL void CLNAND(_In_ unsigned sid, _In_ bool ci, _In_ unsigne
 MICROSOFT_QUANTUM_DECL void CLNOR(_In_ unsigned sid, _In_ bool ci, _In_ unsigned qi, _In_ unsigned qo);
 MICROSOFT_QUANTUM_DECL void CLXNOR(_In_ unsigned sid, _In_ bool ci, _In_ unsigned qi, _In_ unsigned qo);
 
-MICROSOFT_QUANTUM_DECL double Prob(_In_ unsigned sid, _In_ unsigned q);
-
 MICROSOFT_QUANTUM_DECL void QFT(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c);
 MICROSOFT_QUANTUM_DECL void IQFT(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c);
 

--- a/include/pinvoke_api.hpp
+++ b/include/pinvoke_api.hpp
@@ -38,6 +38,7 @@ MICROSOFT_QUANTUM_DECL void Dump(_In_ unsigned sid, _In_ ProbAmpCallback callbac
 
 // pseudo-quantum
 MICROSOFT_QUANTUM_DECL double Prob(_In_ unsigned sid, _In_ unsigned q);
+MICROSOFT_QUANTUM_DECL double PermutationExpectation(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c);
 
 // MICROSOFT_QUANTUM_DECL bool DumpQubits(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* q, _In_
 // ProbAmpCallback callback);

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -2219,6 +2219,16 @@ public:
      */
     virtual void ProbMaskAll(const bitCapInt& mask, real1* probsArray);
 
+    /**
+     * Direct measure of listed permutation probability
+     *
+     * The probabilities of all included permutations of bits, with bits valued from low to high as the order of the
+     * "bits" array parameter argument, are returned in the "probsArray" parameter.
+     *
+     * \warning PSEUDO-QUANTUM
+     */
+    virtual void ProbBitsAll(const bitCapInt* bits, const bitLenInt& length, real1* probsArray);
+
     /** Overall probability of any odd permutation of the masked set of bits */
     virtual real1_f ProbParity(const bitCapInt& mask) = 0;
 

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -2227,7 +2227,7 @@ public:
      *
      * \warning PSEUDO-QUANTUM
      */
-    virtual void ProbBitsAll(const bitCapInt* bits, const bitLenInt& length, real1* probsArray);
+    virtual void ProbBitsAll(const bitLenInt* bits, const bitLenInt& length, real1* probsArray);
 
     /** Overall probability of any odd permutation of the masked set of bits */
     virtual real1_f ProbParity(const bitCapInt& mask) = 0;

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -2229,6 +2229,16 @@ public:
      */
     virtual void ProbBitsAll(const bitLenInt* bits, const bitLenInt& length, real1* probsArray);
 
+    /**
+     * Get permutation expectation value of bits
+     *
+     * The permutation expectation value of all included bits is returned, with bits valued from low to high as the
+     * order of the "bits" array parameter argument.
+     *
+     * \warning PSEUDO-QUANTUM
+     */
+    virtual real1_f ExpectationBitsAll(const bitLenInt* bits, const bitLenInt& length);
+
     /** Overall probability of any odd permutation of the masked set of bits */
     virtual real1_f ProbParity(const bitCapInt& mask) = 0;
 

--- a/src/pinvoke_api.cpp
+++ b/src/pinvoke_api.cpp
@@ -199,10 +199,6 @@ MICROSOFT_QUANTUM_DECL unsigned init_count(_In_ unsigned q)
 
     QInterfacePtr simulator = q ? CreateQuantumInterface(QINTERFACE_OPTIMAL_MULTI, q, 0, randNumGen) : NULL;
 
-    if (q > MaxShardQubits()) {
-        simulator->SetReactiveSeparate(true);
-    }
-
     if (sid == simulators.size()) {
         simulatorReservations.push_back(true);
         simulators.push_back(simulator);
@@ -412,9 +408,6 @@ MICROSOFT_QUANTUM_DECL void allocateQubit(_In_ unsigned sid, _In_ unsigned qid)
         simulators[sid]->Compose(nQubit);
     }
     bitLenInt qubitCount = simulators[sid]->GetQubitCount();
-    if (qubitCount > MaxShardQubits()) {
-        simulators[sid]->SetReactiveSeparate(true);
-    }
     shards[simulators[sid]][qid] = (qubitCount - 1U);
 }
 
@@ -435,9 +428,6 @@ MICROSOFT_QUANTUM_DECL bool release(_In_ unsigned sid, _In_ unsigned q)
         SIMULATOR_LOCK_GUARD(sid)
         bitLenInt oIndex = shards[simulator][q];
         simulator->Dispose(oIndex, 1U);
-        if (simulator->GetQubitCount() <= MaxShardQubits()) {
-            simulator->SetReactiveSeparate(false);
-        }
         for (unsigned i = 0; i < shards[simulator].size(); i++) {
             if (shards[simulator][i] > oIndex) {
                 shards[simulator][i]--;

--- a/src/pinvoke_api.cpp
+++ b/src/pinvoke_api.cpp
@@ -986,6 +986,24 @@ MICROSOFT_QUANTUM_DECL double Prob(_In_ unsigned sid, _In_ unsigned q)
     return simulator->Prob(shards[simulator][q]);
 }
 
+/**
+ * (External API) Get the permutation expectation value, based upon the order of input qubits.
+ */
+MICROSOFT_QUANTUM_DECL double PermutationExpectation(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c)
+{
+    SIMULATOR_LOCK_GUARD(sid)
+
+    bitLenInt* q = new bitLenInt[n];
+    std::copy(c, c + n, q);
+
+    QInterfacePtr simulator = simulators[sid];
+    double result = simulator->ExpectationBitsAll(q, n);
+
+    delete[] q;
+
+    return result;
+}
+
 MICROSOFT_QUANTUM_DECL void QFT(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c)
 {
     SIMULATOR_LOCK_GUARD(sid)

--- a/src/qinterface/qinterface.cpp
+++ b/src/qinterface/qinterface.cpp
@@ -746,6 +746,8 @@ void QInterface::ProbMaskAll(const bitCapInt& mask, real1* probsArray)
 
 void QInterface::ProbBitsAll(const bitLenInt* bits, const bitLenInt& length, real1* probsArray)
 {
+    std::fill(probsArray, probsArray + pow2(length), ZERO_R1);
+
     bitLenInt p;
     std::vector<bitCapInt> bitPowers(length);
     std::map<bitLenInt, bitCapInt> bitMap;
@@ -764,6 +766,21 @@ void QInterface::ProbBitsAll(const bitLenInt* bits, const bitLenInt& length, rea
         }
         probsArray[retIndex] += ProbAll(lcv);
     }
+}
+
+real1_f QInterface::ExpectationBitsAll(const bitLenInt* bits, const bitLenInt& length)
+{
+    bitCapInt lengthPower = pow2(length);
+
+    std::unique_ptr<real1[]> bitProbsArray(new real1[lengthPower]);
+    ProbBitsAll(bits, length, bitProbsArray.get());
+
+    real1_f expectation = ZERO_R1;
+    for (bitCapInt i = 1; i < lengthPower; i++) {
+        expectation += i * bitProbsArray.get()[i];
+    }
+
+    return expectation;
 }
 
 std::map<bitCapInt, int> QInterface::MultiShotMeasureMask(

--- a/src/qinterface/qinterface.cpp
+++ b/src/qinterface/qinterface.cpp
@@ -744,41 +744,25 @@ void QInterface::ProbMaskAll(const bitCapInt& mask, real1* probsArray)
     }
 }
 
-void QInterface::ProbBitsAll(const bitCapInt* bits, const bitLenInt& length, real1* probsArray)
+void QInterface::ProbBitsAll(const bitLenInt* bits, const bitLenInt& length, real1* probsArray)
 {
-    bitCapInt bitPower;
-    bitCapInt mask = 0;
-    std::map<bitCapInt, bitCapInt> bitMap;
-    for (bitLenInt i = 0; i < length; i++) {
-        bitPower = pow2(bits[i]);
-        mask |= bitPower;
-        bitMap[bitPower] = pow2(i);
+    bitLenInt p;
+    std::vector<bitCapInt> bitPowers(length);
+    std::map<bitLenInt, bitCapInt> bitMap;
+    for (p = 0; p < length; p++) {
+        bitPowers[p] = pow2(bits[p]);
+        bitMap[bits[p]] = pow2(p);
     }
 
-    bitCapInt lengthPower = pow2(length);
-    bitCapIntOcl lcv, retIndex;
-    bitLenInt p;
-    bitCapInt i, iHigh, iLow;
-    std::map<bitCapInt, bitCapInt>::iterator bitMapIterator;
-    for (lcv = 0; lcv < lengthPower; lcv++) {
+    bitCapInt retIndex;
+    for (bitCapInt lcv = 0; lcv < maxQPower; lcv++) {
         retIndex = 0;
-        iHigh = lcv;
-        i = 0;
-        bitMapIterator = bitMap.begin();
         for (p = 0; p < length; p++) {
-            if (pow2(p) & lcv) {
-                retIndex |= bitMapIterator->second;
+            if (lcv & bitPowers[p]) {
+                retIndex |= bitMap[bits[p]];
             }
-
-            iLow = iHigh & (bitMapIterator->first - ONE_BCI);
-            i |= iLow;
-            iHigh = (iHigh ^ iLow) << ONE_BCI;
-
-            bitMapIterator++;
         }
-        i |= iHigh;
-
-        probsArray[retIndex] = ProbMask(mask, i);
+        probsArray[retIndex] += ProbAll(lcv);
     }
 }
 

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -2226,8 +2226,7 @@ TEST_CASE("test_iqft_cosmology", "[cosmos]")
 {
     // This is "scratch work" inspired by https://arxiv.org/abs/1702.06959
     //
-    // Per the notes of the previous test, reconsidered in July 2021, the inverse QFT, per "layer," spreads locally, one
-    // qubit at a time, perhaps like a light cone. This might actually be the more appropriate test/simulation.
+    // Per the notes of the previous test, we give the option to consider the inverse as better motivated.
 
     benchmarkLoop([&](QInterfacePtr qUniverse, bitLenInt n) { qUniverse->IQFT(0, n); }, false, false, false, true);
 }

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -3877,13 +3877,23 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_probmask")
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_probmaskall")
 {
-    // We're trying to hit a hardware-specific case of the method, by allocating 1 qubit, but it might not work if the
-    // maximum work item count is extremely small.
     qftReg = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 1, 0, rng);
     real1 probs1[2];
     qftReg->ProbMaskAll(1U, probs1);
     REQUIRE(probs1[0] > 0.99);
     REQUIRE(probs1[1] < 0.01);
+}
+
+TEST_CASE_METHOD(QInterfaceTestFixture, "test_probbitsall")
+{
+    qftReg = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 3, 5, rng);
+    bitLenInt bits[2] = { 2, 1 };
+    real1 probs1[4];
+    qftReg->ProbBitsAll(bits, 2U, probs1);
+    REQUIRE(probs1[0] < 0.01);
+    REQUIRE(probs1[1] > 0.99);
+    REQUIRE(probs1[2] < 0.01);
+    REQUIRE(probs1[3] < 0.01);
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_probparity")

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -3894,6 +3894,22 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_probbitsall")
     REQUIRE(probs1[1] > 0.99);
     REQUIRE(probs1[2] < 0.01);
     REQUIRE(probs1[3] < 0.01);
+
+    qftReg->H(2);
+
+    qftReg->ProbBitsAll(bits, 2U, probs1);
+    REQUIRE_FLOAT(probs1[0], 0.5);
+    REQUIRE_FLOAT(probs1[1], 0.5);
+    REQUIRE(probs1[2] < 0.01);
+    REQUIRE(probs1[3] < 0.01);
+}
+
+TEST_CASE_METHOD(QInterfaceTestFixture, "test_expectationbitsall")
+{
+    qftReg = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 8, 0, rng);
+    bitLenInt bits[8] = { 0, 1, 2, 3, 4, 5, 6, 7 };
+    qftReg->H(0, 8);
+    REQUIRE_FLOAT(qftReg->ExpectationBitsAll(bits, 8U), 127 + (ONE_R1 / 2))
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_probparity")


### PR DESCRIPTION
For stability in the Unity game engine, this removes `SetReactiveSeparate()` thresholds from the PInvoke API, (which brings it into line with recent changes in the general library,) and it adds a simple (but not necessarily performant) method for quickly checking the permutation expectation value of an arbitrary list of bit indices.