### PR TITLE
New QEngine-locking QPager constructor

### DIFF
--- a/include/common/qrack_types.hpp
+++ b/include/common/qrack_types.hpp
@@ -158,6 +158,9 @@ typedef std::shared_ptr<StateVector> StateVectorPtr;
 typedef std::shared_ptr<StateVectorArray> StateVectorArrayPtr;
 typedef std::shared_ptr<StateVectorSparse> StateVectorSparsePtr;
 
+class QEngine;
+typedef std::shared_ptr<QEngine> QEnginePtr;
+
 // This is a buffer struct that's capable of representing controlled single bit gates and arithmetic, when subclassed.
 class StateVector {
 protected:

--- a/include/qpager.hpp
+++ b/include/qpager.hpp
@@ -107,6 +107,8 @@ protected:
     void ApplyEitherControlledSingleBit(const bool& anti, const bitLenInt* controls, const bitLenInt& controlLen,
         const bitLenInt& target, const complex* mtrx);
 
+    void Init();
+
 public:
     QPager(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState = 0, qrack_rand_gen_ptr rgp = nullptr,
         complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = false, bool ignored = false, bool useHostMem = false,
@@ -123,6 +125,12 @@ public:
               deviceId, useHardwareRNG, useSparseStateVec, norm_thresh, devList, qubitThreshold, separation_thresh)
     {
     }
+
+    QPager(QEnginePtr enginePtr, QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt ignored = 0,
+        qrack_rand_gen_ptr rgp = nullptr, complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = false,
+        bool ignored2 = false, bool useHostMem = false, int deviceId = -1, bool useHardwareRNG = true,
+        bool useSparseStateVec = false, real1_f norm_thresh = REAL1_EPSILON, std::vector<int> devList = {},
+        bitLenInt qubitThreshold = 0, real1_f separation_thresh = FP_NORM_EPSILON);
 
     virtual void SetConcurrency(uint32_t threadsPerEngine)
     {

--- a/src/common/qheader_bcd.cl
+++ b/src/common/qheader_bcd.cl
@@ -29,7 +29,7 @@ void kernel incbcd(global cmplx* stateVec, constant bitCapIntOcl* bitCapIntOclPt
         test2 = partToAdd % 10;
         partToAdd /= 10;
         nibbles[0] = test1 + test2;
-        if ((test1 > 9) || (test2 > 9)) {
+        if (test1 > 9) {
             isValid = false;
         }
 
@@ -39,7 +39,7 @@ void kernel incbcd(global cmplx* stateVec, constant bitCapIntOcl* bitCapIntOclPt
             test2 = partToAdd % 10;
             partToAdd /= 10;
             nibbles[j] = test1 + test2;
-            if ((test1 > 9) || (test2 > 9)) {
+            if (test1 > 9) {
                 isValid = false;
             }
         }

--- a/src/qengine/arithmetic.cpp
+++ b/src/qengine/arithmetic.cpp
@@ -785,7 +785,7 @@ void QEngineCPU::INCDECBCDC(
         test2 = (int)(partToAdd % 10);
         partToAdd /= 10;
         nibbles[0] = test1 + test2;
-        if ((test1 > 9) || (test2 > 9)) {
+        if (test1 > 9) {
             isValid = false;
         }
 
@@ -795,7 +795,7 @@ void QEngineCPU::INCDECBCDC(
             test2 = (int)(partToAdd % 10);
             partToAdd /= 10;
             nibbles[j] = test1 + test2;
-            if ((test1 > 9) || (test2 > 9)) {
+            if (test1 > 9) {
                 isValid = false;
             }
         }

--- a/src/qpager.cpp
+++ b/src/qpager.cpp
@@ -34,6 +34,50 @@ QPager::QPager(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState, q
     , thresholdQubitsPerPage(qubitThreshold)
     , pStridePow(PSTRIDEPOW)
 {
+    Init();
+
+    initState &= maxQPower - ONE_BCI;
+    bool isPermInPage;
+    bitCapIntOcl pagePerm = 0;
+    for (bitCapIntOcl i = 0; i < basePageCount; i++) {
+        isPermInPage = (initState >= pagePerm);
+        pagePerm += basePageMaxQPower;
+        isPermInPage &= (initState < pagePerm);
+        if (isPermInPage) {
+            qPages.push_back(MakeEngine(
+                baseQubitsPerPage, initState - (pagePerm - basePageMaxQPower), deviceIDs[i % deviceIDs.size()]));
+        } else {
+            qPages.push_back(MakeEngine(baseQubitsPerPage, 0, deviceIDs[i % deviceIDs.size()]));
+            qPages.back()->SetAmplitude(0, ZERO_CMPLX);
+        }
+    }
+}
+
+QPager::QPager(QEnginePtr enginePtr, QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState,
+    qrack_rand_gen_ptr rgp, complex phaseFac, bool ignored, bool ignored2, bool useHostMem, int deviceId,
+    bool useHardwareRNG, bool useSparseStateVec, real1_f norm_thresh, std::vector<int> devList,
+    bitLenInt qubitThreshold, real1_f sep_thresh)
+    : QInterface(qBitCount, rgp, false, useHardwareRNG, false, norm_thresh)
+    , engine(eng)
+    , devID(deviceId)
+    , phaseFactor(phaseFac)
+    , useHostRam(useHostMem)
+    , useRDRAND(useHardwareRNG)
+    , isSparse(useSparseStateVec)
+    , runningNorm(ONE_R1)
+    , deviceIDs(devList)
+    , useHardwareThreshold(false)
+    , minPageQubits(0)
+    , deviceGlobalQubits(2)
+    , thresholdQubitsPerPage(qubitThreshold)
+    , pStridePow(PSTRIDEPOW)
+{
+    Init();
+    LockEngine(enginePtr);
+}
+
+void QPager::Init()
+{
 #if !ENABLE_OPENCL
     if (engine == QINTERFACE_HYBRID) {
         eng = QINTERFACE_CPU;
@@ -118,22 +162,6 @@ QPager::QPager(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState, q
     if (qubitCount > maxQubits) {
         throw std::invalid_argument(
             "Cannot instantiate a QPager with greater capacity than environment variable QRACK_MAX_PAGING_QB.");
-    }
-
-    initState &= maxQPower - ONE_BCI;
-    bool isPermInPage;
-    bitCapIntOcl pagePerm = 0;
-    for (bitCapIntOcl i = 0; i < basePageCount; i++) {
-        isPermInPage = (initState >= pagePerm);
-        pagePerm += basePageMaxQPower;
-        isPermInPage &= (initState < pagePerm);
-        if (isPermInPage) {
-            qPages.push_back(MakeEngine(
-                baseQubitsPerPage, initState - (pagePerm - basePageMaxQPower), deviceIDs[i % deviceIDs.size()]));
-        } else {
-            qPages.push_back(MakeEngine(baseQubitsPerPage, 0, deviceIDs[i % deviceIDs.size()]));
-            qPages.back()->SetAmplitude(0, ZERO_CMPLX);
-        }
     }
 }
 

--- a/src/qpager.cpp
+++ b/src/qpager.cpp
@@ -80,7 +80,7 @@ void QPager::Init()
 {
 #if !ENABLE_OPENCL
     if (engine == QINTERFACE_HYBRID) {
-        eng = QINTERFACE_CPU;
+        engine = QINTERFACE_CPU;
     }
 #endif
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -148,8 +148,9 @@ void QUnit::TurnOnPaging()
         for (i = 0; i < qubitCount; i++) {
             QEnginePtr unit = std::dynamic_pointer_cast<QEngine>(shards[i].unit);
             if (unit && (nEngines.find(unit) == nEngines.end())) {
-                nEngines[unit] = std::dynamic_pointer_cast<QPager>(MakeEngine(unit->GetQubitCount(), 0));
-                nEngines[unit]->LockEngine(unit);
+                nEngines[unit] = std::make_shared<QPager>(unit, subEngine, unit->GetQubitCount(), 0, rand_generator,
+                    phaseFactor, doNormalize, randGlobalPhase, useHostRam, devID, useRDRAND, isSparse,
+                    (real1_f)amplitudeFloor, deviceIDs, thresholdQubits, separabilityThreshold);
             }
         }
 


### PR DESCRIPTION
The `QUnit` layer has a qubit count activation threshold, before it will use an intermediate `QPager` layer for its "shards." If `QUnit` qubit width changes, there is a switch-over process, where all shards gain an intermediate `QPager` layer. Previously, this caused redundant allocation in `QPager`, before "locking" the old shard and splitting it into pages.

This PR adds a constructor to `QPager` that lets `QUnit` turn on an interstitial paging layer without generating redundant state vector garbage, by directly locking a `QEngine` as its first "page."