### PR TITLE
OpenCL tweak

### DIFF
--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -33,16 +33,14 @@ namespace Qrack {
     if (error != CL_SUCCESS) {                                                                                         \
         FreeAll();                                                                                                     \
         throw std::runtime_error("Failed to enqueue buffer write, error code: " + std::to_string(error));              \
-    }                                                                                                                  \
-    clFlush();
+    }
 
 #define DISPATCH_LOC_WRITE(buff, size, array, clEvent, error)                                                          \
     error = queue.enqueueWriteBuffer(buff, CL_FALSE, 0, size, array, NULL, &clEvent);                                  \
     if (error != CL_SUCCESS) {                                                                                         \
         FreeAll();                                                                                                     \
         throw std::runtime_error("Failed to enqueue buffer write, error code: " + std::to_string(error));              \
-    }                                                                                                                  \
-    clFlush();
+    }
 
 #define DISPATCH_WRITE(waitVec, buff, size, array, error)                                                              \
     device_context->LockWaitEvents();                                                                                  \
@@ -53,8 +51,7 @@ namespace Qrack {
     if (error != CL_SUCCESS) {                                                                                         \
         FreeAll();                                                                                                     \
         throw std::runtime_error("Failed to enqueue buffer write, error code: " + std::to_string(error));              \
-    }                                                                                                                  \
-    clFlush();
+    }
 
 #define DISPATCH_COPY(waitVec, buff1, buff2, size, error)                                                              \
     device_context->LockWaitEvents();                                                                                  \
@@ -64,8 +61,7 @@ namespace Qrack {
     if (error != CL_SUCCESS) {                                                                                         \
         FreeAll();                                                                                                     \
         throw std::runtime_error("Failed to enqueue buffer read, error code: " + std::to_string(error));               \
-    }                                                                                                                  \
-    clFlush();
+    }
 
 #define WAIT_REAL1_SUM(buff, size, array, sumPtr, error)                                                               \
     clFinish();                                                                                                        \
@@ -678,7 +674,6 @@ void QEngineOCL::CArithmeticCall(OCLAPI api_call, bitCapIntOcl (&bciArgs)[BCI_AR
         queue.enqueueCopyBuffer(*stateBuffer, *nStateBuffer, 0, 0, sizeof(complex) * maxQPowerOcl, waitVec.get(),
             &(device_context->wait_events->back()));
         device_context->UnlockWaitEvents();
-        clFlush();
     } else {
         ClearBuffer(nStateBuffer, 0, maxQPowerOcl);
     }

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -628,7 +628,6 @@ void QEngineOCL::SetPermutation(bitCapInt perm, complex phaseFac)
     queue.enqueueWriteBuffer(*stateBuffer, CL_FALSE, sizeof(complex) * (bitCapIntOcl)perm, sizeof(complex),
         &permutationAmp, waitVec.get(), &(device_context->wait_events->back()));
     device_context->UnlockWaitEvents();
-    clFlush();
 
     QueueSetRunningNorm(ONE_R1);
 }
@@ -2660,7 +2659,6 @@ void QEngineOCL::SetAmplitude(bitCapInt perm, complex amp)
     queue.enqueueWriteBuffer(*stateBuffer, CL_FALSE, sizeof(complex) * (bitCapIntOcl)perm, sizeof(complex),
         &permutationAmp, waitVec.get(), &(device_context->wait_events->back()));
     device_context->UnlockWaitEvents();
-    clFlush();
 }
 
 /// Get pure quantum state, in unsigned int permutation basis


### PR DESCRIPTION
Nearly all `QEngineOCL` method calls themselves internally call `QueueCall()` or `WaitCall()` to dispatch the payload kernel. It is probably preferable to always allow OpenCL to decide when to flush the command queue, otherwise.

A method like `SetAmplitude()`, for setting single amplitudes of the wave function state vector, does not call `QueueCall()` or `WaitCall()` and therefore does not flush. However, should OpenCL actually defer `SetAmplitude()` command queue dispatch, it might achieve _batching_ on otherwise inefficiently slow single work items, as on a sequential string of amplitude writes.