### PR TITLE
Tweak OpenCL compile options

### DIFF
--- a/src/common/oclengine.cpp
+++ b/src/common/oclengine.cpp
@@ -343,7 +343,7 @@ void OCLEngine::InitOCL(bool buildFromSource, bool saveBinaries, std::string hom
         std::cout << "Device #" << i << ", ";
         cl::Program program = MakeProgram(buildFromSource, sources, clBinName, devCntxt);
 
-        cl_int buildError = program.build({ all_devices[i] }, "-cl-strict-aliasing -cl-fast-relaxed-math");
+        cl_int buildError = program.build({ all_devices[i] }, "-cl-strict-aliasing -cl-denorms-are-zero -cl-fast-relaxed-math -Werror");
         if (buildError != CL_SUCCESS) {
             std::cout << "Error building for device #" << i << ": " << buildError << ", "
                       << program.getBuildInfo<CL_PROGRAM_BUILD_STATUS>(all_devices[i])

--- a/src/common/oclengine.cpp
+++ b/src/common/oclengine.cpp
@@ -343,7 +343,7 @@ void OCLEngine::InitOCL(bool buildFromSource, bool saveBinaries, std::string hom
         std::cout << "Device #" << i << ", ";
         cl::Program program = MakeProgram(buildFromSource, sources, clBinName, devCntxt);
 
-        cl_int buildError = program.build({ all_devices[i] }, "-cl-denorms-are-zero -cl-fast-relaxed-math");
+        cl_int buildError = program.build({ all_devices[i] }, "-cl-strict-aliasing -cl-fast-relaxed-math");
         if (buildError != CL_SUCCESS) {
             std::cout << "Error building for device #" << i << ": " << buildError << ", "
                       << program.getBuildInfo<CL_PROGRAM_BUILD_STATUS>(all_devices[i])


### PR DESCRIPTION
I have added `-cl-strict-aliasing` to the OpenCL compilation optimization flags. (I think we never alias any pointer range, in kernels.) I considered removing `-cl-denorms-are-zero`, but denorms are smaller absolute value than our suggested minimum single amplitude values per FP type, in `qrack_types.hpp`.