### PR TITLE
OpenCL host pointer option in benchmarks

### DIFF
--- a/src/common/oclengine.cpp
+++ b/src/common/oclengine.cpp
@@ -343,7 +343,8 @@ void OCLEngine::InitOCL(bool buildFromSource, bool saveBinaries, std::string hom
         std::cout << "Device #" << i << ", ";
         cl::Program program = MakeProgram(buildFromSource, sources, clBinName, devCntxt);
 
-        cl_int buildError = program.build({ all_devices[i] }, "-cl-strict-aliasing -cl-denorms-are-zero -cl-fast-relaxed-math -Werror");
+        cl_int buildError =
+            program.build({ all_devices[i] }, "-cl-strict-aliasing -cl-denorms-are-zero -cl-fast-relaxed-math -Werror");
         if (buildError != CL_SUCCESS) {
             std::cout << "Error building for device #" << i << ": " << buildError << ", "
                       << program.getBuildInfo<CL_PROGRAM_BUILD_STATUS>(all_devices[i])

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -47,8 +47,9 @@ double formatTime(double t, bool logNormal)
 
 QInterfacePtr MakeRandQubit()
 {
-    QInterfacePtr qubit = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 1U, 0, rng,
-        ONE_CMPLX, enable_normalization, true, false, device_id, !disable_hardware_rng, sparse, REAL1_EPSILON, devList);
+    QInterfacePtr qubit =
+        CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 1U, 0, rng, ONE_CMPLX,
+            enable_normalization, true, use_host_dma, device_id, !disable_hardware_rng, sparse, REAL1_EPSILON, devList);
 
     real1_f theta = 2 * M_PI * qubit->Rand();
     real1_f phi = 2 * M_PI * qubit->Rand();
@@ -137,7 +138,7 @@ void benchmarkLoopVariable(std::function<void(QInterfacePtr, bitLenInt)> fn, bit
 
             if (!qUniverse) {
                 qftReg = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, numBits, 0,
-                    rng, ONE_CMPLX, enable_normalization, true, false, device_id, !disable_hardware_rng, sparse,
+                    rng, ONE_CMPLX, enable_normalization, true, use_host_dma, device_id, !disable_hardware_rng, sparse,
                     REAL1_EPSILON, devList);
                 if (resetRandomPerm) {
                     qftReg->SetPermutation((bitCapIntOcl)(qftReg->Rand() * (bitCapIntOcl)qftReg->GetMaxQPower()));
@@ -2308,7 +2309,7 @@ TEST_CASE("test_universal_circuit_digital_cross_entropy", "[supreme]")
     int maxGates;
 
     QInterfacePtr goldStandard = CreateQuantumInterface(testSubEngineType, testSubSubEngineType, n, 0, rng, ONE_CMPLX,
-        enable_normalization, true, false, device_id, !disable_hardware_rng);
+        enable_normalization, true, use_host_dma, device_id, !disable_hardware_rng);
 
     for (d = 0; d < Depth; d++) {
         std::vector<int>& layer1QbRands = gate1QbRands[d];
@@ -2429,7 +2430,7 @@ TEST_CASE("test_universal_circuit_digital_cross_entropy", "[supreme]")
     std::cout << "Gold standard vs. gold standard cross entropy (out of 1.0): " << crossEntropy << std::endl;
 
     QInterfacePtr testCase = CreateQuantumInterface(testEngineType, testSubEngineType, n, 0, rng, ONE_CMPLX,
-        enable_normalization, true, false, device_id, !disable_hardware_rng, sparse);
+        enable_normalization, true, use_host_dma, device_id, !disable_hardware_rng, sparse);
 
     std::map<bitCapInt, int> testCaseResult;
 

--- a/test/benchmarks_main.cpp
+++ b/test/benchmarks_main.cpp
@@ -28,6 +28,7 @@ enum QInterfaceEngine testSubEngineType = QINTERFACE_CPU;
 enum QInterfaceEngine testSubSubEngineType = QINTERFACE_CPU;
 qrack_rand_gen_ptr rng;
 bool enable_normalization = false;
+bool use_host_dma = false;
 bool disable_hardware_rng = false;
 bool async_time = false;
 bool sparse = false;
@@ -90,6 +91,10 @@ int main(int argc, char* argv[])
         Opt(enable_normalization)["--enable-normalization"](
             "Enable state vector normalization. (Usually not "
             "necessary, though might benefit accuracy at very high circuit depth.)") |
+        Opt(use_host_dma)["--use-host-dma"](
+            "Allocate state vectors as OpenCL host pointers, in an attempt to use Direct Memory Access. This will "
+            "probably be slower, and incompatible with OpenCL virtualization, but it can allow greater state vector "
+            "buffer RAM width, potentially including swap disk, depending on OpenCL device DMA capabilities.") |
         Opt(disable_hardware_rng)["--disable-hardware-rng"]("Modern Intel chips provide an instruction for hardware "
                                                             "random number generation, which this option turns off. "
                                                             "(Hardware generation is on by default, if available.)") |

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -26,6 +26,7 @@ enum QInterfaceEngine testSubEngineType = QINTERFACE_CPU;
 enum QInterfaceEngine testSubSubEngineType = QINTERFACE_CPU;
 qrack_rand_gen_ptr rng;
 bool enable_normalization = false;
+bool use_host_dma = false;
 bool disable_hardware_rng = false;
 bool async_time = false;
 bool sparse = false;

--- a/test/tests.hpp
+++ b/test/tests.hpp
@@ -31,6 +31,7 @@ extern enum Qrack::QInterfaceEngine testSubEngineType;
 extern enum Qrack::QInterfaceEngine testSubSubEngineType;
 extern qrack_rand_gen_ptr rng;
 extern bool enable_normalization;
+extern bool use_host_dma;
 extern bool disable_hardware_rng;
 extern bool async_time;
 extern bool sparse;


### PR DESCRIPTION
(We had this previously, but I didn't see actual use for it, until now:)

We add an option to the benchmark executable to allow users to require that OpenCL state vector buffers are allocated in general heap. I'm not so lucky, with my personal devices, but this could sometimes allow the use of greater general heap capacities than GPU internal VRAM, potentially including swap space, dependent on DMA capabilities of the GPU/system.