### PR TITLE
PInvoke `Mtrx()` methods

### DIFF
--- a/include/pinvoke_api.hpp
+++ b/include/pinvoke_api.hpp
@@ -81,7 +81,8 @@ MICROSOFT_QUANTUM_DECL void MCAdjS(_In_ unsigned sid, _In_ unsigned n, _In_reads
 MICROSOFT_QUANTUM_DECL void MCAdjT(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c, _In_ unsigned q);
 MICROSOFT_QUANTUM_DECL void MCU(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c, _In_ unsigned q,
     _In_ double theta, _In_ double phi, _In_ double lambda);
-MICROSOFT_QUANTUM_DECL void MCMtrx(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c, _In_reads_(8) double* m, _In_ unsigned q);
+MICROSOFT_QUANTUM_DECL void MCMtrx(
+    _In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c, _In_reads_(8) double* m, _In_ unsigned q);
 
 // rotations
 MICROSOFT_QUANTUM_DECL void R(_In_ unsigned sid, _In_ unsigned b, _In_ double phi, _In_ unsigned q);

--- a/include/pinvoke_api.hpp
+++ b/include/pinvoke_api.hpp
@@ -67,6 +67,7 @@ MICROSOFT_QUANTUM_DECL void AdjS(_In_ unsigned sid, _In_ unsigned q);
 MICROSOFT_QUANTUM_DECL void AdjT(_In_ unsigned sid, _In_ unsigned q);
 MICROSOFT_QUANTUM_DECL void U(
     _In_ unsigned sid, _In_ unsigned q, _In_ double theta, _In_ double phi, _In_ double lambda);
+MICROSOFT_QUANTUM_DECL void Mtrx(_In_ unsigned sid, _In_reads_(8) double* m, _In_ unsigned q);
 
 // multi-controlled single-qubit gates
 
@@ -80,6 +81,7 @@ MICROSOFT_QUANTUM_DECL void MCAdjS(_In_ unsigned sid, _In_ unsigned n, _In_reads
 MICROSOFT_QUANTUM_DECL void MCAdjT(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c, _In_ unsigned q);
 MICROSOFT_QUANTUM_DECL void MCU(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c, _In_ unsigned q,
     _In_ double theta, _In_ double phi, _In_ double lambda);
+MICROSOFT_QUANTUM_DECL void MCMtrx(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c, _In_reads_(8) double* m, _In_ unsigned q);
 
 // rotations
 MICROSOFT_QUANTUM_DECL void R(_In_ unsigned sid, _In_ unsigned b, _In_ double phi, _In_ unsigned q);

--- a/src/pinvoke_api.cpp
+++ b/src/pinvoke_api.cpp
@@ -733,7 +733,7 @@ MICROSOFT_QUANTUM_DECL void MCU(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n
 }
 
 /**
- * (External API) 2x2 complex matrix unitary gate
+ * (External API) Controlled 2x2 complex matrix unitary gate
  */
 MICROSOFT_QUANTUM_DECL void MCMtrx(
     _In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c, _In_reads_(8) double* m, _In_ unsigned q)

--- a/src/pinvoke_api.cpp
+++ b/src/pinvoke_api.cpp
@@ -557,8 +557,8 @@ MICROSOFT_QUANTUM_DECL void Mtrx(_In_ unsigned sid, _In_reads_(8) double* m, _In
 {
     SIMULATOR_LOCK_GUARD(sid)
 
-    Qrack::complex mtrx[4] = { Qrack::complex(m[0], m[1]), Qrack::complex(m[2], m[3]), Qrack::complex(m[4], m[5]),
-        Qrack::complex(m[6], m[7]) };
+    complex mtrx[4] = { complex((real1)m[0], (real1)m[1]), complex((real1)m[2], (real1)m[3]),
+        complex((real1)m[4], (real1)m[5]), complex((real1)m[6], (real1)m[7]) };
 
     QInterfacePtr simulator = simulators[sid];
     simulator->ApplySingleBit(mtrx, shards[simulator][q]);
@@ -740,8 +740,8 @@ MICROSOFT_QUANTUM_DECL void MCMtrx(
 {
     SIMULATOR_LOCK_GUARD(sid)
 
-    Qrack::complex mtrx[4] = { Qrack::complex(m[0], m[1]), Qrack::complex(m[2], m[3]), Qrack::complex(m[4], m[5]),
-        Qrack::complex(m[6], m[7]) };
+    complex mtrx[4] = { complex((real1)m[0], (real1)m[1]), complex((real1)m[2], (real1)m[3]),
+        complex((real1)m[4], (real1)m[5]), complex((real1)m[6], (real1)m[7]) };
 
     QInterfacePtr simulator = simulators[sid];
     bitLenInt* ctrlsArray = new bitLenInt[n];

--- a/src/pinvoke_api.cpp
+++ b/src/pinvoke_api.cpp
@@ -551,6 +551,20 @@ MICROSOFT_QUANTUM_DECL void U(
 }
 
 /**
+ * (External API) 2x2 complex matrix unitary gate
+ */
+MICROSOFT_QUANTUM_DECL void Mtrx(_In_ unsigned sid, _In_reads_(8) double* m, _In_ unsigned q)
+{
+    SIMULATOR_LOCK_GUARD(sid)
+
+    Qrack::complex mtrx[4] = { Qrack::complex(m[0], m[1]), Qrack::complex(m[2], m[3]), Qrack::complex(m[4], m[5]),
+        Qrack::complex(m[6], m[7]) };
+
+    QInterfacePtr simulator = simulators[sid];
+    simulator->ApplySingleBit(mtrx, shards[simulator][q]);
+}
+
+/**
  * (External API) Controlled "X" Gate
  */
 MICROSOFT_QUANTUM_DECL void MCX(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c, _In_ unsigned q)
@@ -716,6 +730,26 @@ MICROSOFT_QUANTUM_DECL void MCU(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n
     simulator->CU(ctrlsArray, n, shards[simulator][q], theta, phi, lambda);
 
     delete[] ctrlsArray;
+}
+
+/**
+ * (External API) 2x2 complex matrix unitary gate
+ */
+MICROSOFT_QUANTUM_DECL void MCMtrx(
+    _In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c, _In_reads_(8) double* m, _In_ unsigned q)
+{
+    SIMULATOR_LOCK_GUARD(sid)
+
+    Qrack::complex mtrx[4] = { Qrack::complex(m[0], m[1]), Qrack::complex(m[2], m[3]), Qrack::complex(m[4], m[5]),
+        Qrack::complex(m[6], m[7]) };
+
+    QInterfacePtr simulator = simulators[sid];
+    bitLenInt* ctrlsArray = new bitLenInt[n];
+    for (unsigned i = 0; i < n; i++) {
+        ctrlsArray[i] = shards[simulator][c[i]];
+    }
+
+    simulator->ApplyControlledSingleBit(ctrlsArray, n, shards[simulator][q], mtrx);
 }
 
 /**


### PR DESCRIPTION
This directly exposes 2x2 complex matrix gate definitions via the PInvoke API. (It is worth noting that Qrack intends, by design, to divert these method calls to "phase," "invert," and even gate-fusion-over-Clifford gates, etc., when it can.)