### PR TITLE
#661: Refactor qfactory.hpp with vector of QInterface types

### DIFF
--- a/examples/grovers.cpp
+++ b/examples/grovers.cpp
@@ -34,10 +34,10 @@ int main()
 {
 #if ENABLE_OPENCL
     // OpenCL type, if available.
-    QInterfacePtr qReg = CreateQuantumInterface(QINTERFACE_OPENCL, 20, 0);
+    QInterfacePtr qReg = CreateQuantumInterface({ QINTERFACE_OPENCL }, 20, 0);
 #else
     // Non-OpenCL type, if OpenCL is not available.
-    QInterfacePtr qReg = CreateQuantumInterface(QINTERFACE_CPU, 20, 0);
+    QInterfacePtr qReg = CreateQuantumInterface({ QINTERFACE_CPU }, 20, 0);
 #endif
 
     // All simulator types share the QInterface API.

--- a/examples/grovers_lookup.cpp
+++ b/examples/grovers_lookup.cpp
@@ -57,9 +57,9 @@ int main()
 
     // Both CPU and GPU types share the QInterface API.
 #if ENABLE_OPENCL
-    QInterfacePtr qReg = CreateQuantumInterface(QINTERFACE_OPENCL, 20, 0);
+    QInterfacePtr qReg = CreateQuantumInterface({ QINTERFACE_OPENCL }, 20, 0);
 #else
-    QInterfacePtr qReg = CreateQuantumInterface(QINTERFACE_CPU, 20, 0);
+    QInterfacePtr qReg = CreateQuantumInterface({ QINTERFACE_CPU }, 20, 0);
 #endif
 
     // This array should actually be allocated aligned for best performance, but this will work. We'll talk about

--- a/examples/ordered_list_search.cpp
+++ b/examples/ordered_list_search.cpp
@@ -39,9 +39,9 @@ int main()
 
     // Both CPU and GPU types share the QInterface API.
 #if ENABLE_OPENCL
-    QInterfacePtr qReg = CreateQuantumInterface(QINTERFACE_OPENCL, 20, 0);
+    QInterfacePtr qReg = CreateQuantumInterface({ QINTERFACE_OPENCL }, 20, 0);
 #else
-    QInterfacePtr qReg = CreateQuantumInterface(QINTERFACE_CPU, 20, 0);
+    QInterfacePtr qReg = CreateQuantumInterface({ QINTERFACE_CPU }, 20, 0);
 #endif
 
     const bitLenInt indexLength = 6;

--- a/examples/pearson32.cpp
+++ b/examples/pearson32.cpp
@@ -81,7 +81,7 @@ int main()
 {
     size_t i;
 
-    QInterfacePtr qReg = CreateQuantumInterface(QINTERFACE_QUNIT, QINTERFACE_CPU, 8U * (KEY_SIZE + HASH_SIZE), 0,
+    QInterfacePtr qReg = CreateQuantumInterface({ QINTERFACE_QUNIT, QINTERFACE_CPU }, 8U * (KEY_SIZE + HASH_SIZE), 0,
         nullptr, CMPLX_DEFAULT_ARG, true, true, false, -1, true, true);
 
     unsigned char T[TABLE_SIZE];

--- a/examples/qneuron_classification.cpp
+++ b/examples/qneuron_classification.cpp
@@ -314,7 +314,7 @@ int main()
     std::cout << "Column count: " << rawYX[0].size() << std::endl;
     bitLenInt predictorCount = rawYX[0].size() - 1U;
 
-    QInterfacePtr qReg = CreateQuantumInterface(QINTERFACE_OPTIMAL, predictorCount + 1U, 0);
+    QInterfacePtr qReg = CreateQuantumInterface({ QINTERFACE_OPTIMAL }, predictorCount + 1U, 0);
 
     std::vector<QNeuronPtr> outputLayer;
     std::vector<real1> etas;

--- a/examples/quantum_associative_memory.cpp
+++ b/examples/quantum_associative_memory.cpp
@@ -29,7 +29,7 @@ int main()
 
     // QINTERFACE_OPTIMAL uses the (single-processor) OpenCL engine type, if available. Otherwise, it falls back to
     // QEngineCPU.
-    QInterfacePtr qReg = CreateQuantumInterface(QINTERFACE_OPTIMAL, InputCount + OutputCount, 0);
+    QInterfacePtr qReg = CreateQuantumInterface({ QINTERFACE_OPTIMAL }, InputCount + OutputCount, 0);
 
     bitLenInt inputIndices[InputCount];
     for (bitLenInt i = 0; i < InputCount; i++) {

--- a/examples/quantum_perceptron.cpp
+++ b/examples/quantum_perceptron.cpp
@@ -27,7 +27,7 @@ int main()
 
     // QINTERFACE_OPTIMAL uses the (single-processor) OpenCL engine type, if available. Otherwise, it falls back to
     // QEngineCPU.
-    QInterfacePtr qReg = CreateQuantumInterface(QINTERFACE_OPTIMAL, ControlCount + 1, 0);
+    QInterfacePtr qReg = CreateQuantumInterface({ QINTERFACE_OPTIMAL }, ControlCount + 1, 0);
 
     bitLenInt inputIndices[ControlCount];
     for (bitLenInt i = 0; i < ControlCount; i++) {
@@ -59,7 +59,7 @@ int main()
         powersOf2[i] = 1U << i;
     }
 
-    QInterfacePtr qReg2 = CreateQuantumInterface(QINTERFACE_QUNIT, QINTERFACE_OPTIMAL, ControlLog, 0);
+    QInterfacePtr qReg2 = CreateQuantumInterface({ QINTERFACE_OPTIMAL }, ControlLog, 0);
 
     qReg->Compose(qReg2);
     qReg->SetPermutation(1U << (ControlCount + 1));

--- a/examples/shors_factoring.cpp
+++ b/examples/shors_factoring.cpp
@@ -80,7 +80,7 @@ int main()
 
     // QINTERFACE_OPTIMAL uses the (single-processor) OpenCL engine type, if available. Otherwise, it falls back to
     // QEngineCPU.
-    QInterfacePtr qReg = CreateQuantumInterface(QINTERFACE_OPTIMAL, qubitCount * 2, 0);
+    QInterfacePtr qReg = CreateQuantumInterface({ QINTERFACE_OPTIMAL }, qubitCount * 2, 0);
 
     // This is the period-finding subroutine of Shor's algorithm.
     qReg->H(0, qubitCount);

--- a/examples/teleport.cpp
+++ b/examples/teleport.cpp
@@ -35,7 +35,7 @@ void StatePrep(QInterfacePtr qReg)
 
 int main()
 {
-    QInterfacePtr qReg = CreateQuantumInterface(QINTERFACE_OPTIMAL, 3, 0);
+    QInterfacePtr qReg = CreateQuantumInterface({ QINTERFACE_OPTIMAL }, 3, 0);
     // "Eve" prepares a Bell pair.
     qReg->H(1);
     qReg->CNOT(1, 2);

--- a/include/qfactory.hpp
+++ b/include/qfactory.hpp
@@ -29,24 +29,27 @@ namespace Qrack {
 /** Factory method to create specific engine implementations. */
 template <typename... Ts>
 QInterfacePtr CreateQuantumInterface(
-    QInterfaceEngine engine, QInterfaceEngine subengine1, QInterfaceEngine subengine2, Ts... args)
+    QInterfaceEngine engine1, QInterfaceEngine engine2, QInterfaceEngine engine3, Ts... args)
 {
+    QInterfaceEngine engine = engine1;
+    std::vector<QInterfaceEngine> engines = { engine2, engine3 };
+
     switch (engine) {
     case QINTERFACE_CPU:
         return std::make_shared<QEngineCPU>(args...);
     case QINTERFACE_QPAGER:
-        return std::make_shared<QPager>(subengine1, args...);
+        return std::make_shared<QPager>(engines, args...);
     case QINTERFACE_STABILIZER_HYBRID:
-        return std::make_shared<QStabilizerHybrid>(subengine1, subengine2, args...);
+        return std::make_shared<QStabilizerHybrid>(engines, args...);
     case QINTERFACE_QUNIT:
-        return std::make_shared<QUnit>(subengine1, subengine2, args...);
+        return std::make_shared<QUnit>(engines, args...);
 #if ENABLE_OPENCL
     case QINTERFACE_OPENCL:
         return std::make_shared<QEngineOCL>(args...);
     case QINTERFACE_HYBRID:
         return std::make_shared<QHybrid>(args...);
     case QINTERFACE_QUNIT_MULTI:
-        return std::make_shared<QUnitMulti>(subengine1, subengine2, args...);
+        return std::make_shared<QUnitMulti>(engines, args...);
 #endif
     default:
         return NULL;
@@ -54,24 +57,27 @@ QInterfacePtr CreateQuantumInterface(
 }
 
 template <typename... Ts>
-QInterfacePtr CreateQuantumInterface(QInterfaceEngine engine, QInterfaceEngine subengine, Ts... args)
+QInterfacePtr CreateQuantumInterface(QInterfaceEngine engine1, QInterfaceEngine engine2, Ts... args)
 {
+    QInterfaceEngine engine = engine1;
+    std::vector<QInterfaceEngine> engines = { engine2 };
+
     switch (engine) {
     case QINTERFACE_CPU:
         return std::make_shared<QEngineCPU>(args...);
     case QINTERFACE_QPAGER:
-        return std::make_shared<QPager>(subengine, args...);
+        return std::make_shared<QPager>(engines, args...);
     case QINTERFACE_STABILIZER_HYBRID:
-        return std::make_shared<QStabilizerHybrid>(subengine, args...);
+        return std::make_shared<QStabilizerHybrid>(engines, args...);
     case QINTERFACE_QUNIT:
-        return std::make_shared<QUnit>(subengine, args...);
+        return std::make_shared<QUnit>(engines, args...);
 #if ENABLE_OPENCL
     case QINTERFACE_OPENCL:
         return std::make_shared<QEngineOCL>(args...);
     case QINTERFACE_HYBRID:
         return std::make_shared<QHybrid>(args...);
     case QINTERFACE_QUNIT_MULTI:
-        return std::make_shared<QUnitMulti>(subengine, args...);
+        return std::make_shared<QUnitMulti>(engines, args...);
 #endif
     default:
         return NULL;
@@ -95,6 +101,45 @@ template <typename... Ts> QInterfacePtr CreateQuantumInterface(QInterfaceEngine 
     case QINTERFACE_HYBRID:
         return std::make_shared<QHybrid>(args...);
     case QINTERFACE_QUNIT_MULTI:
+        return std::make_shared<QUnitMulti>(args...);
+#endif
+    default:
+        return NULL;
+    }
+}
+
+template <typename... Ts> QInterfacePtr CreateQuantumInterface(std::vector<QInterfaceEngine> engines, Ts... args)
+{
+    QInterfaceEngine engine = engines[0];
+    engines.erase(engines.begin());
+
+    switch (engine) {
+    case QINTERFACE_CPU:
+        return std::make_shared<QEngineCPU>(args...);
+    case QINTERFACE_QPAGER:
+        if (engines.size()) {
+            return std::make_shared<QPager>(engines, args...);
+        }
+        return std::make_shared<QPager>(args...);
+    case QINTERFACE_STABILIZER_HYBRID:
+        if (engines.size()) {
+            return std::make_shared<QStabilizerHybrid>(engines, args...);
+        }
+        return std::make_shared<QStabilizerHybrid>(args...);
+    case QINTERFACE_QUNIT:
+        if (engines.size()) {
+            return std::make_shared<QUnit>(engines, args...);
+        }
+        return std::make_shared<QUnit>(args...);
+#if ENABLE_OPENCL
+    case QINTERFACE_OPENCL:
+        return std::make_shared<QEngineOCL>(args...);
+    case QINTERFACE_HYBRID:
+        return std::make_shared<QHybrid>(args...);
+    case QINTERFACE_QUNIT_MULTI:
+        if (engines.size()) {
+            return std::make_shared<QUnitMulti>(engines, args...);
+        }
         return std::make_shared<QUnitMulti>(args...);
 #endif
     default:

--- a/include/qpager.hpp
+++ b/include/qpager.hpp
@@ -24,7 +24,7 @@ typedef std::shared_ptr<QPager> QPagerPtr;
  */
 class QPager : public QInterface {
 protected:
-    QInterfaceEngine engine;
+    std::vector<QInterfaceEngine> engines;
     int devID;
     complex phaseFactor;
     bool useHostRam;
@@ -52,7 +52,7 @@ protected:
     {
         QInterface::SetQubitCount(qb);
 
-        if (useHardwareThreshold && ((engine == QINTERFACE_OPENCL) || (engine == QINTERFACE_HYBRID))) {
+        if (useHardwareThreshold && ((engines[0] == QINTERFACE_OPENCL) || (engines[0] == QINTERFACE_HYBRID))) {
             // Limit at the power of 2 less-than-or-equal-to a full max memory allocation segment, or choose with
             // environment variable.
 
@@ -110,23 +110,23 @@ protected:
     void Init();
 
 public:
-    QPager(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState = 0, qrack_rand_gen_ptr rgp = nullptr,
-        complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = false, bool ignored = false, bool useHostMem = false,
-        int deviceId = -1, bool useHardwareRNG = true, bool useSparseStateVec = false,
-        real1_f norm_thresh = REAL1_EPSILON, std::vector<int> devList = {}, bitLenInt qubitThreshold = 0,
-        real1_f separation_thresh = FP_NORM_EPSILON);
+    QPager(std::vector<QInterfaceEngine> eng, bitLenInt qBitCount, bitCapInt initState = 0,
+        qrack_rand_gen_ptr rgp = nullptr, complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = false,
+        bool ignored = false, bool useHostMem = false, int deviceId = -1, bool useHardwareRNG = true,
+        bool useSparseStateVec = false, real1_f norm_thresh = REAL1_EPSILON, std::vector<int> devList = {},
+        bitLenInt qubitThreshold = 0, real1_f separation_thresh = FP_NORM_EPSILON);
 
     QPager(bitLenInt qBitCount, bitCapInt initState = 0, qrack_rand_gen_ptr rgp = nullptr,
         complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = false, bool ignored = false, bool useHostMem = false,
         int deviceId = -1, bool useHardwareRNG = true, bool useSparseStateVec = false,
         real1_f norm_thresh = REAL1_EPSILON, std::vector<int> devList = {}, bitLenInt qubitThreshold = 0,
         real1_f separation_thresh = FP_NORM_EPSILON)
-        : QPager(QINTERFACE_OPTIMAL_SINGLE_PAGE, qBitCount, initState, rgp, phaseFac, doNorm, ignored, useHostMem,
+        : QPager({ QINTERFACE_OPTIMAL_SINGLE_PAGE }, qBitCount, initState, rgp, phaseFac, doNorm, ignored, useHostMem,
               deviceId, useHardwareRNG, useSparseStateVec, norm_thresh, devList, qubitThreshold, separation_thresh)
     {
     }
 
-    QPager(QEnginePtr enginePtr, QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt ignored = 0,
+    QPager(QEnginePtr enginePtr, std::vector<QInterfaceEngine> eng, bitLenInt qBitCount, bitCapInt ignored = 0,
         qrack_rand_gen_ptr rgp = nullptr, complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = false,
         bool ignored2 = false, bool useHostMem = false, int deviceId = -1, bool useHardwareRNG = true,
         bool useSparseStateVec = false, real1_f norm_thresh = REAL1_EPSILON, std::vector<int> devList = {},

--- a/include/qstabilizerhybrid.hpp
+++ b/include/qstabilizerhybrid.hpp
@@ -55,8 +55,7 @@ struct QStabilizerShard {
  */
 class QStabilizerHybrid : public QInterface {
 protected:
-    QInterfaceEngine engineType;
-    QInterfaceEngine subEngineType;
+    std::vector<QInterfaceEngine> engineTypes;
     QInterfacePtr engine;
     QStabilizerPtr stabilizer;
     std::vector<QStabilizerShardPtr> shards;
@@ -219,30 +218,20 @@ protected:
     virtual void CacheEigenstate(const bitLenInt& target);
 
 public:
-    QStabilizerHybrid(QInterfaceEngine eng, QInterfaceEngine subEng, bitLenInt qBitCount, bitCapInt initState = 0,
+    QStabilizerHybrid(std::vector<QInterfaceEngine> eng, bitLenInt qBitCount, bitCapInt initState = 0,
         qrack_rand_gen_ptr rgp = nullptr, complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = false,
         bool randomGlobalPhase = true, bool useHostMem = false, int deviceId = -1, bool useHardwareRNG = true,
         bool useSparseStateVec = false, real1_f norm_thresh = REAL1_EPSILON, std::vector<int> ignored = {},
         bitLenInt qubitThreshold = 0, real1_f separation_thresh = FP_NORM_EPSILON);
-
-    QStabilizerHybrid(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState = 0,
-        qrack_rand_gen_ptr rgp = nullptr, complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = false,
-        bool randomGlobalPhase = true, bool useHostMem = false, int deviceId = -1, bool useHardwareRNG = true,
-        bool useSparseStateVec = false, real1_f norm_thresh = REAL1_EPSILON, std::vector<int> ignored = {},
-        bitLenInt qubitThreshold = 0, real1_f separation_thresh = FP_NORM_EPSILON)
-        : QStabilizerHybrid(eng, eng, qBitCount, initState, rgp, phaseFac, doNorm, randomGlobalPhase, useHostMem,
-              deviceId, useHardwareRNG, useSparseStateVec, norm_thresh, ignored, qubitThreshold, separation_thresh)
-    {
-    }
 
     QStabilizerHybrid(bitLenInt qBitCount, bitCapInt initState = 0, qrack_rand_gen_ptr rgp = nullptr,
         complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = false, bool randomGlobalPhase = true,
         bool useHostMem = false, int deviceId = -1, bool useHardwareRNG = true, bool useSparseStateVec = false,
         real1_f norm_thresh = REAL1_EPSILON, std::vector<int> ignored = {}, bitLenInt qubitThreshold = 0,
         real1_f separation_thresh = FP_NORM_EPSILON)
-        : QStabilizerHybrid(QINTERFACE_OPTIMAL_SCHROEDINGER, QINTERFACE_OPTIMAL_SINGLE_PAGE, qBitCount, initState, rgp,
-              phaseFac, doNorm, randomGlobalPhase, useHostMem, deviceId, useHardwareRNG, useSparseStateVec, norm_thresh,
-              ignored, qubitThreshold, separation_thresh)
+        : QStabilizerHybrid({ QINTERFACE_OPTIMAL_SCHROEDINGER }, qBitCount, initState, rgp, phaseFac, doNorm,
+              randomGlobalPhase, useHostMem, deviceId, useHardwareRNG, useSparseStateVec, norm_thresh, ignored,
+              qubitThreshold, separation_thresh)
     {
     }
 
@@ -267,10 +256,10 @@ public:
 
     virtual void TurnOnPaging()
     {
-        if (engineType == QINTERFACE_QPAGER) {
+        if (engineTypes[0] == QINTERFACE_QPAGER) {
             return;
         }
-        engineType = QINTERFACE_QPAGER;
+        engineTypes.insert(engineTypes.begin(), QINTERFACE_QPAGER);
 
         if (engine) {
             QPagerPtr nEngine = std::dynamic_pointer_cast<QPager>(MakeEngine());
@@ -281,10 +270,10 @@ public:
 
     virtual void TurnOffPaging()
     {
-        if (engineType != QINTERFACE_QPAGER) {
+        if (engineTypes[0] != QINTERFACE_QPAGER) {
             return;
         }
-        engineType = subEngineType;
+        engineTypes.erase(engineTypes.begin());
 
         if (engine) {
             engine = std::dynamic_pointer_cast<QPager>(engine)->ReleaseEngine();

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -21,8 +21,8 @@ typedef std::shared_ptr<QUnit> QUnitPtr;
 
 class QUnit : public QInterface {
 protected:
-    QInterfaceEngine engine;
-    QInterfaceEngine subEngine;
+    std::vector<QInterfaceEngine> engines;
+    std::vector<QInterfaceEngine> unpagedEngines;
     int devID;
     QEngineShardMap shards;
     complex phaseFactor;
@@ -64,30 +64,20 @@ protected:
     }
 
 public:
-    QUnit(QInterfaceEngine eng, QInterfaceEngine subEng, bitLenInt qBitCount, bitCapInt initState = 0,
+    QUnit(std::vector<QInterfaceEngine> eng, bitLenInt qBitCount, bitCapInt initState = 0,
         qrack_rand_gen_ptr rgp = nullptr, complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = false,
         bool randomGlobalPhase = true, bool useHostMem = false, int deviceId = -1, bool useHardwareRNG = true,
         bool useSparseStateVec = false, real1_f norm_thresh = REAL1_EPSILON, std::vector<int> ignored = {},
         bitLenInt qubitThreshold = 0, real1_f separation_thresh = FP_NORM_EPSILON);
-
-    QUnit(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState = 0, qrack_rand_gen_ptr rgp = nullptr,
-        complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = false, bool randomGlobalPhase = true,
-        bool useHostMem = false, int deviceId = -1, bool useHardwareRNG = true, bool useSparseStateVec = false,
-        real1_f norm_thresh = REAL1_EPSILON, std::vector<int> ignored = {}, bitLenInt qubitThreshold = 0,
-        real1_f separation_thresh = FP_NORM_EPSILON)
-        : QUnit(eng, eng, qBitCount, initState, rgp, phaseFac, doNorm, randomGlobalPhase, useHostMem, deviceId,
-              useHardwareRNG, useSparseStateVec, norm_thresh, ignored, qubitThreshold, separation_thresh)
-    {
-    }
 
     QUnit(bitLenInt qBitCount, bitCapInt initState = 0, qrack_rand_gen_ptr rgp = nullptr,
         complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = false, bool randomGlobalPhase = true,
         bool useHostMem = false, int deviceId = -1, bool useHardwareRNG = true, bool useSparseStateVec = false,
         real1_f norm_thresh = REAL1_EPSILON, std::vector<int> ignored = {}, bitLenInt qubitThreshold = 0,
         real1_f separation_thresh = FP_NORM_EPSILON)
-        : QUnit(QINTERFACE_OPTIMAL_G0_CHILD, QINTERFACE_OPTIMAL_G1_CHILD, qBitCount, initState, rgp, phaseFac, doNorm,
-              randomGlobalPhase, useHostMem, deviceId, useHardwareRNG, useSparseStateVec, norm_thresh, ignored,
-              qubitThreshold, separation_thresh)
+        : QUnit({ QINTERFACE_OPTIMAL_G0_CHILD }, qBitCount, initState, rgp, phaseFac, doNorm, randomGlobalPhase,
+              useHostMem, deviceId, useHardwareRNG, useSparseStateVec, norm_thresh, ignored, qubitThreshold,
+              separation_thresh)
     {
     }
 

--- a/include/qunitmulti.hpp
+++ b/include/qunitmulti.hpp
@@ -70,30 +70,20 @@ protected:
     QInterfacePtr MakeEngine(bitLenInt length, bitCapInt perm);
 
 public:
-    QUnitMulti(QInterfaceEngine eng, QInterfaceEngine subEng, bitLenInt qBitCount, bitCapInt initState = 0,
+    QUnitMulti(std::vector<QInterfaceEngine> eng, bitLenInt qBitCount, bitCapInt initState = 0,
         qrack_rand_gen_ptr rgp = nullptr, complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = false,
         bool randomGlobalPhase = true, bool useHostMem = false, int deviceID = -1, bool useHardwareRNG = true,
         bool useSparseStateVec = false, real1_f norm_thresh = REAL1_EPSILON, std::vector<int> devList = {},
         bitLenInt qubitThreshold = 0, real1_f separation_thresh = FP_NORM_EPSILON);
-
-    QUnitMulti(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState = 0, qrack_rand_gen_ptr rgp = nullptr,
-        complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = false, bool randomGlobalPhase = true,
-        bool useHostMem = false, int deviceID = -1, bool useHardwareRNG = true, bool useSparseStateVec = false,
-        real1_f norm_thresh = REAL1_EPSILON, std::vector<int> devList = {}, bitLenInt qubitThreshold = 0,
-        real1_f separation_thresh = FP_NORM_EPSILON)
-        : QUnitMulti(eng, eng, qBitCount, initState, rgp, phaseFac, doNorm, randomGlobalPhase, useHostMem, deviceID,
-              useHardwareRNG, useSparseStateVec, norm_thresh, devList, qubitThreshold, separation_thresh)
-    {
-    }
 
     QUnitMulti(bitLenInt qBitCount, bitCapInt initState = 0, qrack_rand_gen_ptr rgp = nullptr,
         complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = false, bool randomGlobalPhase = true,
         bool useHostMem = false, int deviceID = -1, bool useHardwareRNG = true, bool useSparseStateVec = false,
         real1_f norm_thresh = REAL1_EPSILON, std::vector<int> devList = {}, bitLenInt qubitThreshold = 0,
         real1_f separation_thresh = FP_NORM_EPSILON)
-        : QUnitMulti(QINTERFACE_OPTIMAL_G0_CHILD, QINTERFACE_OPTIMAL_G1_CHILD, qBitCount, initState, rgp, phaseFac,
-              doNorm, randomGlobalPhase, useHostMem, deviceID, useHardwareRNG, useSparseStateVec, norm_thresh, devList,
-              qubitThreshold, separation_thresh)
+        : QUnitMulti({ QINTERFACE_OPTIMAL_G0_CHILD }, qBitCount, initState, rgp, phaseFac, doNorm, randomGlobalPhase,
+              useHostMem, deviceID, useHardwareRNG, useSparseStateVec, norm_thresh, devList, qubitThreshold,
+              separation_thresh)
     {
     }
 

--- a/src/pinvoke_api.cpp
+++ b/src/pinvoke_api.cpp
@@ -195,7 +195,7 @@ MICROSOFT_QUANTUM_DECL unsigned init_count(_In_ unsigned q)
         }
     }
 
-    QInterfacePtr simulator = q ? CreateQuantumInterface(QINTERFACE_OPTIMAL_MULTI, q, 0, randNumGen) : NULL;
+    QInterfacePtr simulator = q ? CreateQuantumInterface({ QINTERFACE_OPTIMAL_MULTI }, q, 0, randNumGen) : NULL;
 
     if (sid == simulators.size()) {
         simulatorReservations.push_back(true);
@@ -397,7 +397,7 @@ MICROSOFT_QUANTUM_DECL void allocateQubit(_In_ unsigned sid, _In_ unsigned qid)
 {
     SIMULATOR_LOCK_GUARD(sid)
 
-    QInterfacePtr nQubit = CreateQuantumInterface(QINTERFACE_OPTIMAL_MULTI, 1, 0, randNumGen);
+    QInterfacePtr nQubit = CreateQuantumInterface({ QINTERFACE_OPTIMAL_MULTI }, 1, 0, randNumGen);
     if (simulators[sid] == NULL) {
         simulators[sid] = nQubit;
         shards[simulators[sid]] = {};

--- a/src/qengine/utility.cpp
+++ b/src/qengine/utility.cpp
@@ -19,8 +19,8 @@ QInterfacePtr QEngineCPU::Clone()
     Finish();
 
     QEngineCPUPtr clone = std::dynamic_pointer_cast<QEngineCPU>(
-        CreateQuantumInterface(QINTERFACE_CPU, qubitCount, 0, rand_generator, ONE_CMPLX, doNormalize, randGlobalPhase,
-            false, 0, (hardware_rand_generator == NULL) ? false : true, isSparse));
+        CreateQuantumInterface({ QINTERFACE_CPU }, qubitCount, 0, rand_generator, ONE_CMPLX, doNormalize,
+            randGlobalPhase, false, 0, (hardware_rand_generator == NULL) ? false : true, isSparse));
     if (stateVec) {
         clone->stateVec->copy(stateVec);
     } else {

--- a/src/qhybrid.cpp
+++ b/src/qhybrid.cpp
@@ -51,7 +51,7 @@ QHybrid::QHybrid(bitLenInt qBitCount, bitCapInt initState, qrack_rand_gen_ptr rg
 QEnginePtr QHybrid::MakeEngine(bool isOpenCL, bitCapInt initState)
 {
     QEnginePtr toRet =
-        std::dynamic_pointer_cast<QEngine>(CreateQuantumInterface(isOpenCL ? QINTERFACE_OPENCL : QINTERFACE_CPU,
+        std::dynamic_pointer_cast<QEngine>(CreateQuantumInterface({ isOpenCL ? QINTERFACE_OPENCL : QINTERFACE_CPU },
             qubitCount, initState, rand_generator, phaseFactor, doNormalize, randGlobalPhase, useHostRam, devID,
             useRDRAND, isSparse, (real1_f)amplitudeFloor, std::vector<int>{}, thresholdQubits, separabilityThreshold));
     toRet->SetConcurrency(concurrency);
@@ -60,7 +60,7 @@ QEnginePtr QHybrid::MakeEngine(bool isOpenCL, bitCapInt initState)
 
 QInterfacePtr QHybrid::Clone()
 {
-    QHybridPtr c = std::dynamic_pointer_cast<QHybrid>(CreateQuantumInterface(QINTERFACE_HYBRID, qubitCount, 0,
+    QHybridPtr c = std::dynamic_pointer_cast<QHybrid>(CreateQuantumInterface({ QINTERFACE_HYBRID }, qubitCount, 0,
         rand_generator, phaseFactor, doNormalize, randGlobalPhase, useHostRam, devID, useRDRAND, isSparse,
         (real1_f)amplitudeFloor, std::vector<int>{}, thresholdQubits, separabilityThreshold));
     c->SetConcurrency(concurrency);

--- a/src/qpager.cpp
+++ b/src/qpager.cpp
@@ -16,11 +16,11 @@
 
 namespace Qrack {
 
-QPager::QPager(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState, qrack_rand_gen_ptr rgp, complex phaseFac,
-    bool ignored, bool ignored2, bool useHostMem, int deviceId, bool useHardwareRNG, bool useSparseStateVec,
-    real1_f norm_thresh, std::vector<int> devList, bitLenInt qubitThreshold, real1_f sep_thresh)
+QPager::QPager(std::vector<QInterfaceEngine> eng, bitLenInt qBitCount, bitCapInt initState, qrack_rand_gen_ptr rgp,
+    complex phaseFac, bool ignored, bool ignored2, bool useHostMem, int deviceId, bool useHardwareRNG,
+    bool useSparseStateVec, real1_f norm_thresh, std::vector<int> devList, bitLenInt qubitThreshold, real1_f sep_thresh)
     : QInterface(qBitCount, rgp, false, useHardwareRNG, false, norm_thresh)
-    , engine(eng)
+    , engines(eng)
     , devID(deviceId)
     , phaseFactor(phaseFac)
     , useHostRam(useHostMem)
@@ -53,12 +53,12 @@ QPager::QPager(QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState, q
     }
 }
 
-QPager::QPager(QEnginePtr enginePtr, QInterfaceEngine eng, bitLenInt qBitCount, bitCapInt initState,
+QPager::QPager(QEnginePtr enginePtr, std::vector<QInterfaceEngine> eng, bitLenInt qBitCount, bitCapInt initState,
     qrack_rand_gen_ptr rgp, complex phaseFac, bool ignored, bool ignored2, bool useHostMem, int deviceId,
     bool useHardwareRNG, bool useSparseStateVec, real1_f norm_thresh, std::vector<int> devList,
     bitLenInt qubitThreshold, real1_f sep_thresh)
     : QInterface(qBitCount, rgp, false, useHardwareRNG, false, norm_thresh)
-    , engine(eng)
+    , engines(eng)
     , devID(deviceId)
     , phaseFactor(phaseFac)
     , useHostRam(useHostMem)
@@ -79,12 +79,12 @@ QPager::QPager(QEnginePtr enginePtr, QInterfaceEngine eng, bitLenInt qBitCount, 
 void QPager::Init()
 {
 #if !ENABLE_OPENCL
-    if (engine == QINTERFACE_HYBRID) {
-        engine = QINTERFACE_CPU;
+    if (engines[0] == QINTERFACE_HYBRID) {
+        engines[0] = QINTERFACE_CPU;
     }
 #endif
 
-    if ((engine != QINTERFACE_CPU) && (engine != QINTERFACE_OPENCL) && (engine != QINTERFACE_HYBRID)) {
+    if ((engines[0] != QINTERFACE_CPU) && (engines[0] != QINTERFACE_OPENCL) && (engines[0] != QINTERFACE_HYBRID)) {
         throw std::invalid_argument(
             "QPager sub-engine type must be QINTERFACE_CPU, QINTERFACE_OPENCL or QINTERFACE_HYBRID.");
     }
@@ -95,10 +95,10 @@ void QPager::Init()
 
 #if ENABLE_OPENCL
     if (!(OCLEngine::Instance()->GetDeviceCount())) {
-        engine = QINTERFACE_CPU;
+        engines[0] = QINTERFACE_CPU;
     }
 
-    if ((thresholdQubitsPerPage == 0) && ((engine == QINTERFACE_OPENCL) || (engine == QINTERFACE_HYBRID))) {
+    if ((thresholdQubitsPerPage == 0) && ((engines[0] == QINTERFACE_OPENCL) || (engines[0] == QINTERFACE_HYBRID))) {
         useHardwareThreshold = true;
 
         // Limit at the power of 2 less-than-or-equal-to a full max memory allocation segment, or choose with
@@ -167,7 +167,7 @@ void QPager::Init()
 
 QEnginePtr QPager::MakeEngine(bitLenInt length, bitCapInt perm, int deviceId)
 {
-    return std::dynamic_pointer_cast<QEngine>(CreateQuantumInterface(engine, length, perm, rand_generator, phaseFactor,
+    return std::dynamic_pointer_cast<QEngine>(CreateQuantumInterface(engines, length, perm, rand_generator, phaseFactor,
         false, false, useHostRam, deviceId, useRDRAND, isSparse, (real1_f)amplitudeFloor));
 }
 
@@ -1414,9 +1414,12 @@ QInterfacePtr QPager::Clone()
 {
     SeparateEngines();
 
-    QPagerPtr clone = std::dynamic_pointer_cast<QPager>(CreateQuantumInterface(QINTERFACE_QPAGER, engine, qubitCount, 0,
-        rand_generator, ONE_CMPLX, doNormalize, randGlobalPhase, false, 0,
-        (hardware_rand_generator == NULL) ? false : true, isSparse, (real1_f)amplitudeFloor));
+    std::vector<QInterfaceEngine> tEngines = engines;
+    tEngines.insert(tEngines.begin(), QINTERFACE_QPAGER);
+
+    QPagerPtr clone = std::dynamic_pointer_cast<QPager>(
+        CreateQuantumInterface(tEngines, qubitCount, 0, rand_generator, ONE_CMPLX, doNormalize, randGlobalPhase, false,
+            0, (hardware_rand_generator == NULL) ? false : true, isSparse, (real1_f)amplitudeFloor));
 
     for (bitCapIntOcl i = 0; i < qPages.size(); i++) {
         clone->qPages[i] = std::dynamic_pointer_cast<QEngine>(qPages[i]->Clone());

--- a/test/accuracy.cpp
+++ b/test/accuracy.cpp
@@ -64,7 +64,7 @@ void benchmarkLoopVariable(std::function<void(QInterfacePtr, int)> fn, bitLenInt
     // Grover's search inverts the function of a black box subroutine.
     // Our subroutine returns true only for an input of 100.
     for (numBits = 1; numBits <= mxQbts; numBits++) {
-        QInterfacePtr qftReg = CreateQuantumInterface(testEngineType, testSubEngineType, numBits, 0, rng,
+        QInterfacePtr qftReg = CreateQuantumInterface({ testEngineType, testSubEngineType }, numBits, 0, rng,
             complex(ONE_R1, ZERO_R1), enable_normalization, true, false, device_id, !disable_hardware_rng);
         avge = 0;
         for (i = 0; i < ITERATIONS; i++) {

--- a/test/accuracy_main.cpp
+++ b/test/accuracy_main.cpp
@@ -22,7 +22,7 @@
 
 #define SHOW_OCL_BANNER()                                                                                              \
     if (OCLEngine::Instance()->GetDeviceCount()) {                                                                     \
-        CreateQuantumInterface(QINTERFACE_OPENCL, 1, 0).reset();                                                       \
+        CreateQuantumInterface({ QINTERFACE_OPENCL }, 1, 0).reset();                                                   \
     }
 
 using namespace Qrack;
@@ -150,6 +150,6 @@ QInterfaceTestFixture::QInterfaceTestFixture()
     qrack_rand_gen_ptr rng = std::make_shared<qrack_rand_gen>();
     rng->seed(rngSeed);
 
-    qftReg = CreateQuantumInterface(testEngineType, testSubEngineType, 1, 0, rng, complex(ONE_R1, ZERO_R1),
+    qftReg = CreateQuantumInterface({ testEngineType, testSubEngineType }, 1, 0, rng, complex(ONE_R1, ZERO_R1),
         enable_normalization, false, true, -1, !disable_hardware_rng);
 }

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -48,7 +48,7 @@ double formatTime(double t, bool logNormal)
 QInterfacePtr MakeRandQubit()
 {
     QInterfacePtr qubit =
-        CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 1U, 0, rng, ONE_CMPLX,
+        CreateQuantumInterface({ testEngineType, testSubEngineType, testSubSubEngineType }, 1U, 0, rng, ONE_CMPLX,
             enable_normalization, true, use_host_dma, device_id, !disable_hardware_rng, sparse, REAL1_EPSILON, devList);
 
     real1_f theta = 2 * M_PI * qubit->Rand();
@@ -137,7 +137,7 @@ void benchmarkLoopVariable(std::function<void(QInterfacePtr, bitLenInt)> fn, bit
             }
 
             if (!qUniverse) {
-                qftReg = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, numBits, 0,
+                qftReg = CreateQuantumInterface({ testEngineType, testSubEngineType, testSubSubEngineType }, numBits, 0,
                     rng, ONE_CMPLX, enable_normalization, true, use_host_dma, device_id, !disable_hardware_rng, sparse,
                     REAL1_EPSILON, devList);
                 if (resetRandomPerm) {
@@ -2308,8 +2308,8 @@ TEST_CASE("test_universal_circuit_digital_cross_entropy", "[supreme]")
     std::vector<std::vector<MultiQubitGate>> gateMultiQbRands(Depth);
     int maxGates;
 
-    QInterfacePtr goldStandard = CreateQuantumInterface(testSubEngineType, testSubSubEngineType, n, 0, rng, ONE_CMPLX,
-        enable_normalization, true, use_host_dma, device_id, !disable_hardware_rng);
+    QInterfacePtr goldStandard = CreateQuantumInterface({ testSubEngineType, testSubSubEngineType }, n, 0, rng,
+        ONE_CMPLX, enable_normalization, true, use_host_dma, device_id, !disable_hardware_rng);
 
     for (d = 0; d < Depth; d++) {
         std::vector<int>& layer1QbRands = gate1QbRands[d];
@@ -2429,7 +2429,7 @@ TEST_CASE("test_universal_circuit_digital_cross_entropy", "[supreme]")
     crossEntropy = ONE_R1 - sqrt(crossEntropy) / ITERATIONS;
     std::cout << "Gold standard vs. gold standard cross entropy (out of 1.0): " << crossEntropy << std::endl;
 
-    QInterfacePtr testCase = CreateQuantumInterface(testEngineType, testSubEngineType, n, 0, rng, ONE_CMPLX,
+    QInterfacePtr testCase = CreateQuantumInterface({ testEngineType, testSubEngineType }, n, 0, rng, ONE_CMPLX,
         enable_normalization, true, use_host_dma, device_id, !disable_hardware_rng, sparse);
 
     std::map<bitCapInt, int> testCaseResult;

--- a/test/benchmarks_main.cpp
+++ b/test/benchmarks_main.cpp
@@ -44,7 +44,7 @@ std::vector<int> devList;
 
 #define SHOW_OCL_BANNER()                                                                                              \
     if (OCLEngine::Instance()->GetDeviceCount()) {                                                                     \
-        CreateQuantumInterface(QINTERFACE_OPENCL, 1, 0).reset();                                                       \
+        CreateQuantumInterface({ QINTERFACE_OPENCL }, 1, 0).reset();                                                   \
     }
 
 int main(int argc, char* argv[])

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -40,7 +40,7 @@ std::vector<int> devList;
 
 #define SHOW_OCL_BANNER()                                                                                              \
     if (OCLEngine::Instance()->GetDeviceCount()) {                                                                     \
-        CreateQuantumInterface(QINTERFACE_OPENCL, 1, 0).reset();                                                       \
+        CreateQuantumInterface({ QINTERFACE_OPENCL }, 1, 0).reset();                                                   \
     }
 
 int main(int argc, char* argv[])
@@ -376,6 +376,6 @@ QInterfaceTestFixture::QInterfaceTestFixture()
     qrack_rand_gen_ptr rng = std::make_shared<qrack_rand_gen>();
     rng->seed(rngSeed);
 
-    qftReg = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 20, 0, rng, ONE_CMPLX,
+    qftReg = CreateQuantumInterface({ testEngineType, testSubEngineType, testSubSubEngineType }, 20, 0, rng, ONE_CMPLX,
         enable_normalization, true, false, device_id, !disable_hardware_rng, sparse, REAL1_EPSILON, devList);
 }

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -65,7 +65,7 @@ void log(QInterfacePtr p) { std::cout << std::endl << std::showpoint << p << std
 
 QInterfacePtr MakeEngine(bitLenInt qubitCount)
 {
-    return CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, qubitCount, 0, rng,
+    return CreateQuantumInterface({ testEngineType, testSubEngineType, testSubSubEngineType }, qubitCount, 0, rng,
         ONE_CMPLX, enable_normalization, true, false, device_id, !disable_hardware_rng, sparse, REAL1_EPSILON, devList);
 }
 
@@ -579,8 +579,8 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_cswap")
     qftReg->H(8);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x110));
 
-    QInterfacePtr qftReg2 = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 20U, 0, rng,
-        ONE_CMPLX, enable_normalization, true, false, device_id, !disable_hardware_rng, sparse, REAL1_DEFAULT_ARG,
+    QInterfacePtr qftReg2 = CreateQuantumInterface({ testEngineType, testSubEngineType, testSubSubEngineType }, 20U, 0,
+        rng, ONE_CMPLX, enable_normalization, true, false, device_id, !disable_hardware_rng, sparse, REAL1_DEFAULT_ARG,
         devList, 10);
 
     control[0] = 9;
@@ -3468,8 +3468,8 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_zero_phase_flip")
     qftReg->H(1);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x03));
 
-    QInterfacePtr qftReg2 = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 20U, 0, rng,
-        ONE_CMPLX, enable_normalization, true, false, device_id, !disable_hardware_rng, sparse, REAL1_DEFAULT_ARG,
+    QInterfacePtr qftReg2 = CreateQuantumInterface({ testEngineType, testSubEngineType, testSubSubEngineType }, 20U, 0,
+        rng, ONE_CMPLX, enable_normalization, true, false, device_id, !disable_hardware_rng, sparse, REAL1_DEFAULT_ARG,
         devList, 10);
 
     qftReg2->SetPermutation(3U << 9U);
@@ -3706,9 +3706,9 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_clone")
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_decompose")
 {
-    qftReg = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 4, 0x0b, rng);
+    qftReg = CreateQuantumInterface({ testEngineType, testSubEngineType, testSubSubEngineType }, 4, 0x0b, rng);
     QInterfacePtr qftReg2 =
-        CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 4, 0x02, rng);
+        CreateQuantumInterface({ testEngineType, testSubEngineType, testSubSubEngineType }, 4, 0x02, rng);
     qftReg->Compose(qftReg2);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x2b));
 
@@ -3719,15 +3719,15 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_decompose")
     qftReg->Compose(qftReg2);
 
     // Try across device/heap allocation case:
-    qftReg2 = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 4, 0, rng,
+    qftReg2 = CreateQuantumInterface({ testEngineType, testSubEngineType, testSubSubEngineType }, 4, 0, rng,
         complex(ONE_R1, ZERO_R1), enable_normalization, true, true, device_id, !disable_hardware_rng, sparse,
         REAL1_EPSILON, devList);
 
     qftReg->SetPermutation(0x2b);
     qftReg->Decompose(0, qftReg2);
 
-    qftReg = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 8, 0x33, rng);
-    qftReg2 = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 4, 0x02, rng);
+    qftReg = CreateQuantumInterface({ testEngineType, testSubEngineType, testSubSubEngineType }, 8, 0x33, rng);
+    qftReg2 = CreateQuantumInterface({ testEngineType, testSubEngineType, testSubSubEngineType }, 4, 0x02, rng);
     qftReg->H(1, 2);
     qftReg->CNOT(1, 3, 2);
     qftReg->CNOT(1, 6);
@@ -3768,15 +3768,15 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_dispose_perm")
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_compose")
 {
-    qftReg = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 4, 0x0b, rng);
+    qftReg = CreateQuantumInterface({ testEngineType, testSubEngineType, testSubSubEngineType }, 4, 0x0b, rng);
     QInterfacePtr qftReg2 =
-        CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 4, 0x02, rng);
+        CreateQuantumInterface({ testEngineType, testSubEngineType, testSubSubEngineType }, 4, 0x02, rng);
     qftReg->Compose(qftReg2);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x2b));
 
     // Try across device/heap allocation case:
-    qftReg = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 4, 0x0b, rng);
-    qftReg2 = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 4, 0x02, rng,
+    qftReg = CreateQuantumInterface({ testEngineType, testSubEngineType, testSubSubEngineType }, 4, 0x0b, rng);
+    qftReg2 = CreateQuantumInterface({ testEngineType, testSubEngineType, testSubSubEngineType }, 4, 0x02, rng,
         complex(ONE_R1, ZERO_R1), false, true, true);
     qftReg->Compose(qftReg2);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x2b));
@@ -3807,9 +3807,9 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_trydecompose")
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_qunit_paging")
 {
-    qftReg = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 18, 1, rng, ONE_CMPLX);
+    qftReg = CreateQuantumInterface({ testEngineType, testSubEngineType, testSubSubEngineType }, 18, 1, rng, ONE_CMPLX);
     QInterfacePtr qftReg2 =
-        CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 4, 2, rng, ONE_CMPLX);
+        CreateQuantumInterface({ testEngineType, testSubEngineType, testSubSubEngineType }, 4, 2, rng, ONE_CMPLX);
 
     qftReg->H(0, 3);
     qftReg->CCZ(0, 1, 2);
@@ -3862,7 +3862,7 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_probreg")
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_probmask")
 {
-    qftReg = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 8, 0, rng);
+    qftReg = CreateQuantumInterface({ testEngineType, testSubEngineType, testSubSubEngineType }, 8, 0, rng);
     qftReg->SetPermutation(0x21);
     REQUIRE(qftReg->ProbMask(0xF0, 0x20) > 0.99);
     REQUIRE(qftReg->ProbMask(0xF0, 0x40) < 0.01);
@@ -3877,7 +3877,7 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_probmask")
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_probmaskall")
 {
-    qftReg = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 1, 0, rng);
+    qftReg = CreateQuantumInterface({ testEngineType, testSubEngineType, testSubSubEngineType }, 1, 0, rng);
     real1 probs1[2];
     qftReg->ProbMaskAll(1U, probs1);
     REQUIRE(probs1[0] > 0.99);
@@ -3886,7 +3886,7 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_probmaskall")
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_probbitsall")
 {
-    qftReg = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 3, 5, rng);
+    qftReg = CreateQuantumInterface({ testEngineType, testSubEngineType, testSubSubEngineType }, 3, 5, rng);
     bitLenInt bits[2] = { 2, 1 };
     real1 probs1[4];
     qftReg->ProbBitsAll(bits, 2U, probs1);
@@ -3906,7 +3906,7 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_probbitsall")
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_expectationbitsall")
 {
-    qftReg = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 8, 0, rng);
+    qftReg = CreateQuantumInterface({ testEngineType, testSubEngineType, testSubSubEngineType }, 8, 0, rng);
     bitLenInt bits[8] = { 0, 1, 2, 3, 4, 5, 6, 7 };
     qftReg->H(0, 8);
     REQUIRE_FLOAT(qftReg->ExpectationBitsAll(bits, 8U), 127 + (ONE_R1 / 2))
@@ -4035,7 +4035,7 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_cuniformparityrz")
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_multishotmeasuremask")
 {
-    qftReg = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 8, 0, rng);
+    qftReg = CreateQuantumInterface({ testEngineType, testSubEngineType, testSubSubEngineType }, 8, 0, rng);
 
     bitCapInt qPowers[3] = { pow2(6), pow2(2), pow2(3) };
 
@@ -4096,7 +4096,7 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_getamplitude")
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_getquantumstate")
 {
     complex state[1U << 4U];
-    qftReg = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 4, 0x0b, rng);
+    qftReg = CreateQuantumInterface({ testEngineType, testSubEngineType, testSubSubEngineType }, 4, 0x0b, rng);
     qftReg->GetQuantumState(state);
     for (bitCapIntOcl i = 0; i < 16; i++) {
         if (i == 0x0b) {
@@ -4108,7 +4108,8 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_getquantumstate")
     qftReg->SetQuantumState(state);
 
     complex state2[2] = { ZERO_CMPLX, ONE_CMPLX };
-    QInterfacePtr qftReg2 = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 1, 0, rng);
+    QInterfacePtr qftReg2 =
+        CreateQuantumInterface({ testEngineType, testSubEngineType, testSubSubEngineType }, 1, 0, rng);
     qftReg2->SetQuantumState(state2);
     REQUIRE_THAT(qftReg2, HasProbability(1U));
 }
@@ -4116,7 +4117,7 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_getquantumstate")
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_getprobs")
 {
     real1 state[1U << 4U];
-    qftReg = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 4, 0x0b, rng);
+    qftReg = CreateQuantumInterface({ testEngineType, testSubEngineType, testSubSubEngineType }, 4, 0x0b, rng);
     qftReg->GetProbs(state);
     for (bitCapIntOcl i = 0; i < 16; i++) {
         if (i == 0x0b) {
@@ -4562,7 +4563,7 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_qfusion_controlled")
     bitLenInt controls[2] = { 1, 2 };
     real1 angles[4] = { (real1)3.0f, (real1)0.8f, (real1)1.2f, (real1)0.7f };
 
-    qftReg = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 3, 0, rng);
+    qftReg = CreateQuantumInterface({ testEngineType, testSubEngineType, testSubSubEngineType }, 3, 0, rng);
     qftReg->SetPermutation(2);
     QInterfacePtr qftReg2 = qftReg->Clone();
 
@@ -4722,7 +4723,7 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_universal_set")
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_teleport")
 {
-    qftReg = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 3, 0);
+    qftReg = CreateQuantumInterface({ testEngineType, testSubEngineType, testSubSubEngineType }, 3, 0);
 
     qftReg->SetPermutation(0);
 
@@ -4749,7 +4750,7 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_teleport")
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_h_cnot_rand")
 {
-    qftReg = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, 2, 0);
+    qftReg = CreateQuantumInterface({ testEngineType, testSubEngineType, testSubSubEngineType }, 2, 0);
     qftReg->H(0);
     qftReg->CNOT(0, 1);
 
@@ -5441,7 +5442,8 @@ TEST_CASE("test_mirror_circuit", "[mirror]")
     int gate;
 
     for (int trial = 0; trial < TRIALS; trial++) {
-        QInterfacePtr testCase = CreateQuantumInterface(testEngineType, testSubEngineType, testSubSubEngineType, n, 0);
+        QInterfacePtr testCase =
+            CreateQuantumInterface({ testEngineType, testSubEngineType, testSubSubEngineType }, n, 0);
         testCase->SetReactiveSeparate(true);
 
         std::vector<std::vector<int>> gate1QbRands(Depth);


### PR DESCRIPTION
This addresses #661. The old factory signatures are still supported, as well, so this should not be a breaking change.