### PR TITLE
Add ALU to shared library.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required (VERSION 3.9)
-project (Qrack VERSION 6.1.1 DESCRIPTION "High Performance Quantum Bit Simulation")
+project (Qrack VERSION 6.2.0 DESCRIPTION "High Performance Quantum Bit Simulation")
 
 # Installation commands
 include (GNUInstallDirs)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required (VERSION 3.9)
-project (Qrack VERSION 3.1 DESCRIPTION "High Performance Quantum Bit Simulation")
+project (Qrack VERSION 6.1.1 DESCRIPTION "High Performance Quantum Bit Simulation")
 
 # Installation commands
 include (GNUInstallDirs)

--- a/examples/grovers_lookup.cpp
+++ b/examples/grovers_lookup.cpp
@@ -47,6 +47,7 @@ int main()
     const bitLenInt indexLength = 8;
     const bitLenInt valueLength = 8;
     const bitLenInt carryIndex = indexLength + valueLength;
+    const bitLenInt totBits = indexLength + valueLength + 1;
 
     // We theoretically know that we're looking for a value part of 100.
     const int TARGET_VALUE = 100;
@@ -57,9 +58,9 @@ int main()
 
     // Both CPU and GPU types share the QInterface API.
 #if ENABLE_OPENCL
-    QInterfacePtr qReg = CreateQuantumInterface(QINTERFACE_OPENCL, 20, 0);
+    QInterfacePtr qReg = CreateQuantumInterface(QINTERFACE_OPTIMAL, totBits, 0);
 #else
-    QInterfacePtr qReg = CreateQuantumInterface(QINTERFACE_CPU, 20, 0);
+    QInterfacePtr qReg = CreateQuantumInterface(QINTERFACE_CPU, totBits, 0);
 #endif
 
     // This array should actually be allocated aligned for best performance, but this will work. We'll talk about
@@ -71,9 +72,8 @@ int main()
     toLoad[TARGET_KEY] = TARGET_VALUE;
 
     // Our input to the subroutine "oracle" is 8 bits.
-    qReg->SetPermutation(0);
-    qReg->H(valueLength, indexLength);
-    qReg->IndexedLDA(valueLength, indexLength, 0, valueLength, toLoad);
+    qReg->H(0, indexLength);
+    qReg->IndexedLDA(0, indexLength, indexLength, valueLength, toLoad);
 
     // Twelve iterations maximizes the probablity for 256 searched elements, for example.
     // For an arbitrary number of qubits, this gives the number of iterations for optimal probability.
@@ -82,24 +82,24 @@ int main()
     for (i = 0; i < optIter; i++) {
         // The "oracle" tags one value permutation, which we know. We don't know the key, yet, but the search will
         // return it.
-        TagValue(TARGET_VALUE, qReg, 0, valueLength);
+        TagValue(TARGET_VALUE, qReg, indexLength, valueLength);
 
         qReg->X(carryIndex);
-        qReg->IndexedSBC(valueLength, indexLength, 0, valueLength, carryIndex, toLoad);
+        qReg->IndexedSBC(0, indexLength, indexLength, valueLength, carryIndex, toLoad);
         qReg->X(carryIndex);
-        qReg->H(valueLength, indexLength);
-        qReg->ZeroPhaseFlip(valueLength, indexLength);
-        qReg->H(valueLength, indexLength);
+        qReg->H(0, indexLength);
+        qReg->ZeroPhaseFlip(0, indexLength);
+        qReg->H(0, indexLength);
         // qReg->PhaseFlip();
-        qReg->IndexedADC(valueLength, indexLength, 0, valueLength, carryIndex, toLoad);
+        qReg->IndexedADC(0, indexLength, indexLength, valueLength, carryIndex, toLoad);
         std::cout << "\t" << std::setw(2) << i
-                  << "> chance of match:" << qReg->ProbAll(TARGET_VALUE | (TARGET_KEY << valueLength)) << std::endl;
+                  << "> chance of match:" << qReg->ProbAll(TARGET_KEY | (TARGET_VALUE << indexLength)) << std::endl;
     }
 
     qReg->MReg(0, 8);
 
     std::cout << "After measurement (of value, key, or both):" << std::endl;
-    std::cout << "Chance of match:" << qReg->ProbAll(TARGET_VALUE | (TARGET_KEY << valueLength)) << std::endl;
+    std::cout << "Chance of match:" << qReg->ProbAll(TARGET_KEY | (TARGET_VALUE << indexLength)) << std::endl;
 
     delete[] toLoad;
 }

--- a/include/pinvoke_api.hpp
+++ b/include/pinvoke_api.hpp
@@ -142,6 +142,43 @@ MICROSOFT_QUANTUM_DECL void CLXNOR(_In_ unsigned sid, _In_ bool ci, _In_ unsigne
 MICROSOFT_QUANTUM_DECL void QFT(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c);
 MICROSOFT_QUANTUM_DECL void IQFT(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c);
 
+MICROSOFT_QUANTUM_DECL void ADD(_In_ unsigned sid, unsigned a, _In_ unsigned n, _In_reads_(n) unsigned* q);
+MICROSOFT_QUANTUM_DECL void SUB(_In_ unsigned sid, unsigned a, _In_ unsigned n, _In_reads_(n) unsigned* q);
+MICROSOFT_QUANTUM_DECL void ADDS(_In_ unsigned sid, unsigned a, unsigned s, _In_ unsigned n, _In_reads_(n) unsigned* q);
+MICROSOFT_QUANTUM_DECL void SUBS(_In_ unsigned sid, unsigned a, unsigned s, _In_ unsigned n, _In_reads_(n) unsigned* q);
+MICROSOFT_QUANTUM_DECL void MUL(
+    _In_ unsigned sid, unsigned a, _In_ unsigned n, _In_reads_(n) unsigned* q, _In_reads_(n) unsigned* o);
+MICROSOFT_QUANTUM_DECL void DIV(
+    _In_ unsigned sid, unsigned a, _In_ unsigned n, _In_reads_(n) unsigned* q, _In_reads_(n) unsigned* o);
+MICROSOFT_QUANTUM_DECL void MULN(
+    _In_ unsigned sid, unsigned a, unsigned m, _In_ unsigned n, _In_reads_(n) unsigned* q, _In_reads_(n) unsigned* o);
+MICROSOFT_QUANTUM_DECL void DIVN(
+    _In_ unsigned sid, unsigned a, unsigned m, _In_ unsigned n, _In_reads_(n) unsigned* q, _In_reads_(n) unsigned* o);
+MICROSOFT_QUANTUM_DECL void POWN(
+    _In_ unsigned sid, unsigned a, unsigned m, _In_ unsigned n, _In_reads_(n) unsigned* q, _In_reads_(n) unsigned* o);
+
+MICROSOFT_QUANTUM_DECL void MCADD(_In_ unsigned sid, unsigned a, _In_ unsigned nc, _In_reads_(nc) unsigned* c,
+    _In_ unsigned nq, _In_reads_(nq) unsigned* q);
+MICROSOFT_QUANTUM_DECL void MCSUB(_In_ unsigned sid, unsigned a, _In_ unsigned nc, _In_reads_(nc) unsigned* c,
+    _In_ unsigned nq, _In_reads_(nq) unsigned* q);
+MICROSOFT_QUANTUM_DECL void MCMUL(_In_ unsigned sid, unsigned a, _In_ unsigned nc, _In_reads_(nc) unsigned* c,
+    _In_ unsigned n, _In_reads_(n) unsigned* q, _In_reads_(n) unsigned* o);
+MICROSOFT_QUANTUM_DECL void MCDIV(_In_ unsigned sid, unsigned a, _In_ unsigned nc, _In_reads_(nc) unsigned* c,
+    _In_ unsigned n, _In_reads_(n) unsigned* q, _In_reads_(n) unsigned* o);
+MICROSOFT_QUANTUM_DECL void MCMULN(_In_ unsigned sid, unsigned a, _In_ unsigned nc, _In_reads_(nc) unsigned* c,
+    unsigned m, _In_ unsigned n, _In_reads_(n) unsigned* q, _In_reads_(n) unsigned* o);
+MICROSOFT_QUANTUM_DECL void MCDIVN(_In_ unsigned sid, unsigned a, _In_ unsigned nc, _In_reads_(nc) unsigned* c,
+    unsigned m, _In_ unsigned n, _In_reads_(n) unsigned* q, _In_reads_(n) unsigned* o);
+MICROSOFT_QUANTUM_DECL void MCPOWN(_In_ unsigned sid, unsigned a, _In_ unsigned nc, _In_reads_(nc) unsigned* c,
+    unsigned m, _In_ unsigned n, _In_reads_(n) unsigned* q, _In_reads_(n) unsigned* o);
+
+MICROSOFT_QUANTUM_DECL void LDA(_In_ unsigned sid, _In_ unsigned ni, _In_reads_(ni) unsigned* qi, _In_ unsigned nv,
+    _In_reads_(nv) unsigned* qv, unsigned char* t);
+MICROSOFT_QUANTUM_DECL void ADC(_In_ unsigned sid, unsigned s, _In_ unsigned ni, _In_reads_(ni) unsigned* qi,
+    _In_ unsigned nv, _In_reads_(nv) unsigned* qv, unsigned char* t);
+MICROSOFT_QUANTUM_DECL void SBC(_In_ unsigned sid, unsigned s, _In_ unsigned ni, _In_reads_(ni) unsigned* qi,
+    _In_ unsigned nv, _In_reads_(nv) unsigned* qv, unsigned char* t);
+
 MICROSOFT_QUANTUM_DECL bool TrySeparate1Qb(_In_ unsigned sid, _In_ unsigned qi1);
 MICROSOFT_QUANTUM_DECL bool TrySeparate2Qb(_In_ unsigned sid, _In_ unsigned qi1, _In_ unsigned qi2);
 MICROSOFT_QUANTUM_DECL bool TrySeparateTol(

--- a/src/pinvoke_api.cpp
+++ b/src/pinvoke_api.cpp
@@ -561,11 +561,11 @@ MICROSOFT_QUANTUM_DECL void Mtrx(_In_ unsigned sid, _In_reads_(8) double* m, _In
     simulator->ApplySingleBit(mtrx, shards[simulator][q]);
 }
 
-#define MAP_CONTROLS_AND_LOCK(sid)                                                                                     \
+#define MAP_CONTROLS_AND_LOCK(sid, numC)                                                                               \
     SIMULATOR_LOCK_GUARD(sid)                                                                                          \
     QInterfacePtr simulator = simulators[sid];                                                                         \
-    std::unique_ptr<bitLenInt[]> ctrlsArray(new bitLenInt[n]);                                                         \
-    for (unsigned i = 0; i < n; i++) {                                                                                 \
+    std::unique_ptr<bitLenInt[]> ctrlsArray(new bitLenInt[numC]);                                                      \
+    for (unsigned i = 0; i < numC; i++) {                                                                              \
         ctrlsArray.get()[i] = shards[simulator][c[i]];                                                                 \
     }
 
@@ -574,7 +574,7 @@ MICROSOFT_QUANTUM_DECL void Mtrx(_In_ unsigned sid, _In_reads_(8) double* m, _In
  */
 MICROSOFT_QUANTUM_DECL void MCX(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c, _In_ unsigned q)
 {
-    MAP_CONTROLS_AND_LOCK(sid)
+    MAP_CONTROLS_AND_LOCK(sid, n)
     simulator->ApplyControlledSingleInvert(ctrlsArray.get(), n, shards[simulator][q], ONE_CMPLX, ONE_CMPLX);
 }
 
@@ -583,7 +583,7 @@ MICROSOFT_QUANTUM_DECL void MCX(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n
  */
 MICROSOFT_QUANTUM_DECL void MCY(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c, _In_ unsigned q)
 {
-    MAP_CONTROLS_AND_LOCK(sid)
+    MAP_CONTROLS_AND_LOCK(sid, n)
     simulator->ApplyControlledSingleInvert(ctrlsArray.get(), n, shards[simulator][q], -I_CMPLX, I_CMPLX);
 }
 
@@ -592,7 +592,7 @@ MICROSOFT_QUANTUM_DECL void MCY(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n
  */
 MICROSOFT_QUANTUM_DECL void MCZ(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c, _In_ unsigned q)
 {
-    MAP_CONTROLS_AND_LOCK(sid)
+    MAP_CONTROLS_AND_LOCK(sid, n)
     simulator->ApplyControlledSinglePhase(ctrlsArray.get(), n, shards[simulator][q], ONE_CMPLX, -ONE_CMPLX);
 }
 
@@ -604,7 +604,7 @@ MICROSOFT_QUANTUM_DECL void MCH(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n
     const complex hGate[4] = { complex(SQRT1_2_R1, ZERO_R1), complex(SQRT1_2_R1, ZERO_R1), complex(SQRT1_2_R1, ZERO_R1),
         complex(-SQRT1_2_R1, ZERO_R1) };
 
-    MAP_CONTROLS_AND_LOCK(sid)
+    MAP_CONTROLS_AND_LOCK(sid, n)
     simulator->ApplyControlledSingleBit(ctrlsArray.get(), n, shards[simulator][q], hGate);
 }
 
@@ -613,7 +613,7 @@ MICROSOFT_QUANTUM_DECL void MCH(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n
  */
 MICROSOFT_QUANTUM_DECL void MCS(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c, _In_ unsigned q)
 {
-    MAP_CONTROLS_AND_LOCK(sid)
+    MAP_CONTROLS_AND_LOCK(sid, n)
     simulator->ApplyControlledSinglePhase(ctrlsArray.get(), n, shards[simulator][q], ONE_CMPLX, I_CMPLX);
 }
 
@@ -622,7 +622,7 @@ MICROSOFT_QUANTUM_DECL void MCS(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n
  */
 MICROSOFT_QUANTUM_DECL void MCT(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c, _In_ unsigned q)
 {
-    MAP_CONTROLS_AND_LOCK(sid)
+    MAP_CONTROLS_AND_LOCK(sid, n)
     simulator->ApplyControlledSinglePhase(
         ctrlsArray.get(), n, shards[simulator][q], ONE_CMPLX, complex(SQRT1_2_R1, SQRT1_2_R1));
 }
@@ -632,7 +632,7 @@ MICROSOFT_QUANTUM_DECL void MCT(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n
  */
 MICROSOFT_QUANTUM_DECL void MCAdjS(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c, _In_ unsigned q)
 {
-    MAP_CONTROLS_AND_LOCK(sid)
+    MAP_CONTROLS_AND_LOCK(sid, n)
     simulator->ApplyControlledSinglePhase(ctrlsArray.get(), n, shards[simulator][q], ONE_CMPLX, -I_CMPLX);
 }
 
@@ -641,7 +641,7 @@ MICROSOFT_QUANTUM_DECL void MCAdjS(_In_ unsigned sid, _In_ unsigned n, _In_reads
  */
 MICROSOFT_QUANTUM_DECL void MCAdjT(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c, _In_ unsigned q)
 {
-    MAP_CONTROLS_AND_LOCK(sid)
+    MAP_CONTROLS_AND_LOCK(sid, n)
     simulator->ApplyControlledSinglePhase(
         ctrlsArray.get(), n, shards[simulator][q], ONE_CMPLX, complex(SQRT1_2_R1, -SQRT1_2_R1));
 }
@@ -652,7 +652,7 @@ MICROSOFT_QUANTUM_DECL void MCAdjT(_In_ unsigned sid, _In_ unsigned n, _In_reads
 MICROSOFT_QUANTUM_DECL void MCU(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c, _In_ unsigned q,
     _In_ double theta, _In_ double phi, _In_ double lambda)
 {
-    MAP_CONTROLS_AND_LOCK(sid)
+    MAP_CONTROLS_AND_LOCK(sid, n)
     simulator->CU(ctrlsArray.get(), n, shards[simulator][q], theta, phi, lambda);
 }
 
@@ -665,7 +665,7 @@ MICROSOFT_QUANTUM_DECL void MCMtrx(
     complex mtrx[4] = { complex((real1)m[0], (real1)m[1]), complex((real1)m[2], (real1)m[3]),
         complex((real1)m[4], (real1)m[5]), complex((real1)m[6], (real1)m[7]) };
 
-    MAP_CONTROLS_AND_LOCK(sid)
+    MAP_CONTROLS_AND_LOCK(sid, n)
     simulator->ApplyControlledSingleBit(ctrlsArray.get(), n, shards[simulator][q], mtrx);
 }
 
@@ -674,7 +674,7 @@ MICROSOFT_QUANTUM_DECL void MCMtrx(
  */
 MICROSOFT_QUANTUM_DECL void MACX(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c, _In_ unsigned q)
 {
-    MAP_CONTROLS_AND_LOCK(sid)
+    MAP_CONTROLS_AND_LOCK(sid, n)
     simulator->ApplyAntiControlledSingleInvert(ctrlsArray.get(), n, shards[simulator][q], ONE_CMPLX, ONE_CMPLX);
 }
 
@@ -683,7 +683,7 @@ MICROSOFT_QUANTUM_DECL void MACX(_In_ unsigned sid, _In_ unsigned n, _In_reads_(
  */
 MICROSOFT_QUANTUM_DECL void MACY(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c, _In_ unsigned q)
 {
-    MAP_CONTROLS_AND_LOCK(sid)
+    MAP_CONTROLS_AND_LOCK(sid, n)
     simulator->ApplyAntiControlledSingleInvert(ctrlsArray.get(), n, shards[simulator][q], -I_CMPLX, I_CMPLX);
 }
 
@@ -692,7 +692,7 @@ MICROSOFT_QUANTUM_DECL void MACY(_In_ unsigned sid, _In_ unsigned n, _In_reads_(
  */
 MICROSOFT_QUANTUM_DECL void MACZ(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c, _In_ unsigned q)
 {
-    MAP_CONTROLS_AND_LOCK(sid)
+    MAP_CONTROLS_AND_LOCK(sid, n)
     simulator->ApplyAntiControlledSinglePhase(ctrlsArray.get(), n, shards[simulator][q], ONE_CMPLX, -ONE_CMPLX);
 }
 
@@ -704,7 +704,7 @@ MICROSOFT_QUANTUM_DECL void MACH(_In_ unsigned sid, _In_ unsigned n, _In_reads_(
     const complex hGate[4] = { complex(SQRT1_2_R1, ZERO_R1), complex(SQRT1_2_R1, ZERO_R1), complex(SQRT1_2_R1, ZERO_R1),
         complex(-SQRT1_2_R1, ZERO_R1) };
 
-    MAP_CONTROLS_AND_LOCK(sid)
+    MAP_CONTROLS_AND_LOCK(sid, n)
     simulator->ApplyAntiControlledSingleBit(ctrlsArray.get(), n, shards[simulator][q], hGate);
 }
 
@@ -713,7 +713,7 @@ MICROSOFT_QUANTUM_DECL void MACH(_In_ unsigned sid, _In_ unsigned n, _In_reads_(
  */
 MICROSOFT_QUANTUM_DECL void MACS(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c, _In_ unsigned q)
 {
-    MAP_CONTROLS_AND_LOCK(sid)
+    MAP_CONTROLS_AND_LOCK(sid, n)
     simulator->ApplyAntiControlledSinglePhase(ctrlsArray.get(), n, shards[simulator][q], ONE_CMPLX, I_CMPLX);
 }
 
@@ -722,7 +722,7 @@ MICROSOFT_QUANTUM_DECL void MACS(_In_ unsigned sid, _In_ unsigned n, _In_reads_(
  */
 MICROSOFT_QUANTUM_DECL void MACT(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c, _In_ unsigned q)
 {
-    MAP_CONTROLS_AND_LOCK(sid)
+    MAP_CONTROLS_AND_LOCK(sid, n)
     simulator->ApplyAntiControlledSinglePhase(
         ctrlsArray.get(), n, shards[simulator][q], ONE_CMPLX, complex(SQRT1_2_R1, SQRT1_2_R1));
 }
@@ -732,7 +732,7 @@ MICROSOFT_QUANTUM_DECL void MACT(_In_ unsigned sid, _In_ unsigned n, _In_reads_(
  */
 MICROSOFT_QUANTUM_DECL void MACAdjS(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c, _In_ unsigned q)
 {
-    MAP_CONTROLS_AND_LOCK(sid)
+    MAP_CONTROLS_AND_LOCK(sid, n)
     simulator->ApplyAntiControlledSinglePhase(ctrlsArray.get(), n, shards[simulator][q], ONE_CMPLX, -I_CMPLX);
 }
 
@@ -741,7 +741,7 @@ MICROSOFT_QUANTUM_DECL void MACAdjS(_In_ unsigned sid, _In_ unsigned n, _In_read
  */
 MICROSOFT_QUANTUM_DECL void MACAdjT(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c, _In_ unsigned q)
 {
-    MAP_CONTROLS_AND_LOCK(sid)
+    MAP_CONTROLS_AND_LOCK(sid, n)
     simulator->ApplyAntiControlledSinglePhase(
         ctrlsArray.get(), n, shards[simulator][q], ONE_CMPLX, complex(SQRT1_2_R1, -SQRT1_2_R1));
 }
@@ -752,7 +752,7 @@ MICROSOFT_QUANTUM_DECL void MACAdjT(_In_ unsigned sid, _In_ unsigned n, _In_read
 MICROSOFT_QUANTUM_DECL void MACU(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c, _In_ unsigned q,
     _In_ double theta, _In_ double phi, _In_ double lambda)
 {
-    MAP_CONTROLS_AND_LOCK(sid)
+    MAP_CONTROLS_AND_LOCK(sid, n)
     simulator->AntiCU(ctrlsArray.get(), n, shards[simulator][q], theta, phi, lambda);
 }
 
@@ -765,7 +765,7 @@ MICROSOFT_QUANTUM_DECL void MACMtrx(
     complex mtrx[4] = { complex((real1)m[0], (real1)m[1]), complex((real1)m[2], (real1)m[3]),
         complex((real1)m[4], (real1)m[5]), complex((real1)m[6], (real1)m[7]) };
 
-    MAP_CONTROLS_AND_LOCK(sid)
+    MAP_CONTROLS_AND_LOCK(sid, n)
     simulator->ApplyAntiControlledSingleBit(ctrlsArray.get(), n, shards[simulator][q], mtrx);
 }
 
@@ -934,7 +934,7 @@ MICROSOFT_QUANTUM_DECL void SWAP(_In_ unsigned sid, _In_ unsigned qi1, _In_ unsi
 MICROSOFT_QUANTUM_DECL void CSWAP(
     _In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c, _In_ unsigned qi1, _In_ unsigned qi2)
 {
-    MAP_CONTROLS_AND_LOCK(sid)
+    MAP_CONTROLS_AND_LOCK(sid, n)
     simulator->CSwap(ctrlsArray.get(), n, shards[simulator][qi1], shards[simulator][qi2]);
 }
 
@@ -1155,6 +1155,290 @@ MICROSOFT_QUANTUM_DECL void IQFT(_In_ unsigned sid, _In_ unsigned n, _In_reads_(
     std::copy(c, c + n, q.get());
     simulator->IQFTR(q.get(), n);
 #endif
+}
+
+unsigned MapArithmetic(QInterfacePtr simulator, unsigned n, unsigned* q)
+{
+    unsigned start = shards[simulator][q[0]];
+    std::unique_ptr<bitLenInt[]> bitArray(new bitLenInt[n]);
+    for (unsigned i = 0U; i < n; i++) {
+        bitArray.get()[i] = shards[simulator][q[i]];
+        if (start > bitArray.get()[i]) {
+            start = bitArray.get()[i];
+        }
+    }
+    for (unsigned i = 1U; i < n; i++) {
+        simulator->Swap(i, bitArray.get()[i]);
+    }
+
+    return start;
+}
+
+struct MapArithmeticResult2 {
+    unsigned start1;
+    unsigned start2;
+
+    MapArithmeticResult2(unsigned s1, unsigned s2)
+        : start1(s1)
+        , start2(s2)
+    {
+    }
+};
+
+MapArithmeticResult2 MapArithmetic2(QInterfacePtr simulator, unsigned n, unsigned* q1, unsigned* q2)
+{
+    unsigned start1 = shards[simulator][q1[0]];
+    unsigned start2 = shards[simulator][q2[0]];
+    std::unique_ptr<bitLenInt[]> bitArray1(new bitLenInt[n]);
+    std::unique_ptr<bitLenInt[]> bitArray2(new bitLenInt[n]);
+    for (unsigned i = 0; i < n; i++) {
+        bitArray1.get()[i] = shards[simulator][q1[i]];
+        if (start1 > bitArray1.get()[i]) {
+            start1 = bitArray1.get()[i];
+        }
+
+        bitArray2.get()[i] = shards[simulator][q2[i]];
+        if (start2 > bitArray2.get()[i]) {
+            start2 = bitArray2.get()[i];
+        }
+    }
+
+    bool isReversed = (start2 < start1);
+
+    if (isReversed) {
+        std::swap(start1, start2);
+        bitArray1.swap(bitArray2);
+    }
+
+    for (unsigned i = 1U; i < n; i++) {
+        simulator->Swap(i, bitArray1.get()[i]);
+    }
+
+    if ((start1 + n) > start2) {
+        start2 = start1 + n;
+        simulator->Swap(n, bitArray1.get()[0U]);
+    }
+
+    for (unsigned i = 1U; i < n; i++) {
+        simulator->Swap(n + i, bitArray2.get()[i]);
+    }
+
+    if (isReversed) {
+        std::swap(start1, start2);
+    }
+
+    return MapArithmeticResult2(start1, start2);
+}
+
+MapArithmeticResult2 MapArithmetic3(QInterfacePtr simulator, unsigned n1, unsigned* q1, unsigned n2, unsigned* q2)
+{
+    unsigned start1 = shards[simulator][q1[0]];
+    unsigned start2 = shards[simulator][q2[0]];
+    std::unique_ptr<bitLenInt[]> bitArray1(new bitLenInt[n1]);
+    std::unique_ptr<bitLenInt[]> bitArray2(new bitLenInt[n2]);
+    for (unsigned i = 0; i < n1; i++) {
+        bitArray1.get()[i] = shards[simulator][q1[i]];
+        if (start1 > bitArray1.get()[i]) {
+            start1 = bitArray1.get()[i];
+        }
+    }
+
+    for (unsigned i = 0; i < n2; i++) {
+        bitArray2.get()[i] = shards[simulator][q2[i]];
+        if (start2 > bitArray2.get()[i]) {
+            start2 = bitArray2.get()[i];
+        }
+    }
+
+    bool isReversed = (start2 < start1);
+
+    if (isReversed) {
+        std::swap(start1, start2);
+        std::swap(n1, n2);
+        bitArray1.swap(bitArray2);
+    }
+
+    for (unsigned i = 1U; i < n1; i++) {
+        simulator->Swap(i, bitArray1.get()[i]);
+    }
+
+    if ((start1 + n1) > start2) {
+        start2 = start1 + n1;
+        simulator->Swap(n1, bitArray1.get()[0U]);
+    }
+
+    for (unsigned i = 1U; i < n2; i++) {
+        simulator->Swap(n1 + i, bitArray2.get()[i]);
+    }
+
+    if (isReversed) {
+        std::swap(start1, start2);
+    }
+
+    return MapArithmeticResult2(start1, start2);
+}
+
+MICROSOFT_QUANTUM_DECL void ADD(_In_ unsigned sid, unsigned a, _In_ unsigned n, _In_reads_(n) unsigned* q)
+{
+    SIMULATOR_LOCK_GUARD(sid)
+    QInterfacePtr simulator = simulators[sid];
+
+    unsigned start = MapArithmetic(simulator, n, q);
+    simulator->INC(a, start, n);
+}
+MICROSOFT_QUANTUM_DECL void SUB(_In_ unsigned sid, unsigned a, _In_ unsigned n, _In_reads_(n) unsigned* q)
+{
+    SIMULATOR_LOCK_GUARD(sid)
+    QInterfacePtr simulator = simulators[sid];
+
+    unsigned start = MapArithmetic(simulator, n, q);
+    simulator->DEC(a, start, n);
+}
+MICROSOFT_QUANTUM_DECL void ADDS(_In_ unsigned sid, unsigned a, unsigned s, _In_ unsigned n, _In_reads_(n) unsigned* q)
+{
+    SIMULATOR_LOCK_GUARD(sid)
+    QInterfacePtr simulator = simulators[sid];
+
+    unsigned start = MapArithmetic(simulator, n, q);
+    simulator->INCS(a, start, n, shards[simulator][s]);
+}
+MICROSOFT_QUANTUM_DECL void SUBS(_In_ unsigned sid, unsigned a, unsigned s, _In_ unsigned n, _In_reads_(n) unsigned* q)
+{
+    SIMULATOR_LOCK_GUARD(sid)
+    QInterfacePtr simulator = simulators[sid];
+
+    unsigned start = MapArithmetic(simulator, n, q);
+    simulator->DECS(a, start, n, shards[simulator][s]);
+}
+MICROSOFT_QUANTUM_DECL void MUL(
+    _In_ unsigned sid, unsigned a, _In_ unsigned n, _In_reads_(n) unsigned* q, _In_reads_(n) unsigned* o)
+{
+    SIMULATOR_LOCK_GUARD(sid)
+    QInterfacePtr simulator = simulators[sid];
+
+    MapArithmeticResult2 starts = MapArithmetic2(simulator, n, q, o);
+    simulator->MUL(a, starts.start1, starts.start2, n);
+}
+MICROSOFT_QUANTUM_DECL void DIV(
+    _In_ unsigned sid, unsigned a, _In_ unsigned n, _In_reads_(n) unsigned* q, _In_reads_(n) unsigned* o)
+{
+    SIMULATOR_LOCK_GUARD(sid)
+    QInterfacePtr simulator = simulators[sid];
+
+    MapArithmeticResult2 starts = MapArithmetic2(simulator, n, q, o);
+    simulator->DIV(a, starts.start1, starts.start2, n);
+}
+MICROSOFT_QUANTUM_DECL void MULN(
+    _In_ unsigned sid, unsigned a, unsigned m, _In_ unsigned n, _In_reads_(n) unsigned* q, _In_reads_(n) unsigned* o)
+{
+    SIMULATOR_LOCK_GUARD(sid)
+    QInterfacePtr simulator = simulators[sid];
+
+    MapArithmeticResult2 starts = MapArithmetic2(simulator, n, q, o);
+    simulator->MULModNOut(a, m, starts.start1, starts.start2, n);
+}
+MICROSOFT_QUANTUM_DECL void DIVN(
+    _In_ unsigned sid, unsigned a, unsigned m, _In_ unsigned n, _In_reads_(n) unsigned* q, _In_reads_(n) unsigned* o)
+{
+    SIMULATOR_LOCK_GUARD(sid)
+    QInterfacePtr simulator = simulators[sid];
+
+    MapArithmeticResult2 starts = MapArithmetic2(simulator, n, q, o);
+    simulator->IMULModNOut(a, m, starts.start1, starts.start2, n);
+}
+MICROSOFT_QUANTUM_DECL void POWN(
+    _In_ unsigned sid, unsigned a, unsigned m, _In_ unsigned n, _In_reads_(n) unsigned* q, _In_reads_(n) unsigned* o)
+{
+    SIMULATOR_LOCK_GUARD(sid)
+    QInterfacePtr simulator = simulators[sid];
+
+    MapArithmeticResult2 starts = MapArithmetic2(simulator, n, q, o);
+    simulator->POWModNOut(a, m, starts.start1, starts.start2, n);
+}
+
+MICROSOFT_QUANTUM_DECL void MCADD(_In_ unsigned sid, unsigned a, _In_ unsigned nc, _In_reads_(nc) unsigned* c,
+    _In_ unsigned nq, _In_reads_(nq) unsigned* q)
+{
+    MAP_CONTROLS_AND_LOCK(sid, nc)
+
+    unsigned start = MapArithmetic(simulator, nq, q);
+    simulator->CINC(a, start, nq, ctrlsArray.get(), nc);
+}
+MICROSOFT_QUANTUM_DECL void MCSUB(_In_ unsigned sid, unsigned a, _In_ unsigned nc, _In_reads_(nc) unsigned* c,
+    _In_ unsigned nq, _In_reads_(nq) unsigned* q)
+{
+    MAP_CONTROLS_AND_LOCK(sid, nc)
+
+    unsigned start = MapArithmetic(simulator, nq, q);
+    simulator->CDEC(a, start, nq, ctrlsArray.get(), nc);
+}
+MICROSOFT_QUANTUM_DECL void MCMUL(_In_ unsigned sid, unsigned a, _In_ unsigned nc, _In_reads_(nc) unsigned* c,
+    _In_ unsigned n, _In_reads_(n) unsigned* q, _In_reads_(n) unsigned* o)
+{
+    MAP_CONTROLS_AND_LOCK(sid, nc)
+
+    MapArithmeticResult2 starts = MapArithmetic2(simulator, n, q, o);
+    simulator->CMUL(a, starts.start1, starts.start2, n, ctrlsArray.get(), nc);
+}
+MICROSOFT_QUANTUM_DECL void MCDIV(_In_ unsigned sid, unsigned a, _In_ unsigned nc, _In_reads_(nc) unsigned* c,
+    _In_ unsigned n, _In_reads_(n) unsigned* q, _In_reads_(n) unsigned* o)
+{
+    MAP_CONTROLS_AND_LOCK(sid, nc)
+
+    MapArithmeticResult2 starts = MapArithmetic2(simulator, n, q, o);
+    simulator->CDIV(a, starts.start1, starts.start2, n, ctrlsArray.get(), nc);
+}
+MICROSOFT_QUANTUM_DECL void MCMULN(_In_ unsigned sid, unsigned a, _In_ unsigned nc, _In_reads_(nc) unsigned* c,
+    unsigned m, _In_ unsigned n, _In_reads_(n) unsigned* q, _In_reads_(n) unsigned* o)
+{
+    MAP_CONTROLS_AND_LOCK(sid, nc)
+
+    MapArithmeticResult2 starts = MapArithmetic2(simulator, n, q, o);
+    simulator->CMULModNOut(a, m, starts.start1, starts.start2, n, ctrlsArray.get(), nc);
+}
+MICROSOFT_QUANTUM_DECL void MCDIVN(_In_ unsigned sid, unsigned a, _In_ unsigned nc, _In_reads_(nc) unsigned* c,
+    unsigned m, _In_ unsigned n, _In_reads_(n) unsigned* q, _In_reads_(n) unsigned* o)
+{
+    MAP_CONTROLS_AND_LOCK(sid, nc)
+
+    MapArithmeticResult2 starts = MapArithmetic2(simulator, n, q, o);
+    simulator->CIMULModNOut(a, m, starts.start1, starts.start2, n, ctrlsArray.get(), nc);
+}
+MICROSOFT_QUANTUM_DECL void MCPOWN(_In_ unsigned sid, unsigned a, _In_ unsigned nc, _In_reads_(nc) unsigned* c,
+    unsigned m, _In_ unsigned n, _In_reads_(n) unsigned* q, _In_reads_(n) unsigned* o)
+{
+    MAP_CONTROLS_AND_LOCK(sid, nc)
+
+    MapArithmeticResult2 starts = MapArithmetic2(simulator, n, q, o);
+    simulator->CPOWModNOut(a, m, starts.start1, starts.start2, n, ctrlsArray.get(), nc);
+}
+
+MICROSOFT_QUANTUM_DECL void LDA(_In_ unsigned sid, _In_ unsigned ni, _In_reads_(ni) unsigned* qi, _In_ unsigned nv,
+    _In_reads_(nv) unsigned* qv, unsigned char* t)
+{
+    SIMULATOR_LOCK_GUARD(sid)
+    QInterfacePtr simulator = simulators[sid];
+
+    MapArithmeticResult2 starts = MapArithmetic3(simulator, ni, qi, nv, qv);
+    simulator->IndexedLDA(starts.start1, ni, starts.start2, nv, t, true);
+}
+MICROSOFT_QUANTUM_DECL void ADC(_In_ unsigned sid, unsigned s, _In_ unsigned ni, _In_reads_(ni) unsigned* qi,
+    _In_ unsigned nv, _In_reads_(nv) unsigned* qv, unsigned char* t)
+{
+    SIMULATOR_LOCK_GUARD(sid)
+    QInterfacePtr simulator = simulators[sid];
+
+    MapArithmeticResult2 starts = MapArithmetic3(simulator, ni, qi, nv, qv);
+    simulator->IndexedADC(starts.start1, ni, starts.start2, nv, s, t);
+}
+MICROSOFT_QUANTUM_DECL void SBC(_In_ unsigned sid, unsigned s, _In_ unsigned ni, _In_reads_(ni) unsigned* qi,
+    _In_ unsigned nv, _In_reads_(nv) unsigned* qv, unsigned char* t)
+{
+    SIMULATOR_LOCK_GUARD(sid)
+    QInterfacePtr simulator = simulators[sid];
+
+    MapArithmeticResult2 starts = MapArithmetic3(simulator, ni, qi, nv, qv);
+    simulator->IndexedSBC(starts.start1, ni, starts.start2, nv, s, t);
 }
 
 MICROSOFT_QUANTUM_DECL bool TrySeparate1Qb(_In_ unsigned sid, _In_ unsigned qi1)

--- a/src/pinvoke_api.cpp
+++ b/src/pinvoke_api.cpp
@@ -1429,7 +1429,7 @@ MICROSOFT_QUANTUM_DECL void ADC(_In_ unsigned sid, unsigned s, _In_ unsigned ni,
     QInterfacePtr simulator = simulators[sid];
 
     MapArithmeticResult2 starts = MapArithmetic3(simulator, ni, qi, nv, qv);
-    simulator->IndexedADC(starts.start1, ni, starts.start2, nv, s, t);
+    simulator->IndexedADC(starts.start1, ni, starts.start2, nv, shards[simulator][s], t);
 }
 MICROSOFT_QUANTUM_DECL void SBC(_In_ unsigned sid, unsigned s, _In_ unsigned ni, _In_reads_(ni) unsigned* qi,
     _In_ unsigned nv, _In_reads_(nv) unsigned* qv, unsigned char* t)
@@ -1438,7 +1438,7 @@ MICROSOFT_QUANTUM_DECL void SBC(_In_ unsigned sid, unsigned s, _In_ unsigned ni,
     QInterfacePtr simulator = simulators[sid];
 
     MapArithmeticResult2 starts = MapArithmetic3(simulator, ni, qi, nv, qv);
-    simulator->IndexedSBC(starts.start1, ni, starts.start2, nv, s, t);
+    simulator->IndexedSBC(starts.start1, ni, starts.start2, nv, shards[simulator][s], t);
 }
 
 MICROSOFT_QUANTUM_DECL bool TrySeparate1Qb(_In_ unsigned sid, _In_ unsigned qi1)

--- a/src/pinvoke_api.cpp
+++ b/src/pinvoke_api.cpp
@@ -1242,8 +1242,8 @@ MapArithmeticResult2 MapArithmetic2(QInterfacePtr simulator, unsigned n, unsigne
     }
 
     for (unsigned i = 1U; i < n; i++) {
-        simulator->Swap(n + i, bitArray2.get()[i]);
-        SwapShardValues(n + i, bitArray2.get()[i], shards[simulator]);
+        simulator->Swap(start2 + i, bitArray2.get()[i]);
+        SwapShardValues(start2 + i, bitArray2.get()[i], shards[simulator]);
     }
 
     if (isReversed) {
@@ -1293,8 +1293,8 @@ MapArithmeticResult2 MapArithmetic3(QInterfacePtr simulator, unsigned n1, unsign
     }
 
     for (unsigned i = 1U; i < n2; i++) {
-        simulator->Swap(n1 + i, bitArray2.get()[i]);
-        SwapShardValues(n1 + i, bitArray2.get()[i], shards[simulator]);
+        simulator->Swap(start2 + i, bitArray2.get()[i]);
+        SwapShardValues(start2 + i, bitArray2.get()[i], shards[simulator]);
     }
 
     if (isReversed) {

--- a/src/pinvoke_api.cpp
+++ b/src/pinvoke_api.cpp
@@ -1157,6 +1157,25 @@ MICROSOFT_QUANTUM_DECL void IQFT(_In_ unsigned sid, _In_ unsigned n, _In_reads_(
 #endif
 }
 
+std::map<unsigned, bitLenInt>::iterator FindShardValue(bitLenInt v, std::map<unsigned, bitLenInt>& simMap)
+{
+    for (auto it = simMap.begin(); it != simMap.end(); it++) {
+        if (it->second == v) {
+            // We have the matching it1, if we break.
+            return it;
+        }
+    }
+
+    return simMap.end();
+}
+
+void SwapShardValues(bitLenInt v1, bitLenInt v2, std::map<unsigned, bitLenInt>& simMap)
+{
+    auto it1 = FindShardValue(v1, simMap);
+    auto it2 = FindShardValue(v2, simMap);
+    std::swap(it1->second, it2->second);
+}
+
 unsigned MapArithmetic(QInterfacePtr simulator, unsigned n, unsigned* q)
 {
     unsigned start = shards[simulator][q[0]];
@@ -1169,6 +1188,7 @@ unsigned MapArithmetic(QInterfacePtr simulator, unsigned n, unsigned* q)
     }
     for (unsigned i = 1U; i < n; i++) {
         simulator->Swap(i, bitArray.get()[i]);
+        SwapShardValues(i, bitArray.get()[i], shards[simulator]);
     }
 
     return start;
@@ -1212,15 +1232,18 @@ MapArithmeticResult2 MapArithmetic2(QInterfacePtr simulator, unsigned n, unsigne
 
     for (unsigned i = 1U; i < n; i++) {
         simulator->Swap(i, bitArray1.get()[i]);
+        SwapShardValues(i, bitArray1.get()[i], shards[simulator]);
     }
 
     if ((start1 + n) > start2) {
         start2 = start1 + n;
-        simulator->Swap(n, bitArray1.get()[0U]);
+        simulator->Swap(n, bitArray2.get()[0U]);
+        SwapShardValues(n, bitArray2.get()[0U], shards[simulator]);
     }
 
     for (unsigned i = 1U; i < n; i++) {
         simulator->Swap(n + i, bitArray2.get()[i]);
+        SwapShardValues(n + i, bitArray2.get()[i], shards[simulator]);
     }
 
     if (isReversed) {
@@ -1260,15 +1283,18 @@ MapArithmeticResult2 MapArithmetic3(QInterfacePtr simulator, unsigned n1, unsign
 
     for (unsigned i = 1U; i < n1; i++) {
         simulator->Swap(i, bitArray1.get()[i]);
+        SwapShardValues(i, bitArray1.get()[i], shards[simulator]);
     }
 
     if ((start1 + n1) > start2) {
         start2 = start1 + n1;
-        simulator->Swap(n1, bitArray1.get()[0U]);
+        simulator->Swap(n1, bitArray2.get()[0U]);
+        SwapShardValues(n1, bitArray2.get()[0U], shards[simulator]);
     }
 
     for (unsigned i = 1U; i < n2; i++) {
         simulator->Swap(n1 + i, bitArray2.get()[i]);
+        SwapShardValues(n1 + i, bitArray2.get()[i], shards[simulator]);
     }
 
     if (isReversed) {

--- a/src/pinvoke_api.cpp
+++ b/src/pinvoke_api.cpp
@@ -1237,8 +1237,8 @@ MapArithmeticResult2 MapArithmetic2(QInterfacePtr simulator, unsigned n, unsigne
 
     if ((start1 + n) > start2) {
         start2 = start1 + n;
-        simulator->Swap(n, bitArray2.get()[0U]);
-        SwapShardValues(n, bitArray2.get()[0U], shards[simulator]);
+        simulator->Swap(start2, bitArray2.get()[0U]);
+        SwapShardValues(start2, bitArray2.get()[0U], shards[simulator]);
     }
 
     for (unsigned i = 1U; i < n; i++) {
@@ -1288,8 +1288,8 @@ MapArithmeticResult2 MapArithmetic3(QInterfacePtr simulator, unsigned n1, unsign
 
     if ((start1 + n1) > start2) {
         start2 = start1 + n1;
-        simulator->Swap(n1, bitArray2.get()[0U]);
-        SwapShardValues(n1, bitArray2.get()[0U], shards[simulator]);
+        simulator->Swap(start2, bitArray2.get()[0U]);
+        SwapShardValues(start2, bitArray2.get()[0U], shards[simulator]);
     }
 
     for (unsigned i = 1U; i < n2; i++) {

--- a/src/pinvoke_api.cpp
+++ b/src/pinvoke_api.cpp
@@ -1186,9 +1186,9 @@ unsigned MapArithmetic(QInterfacePtr simulator, unsigned n, unsigned* q)
             start = bitArray.get()[i];
         }
     }
-    for (unsigned i = 1U; i < n; i++) {
-        simulator->Swap(i, bitArray.get()[i]);
-        SwapShardValues(i, bitArray.get()[i], shards[simulator]);
+    for (unsigned i = 0U; i < n; i++) {
+        simulator->Swap(start + i, bitArray.get()[i]);
+        SwapShardValues(start + i, bitArray.get()[i], shards[simulator]);
     }
 
     return start;
@@ -1230,18 +1230,16 @@ MapArithmeticResult2 MapArithmetic2(QInterfacePtr simulator, unsigned n, unsigne
         bitArray1.swap(bitArray2);
     }
 
-    for (unsigned i = 1U; i < n; i++) {
-        simulator->Swap(i, bitArray1.get()[i]);
-        SwapShardValues(i, bitArray1.get()[i], shards[simulator]);
+    for (unsigned i = 0U; i < n; i++) {
+        simulator->Swap(start1 + i, bitArray1.get()[i]);
+        SwapShardValues(start1 + i, bitArray1.get()[i], shards[simulator]);
     }
 
     if ((start1 + n) > start2) {
         start2 = start1 + n;
-        simulator->Swap(start2, bitArray2.get()[0U]);
-        SwapShardValues(start2, bitArray2.get()[0U], shards[simulator]);
     }
 
-    for (unsigned i = 1U; i < n; i++) {
+    for (unsigned i = 0U; i < n; i++) {
         simulator->Swap(start2 + i, bitArray2.get()[i]);
         SwapShardValues(start2 + i, bitArray2.get()[i], shards[simulator]);
     }
@@ -1281,18 +1279,16 @@ MapArithmeticResult2 MapArithmetic3(QInterfacePtr simulator, unsigned n1, unsign
         bitArray1.swap(bitArray2);
     }
 
-    for (unsigned i = 1U; i < n1; i++) {
-        simulator->Swap(i, bitArray1.get()[i]);
-        SwapShardValues(i, bitArray1.get()[i], shards[simulator]);
+    for (unsigned i = 0U; i < n1; i++) {
+        simulator->Swap(start1 + i, bitArray1.get()[i]);
+        SwapShardValues(start1 + i, bitArray1.get()[i], shards[simulator]);
     }
 
     if ((start1 + n1) > start2) {
         start2 = start1 + n1;
-        simulator->Swap(start2, bitArray2.get()[0U]);
-        SwapShardValues(start2, bitArray2.get()[0U], shards[simulator]);
     }
 
-    for (unsigned i = 1U; i < n2; i++) {
+    for (unsigned i = 0U; i < n2; i++) {
         simulator->Swap(start2 + i, bitArray2.get()[i]);
         SwapShardValues(start2 + i, bitArray2.get()[i], shards[simulator]);
     }


### PR DESCRIPTION
This adds all relevant, pre-existing arithmetic methods to the shared library, conforming to the shared libraries' conventions for qubit indexing and function signatures. ("Carry" variants are rendered redundant by arbitrary bit "pile" access, except for `IndexedADC`/`IndexedSBC`.) I'm still debugging this, but I want to start the CI, now.