### PR TITLE
`QUnitMulti` environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,9 @@ After CMake, the project must be built in Visual Studio. Once installed, the `qr
 ## Changing default OpenCL device
 OpenCL device(s) can be specified by index in `Qrack::QInterface` subclass constructors. The global default device can also be overridden with the environment variable `QRACK_OCL_DEFAULT_DEVICE=n`, where `n` is the index of the OpenCL device you want to use, as reported by the OpenCL initialization header.
 
+## Disable OpenCL device redistribution
+For `Qrack::QUnitMulti`, the default behavior is to proactively redistribute simulation workloads between multiple OpenCL devices, (if multiple devices are available). Setting the environment variable `QRACK_DISABLE_QUNITMULTI_REDISTRIBUTE` to any value except a null string disables all redistribution behavior, leaving QUnitMulti to only try to balance load in the process of creating new separable `QEngineShard` instances.
+
 ## QPager distributed simulation options
 `QPager` attempts to smartly allocate low qubit widths for maximum performance. For wider qubit simulations, based on `clinfo`, you can segment your maximum OpenCL accelerator state vector page allocation into global qubits with the environment variable `QRACK_SEGMENT_GLOBAL_QB=n`, where n is an integer >=0. The default n is 0, meaning that maximum allocation segment of your GPU RAM is a single page. (For 1 global qubit, one segment would have 2 pages, akin to 2 single amplitudes, therefore one "global qubit," or 4 pages for n=2, because 2^2=4, etc., by exponent.)
 

--- a/README.md
+++ b/README.md
@@ -103,8 +103,8 @@ After CMake, the project must be built in Visual Studio. Once installed, the `qr
 ## Changing default OpenCL device
 OpenCL device(s) can be specified by index in `Qrack::QInterface` subclass constructors. The global default device can also be overridden with the environment variable `QRACK_OCL_DEFAULT_DEVICE=n`, where `n` is the index of the OpenCL device you want to use, as reported by the OpenCL initialization header.
 
-## Disable OpenCL device redistribution
-For `Qrack::QUnitMulti`, the default behavior is to proactively redistribute simulation workloads between multiple OpenCL devices, (if multiple devices are available). Setting the environment variable `QRACK_DISABLE_QUNITMULTI_REDISTRIBUTE` to any value except a null string disables all redistribution behavior, leaving QUnitMulti to only try to balance load in the process of creating new separable `QEngineShard` instances.
+## Enable OpenCL device redistribution
+Setting the environment variable `QRACK_ENABLE_QUNITMULTI_REDISTRIBUTE` to any value except a null string enables reactive load redistribution or balancing, in `QUnitMulti`. Otherwise, `QUnitMulti` only tries to balance load as opportunity arises when new separable `QEngineShard` instances are created.
 
 ## QPager distributed simulation options
 `QPager` attempts to smartly allocate low qubit widths for maximum performance. For wider qubit simulations, based on `clinfo`, you can segment your maximum OpenCL accelerator state vector page allocation into global qubits with the environment variable `QRACK_SEGMENT_GLOBAL_QB=n`, where n is an integer >=0. The default n is 0, meaning that maximum allocation segment of your GPU RAM is a single page. (For 1 global qubit, one segment would have 2 pages, akin to 2 single amplitudes, therefore one "global qubit," or 4 pages for n=2, because 2^2=4, etc., by exponent.)

--- a/include/common/oclengine.hpp
+++ b/include/common/oclengine.hpp
@@ -289,44 +289,44 @@ public:
 #endif
     }
     size_t GetMaxActiveAllocSize() { return maxActiveAllocSize; }
-    size_t GetActiveAllocSize() { return activeAllocSize; }
-    size_t AddToActiveAllocSize(size_t size)
+    size_t GetActiveAllocSize(const int& dev) { return activeAllocSizes[dev]; }
+    size_t AddToActiveAllocSize(const int& dev, size_t size)
     {
         if (size == 0) {
-            return activeAllocSize;
+            return activeAllocSizes[dev];
         }
 
         std::lock_guard<std::mutex> lock(allocMutex);
-        activeAllocSize += size;
+        activeAllocSizes[dev] += size;
 
-        return activeAllocSize;
+        return activeAllocSizes[dev];
     }
-    size_t SubtractFromActiveAllocSize(size_t size)
+    size_t SubtractFromActiveAllocSize(const int& dev, size_t size)
     {
         if (size == 0) {
-            return activeAllocSize;
+            return activeAllocSizes[dev];
         }
 
         std::lock_guard<std::mutex> lock(allocMutex);
-        if (size < activeAllocSize) {
-            activeAllocSize -= size;
+        if (size < activeAllocSizes[dev]) {
+            activeAllocSizes[dev] -= size;
         } else {
-            activeAllocSize = 0;
+            activeAllocSizes[dev] = 0;
         }
-        return activeAllocSize;
+        return activeAllocSizes[dev];
     }
-    void ResetActiveAllocSize()
+    void ResetActiveAllocSize(const int& dev)
     {
         std::lock_guard<std::mutex> lock(allocMutex);
         // User code should catch std::bad_alloc and reset:
-        activeAllocSize = 0;
+        activeAllocSizes[dev] = 0;
     }
 
 private:
     static const std::vector<OCLKernelHandle> kernelHandles;
     static const std::string binary_file_prefix;
     static const std::string binary_file_ext;
-    size_t activeAllocSize;
+    std::vector<size_t> activeAllocSizes;
     size_t maxActiveAllocSize;
     std::mutex allocMutex;
     std::vector<DeviceContextPtr> all_device_contexts;

--- a/include/qengine_opencl.hpp
+++ b/include/qengine_opencl.hpp
@@ -447,9 +447,9 @@ public:
 protected:
     virtual void AddAlloc(size_t size)
     {
-        size_t currentAlloc = OCLEngine::Instance()->AddToActiveAllocSize(size);
+        size_t currentAlloc = OCLEngine::Instance()->AddToActiveAllocSize(deviceID, size);
         if (currentAlloc > OCLEngine::Instance()->GetMaxActiveAllocSize()) {
-            OCLEngine::Instance()->SubtractFromActiveAllocSize(size);
+            OCLEngine::Instance()->SubtractFromActiveAllocSize(deviceID, size);
             FreeAll();
             throw std::bad_alloc();
         }
@@ -457,7 +457,7 @@ protected:
     }
     virtual void SubtractAlloc(size_t size)
     {
-        OCLEngine::Instance()->SubtractFromActiveAllocSize(size);
+        OCLEngine::Instance()->SubtractFromActiveAllocSize(deviceID, size);
         totalOclAllocSize -= size;
     }
 

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -289,7 +289,7 @@ public:
     virtual bool isFinished();
     virtual void Dump()
     {
-        for (bitLenInt i = 0; i < qubitCount; i++) {
+        for (size_t i = 0; i < shards.size(); i++) {
             shards[i].unit = NULL;
         }
     }

--- a/include/qunitmulti.hpp
+++ b/include/qunitmulti.hpp
@@ -93,8 +93,6 @@ public:
     }
 
     virtual QInterfacePtr Clone();
-    virtual void GetQuantumState(complex* outputState);
-    virtual void GetProbs(real1* outputProbs);
 
 protected:
     virtual std::vector<QEngineInfo> GetQInfos();

--- a/src/common/oclengine.cpp
+++ b/src/common/oclengine.cpp
@@ -389,6 +389,7 @@ void OCLEngine::InitOCL(bool buildFromSource, bool saveBinaries, std::string hom
         m_pInstance = new OCLEngine();
     }
     m_pInstance->SetDeviceContextPtrVector(all_dev_contexts, default_dev_context);
+    m_pInstance->activeAllocSizes = std::vector<size_t>(all_dev_contexts.size());
 
     // For VirtualCL support, the device info can only be accessed AFTER all contexts are created.
     std::cout << "Default platform: " << default_platform.getInfo<CL_PLATFORM_NAME>() << "\n";
@@ -399,8 +400,7 @@ void OCLEngine::InitOCL(bool buildFromSource, bool saveBinaries, std::string hom
 }
 
 OCLEngine::OCLEngine()
-    : activeAllocSize(0)
-    , maxActiveAllocSize(-1)
+    : maxActiveAllocSize(-1)
 {
     if (getenv("QRACK_MAX_ALLOC_MB")) {
         maxActiveAllocSize = 1024 * 1024 * (size_t)std::stoi(std::string(getenv("QRACK_MAX_ALLOC_MB")));

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -96,14 +96,7 @@ QUnit::QUnit(std::vector<QInterfaceEngine> eng, bitLenInt qBitCount, bitCapInt i
 
     isPagingSuppressed = canSuppressPaging && (qubitCount < pagingThresholdQubits);
 
-    shards = QEngineShardMap();
-
-    bool bitState;
-
-    for (bitLenInt i = 0; i < qubitCount; i++) {
-        bitState = ((initState >> (bitCapIntOcl)i) & ONE_BCI) != 0;
-        shards.push_back(QEngineShard(bitState, GetNonunitaryPhase()));
-    }
+    SetPermutation(initState);
 }
 
 QInterfacePtr QUnit::MakeEngine(bitLenInt length, bitCapInt perm)

--- a/src/qunitmulti.cpp
+++ b/src/qunitmulti.cpp
@@ -60,17 +60,14 @@ QUnitMulti::QUnitMulti(std::vector<QInterfaceEngine> eng, bitLenInt qBitCount, b
 QInterfacePtr QUnitMulti::MakeEngine(bitLenInt length, bitCapInt perm)
 {
     bitLenInt deviceId = defaultDeviceID;
-    size_t devAlloc = OCLEngine::Instance()->GetActiveAllocSize(deviceId);
-    // Devices tend to have 4 pages, but we're comparing to the size of a single page.
-    // So, "cap" might go negative, but this still works, if all devices have the same segment count.
-    int64_t cap = deviceList[deviceId].maxSize - devAlloc;
-    int64_t tCap;
+    uint64_t sz = OCLEngine::Instance()->GetActiveAllocSize(deviceId);
+    ;
+    uint64_t tSz;
 
     for (size_t i = 0U; i < deviceList.size(); i++) {
-        devAlloc = OCLEngine::Instance()->GetActiveAllocSize(deviceList[i].id);
-        tCap = deviceList[i].maxSize - devAlloc;
-        if (cap < tCap) {
-            cap = tCap;
+        tSz = OCLEngine::Instance()->GetActiveAllocSize(deviceList[i].id);
+        if (sz > tSz) {
+            sz = tSz;
             deviceId = deviceList[i].id;
         }
     }

--- a/src/qunitmulti.cpp
+++ b/src/qunitmulti.cpp
@@ -59,23 +59,17 @@ QUnitMulti::QUnitMulti(std::vector<QInterfaceEngine> eng, bitLenInt qBitCount, b
 
 QInterfacePtr QUnitMulti::MakeEngine(bitLenInt length, bitCapInt perm)
 {
-    size_t i = 0U;
-    bitCapInt sz = -1;
-    bitLenInt deviceId = defaultDeviceID;
-    do {
-        while ((i < qubitCount) && !shards[i].unit) {
-            i++;
-        }
 
-        if (i >= qubitCount) {
-            continue;
-        }
+    // Get shard sizes and devices
+    std::vector<QEngineInfo> qinfos = GetQInfos();
 
-        if (sz > shards[i].unit->GetMaxQPower()) {
-            sz = shards[i].unit->GetMaxQPower();
-            deviceId = shards[i].unit->GetDeviceID();
+    size_t sz = qinfos[0].unit->GetMaxQPower();
+    bitLenInt deviceId = qinfos[0].unit->GetDeviceID();
+    for (size_t i = 0; i < qinfos.size(); i++) {
+        if (sz > qinfos[i].unit->GetMaxQPower()) {
+            deviceId = qinfos[i].unit->GetDeviceID();
         }
-    } while (i < qubitCount);
+    }
 
     // Suppress passing device list, since QUnitMulti occupies all devices in the list
     QInterfacePtr toRet = CreateQuantumInterface(engines, length, perm, rand_generator, phaseFactor, doNormalize,

--- a/src/qunitmulti.cpp
+++ b/src/qunitmulti.cpp
@@ -62,7 +62,7 @@ QInterfacePtr QUnitMulti::MakeEngine(bitLenInt length, bitCapInt perm)
     bitLenInt deviceId = defaultDeviceID;
     bitCapInt devAlloc = OCLEngine::Instance()->GetActiveAllocSize(deviceId);
     // Devices tend to have 4 pages, but we're comparing to the size of a single page.
-    // So, "cap" might go negative, but this still works.
+    // So, "cap" might go negative, but this still works, if all devices have the same segment count.
     int64_t cap = deviceList[deviceId].maxSize - devAlloc;
     int64_t tCap;
 

--- a/src/qunitmulti.cpp
+++ b/src/qunitmulti.cpp
@@ -61,7 +61,6 @@ QInterfacePtr QUnitMulti::MakeEngine(bitLenInt length, bitCapInt perm)
 {
     bitLenInt deviceId = defaultDeviceID;
     uint64_t sz = OCLEngine::Instance()->GetActiveAllocSize(deviceId);
-    ;
     uint64_t tSz;
 
     for (size_t i = 0U; i < deviceList.size(); i++) {

--- a/src/qunitmulti.cpp
+++ b/src/qunitmulti.cpp
@@ -61,12 +61,14 @@ QInterfacePtr QUnitMulti::MakeEngine(bitLenInt length, bitCapInt perm)
 {
     bitLenInt deviceId = defaultDeviceID;
     bitCapInt devAlloc = OCLEngine::Instance()->GetActiveAllocSize(deviceId);
-    bitCapInt cap = (deviceList[deviceId].maxSize > devAlloc) ? (deviceList[deviceId].maxSize - devAlloc) : 0U;
-    bitCapInt tCap;
+    // Devices tend to have 4 pages, but we're comparing to the size of a single page.
+    // So, "cap" might go negative, but this still works.
+    int64_t cap = deviceList[deviceId].maxSize - devAlloc;
+    int64_t tCap;
 
     for (size_t i = 0U; i < deviceList.size(); i++) {
         devAlloc = OCLEngine::Instance()->GetActiveAllocSize(deviceList[i].id);
-        tCap = (deviceList[i].maxSize > devAlloc) ? (deviceList[i].maxSize - devAlloc) : 0U;
+        tCap = deviceList[i].maxSize - devAlloc;
         if (cap < tCap) {
             cap = tCap;
             deviceId = deviceList[i].id;

--- a/src/qunitmulti.cpp
+++ b/src/qunitmulti.cpp
@@ -251,18 +251,4 @@ QInterfacePtr QUnitMulti::Clone()
     return CloneBody(copyPtr);
 }
 
-void QUnitMulti::GetQuantumState(complex* outputState)
-{
-    ToPermBasisAll();
-    OrderContiguous(EntangleAll());
-    shards[0].unit->GetQuantumState(outputState);
-}
-
-void QUnitMulti::GetProbs(real1* outputProbs)
-{
-    ToPermBasisAll();
-    OrderContiguous(EntangleAll());
-    shards[0].unit->GetProbs(outputProbs);
-}
-
 } // namespace Qrack

--- a/src/qunitmulti.cpp
+++ b/src/qunitmulti.cpp
@@ -59,17 +59,23 @@ QUnitMulti::QUnitMulti(std::vector<QInterfaceEngine> eng, bitLenInt qBitCount, b
 
 QInterfacePtr QUnitMulti::MakeEngine(bitLenInt length, bitCapInt perm)
 {
-
-    // Get shard sizes and devices
-    std::vector<QEngineInfo> qinfos = GetQInfos();
-
-    size_t sz = qinfos[0].unit->GetMaxQPower();
-    bitLenInt deviceId = qinfos[0].unit->GetDeviceID();
-    for (size_t i = 0; i < qinfos.size(); i++) {
-        if (sz > qinfos[i].unit->GetMaxQPower()) {
-            deviceId = qinfos[i].unit->GetDeviceID();
+    size_t i = 0U;
+    bitCapInt sz = -1;
+    bitLenInt deviceId = defaultDeviceID;
+    do {
+        while ((i < qubitCount) && !shards[i].unit) {
+            i++;
         }
-    }
+
+        if (i >= qubitCount) {
+            continue;
+        }
+
+        if (sz > shards[i].unit->GetMaxQPower()) {
+            sz = shards[i].unit->GetMaxQPower();
+            deviceId = shards[i].unit->GetDeviceID();
+        }
+    } while (i < qubitCount);
 
     // Suppress passing device list, since QUnitMulti occupies all devices in the list
     QInterfacePtr toRet = CreateQuantumInterface(engines, length, perm, rand_generator, phaseFactor, doNormalize,

--- a/src/qunitmulti.cpp
+++ b/src/qunitmulti.cpp
@@ -60,7 +60,7 @@ QUnitMulti::QUnitMulti(std::vector<QInterfaceEngine> eng, bitLenInt qBitCount, b
 QInterfacePtr QUnitMulti::MakeEngine(bitLenInt length, bitCapInt perm)
 {
     bitLenInt deviceId = defaultDeviceID;
-    bitCapInt devAlloc = OCLEngine::Instance()->GetActiveAllocSize(deviceId);
+    size_t devAlloc = OCLEngine::Instance()->GetActiveAllocSize(deviceId);
     // Devices tend to have 4 pages, but we're comparing to the size of a single page.
     // So, "cap" might go negative, but this still works, if all devices have the same segment count.
     int64_t cap = deviceList[deviceId].maxSize - devAlloc;

--- a/src/qunitmulti.cpp
+++ b/src/qunitmulti.cpp
@@ -104,14 +104,13 @@ std::vector<QEngineInfo> QUnitMulti::GetQInfos()
 
 void QUnitMulti::RedistributeQEngines()
 {
-    // No need to redistribute, if there is only 1 device
-    if (deviceList.size() == 1) {
+    // Only redistribute if the env var flag is set and NOT a null string.
+    if (!getenv("QRACK_ENABLE_QUNITMULTI_REDISTRIBUTE") || strcmp(getenv("QRACK_ENABLE_QUNITMULTI_REDISTRIBUTE"), "")) {
         return;
     }
 
-    // If the env var flag is NOT a null string, never redistribute.
-    if (getenv("QRACK_DISABLE_QUNITMULTI_REDISTRIBUTE") &&
-        (strcmp(getenv("QRACK_DISABLE_QUNITMULTI_REDISTRIBUTE"), "") == 0)) {
+    // No need to redistribute, if there is only 1 device
+    if (deviceList.size() == 1) {
         return;
     }
 


### PR DESCRIPTION
The default behavior of `QUnitMulti` has been changed. To turn **on** reactive redistribution of device shard load, (which used to be **on** by default, but is now **off** by default,) set the `QRACK_ENABLE_QUNITMULTI_REDISTRIBUTE` environment variable to any value except the null string.

Also, `QUnitMulti` now **proactively** distributes and balances load, whenever there is a request to create a new shard engine.