### PR TITLE
Extend shared library API

### DIFF
--- a/include/pinvoke_api.hpp
+++ b/include/pinvoke_api.hpp
@@ -122,6 +122,8 @@ MICROSOFT_QUANTUM_DECL void MeasureShots(
 
 MICROSOFT_QUANTUM_DECL void SWAP(_In_ unsigned sid, _In_ unsigned qi1, _In_ unsigned qi2);
 MICROSOFT_QUANTUM_DECL void ISWAP(_In_ unsigned sid, _In_ unsigned qi1, _In_ unsigned qi2);
+MICROSOFT_QUANTUM_DECL void FSim(
+    _In_ unsigned sid, _In_ double theta, _In_ double phi, _In_ unsigned qi1, _In_ unsigned qi2);
 MICROSOFT_QUANTUM_DECL void CSWAP(
     _In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c, _In_ unsigned qi1, _In_ unsigned qi2);
 MICROSOFT_QUANTUM_DECL void ACSWAP(

--- a/include/pinvoke_api.hpp
+++ b/include/pinvoke_api.hpp
@@ -118,7 +118,10 @@ MICROSOFT_QUANTUM_DECL void MeasureShots(
     _In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* q, _In_ unsigned s, _In_reads_(s) unsigned* m);
 
 MICROSOFT_QUANTUM_DECL void SWAP(_In_ unsigned sid, _In_ unsigned qi1, _In_ unsigned qi2);
+MICROSOFT_QUANTUM_DECL void ISWAP(_In_ unsigned sid, _In_ unsigned qi1, _In_ unsigned qi2);
 MICROSOFT_QUANTUM_DECL void CSWAP(
+    _In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c, _In_ unsigned qi1, _In_ unsigned qi2);
+MICROSOFT_QUANTUM_DECL void ACSWAP(
     _In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c, _In_ unsigned qi1, _In_ unsigned qi2);
 
 // Schmidt decomposition

--- a/include/pinvoke_api.hpp
+++ b/include/pinvoke_api.hpp
@@ -97,6 +97,9 @@ MICROSOFT_QUANTUM_DECL void MACU(_In_ unsigned sid, _In_ unsigned n, _In_reads_(
 MICROSOFT_QUANTUM_DECL void MACMtrx(
     _In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c, _In_reads_(8) double* m, _In_ unsigned q);
 
+MICROSOFT_QUANTUM_DECL void multiplex1_mtrx(
+    _In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c, _In_ unsigned q, double* m);
+
 // rotations
 MICROSOFT_QUANTUM_DECL void R(_In_ unsigned sid, _In_ unsigned b, _In_ double phi, _In_ unsigned q);
 

--- a/include/pinvoke_api.hpp
+++ b/include/pinvoke_api.hpp
@@ -97,7 +97,7 @@ MICROSOFT_QUANTUM_DECL void MACU(_In_ unsigned sid, _In_ unsigned n, _In_reads_(
 MICROSOFT_QUANTUM_DECL void MACMtrx(
     _In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c, _In_reads_(8) double* m, _In_ unsigned q);
 
-MICROSOFT_QUANTUM_DECL void multiplex1_mtrx(
+MICROSOFT_QUANTUM_DECL void Multiplex1Mtrx(
     _In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c, _In_ unsigned q, double* m);
 
 // rotations

--- a/include/pinvoke_api.hpp
+++ b/include/pinvoke_api.hpp
@@ -181,6 +181,7 @@ MICROSOFT_QUANTUM_DECL void ADC(_In_ unsigned sid, unsigned s, _In_ unsigned ni,
     _In_ unsigned nv, _In_reads_(nv) unsigned* qv, unsigned char* t);
 MICROSOFT_QUANTUM_DECL void SBC(_In_ unsigned sid, unsigned s, _In_ unsigned ni, _In_reads_(ni) unsigned* qi,
     _In_ unsigned nv, _In_reads_(nv) unsigned* qv, unsigned char* t);
+MICROSOFT_QUANTUM_DECL void Hash(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* q, unsigned char* t);
 
 MICROSOFT_QUANTUM_DECL bool TrySeparate1Qb(_In_ unsigned sid, _In_ unsigned qi1);
 MICROSOFT_QUANTUM_DECL bool TrySeparate2Qb(_In_ unsigned sid, _In_ unsigned qi1, _In_ unsigned qi2);

--- a/src/pinvoke_api.cpp
+++ b/src/pinvoke_api.cpp
@@ -1074,11 +1074,26 @@ MICROSOFT_QUANTUM_DECL void SWAP(_In_ unsigned sid, _In_ unsigned qi1, _In_ unsi
     simulator->Swap(shards[simulator][qi1], shards[simulator][qi2]);
 }
 
+MICROSOFT_QUANTUM_DECL void ISWAP(_In_ unsigned sid, _In_ unsigned qi1, _In_ unsigned qi2)
+{
+    SIMULATOR_LOCK_GUARD(sid)
+
+    QInterfacePtr simulator = simulators[sid];
+    simulator->ISwap(shards[simulator][qi1], shards[simulator][qi2]);
+}
+
 MICROSOFT_QUANTUM_DECL void CSWAP(
     _In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c, _In_ unsigned qi1, _In_ unsigned qi2)
 {
     MAP_CONTROLS_AND_LOCK(sid, n)
     simulator->CSwap(ctrlsArray.get(), n, shards[simulator][qi1], shards[simulator][qi2]);
+}
+
+MICROSOFT_QUANTUM_DECL void ACSWAP(
+    _In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c, _In_ unsigned qi1, _In_ unsigned qi2)
+{
+    MAP_CONTROLS_AND_LOCK(sid, n)
+    simulator->AntiCSwap(ctrlsArray.get(), n, shards[simulator][qi1], shards[simulator][qi2]);
 }
 
 MICROSOFT_QUANTUM_DECL void Compose(_In_ unsigned sid1, _In_ unsigned sid2, unsigned* q)

--- a/src/pinvoke_api.cpp
+++ b/src/pinvoke_api.cpp
@@ -1477,6 +1477,14 @@ MICROSOFT_QUANTUM_DECL void SBC(_In_ unsigned sid, unsigned s, _In_ unsigned ni,
     MapArithmeticResult2 starts = MapArithmetic3(simulator, ni, qi, nv, qv);
     simulator->IndexedSBC(starts.start1, ni, starts.start2, nv, shards[simulator][s], t);
 }
+MICROSOFT_QUANTUM_DECL void Hash(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* q, unsigned char* t)
+{
+    SIMULATOR_LOCK_GUARD(sid)
+    QInterfacePtr simulator = simulators[sid];
+
+    unsigned start = MapArithmetic(simulator, n, q);
+    simulator->Hash(start, n, t);
+}
 
 MICROSOFT_QUANTUM_DECL bool TrySeparate1Qb(_In_ unsigned sid, _In_ unsigned qi1)
 {

--- a/src/pinvoke_api.cpp
+++ b/src/pinvoke_api.cpp
@@ -919,7 +919,7 @@ MICROSOFT_QUANTUM_DECL void MACMtrx(
     simulator->ApplyAntiControlledSingleBit(ctrlsArray.get(), n, shards[simulator][q], mtrx);
 }
 
-MICROSOFT_QUANTUM_DECL void multiplex1_mtrx(
+MICROSOFT_QUANTUM_DECL void Multiplex1Mtrx(
     _In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c, _In_ unsigned q, double* m)
 {
     bitCapInt componentCount = 4U * pow2(n);

--- a/src/pinvoke_api.cpp
+++ b/src/pinvoke_api.cpp
@@ -1106,7 +1106,7 @@ MICROSOFT_QUANTUM_DECL void FSim(
     SIMULATOR_LOCK_GUARD(sid)
 
     QInterfacePtr simulator = simulators[sid];
-    simulator->FSim(theta, phi, shards[simulator][qi1], shards[simulator][qi2]);
+    simulator->FSim((real1_f)theta, (real1_f)phi, shards[simulator][qi1], shards[simulator][qi2]);
 }
 
 MICROSOFT_QUANTUM_DECL void CSWAP(

--- a/src/pinvoke_api.cpp
+++ b/src/pinvoke_api.cpp
@@ -314,6 +314,13 @@ MapArithmeticResult2 MapArithmetic3(QInterfacePtr simulator, unsigned n1, unsign
     return MapArithmeticResult2(start1, start2);
 }
 
+void _darray_to_creal1_array(double* params, bitCapInt componentCount, complex* amps)
+{
+    for (bitCapInt j = 0; j < componentCount; j++) {
+        amps[j] = complex(real1(params[2 * j]), real1(params[2 * j + 1]));
+    }
+}
+
 extern "C" {
 
 /**
@@ -910,6 +917,17 @@ MICROSOFT_QUANTUM_DECL void MACMtrx(
 
     MAP_CONTROLS_AND_LOCK(sid, n)
     simulator->ApplyAntiControlledSingleBit(ctrlsArray.get(), n, shards[simulator][q], mtrx);
+}
+
+MICROSOFT_QUANTUM_DECL void multiplex1_mtrx(
+    _In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c, _In_ unsigned q, double* m)
+{
+    bitCapInt componentCount = 4U * pow2(n);
+    std::unique_ptr<complex[]> mtrxs(new complex[componentCount]);
+    _darray_to_creal1_array(m, componentCount, mtrxs.get());
+
+    MAP_CONTROLS_AND_LOCK(sid, n)
+    simulator->UniformlyControlledSingleBit(ctrlsArray.get(), n, shards[simulator][q], mtrxs.get());
 }
 
 /**

--- a/src/pinvoke_api.cpp
+++ b/src/pinvoke_api.cpp
@@ -1100,6 +1100,15 @@ MICROSOFT_QUANTUM_DECL void ISWAP(_In_ unsigned sid, _In_ unsigned qi1, _In_ uns
     simulator->ISwap(shards[simulator][qi1], shards[simulator][qi2]);
 }
 
+MICROSOFT_QUANTUM_DECL void FSim(
+    _In_ unsigned sid, _In_ double theta, _In_ double phi, _In_ unsigned qi1, _In_ unsigned qi2)
+{
+    SIMULATOR_LOCK_GUARD(sid)
+
+    QInterfacePtr simulator = simulators[sid];
+    simulator->FSim(theta, phi, shards[simulator][qi1], shards[simulator][qi2]);
+}
+
 MICROSOFT_QUANTUM_DECL void CSWAP(
     _In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c, _In_ unsigned qi1, _In_ unsigned qi2)
 {


### PR DESCRIPTION
I love how beautifully succinct the shared library is, while exposing almost _all_ the optimization and universality of Qrack. I noticed a few key API methods might have still been missing. We don't want to add _anything_ redundant in this API, if we can help it, but I think this PR basically exposes the _full extent_ of _optimal_ and _direct_ Qrack, to date, with these particular methods.