### PR TITLE
Shared library interface mutexes

### DIFF
--- a/src/pinvoke_api.cpp
+++ b/src/pinvoke_api.cpp
@@ -438,7 +438,10 @@ MICROSOFT_QUANTUM_DECL unsigned init_clone(_In_ unsigned sid)
  */
 MICROSOFT_QUANTUM_DECL void destroy(_In_ unsigned sid)
 {
+    META_LOCK_GUARD()
+
     shards[simulators[sid]] = {};
+    simulatorMutexes.erase(simulators[sid]);
     simulators[sid] = NULL;
     simulatorReservations[sid] = false;
 }

--- a/src/pinvoke_api.cpp
+++ b/src/pinvoke_api.cpp
@@ -429,13 +429,13 @@ MICROSOFT_QUANTUM_DECL unsigned init_clone(_In_ unsigned sid)
         }
     }
 
+    META_LOCK()
+
     QInterfacePtr simulator = simulators[sid]->Clone();
     if (nsid == simulators.size()) {
-        META_LOCK()
         simulatorReservations.push_back(true);
         simulators.push_back(simulator);
         shards[simulator] = {};
-        META_UNLOCK()
     } else {
         simulatorReservations[nsid] = true;
         simulators[nsid] = simulator;
@@ -445,6 +445,8 @@ MICROSOFT_QUANTUM_DECL unsigned init_clone(_In_ unsigned sid)
     for (unsigned i = 0; i < simulator->GetQubitCount(); i++) {
         shards[simulator][i] = shards[simulators[sid]][i];
     }
+
+    META_UNLOCK()
 
     return nsid;
 }

--- a/src/pinvoke_api.cpp
+++ b/src/pinvoke_api.cpp
@@ -440,7 +440,7 @@ MICROSOFT_QUANTUM_DECL void destroy(_In_ unsigned sid)
 {
     META_LOCK_GUARD()
 
-    shards[simulators[sid]] = {};
+    shards.erase(simulators[sid]);
     simulatorMutexes.erase(simulators[sid]);
     simulators[sid] = NULL;
     simulatorReservations[sid] = false;


### PR DESCRIPTION
With a mutex per simulator, and a meta-level mutex for STL containers associated with simulators, it should be possible to use simulator instances concurrently in different threads, above the shared library level, without unnecessary blocking.