### PR TITLE
`QPager::PhaseParity()` debug

### DIFF
--- a/include/qpager.hpp
+++ b/include/qpager.hpp
@@ -110,7 +110,7 @@ protected:
     void ApplyEitherControlledSingleBit(const bool& anti, const bitLenInt* controls, const bitLenInt& controlLen,
         const bitLenInt& target, const complex* mtrx);
 
-    void BitMask(bitCapInt mask, bool isX);
+    void BitMask(bitCapInt mask, bool isX, real1 angle = PI_R1);
 
     void Init();
 
@@ -229,6 +229,7 @@ public:
 
     virtual void XMask(bitCapInt mask) { BitMask(mask, true); }
     virtual void ZMask(bitCapInt mask) { BitMask(mask, false); }
+    virtual void PhaseParity(real1 radians, bitCapInt mask) { BitMask(mask, false, radians); }
 
     virtual bool ForceM(bitLenInt qubit, bool result, bool doForce = true, bool doApply = true);
 

--- a/include/qpager.hpp
+++ b/include/qpager.hpp
@@ -110,8 +110,6 @@ protected:
     void ApplyEitherControlledSingleBit(const bool& anti, const bitLenInt* controls, const bitLenInt& controlLen,
         const bitLenInt& target, const complex* mtrx);
 
-    void BitMask(bitCapInt mask, bool isX, real1 angle = PI_R1);
-
     void Init();
 
 public:
@@ -227,9 +225,9 @@ public:
     virtual void AntiCISqrtSwap(
         const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& qubit1, const bitLenInt& qubit2);
 
-    virtual void XMask(bitCapInt mask) { BitMask(mask, true); }
-    virtual void ZMask(bitCapInt mask) { BitMask(mask, false); }
-    virtual void PhaseParity(real1 radians, bitCapInt mask) { BitMask(mask, false, radians); }
+    virtual void XMask(bitCapInt mask);
+    virtual void ZMask(bitCapInt mask) { PhaseParity(PI_R1, mask); }
+    virtual void PhaseParity(real1 radians, bitCapInt mask);
 
     virtual bool ForceM(bitLenInt qubit, bool result, bool doForce = true, bool doApply = true);
 

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -1246,6 +1246,26 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_zmask")
     qftReg->ZMask(pow2Ocl(18) | pow2Ocl(19));
     qftReg->H(18, 2);
     REQUIRE_THAT(qftReg, HasProbability(0, 20, 0x40001));
+    qftReg->H(18, 2);
+    qftReg->ZMask(pow2Ocl(0) | pow2Ocl(18) | pow2Ocl(19));
+    qftReg->H(18, 2);
+    REQUIRE_THAT(qftReg, HasProbability(0, 20, 0x80001));
+}
+
+TEST_CASE_METHOD(QInterfaceTestFixture, "test_phaseparity")
+{
+    qftReg->SetPermutation(0x40001);
+    REQUIRE_THAT(qftReg, HasProbability(0, 20, 0x40001));
+    qftReg->H(18, 2);
+    qftReg->PhaseParity(PI_R1 / 2, pow2Ocl(0) | pow2Ocl(18) | pow2Ocl(19));
+    qftReg->PhaseParity(PI_R1 / 2, pow2Ocl(0) | pow2Ocl(18) | pow2Ocl(19));
+    qftReg->H(18, 2);
+    REQUIRE_THAT(qftReg, HasProbability(0, 20, 0x80001));
+    qftReg->H(18, 2);
+    qftReg->PhaseParity(PI_R1 / 2, pow2Ocl(0) | pow2Ocl(18) | pow2Ocl(19));
+    qftReg->PhaseParity(PI_R1 / 2, pow2Ocl(18) | pow2Ocl(19));
+    qftReg->H(18, 2);
+    REQUIRE_THAT(qftReg, HasProbability(0, 20, 0x80001));
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_sqrtx")


### PR DESCRIPTION
I'm still thinking about this fix, but I want to start the CI process. In `QPager::PhaseParity()`, if the page being operated on has odd parity among just the "global qubits" in the mask, then the phase factor is flipped, between the "local qubit" on/off permutations. Otherwise, with even parity of "global qubits," the phase factor is simply directly based upon the "local qubit" on/off permutations.