### PR TITLE
Option to disable shared library Schmidt decomposition

### DIFF
--- a/include/pinvoke_api.hpp
+++ b/include/pinvoke_api.hpp
@@ -28,8 +28,9 @@ struct _QrackTimeEvolveOpHeader;
 
 extern "C" {
 // non-quantum
-MICROSOFT_QUANTUM_DECL unsigned init();
-MICROSOFT_QUANTUM_DECL unsigned init_count(_In_ unsigned q);
+MICROSOFT_QUANTUM_DECL unsigned init_count_type(_In_ unsigned q, _In_ bool sd);
+MICROSOFT_QUANTUM_DECL unsigned init_count(_In_ unsigned q) { return init_count_type(q, true); }
+MICROSOFT_QUANTUM_DECL unsigned init() { return init_count(0); }
 MICROSOFT_QUANTUM_DECL unsigned init_clone(_In_ unsigned sid);
 MICROSOFT_QUANTUM_DECL void destroy(_In_ unsigned sid);
 MICROSOFT_QUANTUM_DECL void seed(_In_ unsigned sid, _In_ unsigned s);


### PR DESCRIPTION
This add the option to disable Schmidt decomposition upon simulator initialization, in the shared library interface.