### PR TITLE
Wait on current event before dumping wait events in `clDump()`

### DIFF
--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -271,8 +271,11 @@ void QEngineOCL::clDump()
         return;
     }
 
+    if (wait_queue_items.size()) {
+        device_context->WaitOnAllEvents();
+    }
+
     wait_queue_items.clear();
-    device_context->WaitOnAllEvents();
     wait_refs.clear();
 }
 


### PR DESCRIPTION
The `shared_ptr` garbage collection work seemed to fix some problems in PyQrack, but I still run into issues with long-running, high-width, high-depth "Sycamore circuits." Specifically, on my system, OpenCL throws a `-5`/`CL_OUT_OF_RESOURCES` error code. I'm reading, on NVIDIA systems, this could be due to an out-of-bounds read or write.

Initial tests suggest that replacing `clDump()` instances with `clFinish()` instances might fix this. There shouldn't be any problem with using `clDump()` as intended, except for the possibility that `QEngineOCL` buffers might be freed _while_ running kernels. I thought our old implementation avoided this, but perhaps the one in this PR is necessary to guarantee it.

I'm testing this on a secondary machine, for a long benchmark run, before merging.