### PR TITLE
Generalize `QBinaryDecisionTree` Schmidt decomposition

### DIFF
--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -393,7 +393,17 @@ public:
      */
     virtual bitLenInt Compose(QInterfacePtr toCopy) { return Compose(toCopy, qubitCount); }
     virtual std::map<QInterfacePtr, bitLenInt> Compose(std::vector<QInterfacePtr> toCopy);
-    virtual bitLenInt Compose(QInterfacePtr toCopy, bitLenInt start) = 0;
+    virtual bitLenInt Compose(QInterfacePtr toCopy, bitLenInt start)
+    {
+        bitLenInt origSize = qubitCount;
+        ROL(origSize - start, 0, origSize);
+
+        bitLenInt result = Compose(toCopy);
+
+        ROR(origSize - start, 0, qubitCount);
+
+        return result;
+    }
 
     /**
      * Minimally decompose a set of contiguous bits from the separably composed unit,


### PR DESCRIPTION
This PR changes `QBinaryDecisionTree` (and adds default virtual `QInterface` decompositions) to handle _all_ starting index cases, for `QBinaryDecisionTree` `Compose()`/`Decompose()`/`Dispose()`.