### PR TITLE
`size_t` equivalent types should be `bitCapIntOcl`

### DIFF
--- a/include/common/parallel_for.hpp
+++ b/include/common/parallel_for.hpp
@@ -43,10 +43,10 @@ public:
      * Iterate through the permutations a maximum of end-begin times, allowing
      * the caller to control the incrementation offset through 'inc'.
      */
-    void par_for_inc(const bitCapInt begin, const bitCapInt itemCount, IncrementFunc, ParallelFunc fn);
+    void par_for_inc(const bitCapIntOcl begin, const bitCapIntOcl itemCount, IncrementFunc, ParallelFunc fn);
 
     /** Call fn once for every numerical value between begin and end. */
-    void par_for(const bitCapInt begin, const bitCapInt end, ParallelFunc fn);
+    void par_for(const bitCapIntOcl begin, const bitCapIntOcl end, ParallelFunc fn);
 
     /**
      * Skip over the skipPower bits.
@@ -56,28 +56,28 @@ public:
      *     ^     ^     ^     ^     ^     ^     ^     ^ - The second bit is
      *                                                   untouched.
      */
-    void par_for_skip(const bitCapInt begin, const bitCapInt end, const bitCapInt skipPower,
+    void par_for_skip(const bitCapIntOcl begin, const bitCapIntOcl end, const bitCapIntOcl skipPower,
         const bitLenInt skipBitCount, ParallelFunc fn);
 
     /** Skip over the bits listed in maskArray in the same fashion as par_for_skip. */
-    void par_for_mask(
-        const bitCapInt, const bitCapInt, const bitCapInt* maskArray, const bitLenInt maskLen, ParallelFunc fn);
+    void par_for_mask(const bitCapIntOcl, const bitCapIntOcl, const bitCapIntOcl* maskArray, const bitLenInt maskLen,
+        ParallelFunc fn);
 
     /** Iterate over a sparse state vector. */
-    void par_for_set(const std::set<bitCapInt>& sparseSet, ParallelFunc fn);
+    void par_for_set(const std::set<bitCapIntOcl>& sparseSet, ParallelFunc fn);
 
     /** Iterate over a sparse state vector. */
-    void par_for_set(const std::vector<bitCapInt>& sparseSet, ParallelFunc fn);
+    void par_for_set(const std::vector<bitCapIntOcl>& sparseSet, ParallelFunc fn);
 
     /** Iterate over the power set of 2 sparse state vectors. */
-    void par_for_sparse_compose(const std::vector<bitCapInt>& lowSet, const std::vector<bitCapInt>& highSet,
+    void par_for_sparse_compose(const std::vector<bitCapIntOcl>& lowSet, const std::vector<bitCapIntOcl>& highSet,
         const bitLenInt& highStart, ParallelFunc fn);
 
     /** Calculate the normal for the array, (with flooring). */
-    real1_f par_norm(const bitCapInt maxQPower, const StateVectorPtr stateArray, real1_f norm_thresh = ZERO_R1);
+    real1_f par_norm(const bitCapIntOcl maxQPower, const StateVectorPtr stateArray, real1_f norm_thresh = ZERO_R1);
 
     /** Calculate the normal for the array, (without flooring.) */
-    real1_f par_norm_exact(const bitCapInt maxQPower, const StateVectorPtr stateArray);
+    real1_f par_norm_exact(const bitCapIntOcl maxQPower, const StateVectorPtr stateArray);
 };
 
 } // namespace Qrack

--- a/include/common/qrack_types.hpp
+++ b/include/common/qrack_types.hpp
@@ -147,8 +147,8 @@ namespace Qrack {
 typedef std::shared_ptr<complex> BitOp;
 
 /** Called once per value between begin and end. */
-typedef std::function<void(const bitCapInt&, const unsigned& cpu)> ParallelFunc;
-typedef std::function<bitCapInt(const bitCapInt&, const unsigned& cpu)> IncrementFunc;
+typedef std::function<void(const bitCapIntOcl&, const unsigned& cpu)> ParallelFunc;
+typedef std::function<bitCapIntOcl(const bitCapIntOcl&, const unsigned& cpu)> IncrementFunc;
 
 class StateVector;
 class StateVectorArray;
@@ -164,28 +164,28 @@ typedef std::shared_ptr<QEngine> QEnginePtr;
 // This is a buffer struct that's capable of representing controlled single bit gates and arithmetic, when subclassed.
 class StateVector {
 protected:
-    bitCapInt capacity;
+    bitCapIntOcl capacity;
 
 public:
     bool isReadLocked;
 
-    StateVector(bitCapInt cap)
+    StateVector(bitCapIntOcl cap)
         : capacity(cap)
         , isReadLocked(true)
     {
     }
-    virtual complex read(const bitCapInt& i) = 0;
-    virtual void write(const bitCapInt& i, const complex& c) = 0;
+    virtual complex read(const bitCapIntOcl& i) = 0;
+    virtual void write(const bitCapIntOcl& i, const complex& c) = 0;
     /// Optimized "write" that is only guaranteed to write if either amplitude is nonzero. (Useful for the result of 2x2
     /// tensor slicing.)
-    virtual void write2(const bitCapInt& i1, const complex& c1, const bitCapInt& i2, const complex& c2) = 0;
+    virtual void write2(const bitCapIntOcl& i1, const complex& c1, const bitCapIntOcl& i2, const complex& c2) = 0;
     virtual void clear() = 0;
     virtual void copy_in(const complex* inArray) = 0;
-    virtual void copy_in(const complex* copyIn, const bitCapInt offset, const bitCapInt length) = 0;
-    virtual void copy_in(
-        StateVectorPtr copyInSv, const bitCapInt srcOffset, const bitCapInt dstOffset, const bitCapInt length) = 0;
+    virtual void copy_in(const complex* copyIn, const bitCapIntOcl offset, const bitCapIntOcl length) = 0;
+    virtual void copy_in(StateVectorPtr copyInSv, const bitCapIntOcl srcOffset, const bitCapIntOcl dstOffset,
+        const bitCapIntOcl length) = 0;
     virtual void copy_out(complex* outArray) = 0;
-    virtual void copy_out(complex* copyIn, const bitCapInt offset, const bitCapInt length) = 0;
+    virtual void copy_out(complex* copyIn, const bitCapIntOcl offset, const bitCapIntOcl length) = 0;
     virtual void copy(StateVectorPtr toCopy) = 0;
     virtual void shuffle(StateVectorPtr svp) = 0;
     virtual void get_probs(real1* outArray) = 0;

--- a/include/qbinary_decision_tree.hpp
+++ b/include/qbinary_decision_tree.hpp
@@ -36,6 +36,13 @@ protected:
     DispatchQueue dispatchQueue;
 #endif
     bitLenInt pStridePow;
+    bitCapIntOcl maxQPowerOcl;
+
+    virtual void SetQubitCount(bitLenInt qb)
+    {
+        QInterface::SetQubitCount(qb);
+        maxQPowerOcl = (bitCapIntOcl)maxQPower;
+    }
 
     typedef std::function<void(void)> DispatchFn;
     virtual void Dispatch(bitCapInt workItemCount, DispatchFn fn)

--- a/include/qengine_cpu.hpp
+++ b/include/qengine_cpu.hpp
@@ -89,20 +89,20 @@ public:
 
     virtual void FreeStateVec(complex* sv = NULL) { stateVec = NULL; }
 
-    virtual void GetAmplitudePage(complex* pagePtr, const bitCapInt offset, const bitCapInt length)
+    virtual void GetAmplitudePage(complex* pagePtr, const bitCapIntOcl offset, const bitCapIntOcl length)
     {
         Finish();
 
         if (stateVec) {
             stateVec->copy_out(pagePtr, offset, length);
         } else {
-            std::fill(pagePtr, pagePtr + (bitCapIntOcl)length, ZERO_CMPLX);
+            std::fill(pagePtr, pagePtr + length, ZERO_CMPLX);
         }
     }
-    virtual void SetAmplitudePage(const complex* pagePtr, const bitCapInt offset, const bitCapInt length)
+    virtual void SetAmplitudePage(const complex* pagePtr, const bitCapIntOcl offset, const bitCapIntOcl length)
     {
         if (!stateVec) {
-            ResetStateVec(AllocStateVec(maxQPower));
+            ResetStateVec(AllocStateVec(maxQPowerOcl));
             stateVec->clear();
         }
 
@@ -113,7 +113,7 @@ public:
         runningNorm = REAL1_DEFAULT_ARG;
     }
     virtual void SetAmplitudePage(
-        QEnginePtr pageEnginePtr, const bitCapInt srcOffset, const bitCapInt dstOffset, const bitCapInt length)
+        QEnginePtr pageEnginePtr, const bitCapIntOcl srcOffset, const bitCapIntOcl dstOffset, const bitCapIntOcl length)
     {
         QEngineCPUPtr pageEngineCpuPtr = std::dynamic_pointer_cast<QEngineCPU>(pageEnginePtr);
         StateVectorPtr oStateVec = pageEngineCpuPtr->stateVec;
@@ -128,7 +128,7 @@ public:
         }
 
         if (!stateVec) {
-            ResetStateVec(AllocStateVec(maxQPower));
+            ResetStateVec(AllocStateVec(maxQPowerOcl));
             stateVec->clear();
         }
 
@@ -148,12 +148,12 @@ public:
         }
 
         if (!stateVec) {
-            ResetStateVec(AllocStateVec(maxQPower));
+            ResetStateVec(AllocStateVec(maxQPowerOcl));
             stateVec->clear();
         }
 
         if (!(engineCpu->stateVec)) {
-            engineCpu->ResetStateVec(engineCpu->AllocStateVec(maxQPower));
+            engineCpu->ResetStateVec(engineCpu->AllocStateVec(maxQPowerOcl));
             engineCpu->stateVec->clear();
         }
 
@@ -176,7 +176,7 @@ public:
         }
 
         if (!stateVec) {
-            ResetStateVec(AllocStateVec(maxQPower));
+            ResetStateVec(AllocStateVec(maxQPowerOcl));
         }
 
         Finish();
@@ -317,7 +317,7 @@ public:
 protected:
     virtual real1_f GetExpectation(bitLenInt valueStart, bitLenInt valueLength);
 
-    virtual StateVectorPtr AllocStateVec(bitCapInt elemCount);
+    virtual StateVectorPtr AllocStateVec(bitCapIntOcl elemCount);
     virtual void ResetStateVec(StateVectorPtr sv) { stateVec = sv; }
 
     typedef std::function<void(void)> DispatchFn;
@@ -336,8 +336,8 @@ protected:
     }
 
     void DecomposeDispose(bitLenInt start, bitLenInt length, QEngineCPUPtr dest);
-    virtual void Apply2x2(bitCapInt offset1, bitCapInt offset2, const complex* mtrx, const bitLenInt bitCount,
-        const bitCapInt* qPowersSorted, bool doCalcNorm, real1_f norm_thresh = REAL1_DEFAULT_ARG);
+    virtual void Apply2x2(bitCapIntOcl offset1, bitCapIntOcl offset2, const complex* mtrx, const bitLenInt bitCount,
+        const bitCapIntOcl* qPowersSorted, bool doCalcNorm, real1_f norm_thresh = REAL1_DEFAULT_ARG);
     virtual void UpdateRunningNorm(real1_f norm_thresh = REAL1_DEFAULT_ARG);
     virtual void ApplyM(bitCapInt mask, bitCapInt result, complex nrm);
 
@@ -352,13 +352,13 @@ protected:
         bitCapInt toMod, const bitLenInt& inOutStart, const bitLenInt& length, const bitLenInt& carryIndex);
 #endif
 
-    typedef std::function<bitCapInt(const bitCapInt&, const bitCapInt&)> IOFn;
+    typedef std::function<bitCapIntOcl(const bitCapIntOcl&, const bitCapIntOcl&)> IOFn;
     void MULDIV(const IOFn& inFn, const IOFn& outFn, const bitCapInt& toMul, const bitLenInt& inOutStart,
         const bitLenInt& carryStart, const bitLenInt& length);
     void CMULDIV(const IOFn& inFn, const IOFn& outFn, const bitCapInt& toMul, const bitLenInt& inOutStart,
         const bitLenInt& carryStart, const bitLenInt& length, const bitLenInt* controls, const bitLenInt controlLen);
 
-    typedef std::function<bitCapInt(const bitCapInt&)> MFn;
+    typedef std::function<bitCapIntOcl(const bitCapIntOcl&)> MFn;
     void ModNOut(const MFn& kernelFn, const bitCapInt& modN, const bitLenInt& inStart, const bitLenInt& outStart,
         const bitLenInt& length, const bool& inverse = false);
     void CModNOut(const MFn& kernelFn, const bitCapInt& modN, const bitLenInt& inStart, const bitLenInt& outStart,

--- a/include/qengine_opencl.hpp
+++ b/include/qengine_opencl.hpp
@@ -152,7 +152,6 @@ typedef std::shared_ptr<PoolItem> PoolItemPtr;
  */
 class QEngineOCL : virtual public QEngine {
 protected:
-    bitCapIntOcl maxQPowerOcl;
     complex* stateVec;
     int deviceID;
     DeviceContextPtr device_context;
@@ -239,12 +238,6 @@ public:
         SubtractAlloc(sizeof(complex) * maxQPowerOcl);
     }
 
-    virtual void SetQubitCount(bitLenInt qb)
-    {
-        QEngine::SetQubitCount(qb);
-        maxQPowerOcl = (bitCapIntOcl)maxQPower;
-    }
-
     virtual void FreeStateVec(complex* sv = NULL)
     {
         bool doReset = false;
@@ -286,10 +279,10 @@ public:
         runningNorm = src->GetRunningNorm();
     }
 
-    virtual void GetAmplitudePage(complex* pagePtr, const bitCapInt offset, const bitCapInt length);
-    virtual void SetAmplitudePage(const complex* pagePtr, const bitCapInt offset, const bitCapInt length);
-    virtual void SetAmplitudePage(
-        QEnginePtr pageEnginePtr, const bitCapInt srcOffset, const bitCapInt dstOffset, const bitCapInt length);
+    virtual void GetAmplitudePage(complex* pagePtr, const bitCapIntOcl offset, const bitCapIntOcl length);
+    virtual void SetAmplitudePage(const complex* pagePtr, const bitCapIntOcl offset, const bitCapIntOcl length);
+    virtual void SetAmplitudePage(QEnginePtr pageEnginePtr, const bitCapIntOcl srcOffset, const bitCapIntOcl dstOffset,
+        const bitCapIntOcl length);
     virtual void ShuffleBuffers(QEnginePtr engine);
 
     virtual void QueueSetDoNormalize(const bool& doNorm) { AddQueueItem(QueueItem(doNorm)); }
@@ -562,13 +555,14 @@ protected:
         const bitLenInt controlLen, unsigned char* values = NULL, bitCapIntOcl valuesLength = 0);
 
     using QEngine::Apply2x2;
-    virtual void Apply2x2(bitCapInt offset1, bitCapInt offset2, const complex* mtrx, const bitLenInt bitCount,
-        const bitCapInt* qPowersSorted, bool doCalcNorm, real1_f norm_thresh = REAL1_DEFAULT_ARG)
+    virtual void Apply2x2(bitCapIntOcl offset1, bitCapIntOcl offset2, const complex* mtrx, const bitLenInt bitCount,
+        const bitCapIntOcl* qPowersSorted, bool doCalcNorm, real1_f norm_thresh = REAL1_DEFAULT_ARG)
     {
         Apply2x2(offset1, offset2, mtrx, bitCount, qPowersSorted, doCalcNorm, SPECIAL_2X2::NONE, norm_thresh);
     }
-    virtual void Apply2x2(bitCapInt offset1, bitCapInt offset2, const complex* mtrx, const bitLenInt bitCount,
-        const bitCapInt* qPowersSorted, bool doCalcNorm, SPECIAL_2X2 special, real1_f norm_thresh = REAL1_DEFAULT_ARG);
+    virtual void Apply2x2(bitCapIntOcl offset1, bitCapIntOcl offset2, const complex* mtrx, const bitLenInt bitCount,
+        const bitCapIntOcl* qPowersSorted, bool doCalcNorm, SPECIAL_2X2 special,
+        real1_f norm_thresh = REAL1_DEFAULT_ARG);
 
     virtual void BitMask(bitCapIntOcl mask, OCLAPI api_call, real1 phase = PI_R1);
 

--- a/include/qhybrid.hpp
+++ b/include/qhybrid.hpp
@@ -88,22 +88,22 @@ public:
         engine->CopyStateVec(src->engine);
     }
 
-    virtual void GetAmplitudePage(complex* pagePtr, const bitCapInt offset, const bitCapInt length)
+    virtual void GetAmplitudePage(complex* pagePtr, const bitCapIntOcl offset, const bitCapIntOcl length)
     {
         engine->GetAmplitudePage(pagePtr, offset, length);
     }
-    virtual void SetAmplitudePage(const complex* pagePtr, const bitCapInt offset, const bitCapInt length)
+    virtual void SetAmplitudePage(const complex* pagePtr, const bitCapIntOcl offset, const bitCapIntOcl length)
     {
         engine->SetAmplitudePage(pagePtr, offset, length);
     }
     virtual void SetAmplitudePage(
-        QHybridPtr pageEnginePtr, const bitCapInt srcOffset, const bitCapInt dstOffset, const bitCapInt length)
+        QHybridPtr pageEnginePtr, const bitCapIntOcl srcOffset, const bitCapIntOcl dstOffset, const bitCapIntOcl length)
     {
         pageEnginePtr->SwitchModes(isGpu);
         engine->SetAmplitudePage(pageEnginePtr->engine, srcOffset, dstOffset, length);
     }
     virtual void SetAmplitudePage(
-        QEnginePtr pageEnginePtr, const bitCapInt srcOffset, const bitCapInt dstOffset, const bitCapInt length)
+        QEnginePtr pageEnginePtr, const bitCapIntOcl srcOffset, const bitCapIntOcl dstOffset, const bitCapIntOcl length)
     {
         SetAmplitudePage(std::dynamic_pointer_cast<QHybrid>(pageEnginePtr), srcOffset, dstOffset, length);
     }
@@ -458,8 +458,8 @@ protected:
         return engine->GetExpectation(valueStart, valueLength);
     }
 
-    virtual void Apply2x2(bitCapInt offset1, bitCapInt offset2, const complex* mtrx, const bitLenInt bitCount,
-        const bitCapInt* qPowersSorted, bool doCalcNorm, real1_f norm_thresh = REAL1_DEFAULT_ARG)
+    virtual void Apply2x2(bitCapIntOcl offset1, bitCapIntOcl offset2, const complex* mtrx, const bitLenInt bitCount,
+        const bitCapIntOcl* qPowersSorted, bool doCalcNorm, real1_f norm_thresh = REAL1_DEFAULT_ARG)
     {
         engine->Apply2x2(offset1, offset2, mtrx, bitCount, qPowersSorted, doCalcNorm, norm_thresh);
     }

--- a/include/qmaskfusion.hpp
+++ b/include/qmaskfusion.hpp
@@ -203,23 +203,23 @@ public:
         FlushBuffers();
         engine->CopyStateVec(src->engine);
     }
-    virtual void GetAmplitudePage(complex* pagePtr, const bitCapInt offset, const bitCapInt length)
+    virtual void GetAmplitudePage(complex* pagePtr, const bitCapIntOcl offset, const bitCapIntOcl length)
     {
         FlushBuffers();
         engine->GetAmplitudePage(pagePtr, offset, length);
     }
-    virtual void SetAmplitudePage(const complex* pagePtr, const bitCapInt offset, const bitCapInt length)
+    virtual void SetAmplitudePage(const complex* pagePtr, const bitCapIntOcl offset, const bitCapIntOcl length)
     {
         FlushBuffers();
         engine->SetAmplitudePage(pagePtr, offset, length);
     }
     virtual void SetAmplitudePage(
-        QEnginePtr pageEnginePtr, const bitCapInt srcOffset, const bitCapInt dstOffset, const bitCapInt length)
+        QEnginePtr pageEnginePtr, const bitCapIntOcl srcOffset, const bitCapIntOcl dstOffset, const bitCapIntOcl length)
     {
         SetAmplitudePage(std::dynamic_pointer_cast<QMaskFusion>(pageEnginePtr), srcOffset, dstOffset, length);
     }
-    virtual void SetAmplitudePage(
-        QMaskFusionPtr pageEnginePtr, const bitCapInt srcOffset, const bitCapInt dstOffset, const bitCapInt length)
+    virtual void SetAmplitudePage(QMaskFusionPtr pageEnginePtr, const bitCapIntOcl srcOffset,
+        const bitCapIntOcl dstOffset, const bitCapIntOcl length)
     {
         FlushBuffers();
         pageEnginePtr->FlushBuffers();
@@ -728,8 +728,8 @@ protected:
         return engine->GetExpectation(valueStart, valueLength);
     }
 
-    virtual void Apply2x2(bitCapInt offset1, bitCapInt offset2, const complex* mtrx, const bitLenInt bitCount,
-        const bitCapInt* qPowersSorted, bool doCalcNorm, real1_f norm_thresh = REAL1_DEFAULT_ARG)
+    virtual void Apply2x2(bitCapIntOcl offset1, bitCapIntOcl offset2, const complex* mtrx, const bitLenInt bitCount,
+        const bitCapIntOcl* qPowersSorted, bool doCalcNorm, real1_f norm_thresh = REAL1_DEFAULT_ARG)
     {
         engine->Apply2x2(offset1, offset2, mtrx, bitCount, qPowersSorted, doCalcNorm, norm_thresh);
     }

--- a/include/statevector.hpp
+++ b/include/statevector.hpp
@@ -25,17 +25,17 @@
 #if BOOST_AVAILABLE
 #include <boost/functional/hash.hpp>
 #include <unordered_map>
-#define SparseStateVecMap std::unordered_map<bitCapInt, complex>
+#define SparseStateVecMap std::unordered_map<bitCapIntOcl, complex>
 #else
 #include <map>
-#define SparseStateVecMap std::map<bitCapInt, complex>
+#define SparseStateVecMap std::map<bitCapIntOcl, complex>
 #endif
 #else
 #if QBCAPPOW > 7
 #include <boost/functional/hash.hpp>
 #endif
 #include <unordered_map>
-#define SparseStateVecMap std::unordered_map<bitCapInt, complex>
+#define SparseStateVecMap std::unordered_map<bitCapIntOcl, complex>
 #endif
 
 namespace Qrack {
@@ -47,9 +47,9 @@ public:
 protected:
     static real1_f normHelper(const complex& c) { return norm(c); }
 
-    complex* Alloc(bitCapInt elemCount)
+    complex* Alloc(bitCapIntOcl elemCount)
     {
-        size_t allocSize = sizeof(complex) * (bitCapIntOcl)elemCount;
+        size_t allocSize = sizeof(complex) * elemCount;
         if (allocSize < QRACK_ALIGN_SIZE) {
             allocSize = QRACK_ALIGN_SIZE;
         }
@@ -80,7 +80,7 @@ protected:
     }
 
 public:
-    StateVectorArray(bitCapInt cap)
+    StateVectorArray(bitCapIntOcl cap)
         : StateVector(cap)
     {
         amplitudes = Alloc(capacity);
@@ -88,14 +88,14 @@ public:
 
     virtual ~StateVectorArray() { Free(); }
 
-    complex read(const bitCapInt& i) { return amplitudes[(bitCapIntOcl)i]; };
+    complex read(const bitCapIntOcl& i) { return amplitudes[i]; };
 
-    void write(const bitCapInt& i, const complex& c) { amplitudes[(bitCapIntOcl)i] = c; };
+    void write(const bitCapIntOcl& i, const complex& c) { amplitudes[i] = c; };
 
-    void write2(const bitCapInt& i1, const complex& c1, const bitCapInt& i2, const complex& c2)
+    void write2(const bitCapIntOcl& i1, const complex& c1, const bitCapIntOcl& i2, const complex& c2)
     {
-        amplitudes[(bitCapIntOcl)i1] = c1;
-        amplitudes[(bitCapIntOcl)i2] = c2;
+        amplitudes[i1] = c1;
+        amplitudes[i2] = c2;
     };
 
     void clear() { std::fill(amplitudes, amplitudes + (bitCapIntOcl)capacity, ZERO_CMPLX); }
@@ -109,54 +109,45 @@ public:
         }
     }
 
-    void copy_in(const complex* copyIn, const bitCapInt offset, const bitCapInt length)
+    void copy_in(const complex* copyIn, const bitCapIntOcl offset, const bitCapIntOcl length)
     {
         if (copyIn) {
-            std::copy(copyIn, copyIn + (bitCapIntOcl)length, amplitudes + (bitCapIntOcl)offset);
+            std::copy(copyIn, copyIn + length, amplitudes + offset);
         } else {
-            std::fill(amplitudes, amplitudes + (bitCapIntOcl)length, ZERO_CMPLX);
+            std::fill(amplitudes, amplitudes + length, ZERO_CMPLX);
         }
     }
 
-    void copy_in(StateVectorPtr copyInSv, const bitCapInt srcOffset, const bitCapInt dstOffset, const bitCapInt length)
+    void copy_in(
+        StateVectorPtr copyInSv, const bitCapIntOcl srcOffset, const bitCapIntOcl dstOffset, const bitCapIntOcl length)
     {
         if (copyInSv) {
-            const complex* copyIn =
-                std::dynamic_pointer_cast<StateVectorArray>(copyInSv)->amplitudes + (bitCapIntOcl)srcOffset;
-            std::copy(copyIn, copyIn + (bitCapIntOcl)length, amplitudes + (bitCapIntOcl)dstOffset);
+            const complex* copyIn = std::dynamic_pointer_cast<StateVectorArray>(copyInSv)->amplitudes + srcOffset;
+            std::copy(copyIn, copyIn + length, amplitudes + dstOffset);
         } else {
-            std::fill(amplitudes + (bitCapIntOcl)dstOffset, amplitudes + (bitCapIntOcl)dstOffset + (bitCapIntOcl)length,
-                ZERO_CMPLX);
+            std::fill(amplitudes + dstOffset, amplitudes + dstOffset + length, ZERO_CMPLX);
         }
     }
 
-    void copy_out(complex* copyOut) { std::copy(amplitudes, amplitudes + (bitCapIntOcl)capacity, copyOut); }
+    void copy_out(complex* copyOut) { std::copy(amplitudes, amplitudes + capacity, copyOut); }
 
-    void copy_out(complex* copyOut, const bitCapInt offset, const bitCapInt length)
+    void copy_out(complex* copyOut, const bitCapIntOcl offset, const bitCapIntOcl length)
     {
-        std::copy(
-            amplitudes + (bitCapIntOcl)offset, amplitudes + (bitCapIntOcl)offset + (bitCapIntOcl)capacity, copyOut);
+        std::copy(amplitudes + offset, amplitudes + offset + capacity, copyOut);
     }
 
     void copy(StateVectorPtr toCopy) { copy(std::dynamic_pointer_cast<StateVectorArray>(toCopy)); }
 
-    void copy(StateVectorArrayPtr toCopy)
-    {
-        std::copy(toCopy->amplitudes, toCopy->amplitudes + (bitCapIntOcl)capacity, amplitudes);
-    }
+    void copy(StateVectorArrayPtr toCopy) { std::copy(toCopy->amplitudes, toCopy->amplitudes + capacity, amplitudes); }
 
     void shuffle(StateVectorPtr svp) { shuffle(std::dynamic_pointer_cast<StateVectorArray>(svp)); }
 
     void shuffle(StateVectorArrayPtr svp)
     {
-        std::swap_ranges(
-            amplitudes + (((bitCapIntOcl)capacity) >> ONE_BCI), amplitudes + (bitCapIntOcl)capacity, svp->amplitudes);
+        std::swap_ranges(amplitudes + (capacity >> ONE_BCI), amplitudes + capacity, svp->amplitudes);
     }
 
-    void get_probs(real1* outArray)
-    {
-        std::transform(amplitudes, amplitudes + (bitCapIntOcl)capacity, outArray, normHelper);
-    }
+    void get_probs(real1* outArray) { std::transform(amplitudes, amplitudes + capacity, outArray, normHelper); }
 
     bool is_sparse() { return false; }
 };
@@ -166,13 +157,13 @@ protected:
     SparseStateVecMap amplitudes;
     std::mutex mtx;
 
-    complex readUnlocked(const bitCapInt& i)
+    complex readUnlocked(const bitCapIntOcl& i)
     {
         auto it = amplitudes.find(i);
         return (it == amplitudes.end()) ? ZERO_CMPLX : it->second;
     }
 
-    complex readLocked(const bitCapInt& i)
+    complex readLocked(const bitCapIntOcl& i)
     {
         mtx.lock();
         auto it = amplitudes.find(i);
@@ -182,15 +173,15 @@ protected:
     }
 
 public:
-    StateVectorSparse(bitCapInt cap)
+    StateVectorSparse(bitCapIntOcl cap)
         : StateVector(cap)
         , amplitudes()
     {
     }
 
-    complex read(const bitCapInt& i) { return isReadLocked ? readLocked(i) : readUnlocked(i); }
+    complex read(const bitCapIntOcl& i) { return isReadLocked ? readLocked(i) : readUnlocked(i); }
 
-    void write(const bitCapInt& i, const complex& c)
+    void write(const bitCapIntOcl& i, const complex& c)
     {
         bool isCSet = (c != ZERO_CMPLX);
 
@@ -213,7 +204,7 @@ public:
         }
     }
 
-    void write2(const bitCapInt& i1, const complex& c1, const bitCapInt& i2, const complex& c2)
+    void write2(const bitCapIntOcl& i1, const complex& c1, const bitCapIntOcl& i2, const complex& c2)
     {
         bool isC1Set = (c1 != ZERO_CMPLX);
         bool isC2Set = (c2 != ZERO_CMPLX);
@@ -254,21 +245,21 @@ public:
         }
 
         mtx.lock();
-        for (bitCapInt i = 0; i < capacity; i++) {
-            if (copyIn[(bitCapIntOcl)i] == ZERO_CMPLX) {
+        for (bitCapIntOcl i = 0; i < capacity; i++) {
+            if (copyIn[i] == ZERO_CMPLX) {
                 amplitudes.erase(i);
             } else {
-                amplitudes[i] = copyIn[(bitCapIntOcl)i];
+                amplitudes[i] = copyIn[i];
             }
         }
         mtx.unlock();
     }
 
-    void copy_in(const complex* copyIn, const bitCapInt offset, const bitCapInt length)
+    void copy_in(const complex* copyIn, const bitCapIntOcl offset, const bitCapIntOcl length)
     {
         if (!copyIn) {
             mtx.lock();
-            for (bitCapInt i = 0; i < length; i++) {
+            for (bitCapIntOcl i = 0; i < length; i++) {
                 amplitudes.erase(i);
             }
             mtx.unlock();
@@ -276,23 +267,24 @@ public:
         }
 
         mtx.lock();
-        for (bitCapInt i = 0; i < length; i++) {
-            if (copyIn[(bitCapIntOcl)i] == ZERO_CMPLX) {
+        for (bitCapIntOcl i = 0; i < length; i++) {
+            if (copyIn[i] == ZERO_CMPLX) {
                 amplitudes.erase(i);
             } else {
-                amplitudes[i + offset] = copyIn[(bitCapIntOcl)i];
+                amplitudes[i + offset] = copyIn[i];
             }
         }
         mtx.unlock();
     }
 
-    void copy_in(StateVectorPtr copyInSv, const bitCapInt srcOffset, const bitCapInt dstOffset, const bitCapInt length)
+    void copy_in(
+        StateVectorPtr copyInSv, const bitCapIntOcl srcOffset, const bitCapIntOcl dstOffset, const bitCapIntOcl length)
     {
         StateVectorSparsePtr copyIn = std::dynamic_pointer_cast<StateVectorSparse>(copyInSv);
 
         if (!copyIn) {
             mtx.lock();
-            for (bitCapInt i = 0; i < length; i++) {
+            for (bitCapIntOcl i = 0; i < length; i++) {
                 amplitudes.erase(i + srcOffset);
             }
             mtx.unlock();
@@ -302,7 +294,7 @@ public:
         complex amp;
 
         mtx.lock();
-        for (bitCapInt i = 0; i < length; i++) {
+        for (bitCapIntOcl i = 0; i < length; i++) {
             amp = copyIn->read(i + srcOffset);
             if (amp == ZERO_CMPLX) {
                 amplitudes.erase(i + srcOffset);
@@ -315,15 +307,15 @@ public:
 
     void copy_out(complex* copyOut)
     {
-        for (bitCapInt i = 0; i < capacity; i++) {
-            copyOut[(bitCapIntOcl)i] = read(i);
+        for (bitCapIntOcl i = 0; i < capacity; i++) {
+            copyOut[i] = read(i);
         }
     }
 
-    void copy_out(complex* copyOut, const bitCapInt offset, const bitCapInt length)
+    void copy_out(complex* copyOut, const bitCapIntOcl offset, const bitCapIntOcl length)
     {
-        for (bitCapInt i = 0; i < length; i++) {
-            copyOut[(bitCapIntOcl)i] = read(i + offset);
+        for (bitCapIntOcl i = 0; i < length; i++) {
+            copyOut[i] = read(i + offset);
         }
     }
 
@@ -343,34 +335,34 @@ public:
         complex amp;
         size_t halfCap = (size_t)(capacity >> ONE_BCI);
         mtx.lock();
-        for (bitCapInt i = 0; i < halfCap; i++) {
+        for (bitCapIntOcl i = 0; i < halfCap; i++) {
             amp = svp->read(i);
-            svp->write(i, read(i + (bitCapInt)halfCap));
-            write(i + (bitCapInt)halfCap, amp);
+            svp->write(i, read(i + halfCap));
+            write(i + halfCap, amp);
         }
         mtx.unlock();
     }
 
     void get_probs(real1* outArray)
     {
-        for (bitCapInt i = 0; i < capacity; i++) {
-            outArray[(bitCapIntOcl)i] = norm(read(i));
+        for (bitCapIntOcl i = 0; i < capacity; i++) {
+            outArray[i] = norm(read(i));
         }
     }
 
     bool is_sparse() { return (amplitudes.size() < (capacity >> ONE_BCI)); }
 
-    std::vector<bitCapInt> iterable()
+    std::vector<bitCapIntOcl> iterable()
     {
         int32_t i, combineCount;
 
         int32_t threadCount = GetConcurrencyLevel();
-        std::vector<std::vector<bitCapInt>> toRet(threadCount);
-        std::vector<std::vector<bitCapInt>>::iterator toRetIt;
+        std::vector<std::vector<bitCapIntOcl>> toRet(threadCount);
+        std::vector<std::vector<bitCapIntOcl>>::iterator toRetIt;
 
         mtx.lock();
 
-        par_for(0, (bitCapInt)amplitudes.size(), [&](const bitCapInt lcv, const int cpu) {
+        par_for(0, amplitudes.size(), [&](const bitCapIntOcl& lcv, const unsigned& cpu) {
             auto it = amplitudes.begin();
             std::advance(it, lcv);
             toRet[cpu].push_back(it->first);
@@ -417,8 +409,8 @@ public:
     }
 
     /// Returns empty if iteration should be over full set, otherwise just the iterable elements:
-    std::set<bitCapInt> iterable(
-        const bitCapInt& setMask, const bitCapInt& filterMask = 0, const bitCapInt& filterValues = 0)
+    std::set<bitCapIntOcl> iterable(
+        const bitCapIntOcl& setMask, const bitCapIntOcl& filterMask = 0, const bitCapIntOcl& filterValues = 0)
     {
         if ((filterMask == 0) && (filterValues != 0)) {
             return {};
@@ -426,24 +418,24 @@ public:
 
         int32_t i, combineCount;
 
-        bitCapInt unsetMask = ~setMask;
+        bitCapIntOcl unsetMask = ~setMask;
 
         int32_t threadCount = GetConcurrencyLevel();
-        std::vector<std::set<bitCapInt>> toRet(threadCount);
-        std::vector<std::set<bitCapInt>>::iterator toRetIt;
+        std::vector<std::set<bitCapIntOcl>> toRet(threadCount);
+        std::vector<std::set<bitCapIntOcl>>::iterator toRetIt;
 
         mtx.lock();
 
         if ((filterMask == 0) && (filterValues == 0)) {
-            par_for(0, (bitCapInt)amplitudes.size(), [&](const bitCapInt lcv, const int cpu) {
+            par_for(0, amplitudes.size(), [&](const bitCapIntOcl& lcv, const unsigned& cpu) {
                 auto it = amplitudes.begin();
                 std::advance(it, lcv);
                 toRet[cpu].insert(it->first & unsetMask);
             });
         } else {
-            bitCapInt unfilterMask = ~filterMask;
+            bitCapIntOcl unfilterMask = ~filterMask;
 
-            par_for(0, (bitCapInt)amplitudes.size(), [&](const bitCapInt lcv, const int cpu) {
+            par_for(0, amplitudes.size(), [&](const bitCapIntOcl lcv, const unsigned& cpu) {
                 auto it = amplitudes.begin();
                 std::advance(it, lcv);
                 if ((it->first & filterMask) == filterValues) {

--- a/src/qengine/qengine.cpp
+++ b/src/qengine/qengine.cpp
@@ -169,8 +169,8 @@ void QEngine::ApplySingleBit(const complex* mtrx, bitLenInt qubit)
 
     bool doCalcNorm = doNormalize && !(IsPhase(mtrx) || IsInvert(mtrx));
 
-    bitCapInt qPowers[1];
-    qPowers[0] = pow2(qubit);
+    bitCapIntOcl qPowers[1];
+    qPowers[0] = pow2Ocl(qubit);
     Apply2x2(0, qPowers[0], mtrx, 1, qPowers, doCalcNorm);
 }
 
@@ -223,16 +223,17 @@ void QEngine::CSwap(
 
     const complex pauliX[4] = { complex(ZERO_R1, ZERO_R1), complex(ONE_R1, ZERO_R1), complex(ONE_R1, ZERO_R1),
         complex(ZERO_R1, ZERO_R1) };
-    bitCapInt skipMask = 0;
-    std::unique_ptr<bitCapInt[]> qPowersSorted(new bitCapInt[controlLen + 2]);
+    bitCapIntOcl skipMask = 0;
+    std::unique_ptr<bitCapIntOcl[]> qPowersSorted(new bitCapIntOcl[controlLen + 2]);
     for (bitLenInt i = 0; i < controlLen; i++) {
-        qPowersSorted[i] = pow2(controls[i]);
+        qPowersSorted[i] = pow2Ocl(controls[i]);
         skipMask |= qPowersSorted[i];
     }
-    qPowersSorted[controlLen] = pow2(qubit1);
-    qPowersSorted[controlLen + 1] = pow2(qubit2);
+    qPowersSorted[controlLen] = pow2Ocl(qubit1);
+    qPowersSorted[controlLen + 1] = pow2Ocl(qubit2);
     std::sort(qPowersSorted.get(), qPowersSorted.get() + controlLen + 2);
-    Apply2x2(skipMask | pow2(qubit1), skipMask | pow2(qubit2), pauliX, 2 + controlLen, qPowersSorted.get(), false);
+    Apply2x2(
+        skipMask | pow2Ocl(qubit1), skipMask | pow2Ocl(qubit2), pauliX, 2 + controlLen, qPowersSorted.get(), false);
 }
 
 void QEngine::AntiCSwap(
@@ -244,14 +245,14 @@ void QEngine::AntiCSwap(
 
     const complex pauliX[4] = { complex(ZERO_R1, ZERO_R1), complex(ONE_R1, ZERO_R1), complex(ONE_R1, ZERO_R1),
         complex(ZERO_R1, ZERO_R1) };
-    std::unique_ptr<bitCapInt[]> qPowersSorted(new bitCapInt[controlLen + 2]);
+    std::unique_ptr<bitCapIntOcl[]> qPowersSorted(new bitCapIntOcl[controlLen + 2]);
     for (bitLenInt i = 0; i < controlLen; i++) {
-        qPowersSorted[i] = pow2(controls[i]);
+        qPowersSorted[i] = pow2Ocl(controls[i]);
     }
-    qPowersSorted[controlLen] = pow2(qubit1);
-    qPowersSorted[controlLen + 1] = pow2(qubit2);
+    qPowersSorted[controlLen] = pow2Ocl(qubit1);
+    qPowersSorted[controlLen + 1] = pow2Ocl(qubit2);
     std::sort(qPowersSorted.get(), qPowersSorted.get() + controlLen + 2);
-    Apply2x2(pow2(qubit1), pow2(qubit2), pauliX, 2 + controlLen, qPowersSorted.get(), false);
+    Apply2x2(pow2Ocl(qubit1), pow2Ocl(qubit2), pauliX, 2 + controlLen, qPowersSorted.get(), false);
 }
 
 void QEngine::CSqrtSwap(
@@ -263,16 +264,16 @@ void QEngine::CSqrtSwap(
 
     const complex sqrtX[4] = { complex(ONE_R1, ONE_R1) / (real1)2.0f, complex(ONE_R1, -ONE_R1) / (real1)2.0f,
         complex(ONE_R1, -ONE_R1) / (real1)2.0f, complex(ONE_R1, ONE_R1) / (real1)2.0f };
-    bitCapInt skipMask = 0;
-    std::unique_ptr<bitCapInt[]> qPowersSorted(new bitCapInt[controlLen + 2]);
+    bitCapIntOcl skipMask = 0;
+    std::unique_ptr<bitCapIntOcl[]> qPowersSorted(new bitCapIntOcl[controlLen + 2]);
     for (bitLenInt i = 0; i < controlLen; i++) {
-        qPowersSorted[i] = pow2(controls[i]);
+        qPowersSorted[i] = pow2Ocl(controls[i]);
         skipMask |= qPowersSorted[i];
     }
-    qPowersSorted[controlLen] = pow2(qubit1);
-    qPowersSorted[controlLen + 1] = pow2(qubit2);
+    qPowersSorted[controlLen] = pow2Ocl(qubit1);
+    qPowersSorted[controlLen + 1] = pow2Ocl(qubit2);
     std::sort(qPowersSorted.get(), qPowersSorted.get() + controlLen + 2);
-    Apply2x2(skipMask | pow2(qubit1), skipMask | pow2(qubit2), sqrtX, 2 + controlLen, qPowersSorted.get(), false);
+    Apply2x2(skipMask | pow2Ocl(qubit1), skipMask | pow2Ocl(qubit2), sqrtX, 2 + controlLen, qPowersSorted.get(), false);
 }
 
 void QEngine::AntiCSqrtSwap(
@@ -284,14 +285,14 @@ void QEngine::AntiCSqrtSwap(
 
     const complex sqrtX[4] = { complex(ONE_R1, ONE_R1) / (real1)2.0f, complex(ONE_R1, -ONE_R1) / (real1)2.0f,
         complex(ONE_R1, -ONE_R1) / (real1)2.0f, complex(ONE_R1, ONE_R1) / (real1)2.0f };
-    std::unique_ptr<bitCapInt[]> qPowersSorted(new bitCapInt[controlLen + 2]);
+    std::unique_ptr<bitCapIntOcl[]> qPowersSorted(new bitCapIntOcl[controlLen + 2]);
     for (bitLenInt i = 0; i < controlLen; i++) {
-        qPowersSorted[i] = pow2(controls[i]);
+        qPowersSorted[i] = pow2Ocl(controls[i]);
     }
-    qPowersSorted[controlLen] = pow2(qubit1);
-    qPowersSorted[controlLen + 1] = pow2(qubit2);
+    qPowersSorted[controlLen] = pow2Ocl(qubit1);
+    qPowersSorted[controlLen + 1] = pow2Ocl(qubit2);
     std::sort(qPowersSorted.get(), qPowersSorted.get() + controlLen + 2);
-    Apply2x2(pow2(qubit1), pow2(qubit2), sqrtX, 2 + controlLen, qPowersSorted.get(), false);
+    Apply2x2(pow2Ocl(qubit1), pow2Ocl(qubit2), sqrtX, 2 + controlLen, qPowersSorted.get(), false);
 }
 
 void QEngine::CISqrtSwap(
@@ -303,16 +304,17 @@ void QEngine::CISqrtSwap(
 
     const complex iSqrtX[4] = { complex(ONE_R1, -ONE_R1) / (real1)2.0f, complex(ONE_R1, ONE_R1) / (real1)2.0f,
         complex(ONE_R1, ONE_R1) / (real1)2.0f, complex(ONE_R1, -ONE_R1) / (real1)2.0f };
-    bitCapInt skipMask = 0;
-    std::unique_ptr<bitCapInt[]> qPowersSorted(new bitCapInt[controlLen + 2]);
+    bitCapIntOcl skipMask = 0;
+    std::unique_ptr<bitCapIntOcl[]> qPowersSorted(new bitCapIntOcl[controlLen + 2]);
     for (bitLenInt i = 0; i < controlLen; i++) {
-        qPowersSorted[i] = pow2(controls[i]);
+        qPowersSorted[i] = pow2Ocl(controls[i]);
         skipMask |= qPowersSorted[i];
     }
-    qPowersSorted[controlLen] = pow2(qubit1);
-    qPowersSorted[controlLen + 1] = pow2(qubit2);
+    qPowersSorted[controlLen] = pow2Ocl(qubit1);
+    qPowersSorted[controlLen + 1] = pow2Ocl(qubit2);
     std::sort(qPowersSorted.get(), qPowersSorted.get() + controlLen + 2);
-    Apply2x2(skipMask | pow2(qubit1), skipMask | pow2(qubit2), iSqrtX, 2 + controlLen, qPowersSorted.get(), false);
+    Apply2x2(
+        skipMask | pow2Ocl(qubit1), skipMask | pow2Ocl(qubit2), iSqrtX, 2 + controlLen, qPowersSorted.get(), false);
 }
 
 void QEngine::AntiCISqrtSwap(
@@ -324,25 +326,25 @@ void QEngine::AntiCISqrtSwap(
 
     const complex iSqrtX[4] = { complex(ONE_R1, -ONE_R1) / (real1)2.0f, complex(ONE_R1, ONE_R1) / (real1)2.0f,
         complex(ONE_R1, ONE_R1) / (real1)2.0f, complex(ONE_R1, -ONE_R1) / (real1)2.0f };
-    std::unique_ptr<bitCapInt[]> qPowersSorted(new bitCapInt[controlLen + 2]);
+    std::unique_ptr<bitCapIntOcl[]> qPowersSorted(new bitCapIntOcl[controlLen + 2]);
     for (bitLenInt i = 0; i < controlLen; i++) {
-        qPowersSorted[i] = pow2(controls[i]);
+        qPowersSorted[i] = pow2Ocl(controls[i]);
     }
-    qPowersSorted[controlLen] = pow2(qubit1);
-    qPowersSorted[controlLen + 1] = pow2(qubit2);
+    qPowersSorted[controlLen] = pow2Ocl(qubit1);
+    qPowersSorted[controlLen + 1] = pow2Ocl(qubit2);
     std::sort(qPowersSorted.get(), qPowersSorted.get() + controlLen + 2);
-    Apply2x2(pow2(qubit1), pow2(qubit2), iSqrtX, 2 + controlLen, qPowersSorted.get(), false);
+    Apply2x2(pow2Ocl(qubit1), pow2Ocl(qubit2), iSqrtX, 2 + controlLen, qPowersSorted.get(), false);
 }
 
 void QEngine::ApplyControlled2x2(
     const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& target, const complex* mtrx)
 {
-    std::unique_ptr<bitCapInt[]> qPowersSorted(new bitCapInt[controlLen + 1U]);
-    bitCapInt targetMask = pow2Ocl(target);
-    bitCapInt fullMask = 0U;
-    bitCapInt controlMask;
+    std::unique_ptr<bitCapIntOcl[]> qPowersSorted(new bitCapIntOcl[controlLen + 1U]);
+    bitCapIntOcl targetMask = pow2Ocl(target);
+    bitCapIntOcl fullMask = 0U;
+    bitCapIntOcl controlMask;
     for (bitLenInt i = 0U; i < controlLen; i++) {
-        qPowersSorted[i] = pow2(controls[i]);
+        qPowersSorted[i] = pow2Ocl(controls[i]);
         fullMask |= qPowersSorted[i];
     }
     controlMask = fullMask;
@@ -355,10 +357,10 @@ void QEngine::ApplyControlled2x2(
 void QEngine::ApplyAntiControlled2x2(
     const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& target, const complex* mtrx)
 {
-    std::unique_ptr<bitCapInt[]> qPowersSorted(new bitCapInt[controlLen + 1U]);
-    bitCapInt targetMask = pow2Ocl(target);
+    std::unique_ptr<bitCapIntOcl[]> qPowersSorted(new bitCapIntOcl[controlLen + 1U]);
+    bitCapIntOcl targetMask = pow2Ocl(target);
     for (bitLenInt i = 0U; i < controlLen; i++) {
-        qPowersSorted[i] = pow2(controls[i]);
+        qPowersSorted[i] = pow2Ocl(controls[i]);
     }
     qPowersSorted[controlLen] = targetMask;
     std::sort(qPowersSorted.get(), qPowersSorted.get() + controlLen + 1U);
@@ -374,9 +376,9 @@ void QEngine::Swap(bitLenInt qubit1, bitLenInt qubit2)
 
     const complex pauliX[4] = { complex(ZERO_R1, ZERO_R1), complex(ONE_R1, ZERO_R1), complex(ONE_R1, ZERO_R1),
         complex(ZERO_R1, ZERO_R1) };
-    bitCapInt qPowersSorted[2];
-    qPowersSorted[0] = pow2(qubit1);
-    qPowersSorted[1] = pow2(qubit2);
+    bitCapIntOcl qPowersSorted[2];
+    qPowersSorted[0] = pow2Ocl(qubit1);
+    qPowersSorted[1] = pow2Ocl(qubit2);
     std::sort(qPowersSorted, qPowersSorted + 2);
     Apply2x2(qPowersSorted[0], qPowersSorted[1], pauliX, 2, qPowersSorted, false);
 }
@@ -390,9 +392,9 @@ void QEngine::ISwap(bitLenInt qubit1, bitLenInt qubit2)
 
     const complex pauliX[4] = { complex(ZERO_R1, ZERO_R1), complex(ZERO_R1, ONE_R1), complex(ZERO_R1, ONE_R1),
         complex(ZERO_R1, ZERO_R1) };
-    bitCapInt qPowersSorted[2];
-    qPowersSorted[0] = pow2(qubit1);
-    qPowersSorted[1] = pow2(qubit2);
+    bitCapIntOcl qPowersSorted[2];
+    qPowersSorted[0] = pow2Ocl(qubit1);
+    qPowersSorted[1] = pow2Ocl(qubit2);
     std::sort(qPowersSorted, qPowersSorted + 2);
     Apply2x2(qPowersSorted[0], qPowersSorted[1], pauliX, 2, qPowersSorted, false);
 }
@@ -406,9 +408,9 @@ void QEngine::SqrtSwap(bitLenInt qubit1, bitLenInt qubit2)
 
     const complex sqrtX[4] = { complex(ONE_R1, ONE_R1) / (real1)2.0f, complex(ONE_R1, -ONE_R1) / (real1)2.0f,
         complex(ONE_R1, -ONE_R1) / (real1)2.0f, complex(ONE_R1, ONE_R1) / (real1)2.0f };
-    bitCapInt qPowersSorted[2];
-    qPowersSorted[0] = pow2(qubit1);
-    qPowersSorted[1] = pow2(qubit2);
+    bitCapIntOcl qPowersSorted[2];
+    qPowersSorted[0] = pow2Ocl(qubit1);
+    qPowersSorted[1] = pow2Ocl(qubit2);
     std::sort(qPowersSorted, qPowersSorted + 2);
     Apply2x2(qPowersSorted[0], qPowersSorted[1], sqrtX, 2, qPowersSorted, false);
 }
@@ -422,9 +424,9 @@ void QEngine::ISqrtSwap(bitLenInt qubit1, bitLenInt qubit2)
 
     const complex iSqrtX[4] = { complex(ONE_R1, -ONE_R1) / (real1)2.0f, complex(ONE_R1, ONE_R1) / (real1)2.0f,
         complex(ONE_R1, ONE_R1) / (real1)2.0f, complex(ONE_R1, -ONE_R1) / (real1)2.0f };
-    bitCapInt qPowersSorted[2];
-    qPowersSorted[0] = pow2(qubit1);
-    qPowersSorted[1] = pow2(qubit2);
+    bitCapIntOcl qPowersSorted[2];
+    qPowersSorted[0] = pow2Ocl(qubit1);
+    qPowersSorted[1] = pow2Ocl(qubit2);
     std::sort(qPowersSorted, qPowersSorted + 2);
     Apply2x2(qPowersSorted[0], qPowersSorted[1], iSqrtX, 2, qPowersSorted, false);
 }
@@ -438,9 +440,9 @@ void QEngine::FSim(real1_f theta, real1_f phi, bitLenInt qubit1, bitLenInt qubit
     if (cosTheta != ONE_R1) {
         const complex fSimSwap[4] = { complex(cosTheta, ZERO_R1), complex(ZERO_R1, sinTheta),
             complex(ZERO_R1, sinTheta), complex(cosTheta, ZERO_R1) };
-        bitCapInt qPowersSorted[2];
-        qPowersSorted[0] = pow2(qubit1);
-        qPowersSorted[1] = pow2(qubit2);
+        bitCapIntOcl qPowersSorted[2];
+        qPowersSorted[0] = pow2Ocl(qubit1);
+        qPowersSorted[1] = pow2Ocl(qubit2);
         std::sort(qPowersSorted, qPowersSorted + 2);
         Apply2x2(qPowersSorted[0], qPowersSorted[1], fSimSwap, 2, qPowersSorted, false);
     }
@@ -478,7 +480,7 @@ bitCapInt QEngine::ForceMReg(bitLenInt start, bitLenInt length, bitCapInt result
     }
 
     bitCapIntOcl lengthPower = pow2Ocl(length);
-    bitCapInt regMask = (lengthPower - ONE_BCI) << (bitCapIntOcl)start;
+    bitCapIntOcl regMask = (lengthPower - ONE_BCI) << (bitCapIntOcl)start;
     real1 nrmlzr = ONE_R1;
 
     if (doForce) {

--- a/src/qinterface/rotational.cpp
+++ b/src/qinterface/rotational.cpp
@@ -106,7 +106,7 @@ void QInterface::UniformlyControlledRY(
     const bitLenInt* controls, const bitLenInt& controlLen, bitLenInt qubitIndex, const real1* angles)
 {
     bitCapIntOcl permCount = pow2Ocl(controlLen);
-    std::unique_ptr<complex[]> pauliRYs(new complex[4U * (bitCapIntOcl)permCount]);
+    std::unique_ptr<complex[]> pauliRYs(new complex[4U * permCount]);
 
     real1 cosine, sine;
     for (bitCapIntOcl i = 0; i < permCount; i++) {
@@ -128,7 +128,7 @@ void QInterface::UniformlyControlledRZ(
     const bitLenInt* controls, const bitLenInt& controlLen, bitLenInt qubitIndex, const real1* angles)
 {
     bitCapIntOcl permCount = pow2Ocl(controlLen);
-    std::unique_ptr<complex[]> pauliRZs(new complex[4U * (bitCapIntOcl)permCount]);
+    std::unique_ptr<complex[]> pauliRZs(new complex[4U * permCount]);
 
     real1 cosine, sine;
     for (bitCapIntOcl i = 0; i < permCount; i++) {

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -236,7 +236,7 @@ TEST_CASE("test_qengine_cpu_par_for_mask")
     std::atomic_bool hit[NUM_ENTRIES];
     std::atomic_int calls;
 
-    bitCapInt skipArray[] = { 0x4, 0x100 }; // Skip bits 0b100000100
+    bitCapIntOcl skipArray[] = { 0x4, 0x100 }; // Skip bits 0b100000100
     int NUM_SKIP = sizeof(skipArray) / sizeof(skipArray[0]);
 
     calls.store(0);


### PR DESCRIPTION
In terms of type safety, I've realized that everything descending from `QEngine` or, equivalently, assuming a _state vector_ representation of a quantum computer simulation should strictly use `bitCapIntOcl` as its masking type, except in public method interfaces. (QUnit, for an alternative example, still strictly uses `bitCapInt`, for masking.)

If my original concern was whether `size_t` indexing of arrays would ever exceed 64 bits, the simple and clear answer is "never." The caveat is that we would expect a fully supported set of 128-bit integral types in the compiler first, but 128-bit addressing would have a maximum addressable RAM of something like _2^70 times all the RAM currently in existence on the planet_, so it's moot. (Let's not forget what brings us here, in the first place.)