### PR TITLE
Compute tables

### DIFF
--- a/include/qbinary_decision_tree.hpp
+++ b/include/qbinary_decision_tree.hpp
@@ -37,6 +37,7 @@ protected:
 #endif
     bitLenInt pStridePow;
     bitCapIntOcl maxQPowerOcl;
+    std::vector<std::set<bitCapInt>> zeroMasks;
 
     virtual void SetQubitCount(bitLenInt qb)
     {

--- a/src/qbinary_decision_tree/node.cpp
+++ b/src/qbinary_decision_tree/node.cpp
@@ -120,6 +120,10 @@ void QBinaryDecisionTreeNode::Prune(bitLenInt depth)
             continue;
         }
 
+        if (!leaf0) {
+            continue;
+        }
+
         leaf0 = b0;
         leaf1 = b1;
         for (k = 0; k < (j - 1U); k++) {

--- a/src/qbinary_decision_tree/tree.cpp
+++ b/src/qbinary_decision_tree/tree.cpp
@@ -484,13 +484,13 @@ void QBinaryDecisionTree::Apply2x2OnLeaf(const complex* mtrx, QBinaryDecisionTre
     bool isZero;
 
     for (bitCapIntOcl i = 0; i < remainderPow; i++) {
-        for (j = depth + 1U; j < qubitCount; j++) {
+        for (j = 0; j < remainder; j++) {
             if (halfZeroMasks[j].find(i & (pow2Ocl(j + 1U) - ONE_BCI)) != halfZeroMasks[j].end()) {
                 break;
             }
         }
 
-        if (j < qubitCount) {
+        if (j < remainder) {
             continue;
         }
 
@@ -532,8 +532,6 @@ void QBinaryDecisionTree::Apply2x2OnLeaf(const complex* mtrx, QBinaryDecisionTre
 
             bitCapInt mask = (i & (pow2Ocl(j + 1U) - ONE_BCI));
 
-            j += depth + 1U;
-
             halfZeroMasks[j].insert(mask);
 
             bit ^= 1U;
@@ -570,7 +568,8 @@ template <typename Fn> void QBinaryDecisionTree::ApplySingle(bitLenInt target, F
     Dispatch(targetPow, [this, target, targetPow, leafFunc]() {
         root->Branch(target);
 
-        zeroMasks.resize(qubitCount);
+        bitLenInt remainder = qubitCount - (target + 1);
+        zeroMasks.resize(remainder);
 
         bool isParallel = (targetPow < GetParallelThreshold());
         for (bitCapInt i = 0; i < targetPow; i++) {
@@ -675,7 +674,8 @@ void QBinaryDecisionTree::ApplyControlledSingle(bool isAnti, std::shared_ptr<com
             leafFunc]() {
             root->Branch(target);
 
-            zeroMasks.resize(qubitCount);
+            bitLenInt remainder = qubitCount - (target + 1);
+            zeroMasks.resize(remainder);
 
             bool isPhase = false;
             bool isInvert = false;

--- a/src/qbinary_decision_tree/tree.cpp
+++ b/src/qbinary_decision_tree/tree.cpp
@@ -569,7 +569,7 @@ template <typename Fn> void QBinaryDecisionTree::ApplySingle(bitLenInt target, F
         root->Branch(target);
 
         bitLenInt remainder = qubitCount - (target + 1);
-        zeroMasks = std::vector<std::set<bitCapInt>>(remainder);
+        zeroMasks.resize(remainder);
 
         bool isParallel = (targetPow < GetParallelThreshold());
         for (bitCapInt i = 0; i < targetPow; i++) {
@@ -589,7 +589,7 @@ template <typename Fn> void QBinaryDecisionTree::ApplySingle(bitLenInt target, F
             leafFunc(leaf, isParallel, 0U);
         }
 
-        zeroMasks = std::vector<std::set<bitCapInt>>();
+        zeroMasks.clear();
 
         root->Prune(target);
     });
@@ -675,7 +675,7 @@ void QBinaryDecisionTree::ApplyControlledSingle(bool isAnti, std::shared_ptr<com
             root->Branch(target);
 
             bitLenInt remainder = qubitCount - (target + 1);
-            zeroMasks = std::vector<std::set<bitCapInt>>(remainder);
+            zeroMasks.resize(remainder);
 
             bool isPhase = false;
             bool isInvert = false;
@@ -732,7 +732,7 @@ void QBinaryDecisionTree::ApplyControlledSingle(bool isAnti, std::shared_ptr<com
                 }
             }
 
-            zeroMasks = std::vector<std::set<bitCapInt>>();
+            zeroMasks.clear();
 
             root->Prune(target);
         });

--- a/src/qbinary_decision_tree/tree.cpp
+++ b/src/qbinary_decision_tree/tree.cpp
@@ -484,13 +484,13 @@ void QBinaryDecisionTree::Apply2x2OnLeaf(const complex* mtrx, QBinaryDecisionTre
     bool isZero;
 
     for (bitCapIntOcl i = 0; i < remainderPow; i++) {
-        for (j = 0; j < remainder; j++) {
+        for (j = depth + 1U; j < qubitCount; j++) {
             if (halfZeroMasks[j].find(i & (pow2Ocl(j + 1U) - ONE_BCI)) != halfZeroMasks[j].end()) {
                 break;
             }
         }
 
-        if (j < remainder) {
+        if (j < qubitCount) {
             continue;
         }
 
@@ -532,6 +532,8 @@ void QBinaryDecisionTree::Apply2x2OnLeaf(const complex* mtrx, QBinaryDecisionTre
 
             bitCapInt mask = (i & (pow2Ocl(j + 1U) - ONE_BCI));
 
+            j += depth + 1U;
+
             halfZeroMasks[j].insert(mask);
 
             bit ^= 1U;
@@ -568,8 +570,7 @@ template <typename Fn> void QBinaryDecisionTree::ApplySingle(bitLenInt target, F
     Dispatch(targetPow, [this, target, targetPow, leafFunc]() {
         root->Branch(target);
 
-        bitLenInt remainder = qubitCount - (target + 1);
-        zeroMasks.resize(remainder);
+        zeroMasks.resize(qubitCount);
 
         bool isParallel = (targetPow < GetParallelThreshold());
         for (bitCapInt i = 0; i < targetPow; i++) {
@@ -674,8 +675,7 @@ void QBinaryDecisionTree::ApplyControlledSingle(bool isAnti, std::shared_ptr<com
             leafFunc]() {
             root->Branch(target);
 
-            bitLenInt remainder = qubitCount - (target + 1);
-            zeroMasks.resize(remainder);
+            zeroMasks.resize(qubitCount);
 
             bool isPhase = false;
             bool isInvert = false;


### PR DESCRIPTION
I'm still new to the terminology and concepts of quantum binary decision trees, but, based upon https://arxiv.org/abs/1911.12691, I think this PR naturally reaches for an optimization that is what is referred to as a "compute table." As a result, potentially _much_ less "garbage" is generated, in dead `shared_ptr` instances.