### PR TITLE
(QBDT) Revert from state vector just-in-time

### DIFF
--- a/include/qbinary_decision_tree.hpp
+++ b/include/qbinary_decision_tree.hpp
@@ -238,7 +238,8 @@ public:
         const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& target, const complex* mtrx);
 
     virtual bool ForceMParity(const bitCapInt& mask, bool result, bool doForce = true);
-    virtual real1_f ProbParity(const bitCapInt& mask) {
+    virtual real1_f ProbParity(const bitCapInt& mask)
+    {
         QInterfacePtr unit = stateVecUnit ? stateVecUnit : MakeTempStateVector();
         return unit->ProbParity(mask);
     }

--- a/include/qbinary_decision_tree.hpp
+++ b/include/qbinary_decision_tree.hpp
@@ -222,7 +222,8 @@ public:
     virtual std::map<bitCapInt, int> MultiShotMeasureMask(
         const bitCapInt* qPowers, const bitLenInt qPowerCount, const unsigned int shots)
     {
-        return MakeTempStateVector()->MultiShotMeasureMask(qPowers, qPowerCount, shots);
+        QInterfacePtr unit = stateVecUnit ? stateVecUnit : MakeTempStateVector();
+        return unit->MultiShotMeasureMask(qPowers, qPowerCount, shots);
     }
 
     virtual bool ForceM(bitLenInt qubit, bool result, bool doForce = true, bool doApply = true);
@@ -237,7 +238,10 @@ public:
         const bitLenInt* controls, const bitLenInt& controlLen, const bitLenInt& target, const complex* mtrx);
 
     virtual bool ForceMParity(const bitCapInt& mask, bool result, bool doForce = true);
-    virtual real1_f ProbParity(const bitCapInt& mask) { return MakeTempStateVector()->ProbParity(mask); }
+    virtual real1_f ProbParity(const bitCapInt& mask) {
+        QInterfacePtr unit = stateVecUnit ? stateVecUnit : MakeTempStateVector();
+        return unit->ProbParity(mask);
+    }
 
     virtual bitCapInt IndexedLDA(bitLenInt indexStart, bitLenInt indexLength, bitLenInt valueStart,
         bitLenInt valueLength, unsigned char* values, bool resetValue = true)

--- a/include/qbinary_decision_tree.hpp
+++ b/include/qbinary_decision_tree.hpp
@@ -65,8 +65,8 @@ protected:
 
     QInterfacePtr MakeTempStateVector()
     {
-        Finish();
         QInterfacePtr copyPtr = MakeStateVector();
+        Finish();
         GetQuantumState(copyPtr);
 
         // If the calling function fully deferences our return, it's automatically freed.
@@ -78,6 +78,7 @@ protected:
             return;
         }
 
+        Finish();
         stateVecUnit = MakeStateVector();
         GetQuantumState(stateVecUnit);
         root = NULL;
@@ -88,6 +89,7 @@ protected:
             return;
         }
 
+        Finish();
         SetQuantumState(stateVecUnit);
         stateVecUnit = NULL;
     }
@@ -98,14 +100,12 @@ protected:
     {
         SetStateVector();
         operation(stateVecUnit);
-        ResetStateVector();
     }
 
     template <typename Fn> bitCapInt BitCapIntAsStateVector(Fn operation)
     {
         SetStateVector();
         bitCapInt toRet = operation(stateVecUnit);
-        ResetStateVector();
 
         return toRet;
     }

--- a/src/qbinary_decision_tree/tree.cpp
+++ b/src/qbinary_decision_tree/tree.cpp
@@ -160,6 +160,7 @@ void QBinaryDecisionTree::GetProbs(real1* outputProbs)
 real1_f QBinaryDecisionTree::SumSqrDiff(QBinaryDecisionTreePtr toCompare)
 {
     Finish();
+    toCompare->Finish();
 
     int numCores = GetConcurrencyLevel();
     std::unique_ptr<complex[]> partInner(new complex[numCores]());

--- a/src/qbinary_decision_tree/tree.cpp
+++ b/src/qbinary_decision_tree/tree.cpp
@@ -29,6 +29,7 @@ QBinaryDecisionTree::QBinaryDecisionTree(std::vector<QInterfaceEngine> eng, bitL
     , engines(eng)
     , devID(deviceId)
     , root(NULL)
+    , stateVecUnit(NULL)
     , maxQPowerOcl(pow2Ocl(qBitCount))
     , zeroMasks(qubitCount)
 {
@@ -56,11 +57,9 @@ QInterfacePtr QBinaryDecisionTree::MakeStateVector()
 
 bool QBinaryDecisionTree::ForceMParity(const bitCapInt& mask, bool result, bool doForce)
 {
-    QInterfacePtr copyPtr = MakeStateVector();
-
-    GetQuantumState(copyPtr);
-    bool toRet = copyPtr->ForceMParity(mask, result, doForce);
-    SetQuantumState(copyPtr);
+    SetStateVector();
+    bool toRet = stateVecUnit->ForceMParity(mask, result, doForce);
+    ResetStateVector();
 
     return toRet;
 }


### PR DESCRIPTION
`QBinaryDecisionTree` currently relies on fallback to state vector simulation for a very limited set of its API. To avoid (eager) redundant cyclical conversions to and from state vector representation, wait (until just-in-time) to convert state vector simulations back.