### PR TITLE
Reverse endianness of outer loops

### DIFF
--- a/src/qbinary_decision_tree/tree.cpp
+++ b/src/qbinary_decision_tree/tree.cpp
@@ -602,10 +602,11 @@ template <typename Fn> void QBinaryDecisionTree::ApplySingle(bitLenInt target, F
                 if (IS_NORM_0(leaf->scale)) {
                     break;
                 }
-                leaf = leaf->branches[SelectBit(i, j)];
+                leaf = leaf->branches[SelectBit(i, (target - (j + 1U)))];
             }
 
             if (IS_NORM_0(leaf->scale)) {
+                i |= pow2Ocl(target - j) - ONE_BCI;
                 continue;
             }
 

--- a/src/qbinary_decision_tree/tree.cpp
+++ b/src/qbinary_decision_tree/tree.cpp
@@ -671,16 +671,16 @@ void QBinaryDecisionTree::ApplyControlledSingle(bool isAnti, std::shared_ptr<com
     bitCapIntOcl highControlMask = 0U;
     for (; c < controlLen; c++) {
         highControlMask |= pow2Ocl(sortedControls[c]);
-        ;
     }
     highControlMask >>= (target + 1U);
 
     bitCapIntOcl targetPow = pow2Ocl(target);
+    bitCapIntOcl maskTarget = (isAnti ? 0U : lowControlMask);
 
     ResetStateVector();
 
-    Dispatch(
-        targetPow, [this, isAnti, mtrx, target, targetPow, lowControlMask, highControlMask, controlBound, leafFunc]() {
+    Dispatch(targetPow,
+        [this, mtrx, target, targetPow, lowControlMask, highControlMask, maskTarget, controlBound, leafFunc]() {
             root->Branch(target);
 
             bool isPhase = false;
@@ -691,7 +691,6 @@ void QBinaryDecisionTree::ApplyControlledSingle(bool isAnti, std::shared_ptr<com
             }
             bool isParallel = ((targetPow >> controlBound) < GetParallelThreshold());
 
-            bitCapIntOcl maskTarget = (isAnti ? 0U : lowControlMask);
             bitLenInt j;
             for (bitCapIntOcl i = 0U; i < targetPow; i++) {
                 if ((i & lowControlMask) != maskTarget) {

--- a/src/qbinary_decision_tree/tree.cpp
+++ b/src/qbinary_decision_tree/tree.cpp
@@ -602,7 +602,7 @@ template <typename Fn> void QBinaryDecisionTree::ApplySingle(bitLenInt target, F
                 if (IS_NORM_0(leaf->scale)) {
                     break;
                 }
-                leaf = leaf->branches[SelectBit(i, (target - (j + 1U)))];
+                leaf = leaf->branches[SelectBit(i, target - (j + 1U))];
             }
 
             if (IS_NORM_0(leaf->scale)) {
@@ -678,10 +678,11 @@ void QBinaryDecisionTree::ApplyControlledSingle(bool isAnti, std::shared_ptr<com
     bitCapIntOcl lowControlMask = 0U;
     bitLenInt c;
     for (c = 0U; (c < controlLen) && (sortedControls[c] < target); c++) {
-        qPowersSorted[c] = pow2Ocl(sortedControls[c]);
+        qPowersSorted[c] = pow2Ocl(target - (sortedControls[c] + ONE_BCI));
         lowControlMask |= qPowersSorted[c];
     }
     bitLenInt controlBound = c;
+    std::reverse(qPowersSorted.begin(), qPowersSorted.begin() + controlBound);
     bitCapIntOcl highControlMask = 0U;
     for (; c < controlLen; c++) {
         qPowersSorted[c] = pow2Ocl(sortedControls[c]);
@@ -730,10 +731,11 @@ void QBinaryDecisionTree::ApplyControlledSingle(bool isAnti, std::shared_ptr<com
                     if (IS_NORM_0(leaf->scale)) {
                         break;
                     }
-                    leaf = leaf->branches[SelectBit(i, j)];
+                    leaf = leaf->branches[SelectBit(i, target - (j + 1U))];
                 }
 
                 if (IS_NORM_0(leaf->scale)) {
+                    i |= pow2Ocl(target - j) - ONE_BCI;
                     continue;
                 }
 


### PR DESCRIPTION
Rather than relying on `find()` in a set, if we reverse endianness, we can just advance the loop by skipping all permutations less than the current value, if we reach an `IS_NORM_0()` leaf.