### PR TITLE
QBDT vs. state vector threshold

### DIFF
--- a/include/qbinary_decision_tree.hpp
+++ b/include/qbinary_decision_tree.hpp
@@ -37,7 +37,7 @@ protected:
 #if ENABLE_QUNIT_CPU_PARALLEL
     DispatchQueue dispatchQueue;
 #endif
-    bitLenInt pStridePow;
+    bitLenInt bdtThreshold;
     bitCapIntOcl maxQPowerOcl;
     bool isFusionFlush;
     std::vector<MpsShardPtr> shards;
@@ -250,6 +250,14 @@ public:
 
     virtual void Dispose(bitLenInt start, bitLenInt length, bitCapInt disposedPerm)
     {
+        if (stateVecUnit && ((qubitCount - length) <= bdtThreshold)) {
+            stateVecUnit->Dispose(start, length, disposedPerm);
+            shards.erase(shards.begin() + start, shards.begin() + start + length);
+            SetQubitCount(qubitCount - length);
+
+            return;
+        }
+
         DecomposeDispose(start, length, NULL);
     }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1499,7 +1499,7 @@ bool QUnit::SeparateBit(bool value, bitLenInt qubit)
     }
 
     unit->Dispose(mapped, 1, value ? ONE_BCI : 0);
-    if (((ONE_R1 / 2) - abs((ONE_R1 / 2) - prob)) > FP_NORM_EPSILON) {
+    if (!unit->isBinaryDecisionTree() && (((ONE_R1 / 2) - abs((ONE_R1 / 2) - prob)) > FP_NORM_EPSILON)) {
         unit->UpdateRunningNorm();
         if (!doNormalize) {
             unit->NormalizeState();


### PR DESCRIPTION
For use under `QUnit`, (or in general,) `QBinaryDecisionTree` now has a switch-over threshold from state vector as a more efficient alternative for narrower widths. To recover the original behavior, set the environment variable `QRACK_BDT_THRESHOLD` to `0`. By default, binary decision tree methods will engage in `QBinaryDecisionTree` instances that are 31 qubits or greater in wifth, (equivalent to a `QRACK_BDT_THRESHOLD` of 30).