### PR TITLE
`int64_t` GetDeviceID()

### DIFF
--- a/include/qengine_opencl.hpp
+++ b/include/qengine_opencl.hpp
@@ -414,7 +414,7 @@ public:
     virtual void PhaseFlipIfLess(bitCapInt greaterPerm, bitLenInt start, bitLenInt length);
 
     virtual void SetDevice(const int& dID, const bool& forceReInit = false);
-    virtual int GetDeviceID() { return deviceID; }
+    virtual int64_t GetDeviceID() { return deviceID; }
 
     virtual void SetQuantumState(const complex* inputState);
     virtual void GetQuantumState(complex* outputState);

--- a/include/qhybrid.hpp
+++ b/include/qhybrid.hpp
@@ -448,7 +448,7 @@ public:
         engine->SetDevice(dID, forceReInit);
     }
 
-    virtual int GetDeviceID() { return devID; }
+    virtual int64_t GetDeviceID() { return devID; }
 
     bitCapIntOcl GetMaxSize() { return engine->GetMaxSize(); };
 

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -2456,7 +2456,7 @@ public:
     /**
      *  Get the device index. ("-1" is default).
      */
-    virtual int GetDeviceID() { return -1; }
+    virtual int64_t GetDeviceID() { return -1; }
 
     /**
      *  Get maximum number of amplitudes that can be allocated on current device.

--- a/include/qmaskfusion.hpp
+++ b/include/qmaskfusion.hpp
@@ -717,7 +717,7 @@ public:
         engine->SetDevice(dID, forceReInit);
     }
 
-    virtual int GetDeviceID() { return devID; }
+    virtual int64_t GetDeviceID() { return devID; }
 
     bitCapIntOcl GetMaxSize() { return engine->GetMaxSize(); };
 

--- a/include/qpager.hpp
+++ b/include/qpager.hpp
@@ -342,7 +342,7 @@ public:
         }
     }
 
-    virtual int GetDeviceID() { return qPages[0]->GetDeviceID(); }
+    virtual int64_t GetDeviceID() { return qPages[0]->GetDeviceID(); }
 
     bitCapIntOcl GetMaxSize() { return qPages[0]->GetMaxSize(); };
 

--- a/include/qstabilizerhybrid.hpp
+++ b/include/qstabilizerhybrid.hpp
@@ -938,7 +938,7 @@ public:
         }
     }
 
-    virtual int GetDeviceID() { return devID; }
+    virtual int64_t GetDeviceID() { return devID; }
 
     bitCapIntOcl GetMaxSize()
     {


### PR DESCRIPTION
This converts the return type of `OCLEngine::GetDeviceID()` from `int` to `int64_t`.