### PR TITLE
Shared library exception handling

### DIFF
--- a/include/pinvoke_api.hpp
+++ b/include/pinvoke_api.hpp
@@ -28,6 +28,7 @@ struct _QrackTimeEvolveOpHeader;
 
 extern "C" {
 // non-quantum
+MICROSOFT_QUANTUM_DECL int get_error(_In_ unsigned sid);
 MICROSOFT_QUANTUM_DECL unsigned init_count_type(_In_ unsigned q, _In_ bool md, _In_ bool sd, _In_ bool sh,
     _In_ bool bdt, _In_ bool pg, _In_ bool zxf, _In_ bool hy, _In_ bool oc);
 MICROSOFT_QUANTUM_DECL unsigned init_count(_In_ unsigned q);

--- a/src/pinvoke_api.cpp
+++ b/src/pinvoke_api.cpp
@@ -363,6 +363,11 @@ void _darray_to_creal1_array(double* params, bitCapIntOcl componentCount, comple
 extern "C" {
 
 /**
+ * (External API) Poll after each operation to check whether error occurred.
+ */
+MICROSOFT_QUANTUM_DECL int get_error(_In_ unsigned sid) { return simulatorErrors[sid]; }
+
+/**
  * (External API) Initialize a simulator ID with "q" qubits and explicit layer options on/off
  */
 MICROSOFT_QUANTUM_DECL unsigned init_count_type(_In_ unsigned q, _In_ bool md, _In_ bool sd, _In_ bool sh,

--- a/src/pinvoke_api.cpp
+++ b/src/pinvoke_api.cpp
@@ -683,7 +683,7 @@ MICROSOFT_QUANTUM_DECL double JointEnsembleProbability(
     QInterfacePtr simulator = simulators[sid];
 
     double jointProb = (double)REAL1_DEFAULT_ARG;
-    
+
     try {
         TransformPauliBasis(simulator, n, b, q);
 
@@ -707,7 +707,11 @@ MICROSOFT_QUANTUM_DECL void PhaseParity(
         mask |= pow2(shards[simulator.get()][q[i]]);
     }
 
-    simulator->PhaseParity((real1_f)lambda, mask);
+    try {
+        simulator->PhaseParity((real1_f)lambda, mask);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
 }
 
 /**
@@ -717,7 +721,11 @@ MICROSOFT_QUANTUM_DECL void ResetAll(_In_ unsigned sid)
 {
     SIMULATOR_LOCK_GUARD(sid)
 
-    simulators[sid]->SetPermutation(0);
+    try {
+        simulators[sid]->SetPermutation(0);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
 }
 
 /**
@@ -737,8 +745,14 @@ MICROSOFT_QUANTUM_DECL void allocateQubit(_In_ unsigned sid, _In_ unsigned qid)
         return;
     }
 
-    simulators[sid]->Compose(nQubit);
-    bitLenInt qubitCount = simulators[sid]->GetQubitCount();
+    bitLenInt qubitCount = -1;
+    try {
+        simulators[sid]->Compose(nQubit);
+        qubitCount = simulators[sid]->GetQubitCount();
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
+
     shards[simulators[sid].get()][qid] = (qubitCount - 1U);
 }
 
@@ -775,7 +789,11 @@ MICROSOFT_QUANTUM_DECL unsigned num_qubits(_In_ unsigned sid)
 {
     SIMULATOR_LOCK_GUARD_INT(sid)
 
-    return (unsigned)simulators[sid]->GetQubitCount();
+    try {
+        return (unsigned)simulators[sid]->GetQubitCount();
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
 }
 
 /**
@@ -786,7 +804,11 @@ MICROSOFT_QUANTUM_DECL void X(_In_ unsigned sid, _In_ unsigned q)
     SIMULATOR_LOCK_GUARD(sid)
 
     QInterfacePtr simulator = simulators[sid];
-    simulator->X(shards[simulator.get()][q]);
+    try {
+        simulator->X(shards[simulator.get()][q]);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
 }
 
 /**
@@ -797,7 +819,11 @@ MICROSOFT_QUANTUM_DECL void Y(_In_ unsigned sid, _In_ unsigned q)
     SIMULATOR_LOCK_GUARD(sid)
 
     QInterfacePtr simulator = simulators[sid];
-    simulator->Y(shards[simulator.get()][q]);
+    try {
+        simulator->Y(shards[simulator.get()][q]);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
 }
 
 /**
@@ -808,7 +834,11 @@ MICROSOFT_QUANTUM_DECL void Z(_In_ unsigned sid, _In_ unsigned q)
     SIMULATOR_LOCK_GUARD(sid)
 
     QInterfacePtr simulator = simulators[sid];
-    simulator->Z(shards[simulator.get()][q]);
+    try {
+        simulator->Z(shards[simulator.get()][q]);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
 }
 
 /**
@@ -819,7 +849,11 @@ MICROSOFT_QUANTUM_DECL void H(_In_ unsigned sid, _In_ unsigned q)
     SIMULATOR_LOCK_GUARD(sid)
 
     QInterfacePtr simulator = simulators[sid];
-    simulator->H(shards[simulator.get()][q]);
+    try {
+        simulator->H(shards[simulator.get()][q]);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
 }
 
 /**
@@ -830,7 +864,11 @@ MICROSOFT_QUANTUM_DECL void S(_In_ unsigned sid, _In_ unsigned q)
     SIMULATOR_LOCK_GUARD(sid)
 
     QInterfacePtr simulator = simulators[sid];
-    simulator->S(shards[simulator.get()][q]);
+    try {
+        simulator->S(shards[simulator.get()][q]);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
 }
 
 /**
@@ -841,7 +879,11 @@ MICROSOFT_QUANTUM_DECL void T(_In_ unsigned sid, _In_ unsigned q)
     SIMULATOR_LOCK_GUARD(sid)
 
     QInterfacePtr simulator = simulators[sid];
-    simulator->T(shards[simulator.get()][q]);
+    try {
+        simulator->T(shards[simulator.get()][q]);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
 }
 
 /**
@@ -852,7 +894,11 @@ MICROSOFT_QUANTUM_DECL void AdjS(_In_ unsigned sid, _In_ unsigned q)
     SIMULATOR_LOCK_GUARD(sid)
 
     QInterfacePtr simulator = simulators[sid];
-    simulator->IS(shards[simulator.get()][q]);
+    try {
+        simulator->IS(shards[simulator.get()][q]);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
 }
 
 /**
@@ -863,7 +909,11 @@ MICROSOFT_QUANTUM_DECL void AdjT(_In_ unsigned sid, _In_ unsigned q)
     SIMULATOR_LOCK_GUARD(sid)
 
     QInterfacePtr simulator = simulators[sid];
-    simulator->IT(shards[simulator.get()][q]);
+    try {
+        simulator->IT(shards[simulator.get()][q]);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
 }
 
 /**
@@ -875,7 +925,11 @@ MICROSOFT_QUANTUM_DECL void U(
     SIMULATOR_LOCK_GUARD(sid)
 
     QInterfacePtr simulator = simulators[sid];
-    simulator->U(shards[simulator.get()][q], (real1_f)theta, (real1_f)phi, (real1_f)lambda);
+    try {
+        simulator->U(shards[simulator.get()][q], (real1_f)theta, (real1_f)phi, (real1_f)lambda);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
 }
 
 /**
@@ -889,7 +943,11 @@ MICROSOFT_QUANTUM_DECL void Mtrx(_In_ unsigned sid, _In_reads_(8) double* m, _In
         complex((real1)m[4], (real1)m[5]), complex((real1)m[6], (real1)m[7]) };
 
     QInterfacePtr simulator = simulators[sid];
-    simulator->Mtrx(mtrx, shards[simulator.get()][q]);
+    try {
+        simulator->Mtrx(mtrx, shards[simulator.get()][q]);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
 }
 
 #define MAP_CONTROLS_AND_LOCK(sid, numC)                                                                               \
@@ -906,7 +964,11 @@ MICROSOFT_QUANTUM_DECL void Mtrx(_In_ unsigned sid, _In_reads_(8) double* m, _In
 MICROSOFT_QUANTUM_DECL void MCX(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c, _In_ unsigned q)
 {
     MAP_CONTROLS_AND_LOCK(sid, n)
-    simulator->MCInvert(ctrlsArray.get(), n, ONE_CMPLX, ONE_CMPLX, shards[simulator.get()][q]);
+    try {
+        simulator->MCInvert(ctrlsArray.get(), n, ONE_CMPLX, ONE_CMPLX, shards[simulator.get()][q]);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
 }
 
 /**
@@ -915,7 +977,11 @@ MICROSOFT_QUANTUM_DECL void MCX(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n
 MICROSOFT_QUANTUM_DECL void MCY(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c, _In_ unsigned q)
 {
     MAP_CONTROLS_AND_LOCK(sid, n)
-    simulator->MCInvert(ctrlsArray.get(), n, -I_CMPLX, I_CMPLX, shards[simulator.get()][q]);
+    try {
+        simulator->MCInvert(ctrlsArray.get(), n, -I_CMPLX, I_CMPLX, shards[simulator.get()][q]);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
 }
 
 /**
@@ -924,7 +990,11 @@ MICROSOFT_QUANTUM_DECL void MCY(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n
 MICROSOFT_QUANTUM_DECL void MCZ(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c, _In_ unsigned q)
 {
     MAP_CONTROLS_AND_LOCK(sid, n)
-    simulator->MCPhase(ctrlsArray.get(), n, ONE_CMPLX, -ONE_CMPLX, shards[simulator.get()][q]);
+    try {
+        simulator->MCPhase(ctrlsArray.get(), n, ONE_CMPLX, -ONE_CMPLX, shards[simulator.get()][q]);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
 }
 
 /**
@@ -936,7 +1006,11 @@ MICROSOFT_QUANTUM_DECL void MCH(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n
         complex(-SQRT1_2_R1, ZERO_R1) };
 
     MAP_CONTROLS_AND_LOCK(sid, n)
-    simulator->MCMtrx(ctrlsArray.get(), n, hGate, shards[simulator.get()][q]);
+    try {
+        simulator->MCMtrx(ctrlsArray.get(), n, hGate, shards[simulator.get()][q]);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
 }
 
 /**
@@ -945,7 +1019,11 @@ MICROSOFT_QUANTUM_DECL void MCH(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n
 MICROSOFT_QUANTUM_DECL void MCS(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c, _In_ unsigned q)
 {
     MAP_CONTROLS_AND_LOCK(sid, n)
-    simulator->MCPhase(ctrlsArray.get(), n, ONE_CMPLX, I_CMPLX, shards[simulator.get()][q]);
+    try {
+        simulator->MCPhase(ctrlsArray.get(), n, ONE_CMPLX, I_CMPLX, shards[simulator.get()][q]);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
 }
 
 /**
@@ -954,7 +1032,11 @@ MICROSOFT_QUANTUM_DECL void MCS(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n
 MICROSOFT_QUANTUM_DECL void MCT(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c, _In_ unsigned q)
 {
     MAP_CONTROLS_AND_LOCK(sid, n)
-    simulator->MCPhase(ctrlsArray.get(), n, ONE_CMPLX, complex(SQRT1_2_R1, SQRT1_2_R1), shards[simulator.get()][q]);
+    try {
+        simulator->MCPhase(ctrlsArray.get(), n, ONE_CMPLX, complex(SQRT1_2_R1, SQRT1_2_R1), shards[simulator.get()][q]);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
 }
 
 /**
@@ -963,7 +1045,11 @@ MICROSOFT_QUANTUM_DECL void MCT(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n
 MICROSOFT_QUANTUM_DECL void MCAdjS(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c, _In_ unsigned q)
 {
     MAP_CONTROLS_AND_LOCK(sid, n)
-    simulator->MCPhase(ctrlsArray.get(), n, ONE_CMPLX, -I_CMPLX, shards[simulator.get()][q]);
+    try {
+        simulator->MCPhase(ctrlsArray.get(), n, ONE_CMPLX, -I_CMPLX, shards[simulator.get()][q]);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
 }
 
 /**
@@ -972,7 +1058,12 @@ MICROSOFT_QUANTUM_DECL void MCAdjS(_In_ unsigned sid, _In_ unsigned n, _In_reads
 MICROSOFT_QUANTUM_DECL void MCAdjT(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c, _In_ unsigned q)
 {
     MAP_CONTROLS_AND_LOCK(sid, n)
-    simulator->MCPhase(ctrlsArray.get(), n, ONE_CMPLX, complex(SQRT1_2_R1, -SQRT1_2_R1), shards[simulator.get()][q]);
+    try {
+        simulator->MCPhase(
+            ctrlsArray.get(), n, ONE_CMPLX, complex(SQRT1_2_R1, -SQRT1_2_R1), shards[simulator.get()][q]);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
 }
 
 /**
@@ -982,7 +1073,11 @@ MICROSOFT_QUANTUM_DECL void MCU(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n
     _In_ double theta, _In_ double phi, _In_ double lambda)
 {
     MAP_CONTROLS_AND_LOCK(sid, n)
-    simulator->CU(ctrlsArray.get(), n, shards[simulator.get()][q], (real1_f)theta, (real1_f)phi, (real1_f)lambda);
+    try {
+        simulator->CU(ctrlsArray.get(), n, shards[simulator.get()][q], (real1_f)theta, (real1_f)phi, (real1_f)lambda);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
 }
 
 /**
@@ -995,7 +1090,11 @@ MICROSOFT_QUANTUM_DECL void MCMtrx(
         complex((real1)m[4], (real1)m[5]), complex((real1)m[6], (real1)m[7]) };
 
     MAP_CONTROLS_AND_LOCK(sid, n)
-    simulator->MCMtrx(ctrlsArray.get(), n, mtrx, shards[simulator.get()][q]);
+    try {
+        simulator->MCMtrx(ctrlsArray.get(), n, mtrx, shards[simulator.get()][q]);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
 }
 
 /**
@@ -1004,7 +1103,11 @@ MICROSOFT_QUANTUM_DECL void MCMtrx(
 MICROSOFT_QUANTUM_DECL void MACX(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c, _In_ unsigned q)
 {
     MAP_CONTROLS_AND_LOCK(sid, n)
-    simulator->MACInvert(ctrlsArray.get(), n, ONE_CMPLX, ONE_CMPLX, shards[simulator.get()][q]);
+    try {
+        simulator->MACInvert(ctrlsArray.get(), n, ONE_CMPLX, ONE_CMPLX, shards[simulator.get()][q]);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
 }
 
 /**
@@ -1013,7 +1116,11 @@ MICROSOFT_QUANTUM_DECL void MACX(_In_ unsigned sid, _In_ unsigned n, _In_reads_(
 MICROSOFT_QUANTUM_DECL void MACY(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c, _In_ unsigned q)
 {
     MAP_CONTROLS_AND_LOCK(sid, n)
-    simulator->MACInvert(ctrlsArray.get(), n, -I_CMPLX, I_CMPLX, shards[simulator.get()][q]);
+    try {
+        simulator->MACInvert(ctrlsArray.get(), n, -I_CMPLX, I_CMPLX, shards[simulator.get()][q]);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
 }
 
 /**
@@ -1022,7 +1129,11 @@ MICROSOFT_QUANTUM_DECL void MACY(_In_ unsigned sid, _In_ unsigned n, _In_reads_(
 MICROSOFT_QUANTUM_DECL void MACZ(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c, _In_ unsigned q)
 {
     MAP_CONTROLS_AND_LOCK(sid, n)
-    simulator->MACPhase(ctrlsArray.get(), n, ONE_CMPLX, -ONE_CMPLX, shards[simulator.get()][q]);
+    try {
+        simulator->MACPhase(ctrlsArray.get(), n, ONE_CMPLX, -ONE_CMPLX, shards[simulator.get()][q]);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
 }
 
 /**
@@ -1034,7 +1145,11 @@ MICROSOFT_QUANTUM_DECL void MACH(_In_ unsigned sid, _In_ unsigned n, _In_reads_(
         complex(-SQRT1_2_R1, ZERO_R1) };
 
     MAP_CONTROLS_AND_LOCK(sid, n)
-    simulator->MACMtrx(ctrlsArray.get(), n, hGate, shards[simulator.get()][q]);
+    try {
+        simulator->MACMtrx(ctrlsArray.get(), n, hGate, shards[simulator.get()][q]);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
 }
 
 /**
@@ -1043,7 +1158,11 @@ MICROSOFT_QUANTUM_DECL void MACH(_In_ unsigned sid, _In_ unsigned n, _In_reads_(
 MICROSOFT_QUANTUM_DECL void MACS(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c, _In_ unsigned q)
 {
     MAP_CONTROLS_AND_LOCK(sid, n)
-    simulator->MACPhase(ctrlsArray.get(), n, ONE_CMPLX, I_CMPLX, shards[simulator.get()][q]);
+    try {
+        simulator->MACPhase(ctrlsArray.get(), n, ONE_CMPLX, I_CMPLX, shards[simulator.get()][q]);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
 }
 
 /**
@@ -1052,7 +1171,12 @@ MICROSOFT_QUANTUM_DECL void MACS(_In_ unsigned sid, _In_ unsigned n, _In_reads_(
 MICROSOFT_QUANTUM_DECL void MACT(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c, _In_ unsigned q)
 {
     MAP_CONTROLS_AND_LOCK(sid, n)
-    simulator->MACPhase(ctrlsArray.get(), n, ONE_CMPLX, complex(SQRT1_2_R1, SQRT1_2_R1), shards[simulator.get()][q]);
+    try {
+        simulator->MACPhase(
+            ctrlsArray.get(), n, ONE_CMPLX, complex(SQRT1_2_R1, SQRT1_2_R1), shards[simulator.get()][q]);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
 }
 
 /**
@@ -1061,7 +1185,11 @@ MICROSOFT_QUANTUM_DECL void MACT(_In_ unsigned sid, _In_ unsigned n, _In_reads_(
 MICROSOFT_QUANTUM_DECL void MACAdjS(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c, _In_ unsigned q)
 {
     MAP_CONTROLS_AND_LOCK(sid, n)
-    simulator->MACPhase(ctrlsArray.get(), n, ONE_CMPLX, -I_CMPLX, shards[simulator.get()][q]);
+    try {
+        simulator->MACPhase(ctrlsArray.get(), n, ONE_CMPLX, -I_CMPLX, shards[simulator.get()][q]);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
 }
 
 /**
@@ -1070,7 +1198,12 @@ MICROSOFT_QUANTUM_DECL void MACAdjS(_In_ unsigned sid, _In_ unsigned n, _In_read
 MICROSOFT_QUANTUM_DECL void MACAdjT(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c, _In_ unsigned q)
 {
     MAP_CONTROLS_AND_LOCK(sid, n)
-    simulator->MACPhase(ctrlsArray.get(), n, ONE_CMPLX, complex(SQRT1_2_R1, -SQRT1_2_R1), shards[simulator.get()][q]);
+    try {
+        simulator->MACPhase(
+            ctrlsArray.get(), n, ONE_CMPLX, complex(SQRT1_2_R1, -SQRT1_2_R1), shards[simulator.get()][q]);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
 }
 
 /**
@@ -1080,7 +1213,12 @@ MICROSOFT_QUANTUM_DECL void MACU(_In_ unsigned sid, _In_ unsigned n, _In_reads_(
     _In_ double theta, _In_ double phi, _In_ double lambda)
 {
     MAP_CONTROLS_AND_LOCK(sid, n)
-    simulator->AntiCU(ctrlsArray.get(), n, shards[simulator.get()][q], (real1_f)theta, (real1_f)phi, (real1_f)lambda);
+    try {
+        simulator->AntiCU(
+            ctrlsArray.get(), n, shards[simulator.get()][q], (real1_f)theta, (real1_f)phi, (real1_f)lambda);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
 }
 
 /**
@@ -1093,7 +1231,11 @@ MICROSOFT_QUANTUM_DECL void MACMtrx(
         complex((real1)m[4], (real1)m[5]), complex((real1)m[6], (real1)m[7]) };
 
     MAP_CONTROLS_AND_LOCK(sid, n)
-    simulator->MACMtrx(ctrlsArray.get(), n, mtrx, shards[simulator.get()][q]);
+    try {
+        simulator->MACMtrx(ctrlsArray.get(), n, mtrx, shards[simulator.get()][q]);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
 }
 
 MICROSOFT_QUANTUM_DECL void Multiplex1Mtrx(
@@ -1104,7 +1246,11 @@ MICROSOFT_QUANTUM_DECL void Multiplex1Mtrx(
     _darray_to_creal1_array(m, componentCount, mtrxs.get());
 
     MAP_CONTROLS_AND_LOCK(sid, n)
-    simulator->UniformlyControlledSingleBit(ctrlsArray.get(), n, shards[simulator.get()][q], mtrxs.get());
+    try {
+        simulator->UniformlyControlledSingleBit(ctrlsArray.get(), n, shards[simulator.get()][q], mtrxs.get());
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
 }
 
 /**
@@ -1114,7 +1260,11 @@ MICROSOFT_QUANTUM_DECL void R(_In_ unsigned sid, _In_ unsigned b, _In_ double ph
 {
     SIMULATOR_LOCK_GUARD(sid)
 
-    RHelper(sid, b, phi, q);
+    try {
+        RHelper(sid, b, phi, q);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
 }
 
 /**
@@ -1125,7 +1275,11 @@ MICROSOFT_QUANTUM_DECL void MCR(
 {
     SIMULATOR_LOCK_GUARD(sid)
 
-    MCRHelper(sid, b, phi, n, c, q);
+    try {
+        MCRHelper(sid, b, phi, n, c, q);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
 }
 
 /**
@@ -1147,19 +1301,23 @@ MICROSOFT_QUANTUM_DECL void Exp(
 
     removeIdentities(&bVec, &qVec);
 
-    if (bVec.size() == 0) {
-        RHelper(sid, PauliI, -2. * phi, someQubit);
-    } else if (bVec.size() == 1) {
-        RHelper(sid, bVec.front(), -2. * phi, qVec.front());
-    } else {
-        QInterfacePtr simulator = simulators[sid];
+    try {
+        if (bVec.size() == 0) {
+            RHelper(sid, PauliI, -2. * phi, someQubit);
+        } else if (bVec.size() == 1) {
+            RHelper(sid, bVec.front(), -2. * phi, qVec.front());
+        } else {
+            QInterfacePtr simulator = simulators[sid];
 
-        TransformPauliBasis(simulator, n, b, q);
+            TransformPauliBasis(simulator, n, b, q);
 
-        std::size_t mask = make_mask(qVec);
-        simulator->UniformParityRZ((bitCapInt)mask, (real1_f)(-phi));
+            std::size_t mask = make_mask(qVec);
+            simulator->UniformParityRZ((bitCapInt)mask, (real1_f)(-phi));
 
-        RevertPauliBasis(simulator, n, b, q);
+            RevertPauliBasis(simulator, n, b, q);
+        }
+    } catch (...) {
+        simulatorErrors[sid] = 1;
     }
 }
 
@@ -1182,20 +1340,24 @@ MICROSOFT_QUANTUM_DECL void MCExp(_In_ unsigned sid, _In_ unsigned n, _In_reads_
 
     removeIdentities(&bVec, &qVec);
 
-    if (bVec.size() == 0) {
-        MCRHelper(sid, PauliI, -2. * phi, nc, cs, someQubit);
-    } else if (bVec.size() == 1) {
-        MCRHelper(sid, bVec.front(), -2. * phi, nc, cs, qVec.front());
-    } else {
-        QInterfacePtr simulator = simulators[sid];
-        std::vector<bitLenInt> csVec(cs, cs + nc);
+    try {
+        if (bVec.size() == 0) {
+            MCRHelper(sid, PauliI, -2. * phi, nc, cs, someQubit);
+        } else if (bVec.size() == 1) {
+            MCRHelper(sid, bVec.front(), -2. * phi, nc, cs, qVec.front());
+        } else {
+            QInterfacePtr simulator = simulators[sid];
+            std::vector<bitLenInt> csVec(cs, cs + nc);
 
-        TransformPauliBasis(simulator, n, b, q);
+            TransformPauliBasis(simulator, n, b, q);
 
-        std::size_t mask = make_mask(qVec);
-        simulator->CUniformParityRZ(&(csVec[0]), csVec.size(), (bitCapInt)mask, (real1_f)(-phi));
+            std::size_t mask = make_mask(qVec);
+            simulator->CUniformParityRZ(&(csVec[0]), csVec.size(), (bitCapInt)mask, (real1_f)(-phi));
 
-        RevertPauliBasis(simulator, n, b, q);
+            RevertPauliBasis(simulator, n, b, q);
+        }
+    } catch (...) {
+        simulatorErrors[sid] = 1;
     }
 }
 
@@ -1207,7 +1369,12 @@ MICROSOFT_QUANTUM_DECL unsigned M(_In_ unsigned sid, _In_ unsigned q)
     SIMULATOR_LOCK_GUARD_INT(sid)
 
     QInterfacePtr simulator = simulators[sid];
-    return simulator->M(shards[simulator.get()][q]) ? 1U : 0U;
+    try {
+        return simulator->M(shards[simulator.get()][q]) ? 1U : 0U;
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+        return -1;
+    }
 }
 
 /**
@@ -1217,7 +1384,12 @@ MICROSOFT_QUANTUM_DECL unsigned M(_In_ unsigned sid, _In_ unsigned q)
 MICROSOFT_QUANTUM_DECL unsigned MAll(_In_ unsigned sid)
 {
     SIMULATOR_LOCK_GUARD_INT(sid)
-    return (unsigned)simulators[sid]->MAll();
+    try {
+        return (unsigned)simulators[sid]->MAll();
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+        return -1;
+    }
 }
 
 /**
@@ -1233,13 +1405,18 @@ MICROSOFT_QUANTUM_DECL unsigned Measure(
     std::vector<unsigned> bVec;
     std::vector<unsigned> qVec;
 
-    TransformPauliBasis(simulator, n, b, q);
+    unsigned toRet = -1;
+    try {
+        TransformPauliBasis(simulator, n, b, q);
 
-    double jointProb = _JointEnsembleProbabilityHelper(simulator, n, b, q, true);
+        double jointProb = _JointEnsembleProbabilityHelper(simulator, n, b, q, true);
 
-    unsigned toRet = (jointProb < (ONE_R1 / 2)) ? 0U : 1U;
+        toRet = (jointProb < (ONE_R1 / 2)) ? 0U : 1U;
 
-    RevertPauliBasis(simulator, n, b, q);
+        RevertPauliBasis(simulator, n, b, q);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
 
     return toRet;
 }
@@ -1255,7 +1432,11 @@ MICROSOFT_QUANTUM_DECL void MeasureShots(
         qPowers[i] = Qrack::pow2(shards[simulator.get()][q[i]]);
     }
 
-    simulator->MultiShotMeasureMask(qPowers.get(), n, s, m);
+    try {
+        simulator->MultiShotMeasureMask(qPowers.get(), n, s, m);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
 }
 
 MICROSOFT_QUANTUM_DECL void SWAP(_In_ unsigned sid, _In_ unsigned qi1, _In_ unsigned qi2)
@@ -1263,7 +1444,11 @@ MICROSOFT_QUANTUM_DECL void SWAP(_In_ unsigned sid, _In_ unsigned qi1, _In_ unsi
     SIMULATOR_LOCK_GUARD(sid)
 
     QInterfacePtr simulator = simulators[sid];
-    simulator->Swap(shards[simulator.get()][qi1], shards[simulator.get()][qi2]);
+    try {
+        simulator->Swap(shards[simulator.get()][qi1], shards[simulator.get()][qi2]);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
 }
 
 MICROSOFT_QUANTUM_DECL void ISWAP(_In_ unsigned sid, _In_ unsigned qi1, _In_ unsigned qi2)
@@ -1271,7 +1456,11 @@ MICROSOFT_QUANTUM_DECL void ISWAP(_In_ unsigned sid, _In_ unsigned qi1, _In_ uns
     SIMULATOR_LOCK_GUARD(sid)
 
     QInterfacePtr simulator = simulators[sid];
-    simulator->ISwap(shards[simulator.get()][qi1], shards[simulator.get()][qi2]);
+    try {
+        simulator->ISwap(shards[simulator.get()][qi1], shards[simulator.get()][qi2]);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
 }
 
 MICROSOFT_QUANTUM_DECL void FSim(
@@ -1280,21 +1469,33 @@ MICROSOFT_QUANTUM_DECL void FSim(
     SIMULATOR_LOCK_GUARD(sid)
 
     QInterfacePtr simulator = simulators[sid];
-    simulator->FSim((real1_f)theta, (real1_f)phi, shards[simulator.get()][qi1], shards[simulator.get()][qi2]);
+    try {
+        simulator->FSim((real1_f)theta, (real1_f)phi, shards[simulator.get()][qi1], shards[simulator.get()][qi2]);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
 }
 
 MICROSOFT_QUANTUM_DECL void CSWAP(
     _In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c, _In_ unsigned qi1, _In_ unsigned qi2)
 {
     MAP_CONTROLS_AND_LOCK(sid, n)
-    simulator->CSwap(ctrlsArray.get(), n, shards[simulator.get()][qi1], shards[simulator.get()][qi2]);
+    try {
+        simulator->CSwap(ctrlsArray.get(), n, shards[simulator.get()][qi1], shards[simulator.get()][qi2]);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
 }
 
 MICROSOFT_QUANTUM_DECL void ACSWAP(
     _In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c, _In_ unsigned qi1, _In_ unsigned qi2)
 {
     MAP_CONTROLS_AND_LOCK(sid, n)
-    simulator->AntiCSwap(ctrlsArray.get(), n, shards[simulator.get()][qi1], shards[simulator.get()][qi2]);
+    try {
+        simulator->AntiCSwap(ctrlsArray.get(), n, shards[simulator.get()][qi1], shards[simulator.get()][qi2]);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
 }
 
 MICROSOFT_QUANTUM_DECL void Compose(_In_ unsigned sid1, _In_ unsigned sid2, unsigned* q)
@@ -1316,10 +1517,17 @@ MICROSOFT_QUANTUM_DECL void Compose(_In_ unsigned sid1, _In_ unsigned sid2, unsi
     }
 
     QInterfacePtr simulator1 = simulators[sid1];
-    bitLenInt oQubitCount = simulator1->GetQubitCount();
     QInterfacePtr simulator2 = simulators[sid2];
-    bitLenInt pQubitCount = simulator2->GetQubitCount();
-    simulator1->Compose(simulator2);
+    bitLenInt oQubitCount = 0;
+    bitLenInt pQubitCount = 0;
+    try {
+        oQubitCount = simulator1->GetQubitCount();
+        pQubitCount = simulator2->GetQubitCount();
+        simulator1->Compose(simulator2);
+    } catch (...) {
+        simulatorErrors[sid1] = 1;
+        simulatorErrors[sid2] = 1;
+    }
 
     for (bitLenInt i = 0; i < pQubitCount; i++) {
         shards[simulator1.get()][q[i]] = oQubitCount + i;
@@ -1333,13 +1541,20 @@ MICROSOFT_QUANTUM_DECL unsigned Decompose(_In_ unsigned sid, _In_ unsigned n, _I
     SIMULATOR_LOCK_GUARD_INT(sid)
 
     QInterfacePtr simulator = simulators[sid];
-    bitLenInt nQubitIndex = simulator->GetQubitCount() - n;
+    bitLenInt nQubitIndex = 0;
 
-    for (unsigned i = 0; i < n; i++) {
-        simulator->Swap(shards[simulator.get()][q[i]], i + nQubitIndex);
+    try {
+        nQubitIndex = simulator->GetQubitCount() - n;
+
+        for (unsigned i = 0; i < n; i++) {
+            simulator->Swap(shards[simulator.get()][q[i]], i + nQubitIndex);
+        }
+
+        simulator->Decompose(nQubitIndex, simulators[nSid]);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+        simulatorErrors[nSid] = 1;
     }
-
-    simulator->Decompose(nQubitIndex, simulators[nSid]);
 
     bitLenInt oIndex;
     for (unsigned j = 0; j < n; j++) {
@@ -1362,13 +1577,19 @@ MICROSOFT_QUANTUM_DECL void Dispose(_In_ unsigned sid, _In_ unsigned n, _In_read
     SIMULATOR_LOCK_GUARD(sid)
 
     QInterfacePtr simulator = simulators[sid];
-    bitLenInt nQubitIndex = simulator->GetQubitCount() - n;
+    bitLenInt nQubitIndex = 0;
 
-    for (unsigned i = 0; i < n; i++) {
-        simulator->Swap(shards[simulator.get()][q[i]], i + nQubitIndex);
+    try {
+        nQubitIndex = simulator->GetQubitCount() - n;
+
+        for (unsigned i = 0; i < n; i++) {
+            simulator->Swap(shards[simulator.get()][q[i]], i + nQubitIndex);
+        }
+
+        simulator->Dispose(nQubitIndex, n);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
     }
-
-    simulator->Dispose(nQubitIndex, n);
 
     bitLenInt oIndex;
     for (unsigned j = 0; j < n; j++) {
@@ -1387,7 +1608,11 @@ MICROSOFT_QUANTUM_DECL void AND(_In_ unsigned sid, _In_ unsigned qi1, _In_ unsig
     SIMULATOR_LOCK_GUARD(sid)
 
     QInterfacePtr simulator = simulators[sid];
-    simulator->AND(shards[simulator.get()][qi1], shards[simulator.get()][qi2], shards[simulator.get()][qo]);
+    try {
+        simulator->AND(shards[simulator.get()][qi1], shards[simulator.get()][qi2], shards[simulator.get()][qo]);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
 }
 
 MICROSOFT_QUANTUM_DECL void OR(_In_ unsigned sid, _In_ unsigned qi1, _In_ unsigned qi2, _In_ unsigned qo)
@@ -1395,7 +1620,11 @@ MICROSOFT_QUANTUM_DECL void OR(_In_ unsigned sid, _In_ unsigned qi1, _In_ unsign
     SIMULATOR_LOCK_GUARD(sid)
 
     QInterfacePtr simulator = simulators[sid];
-    simulator->OR(shards[simulator.get()][qi1], shards[simulator.get()][qi2], shards[simulator.get()][qo]);
+    try {
+        simulator->OR(shards[simulator.get()][qi1], shards[simulator.get()][qi2], shards[simulator.get()][qo]);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
 }
 
 MICROSOFT_QUANTUM_DECL void XOR(_In_ unsigned sid, _In_ unsigned qi1, _In_ unsigned qi2, _In_ unsigned qo)
@@ -1403,7 +1632,11 @@ MICROSOFT_QUANTUM_DECL void XOR(_In_ unsigned sid, _In_ unsigned qi1, _In_ unsig
     SIMULATOR_LOCK_GUARD(sid)
 
     QInterfacePtr simulator = simulators[sid];
-    simulator->XOR(shards[simulator.get()][qi1], shards[simulator.get()][qi2], shards[simulator.get()][qo]);
+    try {
+        simulator->XOR(shards[simulator.get()][qi1], shards[simulator.get()][qi2], shards[simulator.get()][qo]);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
 }
 
 MICROSOFT_QUANTUM_DECL void NAND(_In_ unsigned sid, _In_ unsigned qi1, _In_ unsigned qi2, _In_ unsigned qo)
@@ -1411,7 +1644,11 @@ MICROSOFT_QUANTUM_DECL void NAND(_In_ unsigned sid, _In_ unsigned qi1, _In_ unsi
     SIMULATOR_LOCK_GUARD(sid)
 
     QInterfacePtr simulator = simulators[sid];
-    simulator->NAND(shards[simulator.get()][qi1], shards[simulator.get()][qi2], shards[simulator.get()][qo]);
+    try {
+        simulator->NAND(shards[simulator.get()][qi1], shards[simulator.get()][qi2], shards[simulator.get()][qo]);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
 }
 
 MICROSOFT_QUANTUM_DECL void NOR(_In_ unsigned sid, _In_ unsigned qi1, _In_ unsigned qi2, _In_ unsigned qo)
@@ -1419,7 +1656,11 @@ MICROSOFT_QUANTUM_DECL void NOR(_In_ unsigned sid, _In_ unsigned qi1, _In_ unsig
     SIMULATOR_LOCK_GUARD(sid)
 
     QInterfacePtr simulator = simulators[sid];
-    simulator->NOR(shards[simulator.get()][qi1], shards[simulator.get()][qi2], shards[simulator.get()][qo]);
+    try {
+        simulator->NOR(shards[simulator.get()][qi1], shards[simulator.get()][qi2], shards[simulator.get()][qo]);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
 }
 
 MICROSOFT_QUANTUM_DECL void XNOR(_In_ unsigned sid, _In_ unsigned qi1, _In_ unsigned qi2, _In_ unsigned qo)
@@ -1427,7 +1668,11 @@ MICROSOFT_QUANTUM_DECL void XNOR(_In_ unsigned sid, _In_ unsigned qi1, _In_ unsi
     SIMULATOR_LOCK_GUARD(sid)
 
     QInterfacePtr simulator = simulators[sid];
-    simulator->XNOR(shards[simulator.get()][qi1], shards[simulator.get()][qi2], shards[simulator.get()][qo]);
+    try {
+        simulator->XNOR(shards[simulator.get()][qi1], shards[simulator.get()][qi2], shards[simulator.get()][qo]);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
 }
 
 MICROSOFT_QUANTUM_DECL void CLAND(_In_ unsigned sid, _In_ bool ci, _In_ unsigned qi, _In_ unsigned qo)
@@ -1435,7 +1680,11 @@ MICROSOFT_QUANTUM_DECL void CLAND(_In_ unsigned sid, _In_ bool ci, _In_ unsigned
     SIMULATOR_LOCK_GUARD(sid)
 
     QInterfacePtr simulator = simulators[sid];
-    simulator->CLAND(ci, shards[simulator.get()][qi], shards[simulator.get()][qo]);
+    try {
+        simulator->CLAND(ci, shards[simulator.get()][qi], shards[simulator.get()][qo]);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
 }
 
 MICROSOFT_QUANTUM_DECL void CLOR(_In_ unsigned sid, _In_ bool ci, _In_ unsigned qi, _In_ unsigned qo)
@@ -1443,7 +1692,11 @@ MICROSOFT_QUANTUM_DECL void CLOR(_In_ unsigned sid, _In_ bool ci, _In_ unsigned 
     SIMULATOR_LOCK_GUARD(sid)
 
     QInterfacePtr simulator = simulators[sid];
-    simulator->CLOR(ci, shards[simulator.get()][qi], shards[simulator.get()][qo]);
+    try {
+        simulator->CLOR(ci, shards[simulator.get()][qi], shards[simulator.get()][qo]);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
 }
 
 MICROSOFT_QUANTUM_DECL void CLXOR(_In_ unsigned sid, _In_ bool ci, _In_ unsigned qi, _In_ unsigned qo)
@@ -1451,7 +1704,11 @@ MICROSOFT_QUANTUM_DECL void CLXOR(_In_ unsigned sid, _In_ bool ci, _In_ unsigned
     SIMULATOR_LOCK_GUARD(sid)
 
     QInterfacePtr simulator = simulators[sid];
-    simulator->CLXOR(ci, shards[simulator.get()][qi], shards[simulator.get()][qo]);
+    try {
+        simulator->CLXOR(ci, shards[simulator.get()][qi], shards[simulator.get()][qo]);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
 }
 
 MICROSOFT_QUANTUM_DECL void CLNAND(_In_ unsigned sid, _In_ bool ci, _In_ unsigned qi, _In_ unsigned qo)
@@ -1459,7 +1716,11 @@ MICROSOFT_QUANTUM_DECL void CLNAND(_In_ unsigned sid, _In_ bool ci, _In_ unsigne
     SIMULATOR_LOCK_GUARD(sid)
 
     QInterfacePtr simulator = simulators[sid];
-    simulator->CLNAND(ci, shards[simulator.get()][qi], shards[simulator.get()][qo]);
+    try {
+        simulator->CLNAND(ci, shards[simulator.get()][qi], shards[simulator.get()][qo]);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
 }
 
 MICROSOFT_QUANTUM_DECL void CLNOR(_In_ unsigned sid, _In_ bool ci, _In_ unsigned qi, _In_ unsigned qo)
@@ -1467,7 +1728,11 @@ MICROSOFT_QUANTUM_DECL void CLNOR(_In_ unsigned sid, _In_ bool ci, _In_ unsigned
     SIMULATOR_LOCK_GUARD(sid)
 
     QInterfacePtr simulator = simulators[sid];
-    simulator->CLNOR(ci, shards[simulator.get()][qi], shards[simulator.get()][qo]);
+    try {
+        simulator->CLNOR(ci, shards[simulator.get()][qi], shards[simulator.get()][qo]);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
 }
 
 MICROSOFT_QUANTUM_DECL void CLXNOR(_In_ unsigned sid, _In_ bool ci, _In_ unsigned qi, _In_ unsigned qo)
@@ -1475,7 +1740,11 @@ MICROSOFT_QUANTUM_DECL void CLXNOR(_In_ unsigned sid, _In_ bool ci, _In_ unsigne
     SIMULATOR_LOCK_GUARD(sid)
 
     QInterfacePtr simulator = simulators[sid];
-    simulator->CLXNOR(ci, shards[simulator.get()][qi], shards[simulator.get()][qo]);
+    try {
+        simulator->CLXNOR(ci, shards[simulator.get()][qi], shards[simulator.get()][qo]);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
 }
 
 /**
@@ -1485,8 +1754,13 @@ MICROSOFT_QUANTUM_DECL double Prob(_In_ unsigned sid, _In_ unsigned q)
 {
     SIMULATOR_LOCK_GUARD_DOUBLE(sid)
 
-    QInterfacePtr simulator = simulators[sid];
-    return simulator->Prob(shards[simulator.get()][q]);
+    try {
+        QInterfacePtr simulator = simulators[sid];
+        return simulator->Prob(shards[simulator.get()][q]);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+        return (double)REAL1_DEFAULT_ARG;
+    }
 }
 
 /**
@@ -1499,10 +1773,14 @@ MICROSOFT_QUANTUM_DECL double PermutationExpectation(_In_ unsigned sid, _In_ uns
     std::unique_ptr<bitLenInt[]> q(new bitLenInt[n]);
     std::copy(c, c + n, q.get());
 
-    QInterfacePtr simulator = simulators[sid];
-    double result = simulator->ExpectationBitsAll(q.get(), n);
-
-    return result;
+    try {
+        QInterfacePtr simulator = simulators[sid];
+        double result = simulator->ExpectationBitsAll(q.get(), n);
+        return result;
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+        return (double)REAL1_DEFAULT_ARG;
+    }
 }
 
 MICROSOFT_QUANTUM_DECL void QFT(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c)
@@ -1510,26 +1788,34 @@ MICROSOFT_QUANTUM_DECL void QFT(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n
     SIMULATOR_LOCK_GUARD(sid)
 
     QInterfacePtr simulator = simulators[sid];
+    try {
 #if (QBCAPPOW >= 16) && (QBCAPPOW < 32)
-    simulator->QFTR(c, n);
+        simulator->QFTR(c, n);
 #else
-    std::unique_ptr<bitLenInt[]> q(new bitLenInt[n]);
-    std::copy(c, c + n, q.get());
-    simulator->QFTR(q.get(), n);
+        std::unique_ptr<bitLenInt[]> q(new bitLenInt[n]);
+        std::copy(c, c + n, q.get());
+        simulator->QFTR(q.get(), n);
 #endif
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
 }
 MICROSOFT_QUANTUM_DECL void IQFT(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* c)
 {
     SIMULATOR_LOCK_GUARD(sid)
 
     QInterfacePtr simulator = simulators[sid];
+    try {
 #if (QBCAPPOW >= 16) && (QBCAPPOW < 32)
-    simulator->IQFTR(c, n);
+        simulator->IQFTR(c, n);
 #else
-    std::unique_ptr<bitLenInt[]> q(new bitLenInt[n]);
-    std::copy(c, c + n, q.get());
-    simulator->IQFTR(q.get(), n);
+        std::unique_ptr<bitLenInt[]> q(new bitLenInt[n]);
+        std::copy(c, c + n, q.get());
+        simulator->IQFTR(q.get(), n);
 #endif
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
 }
 
 #if ENABLE_ALU
@@ -1538,32 +1824,48 @@ MICROSOFT_QUANTUM_DECL void ADD(_In_ unsigned sid, unsigned a, _In_ unsigned n, 
     SIMULATOR_LOCK_GUARD(sid)
     QInterfacePtr simulator = simulators[sid];
 
-    unsigned start = MapArithmetic(simulator, n, q);
-    simulator->INC(a, start, n);
+    try {
+        unsigned start = MapArithmetic(simulator, n, q);
+        simulator->INC(a, start, n);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
 }
 MICROSOFT_QUANTUM_DECL void SUB(_In_ unsigned sid, unsigned a, _In_ unsigned n, _In_reads_(n) unsigned* q)
 {
     SIMULATOR_LOCK_GUARD(sid)
     QInterfacePtr simulator = simulators[sid];
 
-    unsigned start = MapArithmetic(simulator, n, q);
-    simulator->DEC(a, start, n);
+    try {
+        unsigned start = MapArithmetic(simulator, n, q);
+        simulator->DEC(a, start, n);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
 }
 MICROSOFT_QUANTUM_DECL void ADDS(_In_ unsigned sid, unsigned a, unsigned s, _In_ unsigned n, _In_reads_(n) unsigned* q)
 {
     SIMULATOR_LOCK_GUARD(sid)
     QInterfacePtr simulator = simulators[sid];
 
-    unsigned start = MapArithmetic(simulator, n, q);
-    simulator->INCS(a, start, n, shards[simulator.get()][s]);
+    try {
+        unsigned start = MapArithmetic(simulator, n, q);
+        simulator->INCS(a, start, n, shards[simulator.get()][s]);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
 }
 MICROSOFT_QUANTUM_DECL void SUBS(_In_ unsigned sid, unsigned a, unsigned s, _In_ unsigned n, _In_reads_(n) unsigned* q)
 {
     SIMULATOR_LOCK_GUARD(sid)
     QInterfacePtr simulator = simulators[sid];
 
-    unsigned start = MapArithmetic(simulator, n, q);
-    simulator->DECS(a, start, n, shards[simulator.get()][s]);
+    try {
+        unsigned start = MapArithmetic(simulator, n, q);
+        simulator->DECS(a, start, n, shards[simulator.get()][s]);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
 }
 MICROSOFT_QUANTUM_DECL void MUL(
     _In_ unsigned sid, unsigned a, _In_ unsigned n, _In_reads_(n) unsigned* q, _In_reads_(n) unsigned* o)
@@ -1571,8 +1873,12 @@ MICROSOFT_QUANTUM_DECL void MUL(
     SIMULATOR_LOCK_GUARD(sid)
     QInterfacePtr simulator = simulators[sid];
 
-    MapArithmeticResult2 starts = MapArithmetic2(simulator, n, q, o);
-    simulator->MUL(a, starts.start1, starts.start2, n);
+    try {
+        MapArithmeticResult2 starts = MapArithmetic2(simulator, n, q, o);
+        simulator->MUL(a, starts.start1, starts.start2, n);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
 }
 MICROSOFT_QUANTUM_DECL void DIV(
     _In_ unsigned sid, unsigned a, _In_ unsigned n, _In_reads_(n) unsigned* q, _In_reads_(n) unsigned* o)
@@ -1580,8 +1886,12 @@ MICROSOFT_QUANTUM_DECL void DIV(
     SIMULATOR_LOCK_GUARD(sid)
     QInterfacePtr simulator = simulators[sid];
 
-    MapArithmeticResult2 starts = MapArithmetic2(simulator, n, q, o);
-    simulator->DIV(a, starts.start1, starts.start2, n);
+    try {
+        MapArithmeticResult2 starts = MapArithmetic2(simulator, n, q, o);
+        simulator->DIV(a, starts.start1, starts.start2, n);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
 }
 MICROSOFT_QUANTUM_DECL void MULN(
     _In_ unsigned sid, unsigned a, unsigned m, _In_ unsigned n, _In_reads_(n) unsigned* q, _In_reads_(n) unsigned* o)
@@ -1589,8 +1899,12 @@ MICROSOFT_QUANTUM_DECL void MULN(
     SIMULATOR_LOCK_GUARD(sid)
     QInterfacePtr simulator = simulators[sid];
 
-    MapArithmeticResult2 starts = MapArithmetic2(simulator, n, q, o);
-    simulator->MULModNOut(a, m, starts.start1, starts.start2, n);
+    try {
+        MapArithmeticResult2 starts = MapArithmetic2(simulator, n, q, o);
+        simulator->MULModNOut(a, m, starts.start1, starts.start2, n);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
 }
 MICROSOFT_QUANTUM_DECL void DIVN(
     _In_ unsigned sid, unsigned a, unsigned m, _In_ unsigned n, _In_reads_(n) unsigned* q, _In_reads_(n) unsigned* o)
@@ -1598,8 +1912,12 @@ MICROSOFT_QUANTUM_DECL void DIVN(
     SIMULATOR_LOCK_GUARD(sid)
     QInterfacePtr simulator = simulators[sid];
 
-    MapArithmeticResult2 starts = MapArithmetic2(simulator, n, q, o);
-    simulator->IMULModNOut(a, m, starts.start1, starts.start2, n);
+    try {
+        MapArithmeticResult2 starts = MapArithmetic2(simulator, n, q, o);
+        simulator->IMULModNOut(a, m, starts.start1, starts.start2, n);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
 }
 MICROSOFT_QUANTUM_DECL void POWN(
     _In_ unsigned sid, unsigned a, unsigned m, _In_ unsigned n, _In_reads_(n) unsigned* q, _In_reads_(n) unsigned* o)
@@ -1607,8 +1925,12 @@ MICROSOFT_QUANTUM_DECL void POWN(
     SIMULATOR_LOCK_GUARD(sid)
     QInterfacePtr simulator = simulators[sid];
 
-    MapArithmeticResult2 starts = MapArithmetic2(simulator, n, q, o);
-    simulator->POWModNOut(a, m, starts.start1, starts.start2, n);
+    try {
+        MapArithmeticResult2 starts = MapArithmetic2(simulator, n, q, o);
+        simulator->POWModNOut(a, m, starts.start1, starts.start2, n);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
 }
 
 MICROSOFT_QUANTUM_DECL void MCADD(_In_ unsigned sid, unsigned a, _In_ unsigned nc, _In_reads_(nc) unsigned* c,
@@ -1616,56 +1938,84 @@ MICROSOFT_QUANTUM_DECL void MCADD(_In_ unsigned sid, unsigned a, _In_ unsigned n
 {
     MAP_CONTROLS_AND_LOCK(sid, nc)
 
-    unsigned start = MapArithmetic(simulator, nq, q);
-    simulator->CINC(a, start, nq, ctrlsArray.get(), nc);
+    try {
+        unsigned start = MapArithmetic(simulator, nq, q);
+        simulator->CINC(a, start, nq, ctrlsArray.get(), nc);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
 }
 MICROSOFT_QUANTUM_DECL void MCSUB(_In_ unsigned sid, unsigned a, _In_ unsigned nc, _In_reads_(nc) unsigned* c,
     _In_ unsigned nq, _In_reads_(nq) unsigned* q)
 {
     MAP_CONTROLS_AND_LOCK(sid, nc)
 
-    unsigned start = MapArithmetic(simulator, nq, q);
-    simulator->CDEC(a, start, nq, ctrlsArray.get(), nc);
+    try {
+        unsigned start = MapArithmetic(simulator, nq, q);
+        simulator->CDEC(a, start, nq, ctrlsArray.get(), nc);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
 }
 MICROSOFT_QUANTUM_DECL void MCMUL(_In_ unsigned sid, unsigned a, _In_ unsigned nc, _In_reads_(nc) unsigned* c,
     _In_ unsigned n, _In_reads_(n) unsigned* q, _In_reads_(n) unsigned* o)
 {
     MAP_CONTROLS_AND_LOCK(sid, nc)
 
-    MapArithmeticResult2 starts = MapArithmetic2(simulator, n, q, o);
-    simulator->CMUL(a, starts.start1, starts.start2, n, ctrlsArray.get(), nc);
+    try {
+        MapArithmeticResult2 starts = MapArithmetic2(simulator, n, q, o);
+        simulator->CMUL(a, starts.start1, starts.start2, n, ctrlsArray.get(), nc);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
 }
 MICROSOFT_QUANTUM_DECL void MCDIV(_In_ unsigned sid, unsigned a, _In_ unsigned nc, _In_reads_(nc) unsigned* c,
     _In_ unsigned n, _In_reads_(n) unsigned* q, _In_reads_(n) unsigned* o)
 {
     MAP_CONTROLS_AND_LOCK(sid, nc)
 
-    MapArithmeticResult2 starts = MapArithmetic2(simulator, n, q, o);
-    simulator->CDIV(a, starts.start1, starts.start2, n, ctrlsArray.get(), nc);
+    try {
+        MapArithmeticResult2 starts = MapArithmetic2(simulator, n, q, o);
+        simulator->CDIV(a, starts.start1, starts.start2, n, ctrlsArray.get(), nc);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
 }
 MICROSOFT_QUANTUM_DECL void MCMULN(_In_ unsigned sid, unsigned a, _In_ unsigned nc, _In_reads_(nc) unsigned* c,
     unsigned m, _In_ unsigned n, _In_reads_(n) unsigned* q, _In_reads_(n) unsigned* o)
 {
     MAP_CONTROLS_AND_LOCK(sid, nc)
 
-    MapArithmeticResult2 starts = MapArithmetic2(simulator, n, q, o);
-    simulator->CMULModNOut(a, m, starts.start1, starts.start2, n, ctrlsArray.get(), nc);
+    try {
+        MapArithmeticResult2 starts = MapArithmetic2(simulator, n, q, o);
+        simulator->CMULModNOut(a, m, starts.start1, starts.start2, n, ctrlsArray.get(), nc);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
 }
 MICROSOFT_QUANTUM_DECL void MCDIVN(_In_ unsigned sid, unsigned a, _In_ unsigned nc, _In_reads_(nc) unsigned* c,
     unsigned m, _In_ unsigned n, _In_reads_(n) unsigned* q, _In_reads_(n) unsigned* o)
 {
     MAP_CONTROLS_AND_LOCK(sid, nc)
 
-    MapArithmeticResult2 starts = MapArithmetic2(simulator, n, q, o);
-    simulator->CIMULModNOut(a, m, starts.start1, starts.start2, n, ctrlsArray.get(), nc);
+    try {
+        MapArithmeticResult2 starts = MapArithmetic2(simulator, n, q, o);
+        simulator->CIMULModNOut(a, m, starts.start1, starts.start2, n, ctrlsArray.get(), nc);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
 }
 MICROSOFT_QUANTUM_DECL void MCPOWN(_In_ unsigned sid, unsigned a, _In_ unsigned nc, _In_reads_(nc) unsigned* c,
     unsigned m, _In_ unsigned n, _In_reads_(n) unsigned* q, _In_reads_(n) unsigned* o)
 {
     MAP_CONTROLS_AND_LOCK(sid, nc)
 
-    MapArithmeticResult2 starts = MapArithmetic2(simulator, n, q, o);
-    simulator->CPOWModNOut(a, m, starts.start1, starts.start2, n, ctrlsArray.get(), nc);
+    try {
+        MapArithmeticResult2 starts = MapArithmetic2(simulator, n, q, o);
+        simulator->CPOWModNOut(a, m, starts.start1, starts.start2, n, ctrlsArray.get(), nc);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
 }
 
 MICROSOFT_QUANTUM_DECL void LDA(_In_ unsigned sid, _In_ unsigned ni, _In_reads_(ni) unsigned* qi, _In_ unsigned nv,
@@ -1674,8 +2024,12 @@ MICROSOFT_QUANTUM_DECL void LDA(_In_ unsigned sid, _In_ unsigned ni, _In_reads_(
     SIMULATOR_LOCK_GUARD(sid)
     QInterfacePtr simulator = simulators[sid];
 
-    MapArithmeticResult2 starts = MapArithmetic3(simulator, ni, qi, nv, qv);
-    simulator->IndexedLDA(starts.start1, ni, starts.start2, nv, t, true);
+    try {
+        MapArithmeticResult2 starts = MapArithmetic3(simulator, ni, qi, nv, qv);
+        simulator->IndexedLDA(starts.start1, ni, starts.start2, nv, t, true);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
 }
 MICROSOFT_QUANTUM_DECL void ADC(_In_ unsigned sid, unsigned s, _In_ unsigned ni, _In_reads_(ni) unsigned* qi,
     _In_ unsigned nv, _In_reads_(nv) unsigned* qv, unsigned char* t)
@@ -1683,8 +2037,12 @@ MICROSOFT_QUANTUM_DECL void ADC(_In_ unsigned sid, unsigned s, _In_ unsigned ni,
     SIMULATOR_LOCK_GUARD(sid)
     QInterfacePtr simulator = simulators[sid];
 
-    MapArithmeticResult2 starts = MapArithmetic3(simulator, ni, qi, nv, qv);
-    simulator->IndexedADC(starts.start1, ni, starts.start2, nv, shards[simulator.get()][s], t);
+    try {
+        MapArithmeticResult2 starts = MapArithmetic3(simulator, ni, qi, nv, qv);
+        simulator->IndexedADC(starts.start1, ni, starts.start2, nv, shards[simulator.get()][s], t);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
 }
 MICROSOFT_QUANTUM_DECL void SBC(_In_ unsigned sid, unsigned s, _In_ unsigned ni, _In_reads_(ni) unsigned* qi,
     _In_ unsigned nv, _In_reads_(nv) unsigned* qv, unsigned char* t)
@@ -1692,33 +2050,51 @@ MICROSOFT_QUANTUM_DECL void SBC(_In_ unsigned sid, unsigned s, _In_ unsigned ni,
     SIMULATOR_LOCK_GUARD(sid)
     QInterfacePtr simulator = simulators[sid];
 
-    MapArithmeticResult2 starts = MapArithmetic3(simulator, ni, qi, nv, qv);
-    simulator->IndexedSBC(starts.start1, ni, starts.start2, nv, shards[simulator.get()][s], t);
+    try {
+        MapArithmeticResult2 starts = MapArithmetic3(simulator, ni, qi, nv, qv);
+        simulator->IndexedSBC(starts.start1, ni, starts.start2, nv, shards[simulator.get()][s], t);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
 }
 MICROSOFT_QUANTUM_DECL void Hash(_In_ unsigned sid, _In_ unsigned n, _In_reads_(n) unsigned* q, unsigned char* t)
 {
     SIMULATOR_LOCK_GUARD(sid)
     QInterfacePtr simulator = simulators[sid];
 
-    unsigned start = MapArithmetic(simulator, n, q);
-    simulator->Hash(start, n, t);
+    try {
+        unsigned start = MapArithmetic(simulator, n, q);
+        simulator->Hash(start, n, t);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
 }
 #endif
 
 MICROSOFT_QUANTUM_DECL bool TrySeparate1Qb(_In_ unsigned sid, _In_ unsigned qi1)
 {
     SIMULATOR_LOCK_GUARD_BOOL(sid)
-    QInterfacePtr simulator = simulators[sid];
 
-    return simulators[sid]->TrySeparate(shards[simulator.get()][qi1]);
+    try {
+        QInterfacePtr simulator = simulators[sid];
+        return simulators[sid]->TrySeparate(shards[simulator.get()][qi1]);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+        return 1;
+    }
 }
 
 MICROSOFT_QUANTUM_DECL bool TrySeparate2Qb(_In_ unsigned sid, _In_ unsigned qi1, _In_ unsigned qi2)
 {
     SIMULATOR_LOCK_GUARD_BOOL(sid)
-    QInterfacePtr simulator = simulators[sid];
 
-    return simulators[sid]->TrySeparate(shards[simulator.get()][qi1], shards[simulator.get()][qi2]);
+    try {
+        QInterfacePtr simulator = simulators[sid];
+        return simulators[sid]->TrySeparate(shards[simulator.get()][qi1], shards[simulator.get()][qi2]);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+        return 1;
+    }
 }
 
 MICROSOFT_QUANTUM_DECL bool TrySeparateTol(
@@ -1732,13 +2108,23 @@ MICROSOFT_QUANTUM_DECL bool TrySeparateTol(
         bitArray[i] = shards[simulator.get()][q[i]];
     }
 
-    return simulator->TrySeparate(bitArray.get(), (bitLenInt)n, (real1_f)tol);
+    try {
+        QInterfacePtr simulator = simulators[sid];
+        return simulator->TrySeparate(bitArray.get(), (bitLenInt)n, (real1_f)tol);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+        return 1;
+    }
 }
 
 MICROSOFT_QUANTUM_DECL void SetReactiveSeparate(_In_ unsigned sid, _In_ bool irs)
 {
     SIMULATOR_LOCK_GUARD(sid)
-    simulators[sid]->SetReactiveSeparate(irs);
+    try {
+        simulators[sid]->SetReactiveSeparate(irs);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
 }
 
 #if !(FPPOW < 6 && !ENABLE_COMPLEX_X2)
@@ -1757,8 +2143,12 @@ MICROSOFT_QUANTUM_DECL void TimeEvolve(_In_ unsigned sid, _In_ double t, _In_ un
 
     SIMULATOR_LOCK_GUARD(sid)
 
-    QInterfacePtr simulator = simulators[sid];
-    simulator->TimeEvolve(h, (real1)t);
+    try {
+        QInterfacePtr simulator = simulators[sid];
+        simulator->TimeEvolve(h, (real1)t);
+    } catch (...) {
+        simulatorErrors[sid] = 1;
+    }
 }
 #endif
 }


### PR DESCRIPTION
In considering how PyQrack should handle C++ exceptions, it occurred to me that a C external interface probably should not raise _C++11 exceptions_ at all, past the top level of the API. For PyQrack, likely, the `QrackSimulator` will poll the error code and re-throw a Python exception.