### PR TITLE
Windows stabilizer debug

### DIFF
--- a/include/qstabilizerhybrid.hpp
+++ b/include/qstabilizerhybrid.hpp
@@ -132,7 +132,7 @@ protected:
             MpsShardPtr shard = shards[i];
             if (shard) {
                 shards[i] = NULL;
-                Mtrx(shard->gate, i);
+                engine->Mtrx(shard->gate, i);
             }
         }
     }

--- a/src/qstabilizer.cpp
+++ b/src/qstabilizer.cpp
@@ -106,24 +106,28 @@ QStabilizer::QStabilizer(const bitLenInt& n, const bitCapInt& perm, bool useHard
     dispatchThreshold = PSTRIDEPOW;
 #endif
 
-    SetPermutation(perm);
+    for (bitLenInt j = 0; j < qubitCount; j++) {
+        if ((perm >> j) & 1) {
+            X(j);
+        }
+    }
 }
 
 void QStabilizer::SetPermutation(const bitCapInt& perm)
 {
     Dump();
 
-    const bitLenInt rowCount = (qubitCount << 1U) + 1U;
+    const bitLenInt rowCount = (qubitCount << 1U);
 
     std::fill(r.begin(), r.end(), 0);
 
     for (bitLenInt i = 0; i < rowCount; i++) {
-        std::fill(x[i].begin(), x[i].end(), 0);
-        std::fill(z[i].begin(), z[i].end(), 0);
+        std::fill(x[i].begin(), x[i].end(), false);
+        std::fill(z[i].begin(), z[i].end(), false);
 
         if (i < qubitCount) {
             x[i][i] = true;
-        } else if (i < (qubitCount << 1U)) {
+        } else {
             bitLenInt j = i - qubitCount;
             z[i][j] = true;
         }
@@ -134,7 +138,7 @@ void QStabilizer::SetPermutation(const bitCapInt& perm)
     }
 
     for (bitLenInt j = 0; j < qubitCount; j++) {
-        if (perm & pow2Ocl(j)) {
+        if ((perm >> j) & 1) {
             X(j);
         }
     }

--- a/src/qstabilizer.cpp
+++ b/src/qstabilizer.cpp
@@ -106,11 +106,7 @@ QStabilizer::QStabilizer(const bitLenInt& n, const bitCapInt& perm, bool useHard
     dispatchThreshold = PSTRIDEPOW;
 #endif
 
-    for (bitLenInt j = 0; j < qubitCount; j++) {
-        if ((perm >> j) & 1) {
-            X(j);
-        }
-    }
+    SetPermutation(perm);
 }
 
 void QStabilizer::SetPermutation(const bitCapInt& perm)

--- a/src/qstabilizer.cpp
+++ b/src/qstabilizer.cpp
@@ -402,7 +402,7 @@ void QStabilizer::GetQuantumState(complex* stateVec)
     for (bitCapIntOcl t = 0; t < permCountMin1; t++) {
         bitCapIntOcl t2 = t ^ (t + 1);
         for (bitLenInt i = 0; i < g; i++) {
-            if (t2 & pow2Ocl(i)) {
+            if ((t2 >> i) & 1U) {
                 rowmult(elemCount, qubitCount + i);
             }
         }
@@ -432,7 +432,7 @@ void QStabilizer::GetQuantumState(QInterfacePtr eng)
     for (bitCapIntOcl t = 0; t < permCountMin1; t++) {
         bitCapIntOcl t2 = t ^ (t + 1);
         for (bitLenInt i = 0; i < g; i++) {
-            if (t2 & pow2Ocl(i)) {
+            if ((t2 >> i) & 1U) {
                 rowmult(elemCount, qubitCount + i);
             }
         }
@@ -463,7 +463,7 @@ void QStabilizer::GetProbs(real1* outputProbs)
     for (bitCapIntOcl t = 0; t < permCountMin1; t++) {
         bitCapIntOcl t2 = t ^ (t + 1);
         for (bitLenInt i = 0; i < g; i++) {
-            if (t2 & pow2Ocl(i)) {
+            if ((t2 >> i) & 1U) {
                 rowmult(elemCount, qubitCount + i);
             }
         }

--- a/src/qstabilizerhybrid.cpp
+++ b/src/qstabilizerhybrid.cpp
@@ -157,7 +157,7 @@ void QStabilizerHybrid::SwitchToEngine()
 
     engine = MakeEngine();
     stabilizer->GetQuantumState(engine);
-    stabilizer.reset();
+    stabilizer = NULL;
     FlushBuffers();
 }
 


### PR DESCRIPTION
There might be a particularly bad bug in the Windows compiler implementation of `std::swap()` for `std::vector<std::vector<bool>>` elements, which affects our `QStabilizer` implementation. I hesitate to add a partial workaround I have for that, because it seems unlikely that this particular case of `std::swap()` would be bugged, and we might rather have something like a segmentation fault corrupting `std::vector<std::vector<bool>>`. I need to do more research into the issue, before I address the primary  bug. However, this entailed minor style refactoring that can go in immediately.