### PR TITLE
QUnit refactor

### DIFF
--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -125,8 +125,6 @@ public:
     virtual void CZ(bitLenInt control, bitLenInt target);
     using QInterface::AntiCZ;
     virtual void AntiCZ(bitLenInt control, bitLenInt target);
-    using QInterface::CCZ;
-    virtual void CCZ(bitLenInt control1, bitLenInt control2, bitLenInt target);
     using QInterface::CH;
     virtual void CH(bitLenInt control, bitLenInt target);
     using QInterface::AntiCH;

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -115,10 +115,6 @@ public:
     virtual void CNOT(bitLenInt control, bitLenInt target);
     using QInterface::AntiCNOT;
     virtual void AntiCNOT(bitLenInt control, bitLenInt target);
-    using QInterface::CCNOT;
-    virtual void CCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target);
-    using QInterface::AntiCCNOT;
-    virtual void AntiCCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target);
     using QInterface::CY;
     virtual void CY(bitLenInt control, bitLenInt target);
     using QInterface::AntiCY;

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -350,7 +350,7 @@ protected:
     bool TrimControls(const bitLenInt* controls, bitLenInt controlLen, std::vector<bitLenInt>& output, bool anti);
 
     template <typename CF>
-    void ApplyEitherControlled(std::vector<bitLenInt> controlVec, const std::vector<bitLenInt>& targets, bool anti,
+    void ApplyEitherControlled(std::vector<bitLenInt> controlVec, const std::vector<bitLenInt> targets, bool anti,
         CF cfn, bool isPhase = false, bool isInvert = false);
 
     void ShardAI(bitLenInt qubit, real1_f azimuth, real1_f inclination)

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -111,20 +111,6 @@ public:
     virtual void S(bitLenInt target);
     using QInterface::IS;
     virtual void IS(bitLenInt target);
-    using QInterface::CNOT;
-    virtual void CNOT(bitLenInt control, bitLenInt target);
-    using QInterface::AntiCNOT;
-    virtual void AntiCNOT(bitLenInt control, bitLenInt target);
-    using QInterface::CY;
-    virtual void CY(bitLenInt control, bitLenInt target);
-    using QInterface::AntiCY;
-    virtual void AntiCY(bitLenInt control, bitLenInt target);
-    using QInterface::CCY;
-    virtual void CCY(bitLenInt control1, bitLenInt control2, bitLenInt target);
-    using QInterface::CZ;
-    virtual void CZ(bitLenInt control, bitLenInt target);
-    using QInterface::AntiCZ;
-    virtual void AntiCZ(bitLenInt control, bitLenInt target);
     using QInterface::CH;
     virtual void CH(bitLenInt control, bitLenInt target);
     using QInterface::AntiCH;
@@ -361,9 +347,11 @@ protected:
     };
     void SortUnit(QInterfacePtr unit, std::vector<QSortEntry>& bits, bitLenInt low, bitLenInt high);
 
-    template <typename CF, typename F>
-    void ApplyEitherControlled(const bitLenInt* controls, bitLenInt controlLen, const std::vector<bitLenInt>& targets,
-        bool anti, CF cfn, F f, bool isPhase = false, bool isInvert = false, bool inCurrentBasis = false);
+    bool TrimControls(const bitLenInt* controls, bitLenInt controlLen, std::vector<bitLenInt>& output, bool anti);
+
+    template <typename CF>
+    void ApplyEitherControlled(std::vector<bitLenInt> controlVec, const std::vector<bitLenInt>& targets, bool anti,
+        CF cfn, bool isPhase = false, bool isInvert = false);
 
     void ShardAI(bitLenInt qubit, real1_f azimuth, real1_f inclination)
     {

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -2844,10 +2844,20 @@ bool QUnit::TrimControls(const bitLenInt* controls, bitLenInt controlLen, std::v
         QEngineShard& shard = shards[controls[i]];
         // If the shard's probability is cached, then it's free to check it, so we advance the loop.
         // This might determine that we can just skip out of the whole gate, in which case we return.
-        if (!shard.isProbDirty && !shard.isPauliX && !shard.isPauliY && !shard.IsInvertTarget() &&
-            ((!anti && IS_AMP_0(shard.amp1)) || (anti && IS_AMP_0(shard.amp0)))) {
-            /* This gate does nothing, so return without applying anything. */
-            return true;
+        if (!shard.isProbDirty && !shard.isPauliX && !shard.isPauliY && !shard.IsInvertTarget()) {
+            if (IS_AMP_0(shard.amp1)) {
+                Flush0Eigenstate(controls[i]);
+                if (!anti) {
+                    /* This gate does nothing, so return without applying anything. */
+                    return true;
+                }
+            } else if (IS_AMP_0(shard.amp0)) {
+                Flush1Eigenstate(controls[i]);
+                if (anti) {
+                    /* This gate does nothing, so return without applying anything. */
+                    return true;
+                }
+            }
         }
     }
 
@@ -2860,10 +2870,20 @@ bool QUnit::TrimControls(const bitLenInt* controls, bitLenInt controlLen, std::v
         }
         // If the shard's probability is cached, then it's free to check it, so we advance the loop.
         // This might determine that we can just skip out of the whole gate, in which case we return.
-        if (!shard.isProbDirty && !shard.IsInvertTarget() &&
-            ((!anti && IS_AMP_0(shard.amp1)) || (anti && IS_AMP_0(shard.amp0)))) {
-            /* This gate does nothing, so return without applying anything. */
-            return true;
+        if (!shard.isProbDirty && !shard.IsInvertTarget()) {
+            if (IS_AMP_0(shard.amp1)) {
+                Flush0Eigenstate(controls[i]);
+                if (!anti) {
+                    /* This gate does nothing, so return without applying anything. */
+                    return true;
+                }
+            } else if (IS_AMP_0(shard.amp0)) {
+                Flush1Eigenstate(controls[i]);
+                if (anti) {
+                    /* This gate does nothing, so return without applying anything. */
+                    return true;
+                }
+            }
         }
     }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -2156,7 +2156,7 @@ void QUnit::TransformPhase(complex topLeft, complex bottomRight, complex* mtrxOu
         return;                                                                                                        \
     }                                                                                                                  \
     std::vector<bitLenInt> controlVec;                                                                                 \
-    if (TrimControls(controls, controlLen, controlVec, true)) {                                                        \
+    if (TrimControls(controls, controlLen, controlVec, anti)) {                                                        \
         return;                                                                                                        \
     }                                                                                                                  \
     if (!controlVec.size()) {                                                                                          \

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -2163,8 +2163,6 @@ void QUnit::TransformPhase(complex topLeft, complex bottomRight, complex* mtrxOu
         bare;                                                                                                          \
         return;                                                                                                        \
     }                                                                                                                  \
-    ToPermBasis(qubit1);                                                                                               \
-    ToPermBasis(qubit2);                                                                                               \
     ApplyEitherControlled(controlVec, { qubit1, qubit2 }, anti,                                                        \
         [&](QInterfacePtr unit, std::vector<bitLenInt> mappedControls) { unit->ctrld; })
 #define CTRL_GEN_ARGS &(mappedControls[0]), mappedControls.size(), trnsMtrx, shards[target].mapped
@@ -2878,10 +2876,15 @@ bool QUnit::TrimControls(const bitLenInt* controls, bitLenInt controlLen, std::v
 }
 
 template <typename CF>
-void QUnit::ApplyEitherControlled(std::vector<bitLenInt> controlVec, const std::vector<bitLenInt>& targets, bool anti,
+void QUnit::ApplyEitherControlled(std::vector<bitLenInt> controlVec, const std::vector<bitLenInt> targets, bool anti,
     CF cfn, bool isPhase, bool isInvert)
 {
     for (bitLenInt i = 0; i < (bitLenInt)targets.size(); i++) {
+        if (targets.size() > 1U) {
+            ToPermBasis(targets[i]);
+            continue;
+        }
+
         if (isPhase) {
             RevertBasis2Qb(targets[i], ONLY_INVERT, ONLY_TARGETS);
         } else {

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -5714,6 +5714,113 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_mirror_circuit_22", "[mirror]")
     REQUIRE(qftReg->MAll() == 37);
 }
 
+TEST_CASE_METHOD(QInterfaceTestFixture, "test_mirror_circuit_23", "[mirror]")
+{
+    qftReg = MakeEngine(6);
+    qftReg->SetPermutation(0);
+
+    qftReg->Y(0);
+    qftReg->X(1);
+    qftReg->Y(2);
+    qftReg->X(3);
+    qftReg->IT(4);
+    qftReg->S(5);
+    qftReg->CY(0, 2);
+    qftReg->AntiCCZ(3, 5, 4);
+    qftReg->T(0);
+    qftReg->H(1);
+    qftReg->IT(2);
+    qftReg->X(3);
+    qftReg->S(4);
+    qftReg->X(5);
+    qftReg->AntiCZ(0, 1);
+    qftReg->AntiCCNOT(4, 2, 3);
+    qftReg->IT(0);
+    qftReg->Z(1);
+    qftReg->Z(2);
+    qftReg->T(3);
+    qftReg->Y(4);
+    qftReg->Z(5);
+    qftReg->CCZ(3, 2, 4);
+    qftReg->CCNOT(5, 1, 0);
+    qftReg->IS(0);
+    qftReg->Y(1);
+    qftReg->H(2);
+    qftReg->Z(3);
+    qftReg->Z(4);
+    qftReg->T(5);
+    qftReg->CCNOT(4, 5, 2);
+    qftReg->CCNOT(3, 1, 0);
+    qftReg->H(0);
+    qftReg->IT(1);
+    qftReg->X(2);
+    qftReg->IS(3);
+    qftReg->Y(4);
+    qftReg->IS(5);
+    qftReg->AntiCZ(5, 4);
+    qftReg->CNOT(1, 0);
+    qftReg->AntiCNOT(2, 3);
+    qftReg->IT(0);
+    qftReg->H(1);
+    qftReg->S(2);
+    qftReg->H(3);
+    qftReg->IS(4);
+    qftReg->T(5);
+    qftReg->AntiCCNOT(1, 5, 4);
+    qftReg->CZ(2, 0);
+    qftReg->CZ(2, 0);
+    qftReg->AntiCCNOT(1, 5, 4);
+    qftReg->IT(5);
+    qftReg->S(4);
+    qftReg->H(3);
+    qftReg->IS(2);
+    qftReg->H(1);
+    qftReg->T(0);
+    qftReg->AntiCNOT(2, 3);
+    qftReg->CNOT(1, 0);
+    qftReg->AntiCZ(5, 4);
+    qftReg->S(5);
+    qftReg->Y(4);
+    qftReg->S(3);
+    qftReg->X(2);
+    qftReg->T(1);
+    qftReg->H(0);
+    qftReg->CCNOT(3, 1, 0);
+    qftReg->CCNOT(4, 5, 2);
+    qftReg->IT(5);
+    qftReg->Z(4);
+    qftReg->Z(3);
+    qftReg->H(2);
+    qftReg->Y(1);
+    qftReg->S(0);
+    qftReg->CCNOT(5, 1, 0);
+    qftReg->CCZ(3, 2, 4);
+    qftReg->Z(5);
+    qftReg->Y(4);
+    qftReg->IT(3);
+    qftReg->Z(2);
+    qftReg->Z(1);
+    qftReg->T(0);
+    qftReg->AntiCCNOT(4, 2, 3);
+    qftReg->AntiCZ(0, 1);
+    qftReg->X(5);
+    qftReg->IS(4);
+    qftReg->X(3);
+    qftReg->T(2);
+    qftReg->H(1);
+    qftReg->IT(0);
+    qftReg->AntiCCZ(3, 5, 4);
+    qftReg->CY(0, 2);
+    qftReg->IS(5);
+    qftReg->T(4);
+    qftReg->X(3);
+    qftReg->Y(2);
+    qftReg->X(1);
+    qftReg->Y(0);
+
+    REQUIRE(qftReg->MAll() == 0);
+}
+
 bitLenInt pickRandomBit(QInterfacePtr qReg, std::set<bitLenInt>* unusedBitsPtr)
 {
     std::set<bitLenInt>::iterator bitIterator = unusedBitsPtr->begin();


### PR DESCRIPTION
The controlled Pauli operation overloads in `QUnit` were redundant with controlled `Phase()` and `Invert()` variants. A lot of vacuous code is cut here, but all non-vacuous optimization code from these variants has been condensed and centralized. Control qubit trimming optimizations in `QUnit` now also work for higher control counts.