### PR TITLE
#944: QBdt QEngine node

### DIFF
--- a/include/qbdt.hpp
+++ b/include/qbdt.hpp
@@ -43,7 +43,7 @@ protected:
     }
 
     QInterfacePtr MakeStateVector(bitLenInt qbCount, bitCapInt perm = 0U);
-    QBdtQInterfaceNodePtr MakeQInterfaceNode(complex scale, bitLenInt qbCount, bitCapInt perm = 0U);
+    QBdtQEngineNodePtr MakeQEngineNode(complex scale, bitLenInt qbCount, bitCapInt perm = 0U);
 
     QInterfacePtr MakeTempStateVector()
     {
@@ -179,7 +179,7 @@ public:
     {
         return Compose(std::dynamic_pointer_cast<QBdt>(toCopy), start);
     }
-    virtual bitLenInt Attach(QInterfacePtr toCopy, bitLenInt start)
+    virtual bitLenInt Attach(QEnginePtr toCopy, bitLenInt start)
     {
         if (start == qubitCount) {
             return Attach(toCopy);
@@ -192,7 +192,7 @@ public:
 
         return result;
     }
-    virtual bitLenInt Attach(QInterfacePtr toCopy);
+    virtual bitLenInt Attach(QEnginePtr toCopy);
     virtual void Decompose(bitLenInt start, QInterfacePtr dest)
     {
         DecomposeDispose(start, dest->GetQubitCount(), std::dynamic_pointer_cast<QBdt>(dest));

--- a/include/qbdt_qinterface_node.hpp
+++ b/include/qbdt_qinterface_node.hpp
@@ -144,6 +144,9 @@ protected:
             qReg1->NormalizeState(REAL1_DEFAULT_ARG, REAL1_DEFAULT_ARG, std::arg(b1->scale));
         }
 
+        b0->scale = SQRT1_2_R1;
+        b1->scale = SQRT1_2_R1;
+
         qReg0->ShuffleBuffers(qReg1);
 
         qReg0->Mtrx(mtrx, qReg0->GetQubitCount() - 1U);

--- a/include/qbdt_qinterface_node.hpp
+++ b/include/qbdt_qinterface_node.hpp
@@ -117,8 +117,32 @@ protected:
         QEnginePtr qReg0 = std::dynamic_pointer_cast<QEngine>(std::dynamic_pointer_cast<QBdtQEngineNode>(b0)->qReg);
         QEnginePtr qReg1 = std::dynamic_pointer_cast<QEngine>(std::dynamic_pointer_cast<QBdtQEngineNode>(b1)->qReg);
 
-        qReg0->NormalizeState(REAL1_DEFAULT_ARG, REAL1_DEFAULT_ARG, std::arg(b0->scale));
-        qReg1->NormalizeState(REAL1_DEFAULT_ARG, REAL1_DEFAULT_ARG, std::arg(b1->scale));
+        const bool is0Zero = IS_NORM_0(b0->scale);
+        const bool is1Zero = IS_NORM_0(b1->scale);
+
+        if (is0Zero && is1Zero) {
+            b0->SetZero();
+            b1->SetZero();
+
+            return;
+        }
+
+        if (is0Zero) {
+            qReg0 = std::dynamic_pointer_cast<QEngine>(std::dynamic_pointer_cast<QBdtQEngineNode>(b1)->qReg->Clone());
+            qReg0->ZeroAmplitudes();
+            std::dynamic_pointer_cast<QBdtQEngineNode>(b0)->qReg = qReg0;
+        } else if (is1Zero) {
+            qReg1 = std::dynamic_pointer_cast<QEngine>(std::dynamic_pointer_cast<QBdtQEngineNode>(b0)->qReg->Clone());
+            qReg1->ZeroAmplitudes();
+            std::dynamic_pointer_cast<QBdtQEngineNode>(b1)->qReg = qReg1;
+        }
+
+        if (!is0Zero) {
+            qReg0->NormalizeState(REAL1_DEFAULT_ARG, REAL1_DEFAULT_ARG, std::arg(b0->scale));
+        }
+        if (!is1Zero) {
+            qReg1->NormalizeState(REAL1_DEFAULT_ARG, REAL1_DEFAULT_ARG, std::arg(b1->scale));
+        }
 
         qReg0->ShuffleBuffers(qReg1);
 
@@ -166,6 +190,8 @@ public:
         qReg->NormalizeState(REAL1_DEFAULT_ARG, REAL1_DEFAULT_ARG, -phaseArg);
         scale *= (complex)std::polar((real1_f)ONE_R1, (real1_f)phaseArg);
     }
+
+    virtual void PopStateVector(bitLenInt depth = 1U) { Prune(); }
 };
 
 } // namespace Qrack

--- a/include/qbdt_qinterface_node.hpp
+++ b/include/qbdt_qinterface_node.hpp
@@ -110,6 +110,24 @@ public:
 };
 
 class QBdtQEngineNode : public QBdtQInterfaceNode {
+protected:
+    virtual void PushStateVector(
+        const complex* mtrx, QBdtNodeInterfacePtr& b0, QBdtNodeInterfacePtr& b1, bitLenInt depth)
+    {
+        QEnginePtr qReg0 = std::dynamic_pointer_cast<QEngine>(std::dynamic_pointer_cast<QBdtQEngineNode>(b0)->qReg);
+        QEnginePtr qReg1 = std::dynamic_pointer_cast<QEngine>(std::dynamic_pointer_cast<QBdtQEngineNode>(b1)->qReg);
+
+        qReg0->NormalizeState(REAL1_DEFAULT_ARG, REAL1_DEFAULT_ARG, std::arg(b0->scale));
+        qReg1->NormalizeState(REAL1_DEFAULT_ARG, REAL1_DEFAULT_ARG, std::arg(b1->scale));
+
+        qReg0->ShuffleBuffers(qReg1);
+
+        qReg0->Mtrx(mtrx, qReg0->GetQubitCount() - 1U);
+        qReg1->Mtrx(mtrx, qReg1->GetQubitCount() - 1U);
+
+        qReg0->ShuffleBuffers(qReg1);
+    }
+
 public:
     QBdtQEngineNode()
         : QBdtQInterfaceNode()
@@ -147,7 +165,6 @@ public:
         qReg->UpdateRunningNorm();
         qReg->NormalizeState(REAL1_DEFAULT_ARG, REAL1_DEFAULT_ARG, -phaseArg);
         scale *= (complex)std::polar((real1_f)ONE_R1, (real1_f)phaseArg);
-        ;
     }
 };
 

--- a/src/qbdt/tree.cpp
+++ b/src/qbdt/tree.cpp
@@ -17,7 +17,7 @@
 #include "qbdt_node.hpp"
 #include "qfactory.hpp"
 
-#define NODE_TO_QINTERFACE(leaf) std::dynamic_pointer_cast<QBdtQInterfaceNode>(leaf)->qReg
+#define NODE_TO_QINTERFACE(leaf) (std::dynamic_pointer_cast<QBdtQInterfaceNode>(leaf)->qReg)
 
 namespace Qrack {
 
@@ -45,9 +45,9 @@ QInterfacePtr QBdt::MakeStateVector(bitLenInt qbCount, bitCapInt perm)
         false, devID, hardware_rand_generator != NULL, false, amplitudeFloor);
 }
 
-QBdtQInterfaceNodePtr QBdt::MakeQInterfaceNode(complex scale, bitLenInt qbCount, bitCapInt perm)
+QBdtQEngineNodePtr QBdt::MakeQEngineNode(complex scale, bitLenInt qbCount, bitCapInt perm)
 {
-    return std::make_shared<QBdtQInterfaceNode>(scale,
+    return std::make_shared<QBdtQEngineNode>(scale,
         CreateQuantumInterface(engines, qbCount, perm, rand_generator, ONE_CMPLX, doNormalize, false, false, devID,
             hardware_rand_generator != NULL, false, amplitudeFloor));
 }
@@ -86,8 +86,8 @@ void QBdt::SetPermutation(bitCapInt initState, complex phaseFac)
 
     if (attachedQubitCount) {
         const size_t bit = SelectBit(initState, maxQubit);
-        leaf->branches[bit] = MakeQInterfaceNode(ONE_CMPLX, attachedQubitCount, initState >> bdtQubitCount);
-        leaf->branches[bit ^ 1U] = std::make_shared<QBdtQInterfaceNode>();
+        leaf->branches[bit] = MakeQEngineNode(ONE_CMPLX, attachedQubitCount, initState >> bdtQubitCount);
+        leaf->branches[bit ^ 1U] = std::make_shared<QBdtQEngineNode>();
     }
 }
 
@@ -287,7 +287,7 @@ bitLenInt QBdt::Compose(QBdtPtr toCopy, bitLenInt start)
     return start;
 }
 
-bitLenInt QBdt::Attach(QInterfacePtr toCopy)
+bitLenInt QBdt::Attach(QEnginePtr toCopy)
 {
     bitLenInt toRet = qubitCount;
 
@@ -335,8 +335,8 @@ bitLenInt QBdt::Attach(QInterfacePtr toCopy)
 
         for (size_t j = 0; j < 2; j++) {
             const complex scale = leaf->branches[j]->scale;
-            leaf->branches[j] = IS_NORM_0(scale) ? std::make_shared<QBdtQInterfaceNode>()
-                                                 : std::make_shared<QBdtQInterfaceNode>(scale, toCopyClone);
+            leaf->branches[j] = IS_NORM_0(scale) ? std::make_shared<QBdtQEngineNode>()
+                                                 : std::make_shared<QBdtQEngineNode>(scale, toCopyClone);
         }
 
         return (bitCapInt)0U;


### PR DESCRIPTION
Except for `QBdt` methods that revert to a (separate) ket representation, `QPager` at the lowest tree level of a `QBdt` works! (For example, `[mirror]` unit test suite works.)