### PR TITLE
#944: Recursive QBdt::Compose()

### DIFF
--- a/include/qbdt_node_interface.hpp
+++ b/include/qbdt_node_interface.hpp
@@ -60,6 +60,30 @@ public:
         // Intentionally left blank
     }
 
+    virtual void InsertAtDepth(QBdtNodeInterfacePtr b, bitLenInt depth, bitLenInt size)
+    {
+        if (depth) {
+            depth--;
+            if (branches[0]) {
+                branches[0]->InsertAtDepth(b, depth, size);
+                branches[1]->InsertAtDepth(b, depth, size);
+            }
+
+            return;
+        }
+
+        QBdtNodeInterfacePtr tempBranches[2] = { branches[0], branches[1] };
+        branches[0] = b->branches[0];
+        branches[1] = b->branches[1];
+
+        if (!size || !tempBranches[0]) {
+            return;
+        }
+
+        branches[0]->InsertAtDepth(tempBranches[0], size, 0);
+        branches[1]->InsertAtDepth(tempBranches[1], size, 0);
+    }
+
     virtual void SetZero()
     {
         scale = ZERO_CMPLX;

--- a/include/qbdt_node_interface.hpp
+++ b/include/qbdt_node_interface.hpp
@@ -62,6 +62,10 @@ public:
 
     virtual void InsertAtDepth(QBdtNodeInterfacePtr b, bitLenInt depth, bitLenInt size)
     {
+        if (norm(scale) <= FP_NORM_EPSILON) {
+            return;
+        }
+
         if (depth) {
             depth--;
             if (branches[0]) {

--- a/src/qbdt/tree.cpp
+++ b/src/qbdt/tree.cpp
@@ -243,23 +243,18 @@ complex QBdt::GetAmplitude(bitCapInt perm)
 
 bitLenInt QBdt::Compose(QBdtPtr toCopy, bitLenInt start)
 {
-    if (attachedQubitCount) {
-        throw std::runtime_error("Compose() once attached is not implemented!");
+    if (attachedQubitCount && (bdtQubitCount < start)) {
+        const bitLenInt origBdtSize = bdtQubitCount;
+        ROR(start - origBdtSize, 0, qubitCount);
+        bitLenInt result = Compose(toCopy, origBdtSize);
+        ROL(start - origBdtSize, 0, qubitCount);
+
+        return result;
     }
 
-    if (start && (start != qubitCount)) {
-        return QInterface::Compose(toCopy, start);
-    }
-
-    QBdtNodeInterfacePtr rootClone = toCopy->root->ShallowClone();
-    bitLenInt depth = bdtQubitCount;
+    bitLenInt depth = start;
     bitLenInt size = toCopy->bdtQubitCount;
-    if (!start) {
-        std::swap(depth, size);
-        root.swap(rootClone);
-    }
-
-    root->InsertAtDepth(rootClone, depth, size);
+    root->InsertAtDepth(toCopy->root->ShallowClone(), depth, size);
 
     SetQubitCount(qubitCount + toCopy->qubitCount);
 

--- a/src/qbdt/tree.cpp
+++ b/src/qbdt/tree.cpp
@@ -251,36 +251,15 @@ bitLenInt QBdt::Compose(QBdtPtr toCopy, bitLenInt start)
         return QInterface::Compose(toCopy, start);
     }
 
-    bitLenInt qbCount;
-    bitCapInt maxI;
-
     QBdtNodeInterfacePtr rootClone = toCopy->root->ShallowClone();
-    if (start) {
-        qbCount = bdtQubitCount;
-        maxI = maxQPower;
-    } else {
-        qbCount = toCopy->bdtQubitCount;
-        maxI = toCopy->maxQPower;
+    bitLenInt depth = bdtQubitCount;
+    bitLenInt size = toCopy->bdtQubitCount;
+    if (!start) {
+        std::swap(depth, size);
         root.swap(rootClone);
     }
 
-    par_for_qbdt(0, maxI, [&](const bitCapInt& i, const int& cpu) {
-        QBdtNodeInterfacePtr leaf = root;
-        for (bitLenInt j = 0; j < qbCount; j++) {
-            if (IS_NORM_0(leaf->scale)) {
-                // WARNING: Mutates loop control variable!
-                return (bitCapInt)(pow2(qbCount - j) - ONE_BCI);
-            }
-            leaf = leaf->branches[SelectBit(i, qbCount - (j + 1U))];
-        }
-
-        if (!IS_NORM_0(leaf->scale)) {
-            leaf->branches[0] = rootClone->branches[0];
-            leaf->branches[1] = rootClone->branches[1];
-        }
-
-        return (bitCapInt)0U;
-    });
+    root->InsertAtDepth(rootClone, depth, size);
 
     SetQubitCount(qubitCount + toCopy->qubitCount);
 

--- a/src/qinterface/qinterface.cpp
+++ b/src/qinterface/qinterface.cpp
@@ -269,6 +269,10 @@ void QInterface::ROR(bitLenInt shift, bitLenInt start, bitLenInt length) { ROL(l
 
 bitLenInt QInterface::Compose(QInterfacePtr toCopy, bitLenInt start)
 {
+    if (start == qubitCount) {
+        return Compose(toCopy);
+    }
+
     const bitLenInt origSize = qubitCount;
     ROL(origSize - start, 0, origSize);
     bitLenInt result = Compose(toCopy);


### PR DESCRIPTION
Towards #944, this PR totally generalizes `QBdt::Compose()` over insertion indexes and `Attach()` state, with recursion.