### PR TITLE
#944: QBdt::Compose() after double Attach()

### DIFF
--- a/include/qbdt_node.hpp
+++ b/include/qbdt_node.hpp
@@ -54,6 +54,8 @@ public:
 
     virtual QBdtNodeInterfacePtr ShallowClone() { return std::make_shared<QBdtNode>(scale, branches); }
 
+    virtual void InsertAtDepth(QBdtNodeInterfacePtr b, bitLenInt depth, bitLenInt size);
+
     virtual void PopStateVector(bitLenInt depth = 1U);
 
     virtual void Branch(bitLenInt depth = 1U);

--- a/include/qbdt_node_interface.hpp
+++ b/include/qbdt_node_interface.hpp
@@ -60,7 +60,7 @@ public:
         // Intentionally left blank
     }
 
-    virtual void InsertAtDepth(QBdtNodeInterfacePtr b, bitLenInt depth, bitLenInt size);
+    virtual void InsertAtDepth(QBdtNodeInterfacePtr b, bitLenInt depth, bitLenInt size) = 0;
 
     virtual QBdtNodeInterfacePtr RemoveSeparableAtDepth(bitLenInt depth, bitLenInt size);
 

--- a/src/qbdt/node.cpp
+++ b/src/qbdt/node.cpp
@@ -319,7 +319,6 @@ void QBdtNode::InsertAtDepth(QBdtNodeInterfacePtr b, bitLenInt depth, bitLenInt 
 
         if (norm(branches[0]->scale) > FP_NORM_EPSILON) {
             branches[0] = std::make_shared<QBdtNode>(branches[0]->scale, b->branches);
-            branches[0]->Branch();
             branches[0]->InsertAtDepth(c, size, 0);
 
             if (c.get() == branches[1].get()) {
@@ -334,7 +333,6 @@ void QBdtNode::InsertAtDepth(QBdtNodeInterfacePtr b, bitLenInt depth, bitLenInt 
 
         c = branches[1];
         branches[1] = std::make_shared<QBdtNode>(branches[1]->scale, b->branches);
-        branches[1]->Branch();
         branches[1]->InsertAtDepth(c, size, 0);
 
         return;

--- a/src/qbdt/node.cpp
+++ b/src/qbdt/node.cpp
@@ -299,8 +299,6 @@ void QBdtNode::InsertAtDepth(QBdtNodeInterfacePtr b, bitLenInt depth, bitLenInt 
         return;
     }
 
-    Branch();
-
     if (!depth) {
         QBdtNodeInterfacePtr c = ShallowClone();
         branches[0] = b->branches[0];

--- a/src/qbdt/node.cpp
+++ b/src/qbdt/node.cpp
@@ -292,4 +292,63 @@ void QBdtNode::PushStateVector(const complex* mtrx, QBdtNodeInterfacePtr& b0, QB
     b0->PopStateVector();
     b1->PopStateVector();
 }
+
+void QBdtNode::InsertAtDepth(QBdtNodeInterfacePtr b, bitLenInt depth, bitLenInt size)
+{
+    if (norm(scale) <= FP_NORM_EPSILON) {
+        return;
+    }
+
+    Branch();
+
+    if (!depth) {
+        QBdtNodeInterfacePtr c = ShallowClone();
+        branches[0] = b->branches[0];
+        branches[1] = b->branches[1];
+
+        if (!size || !c->branches[0]) {
+            return;
+        }
+
+        InsertAtDepth(c, size, 0);
+
+        return;
+    }
+    depth--;
+
+    if (!depth && size) {
+        QBdtNodeInterfacePtr c = branches[0];
+
+        if (norm(branches[0]->scale) > FP_NORM_EPSILON) {
+            branches[0] = std::make_shared<QBdtNode>(branches[0]->scale, b->branches);
+            branches[0]->Branch();
+            branches[0]->InsertAtDepth(c, size, 0);
+
+            if (c.get() == branches[1].get()) {
+                branches[1] = branches[0];
+                return;
+            }
+        }
+
+        if (norm(branches[1]->scale) <= FP_NORM_EPSILON) {
+            return;
+        }
+
+        c = branches[1];
+        branches[1] = std::make_shared<QBdtNode>(branches[1]->scale, b->branches);
+        branches[1]->Branch();
+        branches[1]->InsertAtDepth(c, size, 0);
+
+        return;
+    }
+
+    if (!branches[0]) {
+        return;
+    }
+
+    branches[0]->InsertAtDepth(b, depth, size);
+    if (branches[0].get() != branches[1].get()) {
+        branches[1]->InsertAtDepth(b, depth, size);
+    }
+}
 } // namespace Qrack

--- a/src/qbdt/node_interface.cpp
+++ b/src/qbdt/node_interface.cpp
@@ -50,35 +50,6 @@ void QBdtNodeInterface::_par_for_qbdt(const bitCapInt begin, const bitCapInt end
     }
 }
 
-void QBdtNodeInterface::InsertAtDepth(QBdtNodeInterfacePtr b, bitLenInt depth, bitLenInt size)
-{
-    if (norm(scale) <= FP_NORM_EPSILON) {
-        return;
-    }
-
-    if (depth) {
-        depth--;
-        if (branches[0]) {
-            branches[0]->InsertAtDepth(b, depth, size);
-            if (branches[0].get() != branches[1].get()) {
-                branches[1]->InsertAtDepth(b, depth, size);
-            }
-        }
-
-        return;
-    }
-
-    QBdtNodeInterfacePtr c = ShallowClone();
-    branches[0] = b->branches[0];
-    branches[1] = b->branches[1];
-
-    if (!size || !c->branches[0]) {
-        return;
-    }
-
-    InsertAtDepth(c, size, 0);
-}
-
 QBdtNodeInterfacePtr QBdtNodeInterface::RemoveSeparableAtDepth(bitLenInt depth, bitLenInt size)
 {
     if (norm(scale) <= FP_NORM_EPSILON) {

--- a/src/qbdt/qinterface_node.cpp
+++ b/src/qbdt/qinterface_node.cpp
@@ -88,13 +88,7 @@ void QBdtQEngineNode::InsertAtDepth(QBdtNodeInterfacePtr b, bitLenInt depth, bit
     }
 
     QBdtQEngineNodePtr bEng = std::dynamic_pointer_cast<QBdtQEngineNode>(b);
-
-    if (!qReg) {
-        qReg = bEng->qReg ? bEng->qReg->Clone() : NULL;
-        return;
-    }
-
-    qReg->Compose(bEng->qReg, depth);
+    qReg->Compose(bEng->qReg, qReg->GetQubitCount() - depth);
 }
 
 QBdtNodeInterfacePtr QBdtQEngineNode::RemoveSeparableAtDepth(bitLenInt depth, bitLenInt size)

--- a/src/qbdt/tree.cpp
+++ b/src/qbdt/tree.cpp
@@ -256,7 +256,7 @@ bitLenInt QBdt::Compose(QBdtPtr toCopy, bitLenInt start)
         if (start < midIndex) {
             ROL(midIndex - start, 0, qubitCount);
             bitLenInt result = Compose(toCopy, midIndex);
-            ROR(midIndex - start, 0, qubitCount);
+            Reverse(bdtQubitCount, qubitCount);
 
             return result;
         }
@@ -264,7 +264,7 @@ bitLenInt QBdt::Compose(QBdtPtr toCopy, bitLenInt start)
         if (midIndex < start) {
             ROR(start - midIndex, 0, qubitCount);
             bitLenInt result = Compose(toCopy, midIndex);
-            ROL(start - midIndex, 0, qubitCount);
+            Reverse(bdtQubitCount, qubitCount);
 
             return result;
         }

--- a/src/qbdt/tree.cpp
+++ b/src/qbdt/tree.cpp
@@ -256,7 +256,7 @@ bitLenInt QBdt::Compose(QBdtPtr toCopy, bitLenInt start)
         if (start < midIndex) {
             ROL(midIndex - start, 0, qubitCount);
             bitLenInt result = Compose(toCopy, midIndex);
-            Reverse(bdtQubitCount, qubitCount);
+            ROR(midIndex - start, 0, qubitCount);
 
             return result;
         }

--- a/src/qbdt/tree.cpp
+++ b/src/qbdt/tree.cpp
@@ -250,8 +250,6 @@ complex QBdt::GetAmplitude(bitCapInt perm)
 bitLenInt QBdt::Compose(QBdtPtr toCopy, bitLenInt start)
 {
     if (attachedQubitCount && toCopy->attachedQubitCount) {
-        // TODO: This ROL/ROR is right for end points, but is it right for the middle?
-
         const bitLenInt midIndex = bdtQubitCount;
         if (start < midIndex) {
             ROL(midIndex - start, 0, qubitCount);

--- a/src/qbdt/tree.cpp
+++ b/src/qbdt/tree.cpp
@@ -250,6 +250,8 @@ complex QBdt::GetAmplitude(bitCapInt perm)
 bitLenInt QBdt::Compose(QBdtPtr toCopy, bitLenInt start)
 {
     if (attachedQubitCount && toCopy->attachedQubitCount) {
+        // TODO: This ROL/ROR is right for end points, but is it right for the middle?
+
         const bitLenInt midIndex = bdtQubitCount;
         if (start < midIndex) {
             ROL(midIndex - start, 0, qubitCount);
@@ -277,15 +279,15 @@ bitLenInt QBdt::Compose(QBdtPtr toCopy, bitLenInt start)
     }
 
     if (!attachedQubitCount && toCopy->attachedQubitCount && (start < qubitCount)) {
-        const bitLenInt endIndex = bdtQubitCount;
+        const bitLenInt endIndex = qubitCount;
         ROL(endIndex - start, 0, qubitCount);
-        bitLenInt result = Compose(toCopy, endIndex);
+        bitLenInt result = Compose(toCopy);
         ROR(endIndex - start, 0, qubitCount);
 
         return result;
     }
 
-    root->InsertAtDepth(toCopy->root, start, toCopy->qubitCount);
+    root->InsertAtDepth(toCopy->root, start, toCopy->bdtQubitCount);
     attachedQubitCount += toCopy->attachedQubitCount;
     SetQubitCount(qubitCount + toCopy->qubitCount);
 

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -2802,7 +2802,9 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_compose")
         qftReg = CreateQuantumInterface({ testEngineType, testSubEngineType, testSubSubEngineType }, 2, 0x03, rng);
         std::dynamic_pointer_cast<QBdt>(qftReg)->Attach(std::dynamic_pointer_cast<QEngine>(
             CreateQuantumInterface({ testSubEngineType, testSubSubEngineType }, 2, 0x02, rng)));
-        qftReg2 = CreateQuantumInterface({ testEngineType, testSubEngineType, testSubSubEngineType }, 4, 0x02, rng);
+        qftReg2 = CreateQuantumInterface({ testEngineType, testSubEngineType, testSubSubEngineType }, 2, 0x02, rng);
+        std::dynamic_pointer_cast<QBdt>(qftReg2)->Attach(std::dynamic_pointer_cast<QEngine>(
+            CreateQuantumInterface({ testSubEngineType, testSubSubEngineType }, 2, 0x00, rng)));
     } else {
         qftReg = CreateQuantumInterface({ testEngineType, testSubEngineType, testSubSubEngineType }, 4, 0x0b, rng);
         qftReg2 = CreateQuantumInterface({ testEngineType, testSubEngineType, testSubSubEngineType }, 4, 0x02, rng);


### PR DESCRIPTION
Toward #944, this implements general handling for `QBdt::Compose()` after both `QBdt` instances involved have called `Attach()` for their own `QEngine`.