### PR TITLE
pinvoke_api: remove unused variables.

### DIFF
--- a/src/pinvoke_api.cpp
+++ b/src/pinvoke_api.cpp
@@ -1497,9 +1497,6 @@ MICROSOFT_QUANTUM_DECL unsigned Measure(
 
     QInterfacePtr simulator = simulators[sid];
 
-    std::vector<unsigned> bVec;
-    std::vector<unsigned> qVec;
-
     unsigned toRet = -1;
     try {
         TransformPauliBasis(simulator, n, b, q);


### PR DESCRIPTION
Remove two unused variables.