### PR TITLE
Only allow QStabilizer to QBdt::Attach()

### DIFF
--- a/include/qbdt.hpp
+++ b/include/qbdt.hpp
@@ -18,8 +18,8 @@
 
 #include "mpsshard.hpp"
 #include "qbdt_qinterface_node.hpp"
-#include "qinterface.hpp"
 #include "qparity.hpp"
+#include "qstabilizer.hpp"
 
 #if ENABLE_ALU
 #include "qalu.hpp"
@@ -210,7 +210,7 @@ public:
     {
         return Compose(std::dynamic_pointer_cast<QBdt>(toCopy), start);
     }
-    virtual bitLenInt Attach(QInterfacePtr toCopy, bitLenInt start)
+    virtual bitLenInt Attach(QStabilizerPtr toCopy, bitLenInt start)
     {
         if (start == qubitCount) {
             return Attach(toCopy);
@@ -223,7 +223,7 @@ public:
 
         return result;
     }
-    virtual bitLenInt Attach(QInterfacePtr toCopy);
+    virtual bitLenInt Attach(QStabilizerPtr toCopy);
     virtual void Decompose(bitLenInt start, QInterfacePtr dest)
     {
         DecomposeDispose(start, dest->GetQubitCount(), std::dynamic_pointer_cast<QBdt>(dest));

--- a/src/pinvoke_api.cpp
+++ b/src/pinvoke_api.cpp
@@ -674,13 +674,8 @@ MICROSOFT_QUANTUM_DECL unsigned init_qbdt_stabilizer(_In_ unsigned q, _In_ unsig
     if (q || c) {
         try {
             simulator = std::dynamic_pointer_cast<QBdt>(CreateQuantumInterface(simulatorType, q, 0, randNumGen));
-            if (sd) {
-                simulator->Attach(CreateQuantumInterface(
-                    { QINTERFACE_QUNIT, QINTERFACE_STABILIZER }, c, 0, randNumGen, CMPLX_DEFAULT_ARG, false, false));
-            } else {
-                simulator->Attach(CreateQuantumInterface(
-                    { QINTERFACE_STABILIZER }, c, 0, randNumGen, CMPLX_DEFAULT_ARG, false, false));
-            }
+            simulator->Attach(std::dynamic_pointer_cast<QStabilizer>(
+                CreateQuantumInterface({ QINTERFACE_STABILIZER }, c, 0, randNumGen, CMPLX_DEFAULT_ARG, false, false)));
         } catch (...) {
             isSuccess = false;
         }

--- a/src/qbdt/tree.cpp
+++ b/src/qbdt/tree.cpp
@@ -388,7 +388,7 @@ bitLenInt QBdt::Compose(QBdtPtr toCopy, bitLenInt start)
     return start;
 }
 
-bitLenInt QBdt::Attach(QInterfacePtr toCopy)
+bitLenInt QBdt::Attach(QStabilizerPtr toCopy)
 {
     isAttached = true;
     const bitLenInt toRet = qubitCount;

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -2803,11 +2803,11 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_compose")
     QInterfacePtr qftReg2;
     if (testEngineType == QINTERFACE_BDT) {
         qftReg = CreateQuantumInterface({ testEngineType, testSubEngineType, testSubSubEngineType }, 2, 0x03, rng);
-        std::dynamic_pointer_cast<QBdt>(qftReg)->Attach(std::dynamic_pointer_cast<QInterface>(
-            CreateQuantumInterface({ testSubEngineType, testSubSubEngineType }, 2, 0x02, rng)));
+        std::dynamic_pointer_cast<QBdt>(qftReg)->Attach(
+            std::dynamic_pointer_cast<QStabilizer>(CreateQuantumInterface({ QINTERFACE_STABILIZER }, 2, 0x02, rng)));
         qftReg2 = CreateQuantumInterface({ testEngineType, testSubEngineType, testSubSubEngineType }, 2, 0x02, rng);
-        std::dynamic_pointer_cast<QBdt>(qftReg2)->Attach(std::dynamic_pointer_cast<QInterface>(
-            CreateQuantumInterface({ testSubEngineType, testSubSubEngineType }, 2, 0x00, rng)));
+        std::dynamic_pointer_cast<QBdt>(qftReg2)->Attach(
+            std::dynamic_pointer_cast<QStabilizer>(CreateQuantumInterface({ QINTERFACE_STABILIZER }, 2, 0x00, rng)));
     } else {
         qftReg = CreateQuantumInterface({ testEngineType, testSubEngineType, testSubSubEngineType }, 4, 0x0b, rng);
         qftReg2 = CreateQuantumInterface({ testEngineType, testSubEngineType, testSubSubEngineType }, 4, 0x02, rng);
@@ -6040,9 +6040,9 @@ TEST_CASE("test_mirror_circuit", "[mirror]")
                 } else if (gate1Qb == 4) {
                     testCase->S(i);
                 } else if (gate1Qb == 5) {
-                    testCase->T(i);
-                } else if (gate1Qb == 6) {
                     testCase->IS(i);
+                } else if (gate1Qb == 6) {
+                    testCase->T(i);
                 } else {
                     testCase->IT(i);
                 }
@@ -6129,9 +6129,9 @@ TEST_CASE("test_mirror_circuit", "[mirror]")
                 } else if (gate1Qb == 4) {
                     testCase->IS(i);
                 } else if (gate1Qb == 5) {
-                    testCase->IT(i);
-                } else if (gate1Qb == 6) {
                     testCase->S(i);
+                } else if (gate1Qb == 6) {
+                    testCase->IT(i);
                 } else {
                     testCase->T(i);
                 }
@@ -6161,10 +6161,10 @@ TEST_CASE("test_mirror_circuit", "[mirror]")
                         std::cout << "qftReg->S(" << (int)i << ");" << std::endl;
                         // testCase->S(i);
                     } else if (gate1Qb == 5) {
-                        std::cout << "qftReg->T(" << (int)i << ");" << std::endl;
+                        std::cout << "qftReg->IS(" << (int)i << ");" << std::endl;
                         // testCase->T(i);
                     } else if (gate1Qb == 6) {
-                        std::cout << "qftReg->IS(" << (int)i << ");" << std::endl;
+                        std::cout << "qftReg->T(" << (int)i << ");" << std::endl;
                         // testCase->IS(i);
                     } else {
                         std::cout << "qftReg->IT(" << (int)i << ");" << std::endl;
@@ -6309,10 +6309,10 @@ TEST_CASE("test_mirror_circuit", "[mirror]")
                         std::cout << "qftReg->IS(" << (int)i << ");" << std::endl;
                         // testCase->IS(i);
                     } else if (gate1Qb == 5) {
-                        std::cout << "qftReg->IT(" << (int)i << ");" << std::endl;
+                        std::cout << "qftReg->S(" << (int)i << ");" << std::endl;
                         // testCase->IT(i);
                     } else if (gate1Qb == 6) {
-                        std::cout << "qftReg->S(" << (int)i << ");" << std::endl;
+                        std::cout << "qftReg->IT(" << (int)i << ");" << std::endl;
                         // testCase->S(i);
                     } else {
                         std::cout << "qftReg->T(" << (int)i << ");" << std::endl;
@@ -6357,10 +6357,9 @@ TEST_CASE("test_mirror_quantum_volume", "[mirror]")
     int gate;
 
     for (int trial = 0; trial < TRIALS; trial++) {
-        QInterfacePtr testCase =
-            CreateQuantumInterface({ testEngineType, testSubEngineType, testSubSubEngineType }, magic, 0, rng);
-        std::dynamic_pointer_cast<QBdt>(testCase)->Attach(
-            CreateQuantumInterface({ QINTERFACE_STABILIZER }, n - magic, 0, rng, CMPLX_DEFAULT_ARG, false, false));
+        QInterfacePtr testCase = CreateQuantumInterface({ QINTERFACE_BDT }, magic, 0, rng);
+        std::dynamic_pointer_cast<QBdt>(testCase)->Attach(std::dynamic_pointer_cast<QStabilizer>(
+            CreateQuantumInterface({ QINTERFACE_STABILIZER }, n - magic, 0, rng, CMPLX_DEFAULT_ARG, false, false)));
 
         std::vector<std::vector<int>> gate1QbRands(Depth);
         std::vector<std::vector<MultiQubitGate>> gateMultiQbRands(Depth);
@@ -6429,9 +6428,9 @@ TEST_CASE("test_mirror_quantum_volume", "[mirror]")
                 } else if (gate1Qb == 4) {
                     testCase->S(i);
                 } else if (gate1Qb == 5) {
-                    testCase->T(i);
-                } else if (gate1Qb == 6) {
                     testCase->IS(i);
+                } else if (gate1Qb == 6) {
+                    testCase->T(i);
                 } else {
                     testCase->IT(i);
                 }
@@ -6518,9 +6517,9 @@ TEST_CASE("test_mirror_quantum_volume", "[mirror]")
                 } else if (gate1Qb == 4) {
                     testCase->IS(i);
                 } else if (gate1Qb == 5) {
-                    testCase->IT(i);
-                } else if (gate1Qb == 6) {
                     testCase->S(i);
+                } else if (gate1Qb == 6) {
+                    testCase->IT(i);
                 } else {
                     testCase->T(i);
                 }


### PR DESCRIPTION
Per #954, I notice that `QBdt::Attach()` is _very_ bugged for a ket simulator attachment. In general, we probably need to revert and complete d742e03 for this to work, via `PushStateVector()` and `PopStateVector()`, by multiplying out amplitudes to full tree depth. This is surmountable, but the need to multiply out amplitudes would seem to limit our ability to attach stabilizer representation. However, if we limit our gate set to entirely Clifford/Pauli, `QStabilizer` attachments **already work**, (about 98% of the time on `test_mirror_quantum_volume` if "hacked" for only stabilizer gates, to 100%, indicating that there is only a small bug, at most). There seems to be a symmetry to stabilizer sub-states that precludes the need for `PushStateVector()` and `PopStateVector()`.

Seeing as `QBdt::Attach()` is really only **useful** for `QStabilizer`, we can force this as a design requirement, and exclude ket simulator attachments. (If we first restrict the domain of our implementation just to barely what we need, we might re-orient ourselves faster in debugging.)