### PR TITLE
QBdt stabilizer phase debug

### DIFF
--- a/src/pinvoke_api.cpp
+++ b/src/pinvoke_api.cpp
@@ -675,7 +675,7 @@ MICROSOFT_QUANTUM_DECL unsigned init_qbdt_stabilizer(_In_ unsigned q, _In_ unsig
         try {
             simulator = std::dynamic_pointer_cast<QBdt>(CreateQuantumInterface(simulatorType, q, 0, randNumGen));
             simulator->Attach(std::dynamic_pointer_cast<QStabilizer>(
-                CreateQuantumInterface({ QINTERFACE_STABILIZER }, c, 0, randNumGen, CMPLX_DEFAULT_ARG, false, false)));
+                CreateQuantumInterface({ QINTERFACE_STABILIZER }, c, 0, randNumGen)));
         } catch (...) {
             isSuccess = false;
         }

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -5943,28 +5943,16 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_mirror_circuit_26", "[mirror]")
 
     qftReg->SetPermutation(3);
 
-    qftReg->H(0);
-    qftReg->H(2);
-    qftReg->AntiCY(2, 0);
-    qftReg->H(0);
     qftReg->H(1);
     qftReg->Y(2);
-    qftReg->CY(2, 0);
     qftReg->Z(0);
     qftReg->S(1);
-    qftReg->H(2);
     qftReg->Swap(2, 1);
     qftReg->Swap(2, 1);
-    qftReg->H(2);
     qftReg->IS(1);
     qftReg->Z(0);
-    qftReg->CY(2, 0);
     qftReg->Y(2);
     qftReg->H(1);
-    qftReg->H(0);
-    qftReg->AntiCY(2, 0);
-    qftReg->H(2);
-    qftReg->H(0);
 
     REQUIRE(qftReg->MAll() == 3);
 }

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -5938,8 +5938,8 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_mirror_circuit_26", "[mirror]")
     }
 
     qftReg = CreateQuantumInterface({ QINTERFACE_BDT }, 1U, 0, rng);
-    std::dynamic_pointer_cast<QBdt>(qftReg)->Attach(std::dynamic_pointer_cast<QStabilizer>(
-        CreateQuantumInterface({ QINTERFACE_STABILIZER }, 2U, 0, rng, CMPLX_DEFAULT_ARG, false, false)));
+    std::dynamic_pointer_cast<QBdt>(qftReg)->Attach(
+        std::dynamic_pointer_cast<QStabilizer>(CreateQuantumInterface({ QINTERFACE_STABILIZER }, 2U, 0, rng)));
 
     qftReg->SetPermutation(7);
 
@@ -6384,7 +6384,7 @@ TEST_CASE("test_mirror_quantum_volume", "[mirror]")
     for (int trial = 0; trial < TRIALS; trial++) {
         QInterfacePtr testCase = CreateQuantumInterface({ QINTERFACE_BDT }, magic, 0, rng);
         std::dynamic_pointer_cast<QBdt>(testCase)->Attach(std::dynamic_pointer_cast<QStabilizer>(
-            CreateQuantumInterface({ QINTERFACE_STABILIZER }, n - magic, 0, rng, CMPLX_DEFAULT_ARG, false, false)));
+            CreateQuantumInterface({ QINTERFACE_STABILIZER }, n - magic, 0, rng)));
 
         std::vector<std::vector<int>> gate1QbRands(Depth);
         std::vector<std::vector<MultiQubitGate>> gateMultiQbRands(Depth);

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -5941,20 +5941,18 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_mirror_circuit_26", "[mirror]")
     std::dynamic_pointer_cast<QBdt>(qftReg)->Attach(std::dynamic_pointer_cast<QStabilizer>(
         CreateQuantumInterface({ QINTERFACE_STABILIZER }, 2U, 0, rng, CMPLX_DEFAULT_ARG, false, false)));
 
-    qftReg->SetPermutation(3);
+    qftReg->SetPermutation(7);
 
     qftReg->H(1);
-    qftReg->Y(2);
     qftReg->Z(0);
     qftReg->S(1);
     qftReg->Swap(2, 1);
     qftReg->Swap(2, 1);
     qftReg->IS(1);
     qftReg->Z(0);
-    qftReg->Y(2);
     qftReg->H(1);
 
-    REQUIRE(qftReg->MAll() == 3);
+    REQUIRE(qftReg->MAll() == 7);
 }
 
 bitLenInt pickRandomBit(QInterfacePtr qReg, std::set<bitLenInt>* unusedBitsPtr)

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -5930,6 +5930,45 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_mirror_circuit_25", "[mirror]")
     REQUIRE(qftReg->MAll() == 2);
 }
 
+TEST_CASE_METHOD(QInterfaceTestFixture, "test_mirror_circuit_26", "[mirror]")
+{
+    if (testEngineType != QINTERFACE_BDT) {
+        std::cout << "skipped" << std::endl;
+        return;
+    }
+
+    qftReg = CreateQuantumInterface({ QINTERFACE_BDT }, 1U, 0, rng);
+    std::dynamic_pointer_cast<QBdt>(qftReg)->Attach(std::dynamic_pointer_cast<QStabilizer>(
+        CreateQuantumInterface({ QINTERFACE_STABILIZER }, 2U, 0, rng, CMPLX_DEFAULT_ARG, false, false)));
+
+    qftReg->SetPermutation(3);
+
+    qftReg->H(0);
+    qftReg->H(2);
+    qftReg->AntiCY(2, 0);
+    qftReg->H(0);
+    qftReg->H(1);
+    qftReg->Y(2);
+    qftReg->CY(2, 0);
+    qftReg->Z(0);
+    qftReg->S(1);
+    qftReg->H(2);
+    qftReg->Swap(2, 1);
+    qftReg->Swap(2, 1);
+    qftReg->H(2);
+    qftReg->IS(1);
+    qftReg->Z(0);
+    qftReg->CY(2, 0);
+    qftReg->Y(2);
+    qftReg->H(1);
+    qftReg->H(0);
+    qftReg->AntiCY(2, 0);
+    qftReg->H(2);
+    qftReg->H(0);
+
+    REQUIRE(qftReg->MAll() == 3);
+}
+
 bitLenInt pickRandomBit(QInterfacePtr qReg, std::set<bitLenInt>* unusedBitsPtr)
 {
     std::set<bitLenInt>::iterator bitIterator = unusedBitsPtr->begin();


### PR DESCRIPTION
If we limit to just `QStabilizer` attachments to `QBdt`, as we do not `PushStateVector()` or `PopStateVector()` to multiply-out amplitudes, we also do not normalize stabilizer phase per usual `QBdt` rules. (If we limit `test_mirror_quantum_volume` to just Clifford and Pauli gates, this now seems to have a 100% success rate.)