### PR TITLE
QBdt Attach() debug

### DIFF
--- a/include/qbdt_qinterface_node.hpp
+++ b/include/qbdt_qinterface_node.hpp
@@ -71,13 +71,13 @@ public:
 
     virtual void Branch(bitLenInt depth = 1U);
 
-    virtual void Prune(bitLenInt depth = 1U) {}
+    virtual void Prune(bitLenInt depth = 1U);
 
     virtual void InsertAtDepth(QBdtNodeInterfacePtr b, bitLenInt depth, const bitLenInt& size);
 
     virtual QBdtNodeInterfacePtr RemoveSeparableAtDepth(bitLenInt depth, const bitLenInt& size);
 
-    virtual void PopStateVector(bitLenInt depth = 1U) {}
+    virtual void PopStateVector(bitLenInt depth = 1U) { Prune(); }
 
 #if ENABLE_COMPLEX_X2
     virtual void Apply2x2(const complex2& mtrxCol1, const complex2& mtrxCol2, bitLenInt depth)

--- a/include/qstabilizer.hpp
+++ b/include/qstabilizer.hpp
@@ -57,6 +57,7 @@ protected:
     std::vector<BoolVector> z;
     // Phase bits: 0 for +1, 1 for i, 2 for -1, 3 for -i.  Normally either 0 or 2.
     std::vector<uint8_t> r;
+    complex phaseOffset;
 
     unsigned rawRandBools;
     unsigned rawRandBoolsRemaining;

--- a/src/pinvoke_api.cpp
+++ b/src/pinvoke_api.cpp
@@ -675,7 +675,7 @@ MICROSOFT_QUANTUM_DECL unsigned init_qbdt_stabilizer(_In_ unsigned q, _In_ unsig
         try {
             simulator = std::dynamic_pointer_cast<QBdt>(CreateQuantumInterface(simulatorType, q, 0, randNumGen));
             simulator->Attach(std::dynamic_pointer_cast<QStabilizer>(
-                CreateQuantumInterface({ QINTERFACE_STABILIZER }, c, 0, randNumGen)));
+                CreateQuantumInterface({ QINTERFACE_STABILIZER }, c, 0, randNumGen, CMPLX_DEFAULT_ARG, false, false)));
         } catch (...) {
             isSuccess = false;
         }

--- a/src/qbdt/qinterface_node.cpp
+++ b/src/qbdt/qinterface_node.cpp
@@ -83,6 +83,32 @@ void QBdtQInterfaceNode::Branch(bitLenInt depth)
     }
 }
 
+void QBdtQInterfaceNode::Prune(bitLenInt depth)
+{
+    if (!depth) {
+        return;
+    }
+
+    if (norm(scale) <= FP_NORM_EPSILON) {
+        SetZero();
+        return;
+    }
+
+    if (!qReg) {
+        return;
+    }
+
+    if (qReg->GetIsArbitraryGlobalPhase()) {
+        throw std::invalid_argument("QBdt attached qubits cannot have arbitrary global phase!");
+    }
+
+    const real1_f phaseArg = qReg->FirstNonzeroPhase();
+    std::cout << "phaseArg=" << phaseArg << std::endl;
+    const complex phaseFac = std::polar((real1_f)ONE_R1, (real1_f)-phaseArg);
+    qReg->Phase(phaseFac, phaseFac, 0);
+    scale *= (complex)std::polar((real1_f)ONE_R1, (real1_f)phaseArg);
+}
+
 void QBdtQInterfaceNode::InsertAtDepth(QBdtNodeInterfacePtr b, bitLenInt depth, const bitLenInt& size)
 {
     if (norm(scale) <= FP_NORM_EPSILON) {

--- a/src/qbdt/qinterface_node.cpp
+++ b/src/qbdt/qinterface_node.cpp
@@ -103,7 +103,6 @@ void QBdtQInterfaceNode::Prune(bitLenInt depth)
     }
 
     const real1_f phaseArg = qReg->FirstNonzeroPhase();
-    std::cout << "phaseArg=" << phaseArg << std::endl;
     const complex phaseFac = std::polar((real1_f)ONE_R1, (real1_f)-phaseArg);
     qReg->Phase(phaseFac, phaseFac, 0);
     scale *= (complex)std::polar((real1_f)ONE_R1, (real1_f)phaseArg);

--- a/src/qstabilizer.cpp
+++ b/src/qstabilizer.cpp
@@ -1084,7 +1084,11 @@ void QStabilizer::Mtrx(const complex* mtrx, bitLenInt target)
     if (IS_SAME(mtrx[0], mtrx[1]) && IS_SAME(mtrx[0], mtrx[2]) && IS_SAME(mtrx[0], -mtrx[3])) {
         H(target);
         if (!randGlobalPhase) {
-            phaseOffset *= mtrx[0] / std::abs(mtrx[0]);
+            if (!IsSeparableZ(target) || !M(target)) {
+                phaseOffset *= mtrx[0] / std::abs(mtrx[0]);
+            } else {
+                phaseOffset *= mtrx[3] / std::abs(mtrx[3]);
+            }
         }
         return;
     }
@@ -1093,7 +1097,11 @@ void QStabilizer::Mtrx(const complex* mtrx, bitLenInt target)
         // Equivalent to X before H
         StabilizerISqrtY(target);
         if (!randGlobalPhase) {
-            phaseOffset *= mtrx[0] / std::abs(mtrx[0]);
+            if (!IsSeparableZ(target) || !M(target)) {
+                phaseOffset *= mtrx[0] / std::abs(mtrx[0]);
+            } else {
+                phaseOffset *= mtrx[3] / std::abs(mtrx[3]);
+            }
         }
         return;
     }
@@ -1102,7 +1110,11 @@ void QStabilizer::Mtrx(const complex* mtrx, bitLenInt target)
         // Equivalent to H before X
         StabilizerSqrtY(target);
         if (!randGlobalPhase) {
-            phaseOffset *= mtrx[0] / std::abs(mtrx[0]);
+            if (!IsSeparableZ(target) || !M(target)) {
+                phaseOffset *= mtrx[0] / std::abs(mtrx[0]);
+            } else {
+                phaseOffset *= mtrx[3] / std::abs(mtrx[3]);
+            }
         }
         return;
     }
@@ -1112,7 +1124,11 @@ void QStabilizer::Mtrx(const complex* mtrx, bitLenInt target)
         X(target);
         StabilizerSqrtY(target);
         if (!randGlobalPhase) {
-            phaseOffset *= mtrx[0] / std::abs(mtrx[0]);
+            if (!IsSeparableZ(target) || !M(target)) {
+                phaseOffset *= mtrx[0] / std::abs(mtrx[0]);
+            } else {
+                phaseOffset *= mtrx[3] / std::abs(mtrx[3]);
+            }
         }
         return;
     }
@@ -1121,7 +1137,11 @@ void QStabilizer::Mtrx(const complex* mtrx, bitLenInt target)
         H(target);
         S(target);
         if (!randGlobalPhase) {
-            phaseOffset *= mtrx[0] / std::abs(mtrx[0]);
+            if (!IsSeparableZ(target) || !M(target)) {
+                phaseOffset *= mtrx[0] / std::abs(mtrx[0]);
+            } else {
+                phaseOffset *= mtrx[3] / std::abs(mtrx[3]);
+            }
         }
         return;
     }
@@ -1130,7 +1150,11 @@ void QStabilizer::Mtrx(const complex* mtrx, bitLenInt target)
         StabilizerISqrtY(target);
         S(target);
         if (!randGlobalPhase) {
-            phaseOffset *= mtrx[0] / std::abs(mtrx[0]);
+            if (!IsSeparableZ(target) || !M(target)) {
+                phaseOffset *= mtrx[0] / std::abs(mtrx[0]);
+            } else {
+                phaseOffset *= mtrx[3] / std::abs(mtrx[3]);
+            }
         }
         return;
     }
@@ -1140,7 +1164,11 @@ void QStabilizer::Mtrx(const complex* mtrx, bitLenInt target)
         X(target);
         IS(target);
         if (!randGlobalPhase) {
-            phaseOffset *= mtrx[0] / std::abs(mtrx[0]);
+            if (!IsSeparableZ(target) || !M(target)) {
+                phaseOffset *= mtrx[0] / std::abs(mtrx[0]);
+            } else {
+                phaseOffset *= mtrx[3] / std::abs(mtrx[3]);
+            }
         }
         return;
     }
@@ -1150,7 +1178,11 @@ void QStabilizer::Mtrx(const complex* mtrx, bitLenInt target)
         X(target);
         S(target);
         if (!randGlobalPhase) {
-            phaseOffset *= mtrx[0] / std::abs(mtrx[0]);
+            if (!IsSeparableZ(target) || !M(target)) {
+                phaseOffset *= mtrx[0] / std::abs(mtrx[0]);
+            } else {
+                phaseOffset *= mtrx[3] / std::abs(mtrx[3]);
+            }
         }
         return;
     }
@@ -1159,7 +1191,11 @@ void QStabilizer::Mtrx(const complex* mtrx, bitLenInt target)
         IS(target);
         H(target);
         if (!randGlobalPhase) {
-            phaseOffset *= mtrx[0] / std::abs(mtrx[0]);
+            if (!IsSeparableZ(target) || !M(target)) {
+                phaseOffset *= mtrx[0] / std::abs(mtrx[0]);
+            } else {
+                phaseOffset *= mtrx[3] / std::abs(mtrx[3]);
+            }
         }
         return;
     }
@@ -1168,7 +1204,11 @@ void QStabilizer::Mtrx(const complex* mtrx, bitLenInt target)
         S(target);
         H(target);
         if (!randGlobalPhase) {
-            phaseOffset *= mtrx[0] / std::abs(mtrx[0]);
+            if (!IsSeparableZ(target) || !M(target)) {
+                phaseOffset *= mtrx[0] / std::abs(mtrx[0]);
+            } else {
+                phaseOffset *= mtrx[3] / std::abs(mtrx[3]);
+            }
         }
         return;
     }
@@ -1179,7 +1219,11 @@ void QStabilizer::Mtrx(const complex* mtrx, bitLenInt target)
         X(target);
         Z(target);
         if (!randGlobalPhase) {
-            phaseOffset *= mtrx[0] / std::abs(mtrx[0]);
+            if (!IsSeparableZ(target) || !M(target)) {
+                phaseOffset *= mtrx[0] / std::abs(mtrx[0]);
+            } else {
+                phaseOffset *= mtrx[3] / std::abs(mtrx[3]);
+            }
         }
         return;
     }
@@ -1190,7 +1234,11 @@ void QStabilizer::Mtrx(const complex* mtrx, bitLenInt target)
         X(target);
         Z(target);
         if (!randGlobalPhase) {
-            phaseOffset *= mtrx[0] / std::abs(mtrx[0]);
+            if (!IsSeparableZ(target) || !M(target)) {
+                phaseOffset *= mtrx[0] / std::abs(mtrx[0]);
+            } else {
+                phaseOffset *= mtrx[3] / std::abs(mtrx[3]);
+            }
         }
         return;
     }
@@ -1198,7 +1246,11 @@ void QStabilizer::Mtrx(const complex* mtrx, bitLenInt target)
     if (IS_SAME(mtrx[0], I_CMPLX * mtrx[1]) && IS_SAME(mtrx[0], I_CMPLX * mtrx[2]) && IS_SAME(mtrx[0], mtrx[3])) {
         StabilizerSqrtX(target);
         if (!randGlobalPhase) {
-            phaseOffset *= mtrx[0] / std::abs(mtrx[0]);
+            if (!IsSeparableZ(target) || !M(target)) {
+                phaseOffset *= mtrx[0] / std::abs(mtrx[0]);
+            } else {
+                phaseOffset *= mtrx[3] / std::abs(mtrx[3]);
+            }
         }
         return;
     }
@@ -1206,7 +1258,11 @@ void QStabilizer::Mtrx(const complex* mtrx, bitLenInt target)
     if (IS_SAME(mtrx[0], -I_CMPLX * mtrx[1]) && IS_SAME(mtrx[0], -I_CMPLX * mtrx[2]) && IS_SAME(mtrx[0], mtrx[3])) {
         StabilizerISqrtX(target);
         if (!randGlobalPhase) {
-            phaseOffset *= mtrx[0] / std::abs(mtrx[0]);
+            if (!IsSeparableZ(target) || !M(target)) {
+                phaseOffset *= mtrx[0] / std::abs(mtrx[0]);
+            } else {
+                phaseOffset *= mtrx[3] / std::abs(mtrx[3]);
+            }
         }
         return;
     }
@@ -1215,7 +1271,11 @@ void QStabilizer::Mtrx(const complex* mtrx, bitLenInt target)
         StabilizerSqrtX(target);
         Z(target);
         if (!randGlobalPhase) {
-            phaseOffset *= mtrx[0] / std::abs(mtrx[0]);
+            if (!IsSeparableZ(target) || !M(target)) {
+                phaseOffset *= mtrx[0] / std::abs(mtrx[0]);
+            } else {
+                phaseOffset *= mtrx[3] / std::abs(mtrx[3]);
+            }
         }
         return;
     }
@@ -1224,7 +1284,11 @@ void QStabilizer::Mtrx(const complex* mtrx, bitLenInt target)
         Z(target);
         StabilizerSqrtX(target);
         if (!randGlobalPhase) {
-            phaseOffset *= mtrx[0] / std::abs(mtrx[0]);
+            if (!IsSeparableZ(target) || !M(target)) {
+                phaseOffset *= mtrx[0] / std::abs(mtrx[0]);
+            } else {
+                phaseOffset *= mtrx[3] / std::abs(mtrx[3]);
+            }
         }
         return;
     }

--- a/src/qstabilizer.cpp
+++ b/src/qstabilizer.cpp
@@ -1087,7 +1087,7 @@ void QStabilizer::Mtrx(const complex* mtrx, bitLenInt target)
             if (!IsSeparableZ(target) || !M(target)) {
                 phaseOffset *= mtrx[0] / std::abs(mtrx[0]);
             } else {
-                phaseOffset *= mtrx[3] / std::abs(mtrx[3]);
+                phaseOffset *= mtrx[1] / std::abs(mtrx[1]);
             }
         }
         return;
@@ -1100,7 +1100,7 @@ void QStabilizer::Mtrx(const complex* mtrx, bitLenInt target)
             if (!IsSeparableZ(target) || !M(target)) {
                 phaseOffset *= mtrx[0] / std::abs(mtrx[0]);
             } else {
-                phaseOffset *= mtrx[3] / std::abs(mtrx[3]);
+                phaseOffset *= mtrx[1] / std::abs(mtrx[1]);
             }
         }
         return;
@@ -1113,7 +1113,7 @@ void QStabilizer::Mtrx(const complex* mtrx, bitLenInt target)
             if (!IsSeparableZ(target) || !M(target)) {
                 phaseOffset *= mtrx[0] / std::abs(mtrx[0]);
             } else {
-                phaseOffset *= mtrx[3] / std::abs(mtrx[3]);
+                phaseOffset *= mtrx[1] / std::abs(mtrx[1]);
             }
         }
         return;
@@ -1127,7 +1127,7 @@ void QStabilizer::Mtrx(const complex* mtrx, bitLenInt target)
             if (!IsSeparableZ(target) || !M(target)) {
                 phaseOffset *= mtrx[0] / std::abs(mtrx[0]);
             } else {
-                phaseOffset *= mtrx[3] / std::abs(mtrx[3]);
+                phaseOffset *= mtrx[1] / std::abs(mtrx[1]);
             }
         }
         return;
@@ -1140,7 +1140,7 @@ void QStabilizer::Mtrx(const complex* mtrx, bitLenInt target)
             if (!IsSeparableZ(target) || !M(target)) {
                 phaseOffset *= mtrx[0] / std::abs(mtrx[0]);
             } else {
-                phaseOffset *= mtrx[3] / std::abs(mtrx[3]);
+                phaseOffset *= mtrx[1] / std::abs(mtrx[1]);
             }
         }
         return;
@@ -1153,7 +1153,7 @@ void QStabilizer::Mtrx(const complex* mtrx, bitLenInt target)
             if (!IsSeparableZ(target) || !M(target)) {
                 phaseOffset *= mtrx[0] / std::abs(mtrx[0]);
             } else {
-                phaseOffset *= mtrx[3] / std::abs(mtrx[3]);
+                phaseOffset *= mtrx[1] / std::abs(mtrx[1]);
             }
         }
         return;
@@ -1167,7 +1167,7 @@ void QStabilizer::Mtrx(const complex* mtrx, bitLenInt target)
             if (!IsSeparableZ(target) || !M(target)) {
                 phaseOffset *= mtrx[0] / std::abs(mtrx[0]);
             } else {
-                phaseOffset *= mtrx[3] / std::abs(mtrx[3]);
+                phaseOffset *= mtrx[1] / std::abs(mtrx[1]);
             }
         }
         return;
@@ -1181,7 +1181,7 @@ void QStabilizer::Mtrx(const complex* mtrx, bitLenInt target)
             if (!IsSeparableZ(target) || !M(target)) {
                 phaseOffset *= mtrx[0] / std::abs(mtrx[0]);
             } else {
-                phaseOffset *= mtrx[3] / std::abs(mtrx[3]);
+                phaseOffset *= mtrx[1] / std::abs(mtrx[1]);
             }
         }
         return;
@@ -1194,7 +1194,7 @@ void QStabilizer::Mtrx(const complex* mtrx, bitLenInt target)
             if (!IsSeparableZ(target) || !M(target)) {
                 phaseOffset *= mtrx[0] / std::abs(mtrx[0]);
             } else {
-                phaseOffset *= mtrx[3] / std::abs(mtrx[3]);
+                phaseOffset *= mtrx[1] / std::abs(mtrx[1]);
             }
         }
         return;
@@ -1207,7 +1207,7 @@ void QStabilizer::Mtrx(const complex* mtrx, bitLenInt target)
             if (!IsSeparableZ(target) || !M(target)) {
                 phaseOffset *= mtrx[0] / std::abs(mtrx[0]);
             } else {
-                phaseOffset *= mtrx[3] / std::abs(mtrx[3]);
+                phaseOffset *= mtrx[1] / std::abs(mtrx[1]);
             }
         }
         return;
@@ -1222,7 +1222,7 @@ void QStabilizer::Mtrx(const complex* mtrx, bitLenInt target)
             if (!IsSeparableZ(target) || !M(target)) {
                 phaseOffset *= mtrx[0] / std::abs(mtrx[0]);
             } else {
-                phaseOffset *= mtrx[3] / std::abs(mtrx[3]);
+                phaseOffset *= mtrx[1] / std::abs(mtrx[1]);
             }
         }
         return;
@@ -1237,7 +1237,7 @@ void QStabilizer::Mtrx(const complex* mtrx, bitLenInt target)
             if (!IsSeparableZ(target) || !M(target)) {
                 phaseOffset *= mtrx[0] / std::abs(mtrx[0]);
             } else {
-                phaseOffset *= mtrx[3] / std::abs(mtrx[3]);
+                phaseOffset *= mtrx[1] / std::abs(mtrx[1]);
             }
         }
         return;
@@ -1249,7 +1249,7 @@ void QStabilizer::Mtrx(const complex* mtrx, bitLenInt target)
             if (!IsSeparableZ(target) || !M(target)) {
                 phaseOffset *= mtrx[0] / std::abs(mtrx[0]);
             } else {
-                phaseOffset *= mtrx[3] / std::abs(mtrx[3]);
+                phaseOffset *= mtrx[1] / std::abs(mtrx[1]);
             }
         }
         return;
@@ -1261,7 +1261,7 @@ void QStabilizer::Mtrx(const complex* mtrx, bitLenInt target)
             if (!IsSeparableZ(target) || !M(target)) {
                 phaseOffset *= mtrx[0] / std::abs(mtrx[0]);
             } else {
-                phaseOffset *= mtrx[3] / std::abs(mtrx[3]);
+                phaseOffset *= mtrx[1] / std::abs(mtrx[1]);
             }
         }
         return;
@@ -1274,7 +1274,7 @@ void QStabilizer::Mtrx(const complex* mtrx, bitLenInt target)
             if (!IsSeparableZ(target) || !M(target)) {
                 phaseOffset *= mtrx[0] / std::abs(mtrx[0]);
             } else {
-                phaseOffset *= mtrx[3] / std::abs(mtrx[3]);
+                phaseOffset *= mtrx[1] / std::abs(mtrx[1]);
             }
         }
         return;
@@ -1287,7 +1287,7 @@ void QStabilizer::Mtrx(const complex* mtrx, bitLenInt target)
             if (!IsSeparableZ(target) || !M(target)) {
                 phaseOffset *= mtrx[0] / std::abs(mtrx[0]);
             } else {
-                phaseOffset *= mtrx[3] / std::abs(mtrx[3]);
+                phaseOffset *= mtrx[1] / std::abs(mtrx[1]);
             }
         }
         return;

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -2803,11 +2803,11 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_compose")
     QInterfacePtr qftReg2;
     if (testEngineType == QINTERFACE_BDT) {
         qftReg = CreateQuantumInterface({ testEngineType, testSubEngineType, testSubSubEngineType }, 2, 0x03, rng);
-        std::dynamic_pointer_cast<QBdt>(qftReg)->Attach(
-            std::dynamic_pointer_cast<QStabilizer>(CreateQuantumInterface({ QINTERFACE_STABILIZER }, 2, 0x02, rng)));
+        std::dynamic_pointer_cast<QBdt>(qftReg)->Attach(std::dynamic_pointer_cast<QStabilizer>(
+            CreateQuantumInterface({ QINTERFACE_STABILIZER }, 2, 0x02, rng, CMPLX_DEFAULT_ARG, false, false)));
         qftReg2 = CreateQuantumInterface({ testEngineType, testSubEngineType, testSubSubEngineType }, 2, 0x02, rng);
-        std::dynamic_pointer_cast<QBdt>(qftReg2)->Attach(
-            std::dynamic_pointer_cast<QStabilizer>(CreateQuantumInterface({ QINTERFACE_STABILIZER }, 2, 0x00, rng)));
+        std::dynamic_pointer_cast<QBdt>(qftReg2)->Attach(std::dynamic_pointer_cast<QStabilizer>(
+            CreateQuantumInterface({ QINTERFACE_STABILIZER }, 2, 0x00, rng, CMPLX_DEFAULT_ARG, false, false)));
     } else {
         qftReg = CreateQuantumInterface({ testEngineType, testSubEngineType, testSubSubEngineType }, 4, 0x0b, rng);
         qftReg2 = CreateQuantumInterface({ testEngineType, testSubEngineType, testSubSubEngineType }, 4, 0x02, rng);
@@ -3571,11 +3571,15 @@ TEST_CASE("test_attach")
     std::cout << ">>> 'test_attach':" << std::endl;
 
     QInterfacePtr qftReg = CreateQuantumInterface({ QINTERFACE_BDT }, 1U, 0, rng);
-    std::dynamic_pointer_cast<QBdt>(qftReg)->Attach(
-        std::dynamic_pointer_cast<QStabilizer>(CreateQuantumInterface({ QINTERFACE_STABILIZER }, 1U, 0, rng)));
+    std::dynamic_pointer_cast<QBdt>(qftReg)->Attach(std::dynamic_pointer_cast<QStabilizer>(
+        CreateQuantumInterface({ QINTERFACE_STABILIZER }, 1U, 0, rng, CMPLX_DEFAULT_ARG, false, false)));
 
     qftReg->SetPermutation(0x2);
-    qftReg->CNOT(1, 0);
+    qftReg->H(0);
+    REQUIRE_THAT(qftReg, HasProbability(1, 1, 0x1));
+    qftReg->CZ(1, 0);
+    REQUIRE_THAT(qftReg, HasProbability(1, 1, 0x1));
+    qftReg->H(0);
     REQUIRE_THAT(qftReg, HasProbability(0x3));
 }
 
@@ -5956,8 +5960,8 @@ TEST_CASE("test_mirror_circuit_26", "[mirror]")
     std::cout << ">>> 'test_mirror_circuit_26':" << std::endl;
 
     QInterfacePtr qftReg = CreateQuantumInterface({ QINTERFACE_BDT }, 1U, 0, rng);
-    std::dynamic_pointer_cast<QBdt>(qftReg)->Attach(
-        std::dynamic_pointer_cast<QStabilizer>(CreateQuantumInterface({ QINTERFACE_STABILIZER }, 2U, 0, rng)));
+    std::dynamic_pointer_cast<QBdt>(qftReg)->Attach(std::dynamic_pointer_cast<QStabilizer>(
+        CreateQuantumInterface({ QINTERFACE_STABILIZER }, 2U, 0, rng, CMPLX_DEFAULT_ARG, false, false)));
 
     qftReg->SetPermutation(7);
 
@@ -6400,7 +6404,7 @@ TEST_CASE("test_mirror_near_clifford", "[mirror]")
     for (int trial = 0; trial < TRIALS; trial++) {
         QInterfacePtr testCase = CreateQuantumInterface({ QINTERFACE_BDT }, magic, 0, rng);
         std::dynamic_pointer_cast<QBdt>(testCase)->Attach(std::dynamic_pointer_cast<QStabilizer>(
-            CreateQuantumInterface({ QINTERFACE_STABILIZER }, n - magic, 0, rng)));
+            CreateQuantumInterface({ QINTERFACE_STABILIZER }, n - magic, 0, rng, CMPLX_DEFAULT_ARG, false, false)));
 
         std::vector<std::vector<int>> gate1QbRands(Depth);
         std::vector<std::vector<MultiQubitGate>> gateMultiQbRands(Depth);
@@ -6602,7 +6606,7 @@ TEST_CASE("test_mirror_quantum_volume", "[mirror]")
     for (int trial = 0; trial < TRIALS; trial++) {
         QInterfacePtr testCase = CreateQuantumInterface({ QINTERFACE_BDT }, magic, 0, rng);
         std::dynamic_pointer_cast<QBdt>(testCase)->Attach(std::dynamic_pointer_cast<QStabilizer>(
-            CreateQuantumInterface({ QINTERFACE_STABILIZER }, n - magic, 0, rng)));
+            CreateQuantumInterface({ QINTERFACE_STABILIZER }, n - magic, 0, rng, CMPLX_DEFAULT_ARG, false, false)));
 
         std::vector<std::vector<int>> gate1QbRands(Depth);
         std::vector<std::vector<MultiQubitGate>> gateMultiQbRands(Depth);

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -3562,6 +3562,23 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_ciadc")
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 2));
 }
 
+TEST_CASE("test_attach")
+{
+    if (testEngineType != QINTERFACE_BDT) {
+        std::cout << ">>> 'test_attach': skipped" << std::endl;
+        return;
+    }
+    std::cout << ">>> 'test_attach':" << std::endl;
+
+    QInterfacePtr qftReg = CreateQuantumInterface({ QINTERFACE_BDT }, 1U, 0, rng);
+    std::dynamic_pointer_cast<QBdt>(qftReg)->Attach(
+        std::dynamic_pointer_cast<QStabilizer>(CreateQuantumInterface({ QINTERFACE_STABILIZER }, 1U, 0, rng)));
+
+    qftReg->SetPermutation(0x1);
+    qftReg->CNOT(0, 1);
+    REQUIRE_THAT(qftReg, HasProbability(0x3));
+}
+
 int qRand(int high, QInterfacePtr q)
 {
     int rand = (int)(high * q->Rand());
@@ -5930,14 +5947,15 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_mirror_circuit_25", "[mirror]")
     REQUIRE(qftReg->MAll() == 2);
 }
 
-TEST_CASE_METHOD(QInterfaceTestFixture, "test_mirror_circuit_26", "[mirror]")
+TEST_CASE("test_mirror_circuit_26", "[mirror]")
 {
     if (testEngineType != QINTERFACE_BDT) {
-        std::cout << "skipped" << std::endl;
+        std::cout << ">>> 'test_mirror_circuit_26': skipped" << std::endl;
         return;
     }
+    std::cout << ">>> 'test_mirror_circuit_26':" << std::endl;
 
-    qftReg = CreateQuantumInterface({ QINTERFACE_BDT }, 1U, 0, rng);
+    QInterfacePtr qftReg = CreateQuantumInterface({ QINTERFACE_BDT }, 1U, 0, rng);
     std::dynamic_pointer_cast<QBdt>(qftReg)->Attach(
         std::dynamic_pointer_cast<QStabilizer>(CreateQuantumInterface({ QINTERFACE_STABILIZER }, 2U, 0, rng)));
 
@@ -6356,7 +6374,6 @@ TEST_CASE("test_mirror_near_clifford", "[mirror]")
         std::cout << ">>> 'test_mirror_near_clifford': skipped" << std::endl;
         return;
     }
-
     std::cout << ">>> 'test_mirror_near_clifford':" << std::endl;
 
     const int GateCount1Qb = 8;

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -3574,8 +3574,8 @@ TEST_CASE("test_attach")
     std::dynamic_pointer_cast<QBdt>(qftReg)->Attach(
         std::dynamic_pointer_cast<QStabilizer>(CreateQuantumInterface({ QINTERFACE_STABILIZER }, 1U, 0, rng)));
 
-    qftReg->SetPermutation(0x1);
-    qftReg->CNOT(0, 1);
+    qftReg->SetPermutation(0x2);
+    qftReg->CNOT(1, 0);
     REQUIRE_THAT(qftReg, HasProbability(0x3));
 }
 


### PR DESCRIPTION
It turns out, Aaronson's original implementation of stabilizer tableau seems to freely factor out non-observable global phase offset. (Why wouldn't it?) However, we need to track global phase offset as non-arbitrary for `QBdt` attachment. (This PR makes `test_cfulladd` and tests for related adder circuits pass, for example.)