### PR TITLE
QBdt improvements (#954)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -251,7 +251,7 @@ install (FILES
     include/qbdt.hpp
     include/qbdt_node.hpp
     include/qbdt_node_interface.hpp
-    include/qbdt_qinterface_node.hpp
+    include/qbdt_qengine_node.hpp
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/qrack
     )
 

--- a/cmake/Qbdt.cmake
+++ b/cmake/Qbdt.cmake
@@ -4,7 +4,7 @@ if (ENABLE_QBDT)
     target_sources (qrack PRIVATE
         src/qbdt/node_interface.cpp
         src/qbdt/node.cpp
-        src/qbdt/qinterface_node.cpp
+        src/qbdt/qengine_node.cpp
         src/qbdt/tree.cpp
         )
 endif (ENABLE_QBDT)

--- a/include/qbdt.hpp
+++ b/include/qbdt.hpp
@@ -16,7 +16,6 @@
 
 #pragma once
 
-#include "mpsshard.hpp"
 #include "qbdt_qinterface_node.hpp"
 #include "qparity.hpp"
 #include "qstabilizer.hpp"
@@ -47,7 +46,6 @@ protected:
     bitLenInt bdtQubitCount;
     bitCapInt bdtMaxQPower;
     bool isAttached;
-    std::vector<MpsShardPtr> shards;
 
     virtual void SetQubitCount(bitLenInt qb, bitLenInt aqb)
     {
@@ -129,25 +127,6 @@ protected:
         bitCapInt mask = power - ONE_BCI;
         return (perm & mask) | ((perm >> ONE_BCI) & ~mask);
     }
-
-    void FlushBuffer(bitLenInt i);
-
-    void FlushBuffers()
-    {
-        for (bitLenInt i = 0; i < qubitCount; i++) {
-            FlushBuffer(i);
-        }
-        Finish();
-    }
-
-    void DumpBuffers()
-    {
-        for (bitLenInt i = 0U; i < qubitCount; i++) {
-            shards[i] = NULL;
-        }
-    }
-
-    void FlushControlled(const bitLenInt* controls, bitLenInt controlLen, bitLenInt target);
 
     void ApplySingle(const complex* mtrx, bitLenInt target);
 

--- a/include/qbdt.hpp
+++ b/include/qbdt.hpp
@@ -16,15 +16,10 @@
 
 #pragma once
 
-#include "qbdt_qinterface_node.hpp"
-#include "qparity.hpp"
-#include "qstabilizer.hpp"
+#include "qbdt_qengine_node.hpp"
+#include "qengine.hpp"
 
-#if ENABLE_ALU
-#include "qalu.hpp"
-#endif
-
-#define NODE_TO_QINTERFACE(leaf) (std::dynamic_pointer_cast<QBdtQInterfaceNode>(leaf)->qReg)
+#define NODE_TO_QENGINE(leaf) (std::dynamic_pointer_cast<QBdtQEngineNode>(leaf)->qReg)
 #define QINTERFACE_TO_QALU(qReg) std::dynamic_pointer_cast<QAlu>(qReg)
 #define QINTERFACE_TO_QPARITY(qReg) std::dynamic_pointer_cast<QParity>(qReg)
 
@@ -60,7 +55,7 @@ protected:
         bdtMaxQPower = pow2(bdtQubitCount);
     }
 
-    QBdtQInterfaceNodePtr MakeQInterfaceNode(complex scale, bitLenInt qbCount, bitCapInt perm = 0U);
+    QBdtQEngineNodePtr MakeQEngineNode(complex scale, bitLenInt qbCount, bitCapInt perm = 0U);
 
     void FallbackMtrx(const complex* mtrx, bitLenInt target);
     void FallbackMCMtrx(
@@ -68,7 +63,7 @@ protected:
 
     QInterfacePtr MakeTempStateVector()
     {
-        QInterfacePtr copyPtr = NODE_TO_QINTERFACE(MakeQInterfaceNode(ONE_R1, qubitCount));
+        QInterfacePtr copyPtr = NODE_TO_QENGINE(MakeQEngineNode(ONE_R1, qubitCount));
         Finish();
         GetQuantumState(copyPtr);
 
@@ -85,8 +80,8 @@ protected:
             throw std::domain_error("QBdt::SetStateVector() not yet implemented, after Attach() call!");
         }
 
-        QBdtQInterfaceNodePtr nRoot = MakeQInterfaceNode(ONE_R1, qubitCount);
-        GetQuantumState(NODE_TO_QINTERFACE(nRoot));
+        QBdtQEngineNodePtr nRoot = MakeQEngineNode(ONE_R1, qubitCount);
+        GetQuantumState(NODE_TO_QENGINE(nRoot));
         root = nRoot;
         SetQubitCount(qubitCount, qubitCount);
     }
@@ -96,9 +91,9 @@ protected:
             return;
         }
 
-        QBdtQInterfaceNodePtr oRoot = std::dynamic_pointer_cast<QBdtQInterfaceNode>(root);
+        QBdtQEngineNodePtr oRoot = std::dynamic_pointer_cast<QBdtQEngineNode>(root);
         SetQubitCount(qubitCount, 0U);
-        SetQuantumState(NODE_TO_QINTERFACE(oRoot));
+        SetQuantumState(NODE_TO_QENGINE(oRoot));
     }
 
     template <typename Fn> void GetTraversal(Fn getLambda);
@@ -106,13 +101,13 @@ protected:
     template <typename Fn> void ExecuteAsStateVector(Fn operation)
     {
         SetStateVector();
-        operation(NODE_TO_QINTERFACE(root));
+        operation(NODE_TO_QENGINE(root));
     }
 
     template <typename Fn> bitCapInt BitCapIntAsStateVector(Fn operation)
     {
         SetStateVector();
-        return operation(NODE_TO_QINTERFACE(root));
+        return operation(NODE_TO_QENGINE(root));
     }
 
     void DecomposeDispose(bitLenInt start, bitLenInt length, QBdtPtr dest);
@@ -189,7 +184,7 @@ public:
     {
         return Compose(std::dynamic_pointer_cast<QBdt>(toCopy), start);
     }
-    virtual bitLenInt Attach(QStabilizerPtr toCopy, bitLenInt start)
+    virtual bitLenInt Attach(QEnginePtr toCopy, bitLenInt start)
     {
         if (start == qubitCount) {
             return Attach(toCopy);
@@ -202,7 +197,7 @@ public:
 
         return result;
     }
-    virtual bitLenInt Attach(QStabilizerPtr toCopy);
+    virtual bitLenInt Attach(QEnginePtr toCopy);
     virtual void Decompose(bitLenInt start, QInterfacePtr dest)
     {
         DecomposeDispose(start, dest->GetQubitCount(), std::dynamic_pointer_cast<QBdt>(dest));
@@ -236,7 +231,7 @@ public:
 
     virtual real1_f ProbParity(bitCapInt mask)
     {
-        QInterfacePtr unit = (!bdtQubitCount) ? NODE_TO_QINTERFACE(root) : MakeTempStateVector();
+        QInterfacePtr unit = (!bdtQubitCount) ? NODE_TO_QENGINE(root) : MakeTempStateVector();
         return QINTERFACE_TO_QPARITY(unit)->ProbParity(mask);
     }
     virtual void CUniformParityRZ(const bitLenInt* controls, bitLenInt controlLen, bitCapInt mask, real1_f angle)
@@ -248,7 +243,7 @@ public:
     virtual bool ForceMParity(bitCapInt mask, bool result, bool doForce = true)
     {
         SetStateVector();
-        return QINTERFACE_TO_QPARITY(NODE_TO_QINTERFACE(root))->ForceMParity(mask, result, doForce);
+        return QINTERFACE_TO_QPARITY(NODE_TO_QENGINE(root))->ForceMParity(mask, result, doForce);
     }
 
 #if ENABLE_ALU

--- a/include/qbdt_node_interface.hpp
+++ b/include/qbdt_node_interface.hpp
@@ -103,6 +103,16 @@ public:
 #else
     virtual void Apply2x2(const complex* mtrx, bitLenInt depth) = 0;
 #endif
+
+#if ENABLE_COMPLEX_X2
+    virtual void PushSpecial(const complex2& mtrxCol1, const complex2& mtrxCol2, QBdtNodeInterfacePtr& b1)
+#else
+    virtual void PushSpecial(const complex* mtrx, QBdtNodeInterfacePtr& b1)
+#endif
+    {
+        throw std::out_of_range("QBdtNodeInterface::PushSpecial() not implemented! (You probably called "
+                                "PushStateVector() past terminal depth.)");
+    }
 };
 
 bool operator==(const QBdtNodeInterfacePtr& lhs, const QBdtNodeInterfacePtr& rhs);

--- a/include/qbdt_node_interface.hpp
+++ b/include/qbdt_node_interface.hpp
@@ -86,6 +86,8 @@ public:
 
     virtual bool isEqual(QBdtNodeInterfacePtr r);
 
+    virtual bool isEqualUnder(QBdtNodeInterfacePtr r);
+
     virtual QBdtNodeInterfacePtr ShallowClone() = 0;
 
     virtual void PopStateVector(bitLenInt depth = 1U) = 0;

--- a/include/qbdt_qengine_node.hpp
+++ b/include/qbdt_qengine_node.hpp
@@ -17,17 +17,14 @@
 #pragma once
 
 #include "qbdt_node_interface.hpp"
-#include "qinterface.hpp"
+#include "qengine.hpp"
 
 namespace Qrack {
-
-class QBdtQInterfaceNode;
-typedef std::shared_ptr<QBdtQInterfaceNode> QBdtQInterfaceNodePtr;
 
 class QBdtQEngineNode;
 typedef std::shared_ptr<QBdtQEngineNode> QBdtQEngineNodePtr;
 
-class QBdtQInterfaceNode : public QBdtNodeInterface {
+class QBdtQEngineNode : public QBdtNodeInterface {
 protected:
 #if ENABLE_COMPLEX_X2
     virtual void PushStateVector(const complex2& mtrxCol1, const complex2& mtrxCol2, QBdtNodeInterfacePtr& b0,
@@ -37,20 +34,20 @@ protected:
         const complex* mtrx, QBdtNodeInterfacePtr& b0, QBdtNodeInterfacePtr& b1, bitLenInt depth)
 #endif
     {
-        throw std::out_of_range("QBdtQInterfaceNode::PushStateVector() not implemented!");
+        throw std::out_of_range("QBdtQEngineNode::PushStateVector() not implemented!");
     }
 
 public:
-    QInterfacePtr qReg;
+    QEnginePtr qReg;
 
-    QBdtQInterfaceNode()
+    QBdtQEngineNode()
         : QBdtNodeInterface(ZERO_CMPLX)
         , qReg(NULL)
     {
         // Intentionally left blank.
     }
 
-    QBdtQInterfaceNode(complex scl, QInterfacePtr q)
+    QBdtQEngineNode(complex scl, QEnginePtr q)
         : QBdtNodeInterface(scl)
         , qReg(q)
     {
@@ -63,7 +60,7 @@ public:
         qReg = NULL;
     }
 
-    virtual QBdtNodeInterfacePtr ShallowClone() { return std::make_shared<QBdtQInterfaceNode>(scale, qReg); }
+    virtual QBdtNodeInterfacePtr ShallowClone() { return std::make_shared<QBdtQEngineNode>(scale, qReg); }
 
     virtual bool isEqual(QBdtNodeInterfacePtr r);
 
@@ -87,8 +84,13 @@ public:
     virtual void Apply2x2(const complex* mtrx, bitLenInt depth)
 #endif
     {
-        throw std::out_of_range("QBdtQInterfaceNode::Apply2x2() not implemented!");
+        throw std::out_of_range("QBdtQEngineNode::Apply2x2() not implemented!");
     }
+#if ENABLE_COMPLEX_X2
+    virtual void PushSpecial(const complex2& mtrxCol1, const complex2& mtrxCol2, QBdtNodeInterfacePtr& b1);
+#else
+    virtual void PushSpecial(const complex* mtrx, QBdtNodeInterfacePtr& b1);
+#endif
 };
 
 } // namespace Qrack

--- a/include/qbdt_qengine_node.hpp
+++ b/include/qbdt_qengine_node.hpp
@@ -76,7 +76,7 @@ public:
 
     virtual QBdtNodeInterfacePtr RemoveSeparableAtDepth(bitLenInt depth, const bitLenInt& size);
 
-    virtual void PopStateVector(bitLenInt depth = 1U) { Prune(); }
+    virtual void PopStateVector(bitLenInt depth = 1U);
 
 #if ENABLE_COMPLEX_X2
     virtual void Apply2x2(const complex2& mtrxCol1, const complex2& mtrxCol2, bitLenInt depth)

--- a/include/qbdt_qinterface_node.hpp
+++ b/include/qbdt_qinterface_node.hpp
@@ -67,6 +67,8 @@ public:
 
     virtual bool isEqual(QBdtNodeInterfacePtr r);
 
+    virtual bool isEqualUnder(QBdtNodeInterfacePtr r);
+
     virtual void Normalize(bitLenInt depth);
 
     virtual void Branch(bitLenInt depth = 1U);

--- a/include/qpager.hpp
+++ b/include/qpager.hpp
@@ -208,7 +208,7 @@ public:
             return;
         }
 
-        for (bitCapIntOcl i = qPages.size() / 2U; i < qPages.size(); i++) {
+        for (bitCapIntOcl i = qPages.size() >> 1U; i < qPages.size(); i++) {
             qPages[i].swap(engine->qPages[i]);
         }
     }

--- a/include/qpager.hpp
+++ b/include/qpager.hpp
@@ -258,6 +258,17 @@ public:
         return toRet;
     }
 
+    virtual real1_f FirstNonzeroPhase()
+    {
+        for (bitCapIntOcl i = 0U; i < qPages.size(); i++) {
+            if (!qPages[i]->IsZeroAmplitude()) {
+                return qPages[i]->FirstNonzeroPhase();
+            }
+        }
+
+        return ZERO_R1;
+    }
+
     virtual void SetQuantumState(const complex* inputState);
     virtual void GetQuantumState(complex* outputState);
     virtual void GetProbs(real1* outputProbs);

--- a/include/qpager.hpp
+++ b/include/qpager.hpp
@@ -11,12 +11,7 @@
 // for details.
 #pragma once
 
-#include "qinterface.hpp"
-#include "qparity.hpp"
-
-#if ENABLE_ALU
-#include "qalu.hpp"
-#endif
+#include "qengine.hpp"
 
 namespace Qrack {
 
@@ -27,11 +22,7 @@ typedef std::shared_ptr<QPager> QPagerPtr;
  * A "Qrack::QPager" splits a "Qrack::QEngine" implementation into equal-length "pages." This helps both optimization
  * and distribution of a single coherent quantum register across multiple devices.
  */
-#if ENABLE_ALU
-class QPager : public QAlu, public QParity, public QInterface {
-#else
-class QPager : public QParity, public QInterface {
-#endif
+class QPager : public QEngine {
 protected:
     std::vector<QInterfaceEngine> engines;
     QInterfaceEngine rootEngine;
@@ -197,41 +188,6 @@ public:
     virtual bool ForceM(bitLenInt qubit, bool result, bool doForce = true, bool doApply = true);
 
 #if ENABLE_ALU
-    virtual bool M(bitLenInt q) { return QInterface::M(q); }
-    virtual void X(bitLenInt q) { QInterface::X(q); }
-    virtual void INC(bitCapInt toAdd, bitLenInt start, bitLenInt length) { QInterface::INC(toAdd, start, length); }
-    virtual void DEC(bitCapInt toSub, bitLenInt start, bitLenInt length) { QInterface::DEC(toSub, start, length); }
-    virtual void INCC(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt carryIndex)
-    {
-        QInterface::INCC(toAdd, start, length, carryIndex);
-    }
-    virtual void DECC(bitCapInt toSub, bitLenInt start, bitLenInt length, bitLenInt carryIndex)
-    {
-        QInterface::DECC(toSub, start, length, carryIndex);
-    }
-    virtual void INCS(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt overflowIndex)
-    {
-        QInterface::INCS(toAdd, start, length, overflowIndex);
-    }
-    virtual void DECS(bitCapInt toSub, bitLenInt start, bitLenInt length, bitLenInt overflowIndex)
-    {
-        QInterface::DECS(toSub, start, length, overflowIndex);
-    }
-    virtual void CINC(
-        bitCapInt toAdd, bitLenInt inOutStart, bitLenInt length, const bitLenInt* controls, bitLenInt controlLen)
-    {
-        QInterface::CINC(toAdd, inOutStart, length, controls, controlLen);
-    }
-    virtual void CDEC(
-        bitCapInt toSub, bitLenInt inOutStart, bitLenInt length, const bitLenInt* controls, bitLenInt controlLen)
-    {
-        QInterface::CDEC(toSub, inOutStart, length, controls, controlLen);
-    }
-    virtual void INCDECC(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt carryIndex)
-    {
-        QInterface::INCDECC(toAdd, start, length, carryIndex);
-    }
-
     virtual void INCDECSC(
         bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt overflowIndex, bitLenInt carryIndex);
     virtual void INCDECSC(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt carryIndex);

--- a/include/qpager.hpp
+++ b/include/qpager.hpp
@@ -243,11 +243,19 @@ public:
         CombineEngines();
         qPages[0]->Apply2x2(offset1, offset2, mtrx, bitCount, qPowersSorted, doCalcNorm, norm_thresh);
     }
-
     virtual void FreeStateVec(complex* sv = NULL)
     {
         CombineEngines();
         qPages[0]->FreeStateVec(sv);
+    }
+    virtual real1_f GetRunningNorm()
+    {
+        real1_f toRet = ZERO_R1;
+        for (bitCapIntOcl i = 0; i < qPages.size(); i++) {
+            toRet += qPages[i]->GetRunningNorm();
+        }
+
+        return toRet;
     }
 
     virtual void SetQuantumState(const complex* inputState);

--- a/include/qpager.hpp
+++ b/include/qpager.hpp
@@ -86,13 +86,13 @@ protected:
     virtual void GetSetAmplitudePage(
         complex* pagePtr, const complex* cPagePtr, bitCapIntOcl offset, bitCapIntOcl length)
     {
-        const bitCapInt pageLength = pageMaxQPower();
+        const bitCapIntOcl pageLength = (bitCapIntOcl)pageMaxQPower();
         bitCapIntOcl perm = 0U;
         for (bitCapIntOcl i = 0; i < qPages.size(); i++) {
             if (perm >= (offset + length)) {
                 break;
             }
-            if ((perm + pageLength) <= offset) {
+            if ((perm + length) < offset) {
                 continue;
             }
             const bitCapInt partLength = (length < pageLength) ? length : pageLength;
@@ -101,6 +101,7 @@ protected:
             } else {
                 qPages[i]->GetAmplitudePage(pagePtr, (bitCapIntOcl)(offset - perm), (bitCapIntOcl)partLength);
             }
+            perm += pageLength;
         }
     }
 

--- a/include/qstabilizerhybrid.hpp
+++ b/include/qstabilizerhybrid.hpp
@@ -360,11 +360,19 @@ public:
         SwitchToEngine();
         engine->Apply2x2(offset1, offset2, mtrx, bitCount, qPowersSorted, doCalcNorm, norm_thresh);
     }
-
     virtual void FreeStateVec(complex* sv = NULL)
     {
         SwitchToEngine();
         engine->FreeStateVec(sv);
+    }
+    virtual real1_f GetRunningNorm()
+    {
+        if (stabilizer) {
+            return (real1_f)ONE_R1;
+        }
+
+        Finish();
+        return engine->GetRunningNorm();
     }
 
     /**

--- a/include/qstabilizerhybrid.hpp
+++ b/include/qstabilizerhybrid.hpp
@@ -308,15 +308,15 @@ public:
         pageEnginePtr->SwitchToEngine();
         engine->SetAmplitudePage(pageEnginePtr->engine, srcOffset, dstOffset, length);
     }
-    virtual void ShuffleBuffers(QEnginePtr engine)
+    virtual void ShuffleBuffers(QEnginePtr oEngine)
     {
-        ShuffleBuffers(std::dynamic_pointer_cast<QStabilizerHybrid>(engine));
+        ShuffleBuffers(std::dynamic_pointer_cast<QStabilizerHybrid>(oEngine));
     }
-    virtual void ShuffleBuffers(QStabilizerHybridPtr engine)
+    virtual void ShuffleBuffers(QStabilizerHybridPtr oEngine)
     {
         SwitchToEngine();
-        engine->SwitchToEngine();
-        engine->ShuffleBuffers(engine->engine);
+        oEngine->SwitchToEngine();
+        engine->ShuffleBuffers(oEngine->engine);
     }
     virtual QEnginePtr CloneEmpty();
     virtual void QueueSetDoNormalize(bool doNorm)

--- a/include/qstabilizerhybrid.hpp
+++ b/include/qstabilizerhybrid.hpp
@@ -318,7 +318,15 @@ public:
         oEngine->SwitchToEngine();
         engine->ShuffleBuffers(oEngine->engine);
     }
-    virtual QEnginePtr CloneEmpty();
+    virtual QEnginePtr CloneEmpty()
+    {
+        QStabilizerHybridPtr thisClone = stabilizer ? std::dynamic_pointer_cast<QStabilizerHybrid>(Clone()) : NULL;
+        if (thisClone) {
+            thisClone->SwitchToEngine();
+        }
+        QEnginePtr thisEngine = thisClone ? thisClone->engine : engine;
+        return thisEngine->CloneEmpty();
+    }
     virtual void QueueSetDoNormalize(bool doNorm)
     {
         if (engine) {
@@ -373,6 +381,15 @@ public:
 
         Finish();
         return engine->GetRunningNorm();
+    }
+
+    virtual real1_f FirstNonzeroPhase()
+    {
+        if (stabilizer) {
+            return stabilizer->FirstNonzeroPhase();
+        }
+
+        return engine->FirstNonzeroPhase();
     }
 
     /**
@@ -997,7 +1014,13 @@ public:
     virtual void NormalizeState(
         real1_f nrm = REAL1_DEFAULT_ARG, real1_f norm_thresh = REAL1_DEFAULT_ARG, real1_f phaseArg = ZERO_R1)
     {
-        if (engine) {
+        if (nrm != REAL1_DEFAULT_ARG) {
+            SwitchToEngine();
+        }
+
+        if (stabilizer) {
+            NormalizeState(REAL1_DEFAULT_ARG, norm_thresh, phaseArg);
+        } else {
             engine->NormalizeState(nrm, norm_thresh, phaseArg);
         }
     }

--- a/include/qstabilizerhybrid.hpp
+++ b/include/qstabilizerhybrid.hpp
@@ -36,7 +36,6 @@ protected:
     int devID;
     complex phaseFactor;
     bool doNormalize;
-    bool useHostRam;
     bool isSparse;
     bool isDefaultPaging;
     real1_f separabilityThreshold;

--- a/include/qstabilizerhybrid.hpp
+++ b/include/qstabilizerhybrid.hpp
@@ -276,7 +276,7 @@ public:
         }
 
         engine = MakeEngine();
-        src->stabilizer->GetQuantumState(engine);
+        engine->CopyStateVec(src->engine);
     }
     virtual bool IsZeroAmplitude()
     {

--- a/src/pinvoke_api.cpp
+++ b/src/pinvoke_api.cpp
@@ -674,8 +674,8 @@ MICROSOFT_QUANTUM_DECL unsigned init_qbdt_stabilizer(_In_ unsigned q, _In_ unsig
     if (q || c) {
         try {
             simulator = std::dynamic_pointer_cast<QBdt>(CreateQuantumInterface(simulatorType, q, 0, randNumGen));
-            simulator->Attach(std::dynamic_pointer_cast<QStabilizer>(
-                CreateQuantumInterface({ QINTERFACE_STABILIZER }, c, 0, randNumGen, CMPLX_DEFAULT_ARG, false, false)));
+            simulator->Attach(std::dynamic_pointer_cast<QEngine>(CreateQuantumInterface(
+                { QINTERFACE_STABILIZER_HYBRID }, c, 0, randNumGen, CMPLX_DEFAULT_ARG, false, false)));
         } catch (...) {
             isSuccess = false;
         }

--- a/src/qbdt/node.cpp
+++ b/src/qbdt/node.cpp
@@ -332,6 +332,10 @@ void QBdtNode::PushStateVector(const complex2& mtrxCol1, const complex2& mtrxCol
     b0->Branch();
     b1->Branch();
 
+    if (!b0->branches[0]) {
+        throw std::out_of_range("Debug: In PushStateVector(), branches are QInterfaces nodes");
+    }
+
     b0->branches[0]->scale *= b0->scale;
     b0->branches[1]->scale *= b0->scale;
     b0->scale = SQRT1_2_R1;

--- a/src/qbdt/node.cpp
+++ b/src/qbdt/node.cpp
@@ -313,11 +313,8 @@ void QBdtNode::PushStateVector(const complex2& mtrxCol1, const complex2& mtrxCol
         return;
     }
 
-    const bool isSame = ((b0->branches[0] == b1->branches[0]) && (b0->branches[1] == b1->branches[1]));
+    const bool isSame = b0->isEqualUnder(b1);
     if (isSame) {
-        b1->branches[0] = b0->branches[0];
-        b1->branches[1] = b0->branches[1];
-
         complex2 qubit(b0->scale, b1->scale);
         qubit.c2 = matrixMul(mtrxCol1.c2, mtrxCol2.c2, qubit.c2);
         b0->scale = qubit.c[0];

--- a/src/qbdt/node.cpp
+++ b/src/qbdt/node.cpp
@@ -413,11 +413,8 @@ void QBdtNode::PushStateVector(const complex* mtrx, QBdtNodeInterfacePtr& b0, QB
         return;
     }
 
-    const bool isSame = ((b0->branches[0] == b1->branches[0]) && (b0->branches[1] == b1->branches[1]));
+    const bool isSame = b0->isEqualUnder(b1);
     if (isSame) {
-        b1->branches[0] = b0->branches[0];
-        b1->branches[1] = b0->branches[1];
-
         const complex Y0 = b0->scale;
         const complex Y1 = b1->scale;
         b0->scale = mtrx[0] * Y0 + mtrx[1] * Y1;
@@ -434,6 +431,10 @@ void QBdtNode::PushStateVector(const complex* mtrx, QBdtNodeInterfacePtr& b0, QB
 
     b0->Branch();
     b1->Branch();
+
+    if (!b0->branches[0]) {
+        throw std::out_of_range("Debug: In PushStateVector(), branches are QInterfaces nodes");
+    }
 
     b0->branches[0]->scale *= b0->scale;
     b0->branches[1]->scale *= b0->scale;

--- a/src/qbdt/node.cpp
+++ b/src/qbdt/node.cpp
@@ -333,7 +333,12 @@ void QBdtNode::PushStateVector(const complex2& mtrxCol1, const complex2& mtrxCol
     b1->Branch();
 
     if (!b0->branches[0]) {
-        throw std::out_of_range("Debug: In PushStateVector(), branches are QInterfaces nodes");
+        b0->PushSpecial(mtrxCol1, mtrxCol2, b1);
+
+        b0->PopStateVector();
+        b1->PopStateVector();
+
+        return;
     }
 
     b0->branches[0]->scale *= b0->scale;
@@ -433,7 +438,12 @@ void QBdtNode::PushStateVector(const complex* mtrx, QBdtNodeInterfacePtr& b0, QB
     b1->Branch();
 
     if (!b0->branches[0]) {
-        throw std::out_of_range("Debug: In PushStateVector(), branches are QInterfaces nodes");
+        b0->PushSpecial(mtrx, b1);
+
+        b0->PopStateVector();
+        b1->PopStateVector();
+
+        return;
     }
 
     b0->branches[0]->scale *= b0->scale;

--- a/src/qbdt/node_interface.cpp
+++ b/src/qbdt/node_interface.cpp
@@ -72,6 +72,31 @@ bool QBdtNodeInterface::isEqual(QBdtNodeInterfacePtr r)
     return true;
 }
 
+bool QBdtNodeInterface::isEqualUnder(QBdtNodeInterfacePtr r)
+{
+    if (!r) {
+        return false;
+    }
+
+    if (this == r.get()) {
+        return true;
+    }
+
+    if (branches[0] != r->branches[0]) {
+        return false;
+    }
+
+    branches[0] = r->branches[0];
+
+    if (branches[1] != r->branches[1]) {
+        return false;
+    }
+
+    branches[1] = r->branches[1];
+
+    return true;
+}
+
 void QBdtNodeInterface::_par_for_qbdt(const bitCapInt begin, const bitCapInt end, BdtFunc fn)
 {
     const bitCapInt itemCount = end - begin;

--- a/src/qbdt/qengine_node.cpp
+++ b/src/qbdt/qengine_node.cpp
@@ -186,8 +186,6 @@ void QBdtQEngineNode::PushSpecial(const complex* mtrx, QBdtNodeInterfacePtr& b1)
         return;
     }
 
-    throw std::out_of_range("QBdtQEngineNode::PushSpecial() not yet implemented!");
-
     QEnginePtr qReg0 = qReg;
     QEnginePtr qReg1 = std::dynamic_pointer_cast<QBdtQEngineNode>(b1)->qReg;
 
@@ -211,5 +209,33 @@ void QBdtQEngineNode::PushSpecial(const complex* mtrx, QBdtNodeInterfacePtr& b1)
     qReg1->Mtrx(mtrx, qReg1->GetQubitCount() - 1U);
 
     qReg0->ShuffleBuffers(qReg1);
+}
+
+void QBdtQEngineNode::PopStateVector(bitLenInt depth)
+{
+    if (!depth) {
+        return;
+    }
+
+    if (IS_NORM_0(scale)) {
+        SetZero();
+        return;
+    }
+
+    if (!qReg) {
+        return;
+    }
+
+    qReg->UpdateRunningNorm();
+    const real1_f nrm = qReg->GetRunningNorm();
+
+    if (nrm <= FP_NORM_EPSILON) {
+        SetZero();
+        return;
+    }
+
+    const real1_f phaseArg = qReg->FirstNonzeroPhase();
+    qReg->NormalizeState(REAL1_DEFAULT_ARG, REAL1_DEFAULT_ARG, -phaseArg);
+    scale = std::polar((real1)sqrt(nrm), (real1)phaseArg);
 }
 } // namespace Qrack

--- a/src/qbdt/qengine_node.cpp
+++ b/src/qbdt/qengine_node.cpp
@@ -119,7 +119,6 @@ void QBdtQEngineNode::Prune(bitLenInt depth)
     }
 
     if (!qReg) {
-        SetZero();
         return;
     }
 
@@ -129,7 +128,7 @@ void QBdtQEngineNode::Prune(bitLenInt depth)
 
     const real1_f phaseArg = qReg->FirstNonzeroPhase();
     qReg->NormalizeState(REAL1_DEFAULT_ARG, REAL1_DEFAULT_ARG, -phaseArg);
-    scale *= (complex)std::polar((real1_f)ONE_R1, (real1_f)phaseArg);
+    scale *= std::polar(ONE_R1, (real1)phaseArg);
 }
 
 void QBdtQEngineNode::InsertAtDepth(QBdtNodeInterfacePtr b, bitLenInt depth, const bitLenInt& size)
@@ -191,8 +190,8 @@ void QBdtQEngineNode::PushSpecial(const complex* mtrx, QBdtNodeInterfacePtr& b1)
         qReg1 = qReg->CloneEmpty();
     }
 
-    qReg0->NormalizeState(norm(scale), REAL1_DEFAULT_ARG, std::arg(scale));
-    qReg1->NormalizeState(norm(b1->scale), REAL1_DEFAULT_ARG, std::arg(b1->scale));
+    qReg0->NormalizeState(ONE_R1 / norm(scale), REAL1_DEFAULT_ARG, std::arg(scale));
+    qReg1->NormalizeState(ONE_R1 / norm(b1->scale), REAL1_DEFAULT_ARG, std::arg(b1->scale));
 
     scale = SQRT1_2_R1;
     b1->scale = SQRT1_2_R1;

--- a/src/qbdt/qengine_node.cpp
+++ b/src/qbdt/qengine_node.cpp
@@ -113,16 +113,13 @@ void QBdtQEngineNode::Branch(bitLenInt depth)
 
 void QBdtQEngineNode::Prune(bitLenInt depth)
 {
-    if (!depth) {
-        return;
-    }
-
     if (norm(scale) <= FP_NORM_EPSILON) {
         SetZero();
         return;
     }
 
     if (!qReg) {
+        SetZero();
         return;
     }
 
@@ -131,8 +128,7 @@ void QBdtQEngineNode::Prune(bitLenInt depth)
     }
 
     const real1_f phaseArg = qReg->FirstNonzeroPhase();
-    const complex phaseFac = std::polar((real1_f)ONE_R1, (real1_f)-phaseArg);
-    qReg->Phase(phaseFac, phaseFac, 0);
+    qReg->NormalizeState(REAL1_DEFAULT_ARG, REAL1_DEFAULT_ARG, -phaseArg);
     scale *= (complex)std::polar((real1_f)ONE_R1, (real1_f)phaseArg);
 }
 
@@ -191,10 +187,8 @@ void QBdtQEngineNode::PushSpecial(const complex* mtrx, QBdtNodeInterfacePtr& b1)
 
     if (is0Zero) {
         qReg0 = std::dynamic_pointer_cast<QBdtQEngineNode>(b1)->qReg->CloneEmpty();
-        qReg = qReg0;
     } else if (is1Zero) {
         qReg1 = qReg->CloneEmpty();
-        std::dynamic_pointer_cast<QBdtQEngineNode>(b1)->qReg = qReg1;
     }
 
     qReg0->NormalizeState(norm(scale), REAL1_DEFAULT_ARG, std::arg(scale));
@@ -209,20 +203,20 @@ void QBdtQEngineNode::PushSpecial(const complex* mtrx, QBdtNodeInterfacePtr& b1)
     qReg1->Mtrx(mtrx, qReg1->GetQubitCount() - 1U);
 
     qReg0->ShuffleBuffers(qReg1);
+
+    qReg = qReg;
+    std::dynamic_pointer_cast<QBdtQEngineNode>(b1)->qReg = qReg1;
 }
 
 void QBdtQEngineNode::PopStateVector(bitLenInt depth)
 {
-    if (!depth) {
-        return;
-    }
-
     if (IS_NORM_0(scale)) {
         SetZero();
         return;
     }
 
     if (!qReg) {
+        SetZero();
         return;
     }
 

--- a/src/qbdt/qinterface_node.cpp
+++ b/src/qbdt/qinterface_node.cpp
@@ -51,6 +51,34 @@ bool QBdtQInterfaceNode::isEqual(QBdtNodeInterfacePtr r)
     return false;
 }
 
+bool QBdtQInterfaceNode::isEqualUnder(QBdtNodeInterfacePtr r)
+{
+    if (!r) {
+        return false;
+    }
+
+    if (this == r.get()) {
+        return true;
+    }
+
+    if (norm(scale) <= FP_NORM_EPSILON) {
+        return true;
+    }
+
+    QInterfacePtr rReg = std::dynamic_pointer_cast<QBdtQInterfaceNode>(r)->qReg;
+
+    if (qReg.get() == rReg.get()) {
+        return true;
+    }
+
+    if (qReg->ApproxCompare(rReg)) {
+        qReg = rReg;
+        return true;
+    }
+
+    return false;
+}
+
 void QBdtQInterfaceNode::Normalize(bitLenInt depth)
 {
     if (!depth) {

--- a/src/qbdt/tree.cpp
+++ b/src/qbdt/tree.cpp
@@ -657,15 +657,13 @@ void QBdt::ApplySingle(const complex* mtrx, bitLenInt target)
                 }
                 qis.insert(qi);
             }
-        } else {
-            if (qns.find(leaf) == qns.end()) {
+        } else if (qns.find(leaf) == qns.end()) {
 #if ENABLE_COMPLEX_X2
-                leaf->Apply2x2(mtrxCol1, mtrxCol2, bdtQubitCount - target);
+            leaf->Apply2x2(mtrxCol1, mtrxCol2, bdtQubitCount - target);
 #else
-                leaf->Apply2x2(mtrx, bdtQubitCount - target);
+            leaf->Apply2x2(mtrx, bdtQubitCount - target);
 #endif
-                qns.insert(leaf);
-            }
+            qns.insert(leaf);
         }
 
         return (bitCapInt)0U;
@@ -773,15 +771,13 @@ void QBdt::ApplyControlledSingle(
                 }
                 qis.insert(qi);
             }
-        } else {
-            if (qns.find(leaf) == qns.end()) {
+        } else if (qns.find(leaf) == qns.end()) {
 #if ENABLE_COMPLEX_X2
-                leaf->Apply2x2(mtrxCol1, mtrxCol2, bdtQubitCount - target);
+            leaf->Apply2x2(mtrxCol1, mtrxCol2, bdtQubitCount - target);
 #else
-                leaf->Apply2x2(mtrx, bdtQubitCount - target);
+            leaf->Apply2x2(mtrx, bdtQubitCount - target);
 #endif
-                qns.insert(leaf);
-            }
+            qns.insert(leaf);
         }
 
         return (bitCapInt)0U;

--- a/src/qbdt/tree.cpp
+++ b/src/qbdt/tree.cpp
@@ -552,7 +552,7 @@ bool QBdt::ForceM(bitLenInt qubit, bool result, bool doForce, bool doApply)
         }
     }
 
-    root->Prune(maxQubit);
+    root->Prune(maxQubit + 1U);
 
     return result;
 }
@@ -664,7 +664,7 @@ void QBdt::ApplySingle(const complex* mtrx, bitLenInt target)
     });
 
     if (!isFail) {
-        root->Prune(maxQubit);
+        root->Prune(maxQubit + 1U);
 
         return;
     }
@@ -676,7 +676,7 @@ void QBdt::ApplySingle(const complex* mtrx, bitLenInt target)
         (*it)->Mtrx(iMtrx, target - bdtQubitCount);
         it++;
     }
-    root->Prune(maxQubit);
+    root->Prune(maxQubit + 1U);
 
     FallbackMtrx(mtrx, target);
 }
@@ -774,7 +774,7 @@ void QBdt::ApplyControlledSingle(
     });
 
     if (!isFail) {
-        root->Prune(maxQubit);
+        root->Prune(maxQubit + 1U);
         // Undo isSwapped.
         if (isSwapped) {
             Swap(target, controlVec.back());
@@ -796,7 +796,7 @@ void QBdt::ApplyControlledSingle(
         it++;
     }
 
-    root->Prune(maxQubit);
+    root->Prune(maxQubit + 1U);
     // Undo isSwapped.
     if (isSwapped) {
         Swap(target, controlVec.back());

--- a/src/qbdt/tree.cpp
+++ b/src/qbdt/tree.cpp
@@ -338,6 +338,10 @@ bitLenInt QBdt::Compose(QBdtPtr toCopy, bitLenInt start)
 
 bitLenInt QBdt::Attach(QEnginePtr toCopy)
 {
+    if (toCopy->GetIsArbitraryGlobalPhase()) {
+        throw std::invalid_argument("QBdt attached qubits cannot have arbitrary global phase!");
+    }
+
     isAttached = true;
     const bitLenInt toRet = qubitCount;
 

--- a/src/qbdt/tree.cpp
+++ b/src/qbdt/tree.cpp
@@ -552,7 +552,7 @@ bool QBdt::ForceM(bitLenInt qubit, bool result, bool doForce, bool doApply)
         }
     }
 
-    root->Prune(maxQubit + 1U);
+    root->Prune(maxQubit);
 
     return result;
 }
@@ -664,7 +664,7 @@ void QBdt::ApplySingle(const complex* mtrx, bitLenInt target)
     });
 
     if (!isFail) {
-        root->Prune(maxQubit + 1U);
+        root->Prune(maxQubit);
 
         return;
     }
@@ -676,7 +676,7 @@ void QBdt::ApplySingle(const complex* mtrx, bitLenInt target)
         (*it)->Mtrx(iMtrx, target - bdtQubitCount);
         it++;
     }
-    root->Prune(maxQubit + 1U);
+    root->Prune(maxQubit);
 
     FallbackMtrx(mtrx, target);
 }
@@ -774,7 +774,7 @@ void QBdt::ApplyControlledSingle(
     });
 
     if (!isFail) {
-        root->Prune(maxQubit + 1U);
+        root->Prune(maxQubit);
         // Undo isSwapped.
         if (isSwapped) {
             Swap(target, controlVec.back());
@@ -796,7 +796,7 @@ void QBdt::ApplyControlledSingle(
         it++;
     }
 
-    root->Prune(maxQubit + 1U);
+    root->Prune(maxQubit);
     // Undo isSwapped.
     if (isSwapped) {
         Swap(target, controlVec.back());

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -2841,7 +2841,7 @@ void QEngineOCL::NormalizeState(real1_f nrm, real1_f norm_thresh, real1_f phaseA
         ZeroAmplitudes();
         return;
     }
-    if ((abs(ONE_R1 - nrm) <= FP_NORM_EPSILON) && ((phaseArg * phaseArg) < FP_NORM_EPSILON)) {
+    if ((abs(ONE_R1 - nrm) <= FP_NORM_EPSILON) && ((phaseArg * phaseArg) <= FP_NORM_EPSILON)) {
         return;
     }
     // We might have async execution of gates still happening.
@@ -2850,11 +2850,11 @@ void QEngineOCL::NormalizeState(real1_f nrm, real1_f norm_thresh, real1_f phaseA
     if (norm_thresh < ZERO_R1) {
         norm_thresh = amplitudeFloor;
     }
+    nrm = ONE_R1 / std::sqrt(nrm);
 
     PoolItemPtr poolItem = GetFreePoolItem();
 
-    complex c_args[2] = { complex((real1)norm_thresh, ZERO_R1),
-        (complex)std::polar((real1_f)(ONE_R1 / sqrt(nrm)), (real1_f)phaseArg) };
+    complex c_args[2] = { complex((real1)norm_thresh, ZERO_R1), std::polar(nrm, (real1)phaseArg) };
     cl::Event writeRealArgsEvent;
     DISPATCH_LOC_WRITE(*(poolItem->cmplxBuffer), sizeof(complex) * 2, c_args, writeRealArgsEvent, error);
 

--- a/src/qengine/state.cpp
+++ b/src/qengine/state.cpp
@@ -1458,7 +1458,7 @@ void QEngineCPU::NormalizeState(real1_f nrm_f, real1_f norm_thresh_f, real1_f ph
         ZeroAmplitudes();
         return;
     }
-    if ((abs(ONE_R1 - nrm) <= FP_NORM_EPSILON) && ((phaseArg * phaseArg) < FP_NORM_EPSILON)) {
+    if ((abs(ONE_R1 - nrm) <= FP_NORM_EPSILON) && ((phaseArg * phaseArg) <= FP_NORM_EPSILON)) {
         return;
     }
     // We might have async execution of gates still happening.
@@ -1467,9 +1467,8 @@ void QEngineCPU::NormalizeState(real1_f nrm_f, real1_f norm_thresh_f, real1_f ph
     if (norm_thresh < ZERO_R1) {
         norm_thresh = amplitudeFloor;
     }
-
     nrm = ONE_R1 / std::sqrt(nrm);
-    complex cNrm = (complex)std::polar((real1_f)nrm, (real1_f)phaseArg);
+    complex cNrm = std::polar(nrm, (real1)phaseArg);
 
     if (norm_thresh <= ZERO_R1) {
         par_for(0, maxQPowerOcl, [&](const bitCapIntOcl& lcv, const unsigned& cpu) {

--- a/src/qpager.cpp
+++ b/src/qpager.cpp
@@ -20,12 +20,10 @@ namespace Qrack {
 QPager::QPager(std::vector<QInterfaceEngine> eng, bitLenInt qBitCount, bitCapInt initState, qrack_rand_gen_ptr rgp,
     complex phaseFac, bool ignored, bool ignored2, bool useHostMem, int deviceId, bool useHardwareRNG,
     bool useSparseStateVec, real1_f norm_thresh, std::vector<int> devList, bitLenInt qubitThreshold, real1_f sep_thresh)
-    : QInterface(qBitCount, rgp, false, useHardwareRNG, false, norm_thresh)
+    : QEngine(qBitCount, rgp, false, false, useHostMem, useHardwareRNG, norm_thresh)
     , engines(eng)
     , devID(deviceId)
     , phaseFactor(phaseFac)
-    , useHostRam(useHostMem)
-    , useRDRAND(useHardwareRNG)
     , isSparse(useSparseStateVec)
     , deviceIDs(devList)
     , useHardwareThreshold(false)
@@ -83,12 +81,10 @@ QPager::QPager(QEnginePtr enginePtr, std::vector<QInterfaceEngine> eng, bitLenIn
     qrack_rand_gen_ptr rgp, complex phaseFac, bool ignored, bool ignored2, bool useHostMem, int deviceId,
     bool useHardwareRNG, bool useSparseStateVec, real1_f norm_thresh, std::vector<int> devList,
     bitLenInt qubitThreshold, real1_f sep_thresh)
-    : QInterface(qBitCount, rgp, false, useHardwareRNG, false, norm_thresh)
+    : QEngine(qBitCount, rgp, false, false, useHostMem, useHardwareRNG, norm_thresh)
     , engines(eng)
     , devID(deviceId)
     , phaseFactor(phaseFac)
-    , useHostRam(useHostMem)
-    , useRDRAND(useHardwareRNG)
     , isSparse(useSparseStateVec)
     , deviceIDs(devList)
     , useHardwareThreshold(false)
@@ -1404,6 +1400,20 @@ QInterfacePtr QPager::Clone()
 
     for (bitCapIntOcl i = 0; i < qPages.size(); i++) {
         clone->qPages[i] = std::dynamic_pointer_cast<QEngine>(qPages[i]->Clone());
+    }
+
+    return clone;
+}
+
+QEnginePtr QPager::CloneEmpty()
+{
+    SeparateEngines();
+
+    QPagerPtr clone = std::make_shared<QPager>(engines, qubitCount, 0, rand_generator, ONE_CMPLX, doNormalize,
+        randGlobalPhase, false, 0, (hardware_rand_generator == NULL) ? false : true, isSparse, (real1_f)amplitudeFloor);
+
+    for (bitCapIntOcl i = 0; i < qPages.size(); i++) {
+        clone->qPages[i] = qPages[i]->CloneEmpty();
     }
 
     return clone;

--- a/src/qstabilizer.cpp
+++ b/src/qstabilizer.cpp
@@ -305,6 +305,9 @@ AmplitudeEntry QStabilizer::getBasisAmp(const real1_f& nrm)
     if (e & 2) {
         amp *= -ONE_CMPLX;
     }
+    if (!randGlobalPhase) {
+        amp *= phaseOffset;
+    }
 
     bitCapIntOcl perm = 0;
     for (bitLenInt j = 0; j < qubitCount; j++) {
@@ -354,7 +357,7 @@ bool QStabilizer::isEqual(QStabilizerPtr toCompare)
         return true;
     }
 
-    if (!randGlobalPhase && !IS_NORM_0(phaseOffset - toCompare->phaseOffset)) {
+    if ((!randGlobalPhase || !toCompare->randGlobalPhase) && !IS_NORM_0(phaseOffset - toCompare->phaseOffset)) {
         return false;
     }
 
@@ -398,7 +401,7 @@ real1_f QStabilizer::FirstNonzeroPhase()
 
     const AmplitudeEntry entry0 = getBasisAmp(nrm);
     if (entry0.amplitude != ZERO_CMPLX) {
-        return (real1_f)std::arg(phaseOffset * entry0.amplitude);
+        return (real1_f)std::arg(entry0.amplitude);
     }
     for (bitCapIntOcl t = 0; t < permCountMin1; t++) {
         bitCapIntOcl t2 = t ^ (t + 1);
@@ -409,7 +412,7 @@ real1_f QStabilizer::FirstNonzeroPhase()
         }
         const AmplitudeEntry entry = getBasisAmp(nrm);
         if (entry.amplitude != ZERO_CMPLX) {
-            return (real1_f)std::arg(phaseOffset * entry.amplitude);
+            return (real1_f)std::arg(entry.amplitude);
         }
     }
 

--- a/src/qstabilizer.cpp
+++ b/src/qstabilizer.cpp
@@ -354,6 +354,10 @@ bool QStabilizer::isEqual(QStabilizerPtr toCompare)
         return true;
     }
 
+    if (!randGlobalPhase && !IS_NORM_0(phaseOffset - toCompare->phaseOffset)) {
+        return false;
+    }
+
     gaussian();
     toCompare->gaussian();
 

--- a/src/qstabilizerhybrid.cpp
+++ b/src/qstabilizerhybrid.cpp
@@ -29,14 +29,13 @@ QStabilizerHybrid::QStabilizerHybrid(std::vector<QInterfaceEngine> eng, bitLenIn
     qrack_rand_gen_ptr rgp, complex phaseFac, bool doNorm, bool randomGlobalPhase, bool useHostMem, int deviceId,
     bool useHardwareRNG, bool useSparseStateVec, real1_f norm_thresh, std::vector<int> devList,
     bitLenInt qubitThreshold, real1_f sep_thresh)
-    : QInterface(qBitCount, rgp, doNorm, useHardwareRNG, randomGlobalPhase, doNorm ? norm_thresh : ZERO_R1)
+    : QEngine(qBitCount, rgp, doNorm, randomGlobalPhase, useHostMem, useHardwareRNG, norm_thresh)
     , engineTypes(eng)
     , engine(NULL)
     , shards(qubitCount)
     , devID(deviceId)
     , phaseFactor(phaseFac)
     , doNormalize(doNorm)
-    , useHostRam(useHostMem)
     , isSparse(useSparseStateVec)
     , isDefaultPaging(false)
     , separabilityThreshold(sep_thresh)
@@ -72,13 +71,13 @@ QStabilizerPtr QStabilizerHybrid::MakeStabilizer(bitCapInt perm)
         qubitCount, perm, rand_generator, CMPLX_DEFAULT_ARG, false, randGlobalPhase, false, -1, useRDRAND);
 }
 
-QInterfacePtr QStabilizerHybrid::MakeEngine(bitCapInt perm)
+QEnginePtr QStabilizerHybrid::MakeEngine(bitCapInt perm)
 {
     QInterfacePtr toRet = CreateQuantumInterface(engineTypes, qubitCount, perm, rand_generator, phaseFactor,
         doNormalize, randGlobalPhase, useHostRam, devID, useRDRAND, isSparse, (real1_f)amplitudeFloor, deviceIDs,
         thresholdQubits, separabilityThreshold);
     toRet->SetConcurrency(GetConcurrencyLevel());
-    return toRet;
+    return std::dynamic_pointer_cast<QEngine>(toRet);
 }
 
 void QStabilizerHybrid::CacheEigenstate(bitLenInt target)
@@ -142,7 +141,7 @@ QInterfacePtr QStabilizerHybrid::Clone()
         }
     } else {
         // Clone and set engine directly.
-        c->engine = engine->Clone();
+        c->engine = std::dynamic_pointer_cast<QEngine>(engine->Clone());
         c->stabilizer = NULL;
     }
 

--- a/src/qstabilizerhybrid.cpp
+++ b/src/qstabilizerhybrid.cpp
@@ -149,6 +149,26 @@ QInterfacePtr QStabilizerHybrid::Clone()
     return c;
 }
 
+QEnginePtr QStabilizerHybrid::CloneEmpty()
+{
+    if (stabilizer) {
+        return std::dynamic_pointer_cast<QEngine>(Clone());
+    }
+
+    QStabilizerHybridPtr c = std::make_shared<QStabilizerHybrid>(engineTypes, qubitCount, 0, rand_generator,
+        phaseFactor, doNormalize, randGlobalPhase, useHostRam, devID, useRDRAND, isSparse, (real1_f)amplitudeFloor,
+        std::vector<int>{}, thresholdQubits, separabilityThreshold);
+
+    Finish();
+    c->Finish();
+
+    // Clone and set engine directly.
+    c->engine = engine->CloneEmpty();
+    c->stabilizer = NULL;
+
+    return c;
+};
+
 void QStabilizerHybrid::SwitchToEngine()
 {
     if (engine) {

--- a/src/qstabilizerhybrid.cpp
+++ b/src/qstabilizerhybrid.cpp
@@ -148,27 +148,6 @@ QInterfacePtr QStabilizerHybrid::Clone()
     return c;
 }
 
-QEnginePtr QStabilizerHybrid::CloneEmpty()
-{
-    // if (stabilizer) {
-    //     return std::dynamic_pointer_cast<QEngine>(Clone());
-    // }
-    SwitchToEngine();
-
-    QStabilizerHybridPtr c = std::make_shared<QStabilizerHybrid>(engineTypes, qubitCount, 0, rand_generator,
-        phaseFactor, doNormalize, randGlobalPhase, useHostRam, devID, useRDRAND, isSparse, (real1_f)amplitudeFloor,
-        std::vector<int>{}, thresholdQubits, separabilityThreshold);
-
-    Finish();
-    c->Finish();
-
-    // Clone and set engine directly.
-    c->engine = engine->CloneEmpty();
-    c->stabilizer = NULL;
-
-    return c;
-};
-
 void QStabilizerHybrid::SwitchToEngine()
 {
     if (engine) {

--- a/src/qstabilizerhybrid.cpp
+++ b/src/qstabilizerhybrid.cpp
@@ -150,9 +150,10 @@ QInterfacePtr QStabilizerHybrid::Clone()
 
 QEnginePtr QStabilizerHybrid::CloneEmpty()
 {
-    if (stabilizer) {
-        return std::dynamic_pointer_cast<QEngine>(Clone());
-    }
+    // if (stabilizer) {
+    //     return std::dynamic_pointer_cast<QEngine>(Clone());
+    // }
+    SwitchToEngine();
 
     QStabilizerHybridPtr c = std::make_shared<QStabilizerHybrid>(engineTypes, qubitCount, 0, rand_generator,
         phaseFactor, doNormalize, randGlobalPhase, useHostRam, devID, useRDRAND, isSparse, (real1_f)amplitudeFloor,

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -3597,16 +3597,30 @@ TEST_CASE("test_attach")
     qftReg->X(0);
     REQUIRE(qftReg->MAll() == 0x2);
 
-    qftReg->SetPermutation(0x1);
+    qftReg->SetPermutation(0);
     qftReg->H(0);
+    REQUIRE_FLOAT(ONE_R1 / 2, qftReg->Prob(0));
+    REQUIRE_FLOAT(ZERO_R1, qftReg->Prob(1));
     qftReg->CNOT(0, 1);
+    REQUIRE_FLOAT(ONE_R1 / 2, qftReg->Prob(0));
+    REQUIRE_FLOAT(ONE_R1 / 2, qftReg->Prob(1));
     qftReg->X(0);
+    REQUIRE_FLOAT(ONE_R1 / 2, qftReg->Prob(0));
+    REQUIRE_FLOAT(ONE_R1 / 2, qftReg->Prob(1));
     qftReg->CNOT(1, 0);
+    REQUIRE_FLOAT(ONE_R1 / 2, qftReg->Prob(0));
+    REQUIRE_FLOAT(ONE_R1, qftReg->Prob(1));
     qftReg->CNOT(1, 0);
+    REQUIRE_FLOAT(ONE_R1 / 2, qftReg->Prob(0));
+    REQUIRE_FLOAT(ONE_R1 / 2, qftReg->Prob(1));
     qftReg->X(0);
+    REQUIRE_FLOAT(ONE_R1 / 2, qftReg->Prob(0));
+    REQUIRE_FLOAT(ONE_R1 / 2, qftReg->Prob(1));
     qftReg->CNOT(0, 1);
+    REQUIRE_FLOAT(ONE_R1 / 2, qftReg->Prob(0));
+    REQUIRE_FLOAT(ZERO_R1, qftReg->Prob(1));
     qftReg->H(0);
-    REQUIRE(qftReg->MAll() == 0x1);
+    REQUIRE(qftReg->MAll() == 0);
 }
 
 int qRand(int high, QInterfacePtr q)

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -3582,16 +3582,20 @@ TEST_CASE("test_attach")
     qftReg->H(0);
     REQUIRE_THAT(qftReg, HasProbability(0x3));
 
-    qftReg->SetPermutation(0x1);
+    qftReg->SetPermutation(0x2);
+    qftReg->X(0);
+    qftReg->H(1);
+    qftReg->CNOT(1, 0);
     qftReg->H(0);
-    qftReg->AntiCY(1, 0);
-    qftReg->Z(0);
+    qftReg->H(1);
     qftReg->CNOT(1, 0);
     qftReg->CNOT(1, 0);
-    qftReg->Z(0);
-    qftReg->AntiCY(1, 0);
+    qftReg->H(1);
     qftReg->H(0);
-    REQUIRE(qftReg->MAll() == 1);
+    qftReg->CNOT(1, 0);
+    qftReg->H(1);
+    qftReg->X(0);
+    REQUIRE(qftReg->MAll() == 0x2);
 }
 
 int qRand(int high, QInterfacePtr q)
@@ -6590,7 +6594,6 @@ TEST_CASE("test_mirror_quantum_volume", "[mirror]")
         std::cout << ">>> 'test_mirror_quantum_volume': skipped" << std::endl;
         return;
     }
-
     std::cout << ">>> 'test_mirror_quantum_volume':" << std::endl;
 
     const int GateCount1Qb = 8;

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -3596,6 +3596,21 @@ TEST_CASE("test_attach")
     qftReg->H(1);
     qftReg->X(0);
     REQUIRE(qftReg->MAll() == 0x2);
+
+    qftReg->SetPermutation(0x3);
+    qftReg->H(0);
+    qftReg->X(1);
+    qftReg->CNOT(0, 1);
+    qftReg->X(0);
+    qftReg->X(1);
+    qftReg->CNOT(1, 0);
+    qftReg->CNOT(1, 0);
+    qftReg->X(1);
+    qftReg->X(0);
+    qftReg->CNOT(0, 1);
+    qftReg->X(1);
+    qftReg->H(0);
+    REQUIRE(qftReg->MAll() == 0x3);
 }
 
 int qRand(int high, QInterfacePtr q)

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -3599,26 +3599,12 @@ TEST_CASE("test_attach")
 
     qftReg->SetPermutation(0);
     qftReg->H(0);
-    REQUIRE_FLOAT(ONE_R1 / 2, qftReg->Prob(0));
-    REQUIRE_FLOAT(ZERO_R1, qftReg->Prob(1));
     qftReg->CNOT(0, 1);
-    REQUIRE_FLOAT(ONE_R1 / 2, qftReg->Prob(0));
-    REQUIRE_FLOAT(ONE_R1 / 2, qftReg->Prob(1));
     qftReg->X(0);
-    REQUIRE_FLOAT(ONE_R1 / 2, qftReg->Prob(0));
-    REQUIRE_FLOAT(ONE_R1 / 2, qftReg->Prob(1));
     qftReg->CNOT(1, 0);
-    REQUIRE_FLOAT(ONE_R1 / 2, qftReg->Prob(0));
-    REQUIRE_FLOAT(ONE_R1, qftReg->Prob(1));
     qftReg->CNOT(1, 0);
-    REQUIRE_FLOAT(ONE_R1 / 2, qftReg->Prob(0));
-    REQUIRE_FLOAT(ONE_R1 / 2, qftReg->Prob(1));
     qftReg->X(0);
-    REQUIRE_FLOAT(ONE_R1 / 2, qftReg->Prob(0));
-    REQUIRE_FLOAT(ONE_R1 / 2, qftReg->Prob(1));
     qftReg->CNOT(0, 1);
-    REQUIRE_FLOAT(ONE_R1 / 2, qftReg->Prob(0));
-    REQUIRE_FLOAT(ZERO_R1, qftReg->Prob(1));
     qftReg->H(0);
     REQUIRE(qftReg->MAll() == 0);
 }

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -2800,18 +2800,9 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_dispose_perm")
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_compose")
 {
-    QInterfacePtr qftReg2;
-    if (testEngineType == QINTERFACE_BDT) {
-        qftReg = CreateQuantumInterface({ testEngineType, testSubEngineType, testSubSubEngineType }, 2, 0x03, rng);
-        std::dynamic_pointer_cast<QBdt>(qftReg)->Attach(std::dynamic_pointer_cast<QEngine>(
-            CreateQuantumInterface({ QINTERFACE_STABILIZER_HYBRID }, 2, 0x02, rng, CMPLX_DEFAULT_ARG, false, false)));
-        qftReg2 = CreateQuantumInterface({ testEngineType, testSubEngineType, testSubSubEngineType }, 2, 0x02, rng);
-        std::dynamic_pointer_cast<QBdt>(qftReg2)->Attach(std::dynamic_pointer_cast<QEngine>(
-            CreateQuantumInterface({ QINTERFACE_STABILIZER_HYBRID }, 2, 0x00, rng, CMPLX_DEFAULT_ARG, false, false)));
-    } else {
-        qftReg = CreateQuantumInterface({ testEngineType, testSubEngineType, testSubSubEngineType }, 4, 0x0b, rng);
-        qftReg2 = CreateQuantumInterface({ testEngineType, testSubEngineType, testSubSubEngineType }, 4, 0x02, rng);
-    }
+    qftReg = CreateQuantumInterface({ testEngineType, testSubEngineType, testSubSubEngineType }, 4, 0x0b, rng);
+    QInterfacePtr qftReg2 =
+        CreateQuantumInterface({ testEngineType, testSubEngineType, testSubSubEngineType }, 4, 0x02, rng);
     qftReg->Compose(qftReg2);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x2b));
 

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -2803,11 +2803,11 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_compose")
     QInterfacePtr qftReg2;
     if (testEngineType == QINTERFACE_BDT) {
         qftReg = CreateQuantumInterface({ testEngineType, testSubEngineType, testSubSubEngineType }, 2, 0x03, rng);
-        std::dynamic_pointer_cast<QBdt>(qftReg)->Attach(std::dynamic_pointer_cast<QStabilizer>(
-            CreateQuantumInterface({ QINTERFACE_STABILIZER }, 2, 0x02, rng, CMPLX_DEFAULT_ARG, false, false)));
+        std::dynamic_pointer_cast<QBdt>(qftReg)->Attach(std::dynamic_pointer_cast<QEngine>(
+            CreateQuantumInterface({ QINTERFACE_STABILIZER_HYBRID }, 2, 0x02, rng, CMPLX_DEFAULT_ARG, false, false)));
         qftReg2 = CreateQuantumInterface({ testEngineType, testSubEngineType, testSubSubEngineType }, 2, 0x02, rng);
-        std::dynamic_pointer_cast<QBdt>(qftReg2)->Attach(std::dynamic_pointer_cast<QStabilizer>(
-            CreateQuantumInterface({ QINTERFACE_STABILIZER }, 2, 0x00, rng, CMPLX_DEFAULT_ARG, false, false)));
+        std::dynamic_pointer_cast<QBdt>(qftReg2)->Attach(std::dynamic_pointer_cast<QEngine>(
+            CreateQuantumInterface({ QINTERFACE_STABILIZER_HYBRID }, 2, 0x00, rng, CMPLX_DEFAULT_ARG, false, false)));
     } else {
         qftReg = CreateQuantumInterface({ testEngineType, testSubEngineType, testSubSubEngineType }, 4, 0x0b, rng);
         qftReg2 = CreateQuantumInterface({ testEngineType, testSubEngineType, testSubSubEngineType }, 4, 0x02, rng);
@@ -3571,8 +3571,8 @@ TEST_CASE("test_attach")
     std::cout << ">>> 'test_attach':" << std::endl;
 
     QInterfacePtr qftReg = CreateQuantumInterface({ QINTERFACE_BDT }, 1U, 0, rng);
-    std::dynamic_pointer_cast<QBdt>(qftReg)->Attach(std::dynamic_pointer_cast<QStabilizer>(
-        CreateQuantumInterface({ QINTERFACE_STABILIZER }, 1U, 0, rng, CMPLX_DEFAULT_ARG, false, false)));
+    std::dynamic_pointer_cast<QBdt>(qftReg)->Attach(std::dynamic_pointer_cast<QEngine>(
+        CreateQuantumInterface({ QINTERFACE_STABILIZER_HYBRID }, 1U, 0, rng, CMPLX_DEFAULT_ARG, false, false)));
 
     qftReg->SetPermutation(0x2);
     qftReg->H(0);
@@ -6000,8 +6000,8 @@ TEST_CASE("test_mirror_circuit_26", "[mirror]")
     std::cout << ">>> 'test_mirror_circuit_26':" << std::endl;
 
     QInterfacePtr qftReg = CreateQuantumInterface({ QINTERFACE_BDT }, 1U, 0, rng);
-    std::dynamic_pointer_cast<QBdt>(qftReg)->Attach(std::dynamic_pointer_cast<QStabilizer>(
-        CreateQuantumInterface({ QINTERFACE_STABILIZER }, 2U, 0, rng, CMPLX_DEFAULT_ARG, false, false)));
+    std::dynamic_pointer_cast<QBdt>(qftReg)->Attach(std::dynamic_pointer_cast<QEngine>(
+        CreateQuantumInterface({ QINTERFACE_STABILIZER_HYBRID }, 2U, 0, rng, CMPLX_DEFAULT_ARG, false, false)));
 
     qftReg->SetPermutation(7);
 
@@ -6443,8 +6443,8 @@ TEST_CASE("test_mirror_near_clifford", "[mirror]")
     real1_f tRate = ZERO_R1;
     for (int trial = 0; trial < TRIALS; trial++) {
         QInterfacePtr testCase = CreateQuantumInterface({ QINTERFACE_BDT }, magic, 0, rng);
-        std::dynamic_pointer_cast<QBdt>(testCase)->Attach(std::dynamic_pointer_cast<QStabilizer>(
-            CreateQuantumInterface({ QINTERFACE_STABILIZER }, n - magic, 0, rng, CMPLX_DEFAULT_ARG, false, false)));
+        std::dynamic_pointer_cast<QBdt>(testCase)->Attach(std::dynamic_pointer_cast<QEngine>(CreateQuantumInterface(
+            { QINTERFACE_STABILIZER_HYBRID }, n - magic, 0, rng, CMPLX_DEFAULT_ARG, false, false)));
 
         std::vector<std::vector<int>> gate1QbRands(Depth);
         std::vector<std::vector<MultiQubitGate>> gateMultiQbRands(Depth);
@@ -6644,8 +6644,8 @@ TEST_CASE("test_mirror_quantum_volume", "[mirror]")
 
     for (int trial = 0; trial < TRIALS; trial++) {
         QInterfacePtr testCase = CreateQuantumInterface({ QINTERFACE_BDT }, magic, 0, rng);
-        std::dynamic_pointer_cast<QBdt>(testCase)->Attach(std::dynamic_pointer_cast<QStabilizer>(
-            CreateQuantumInterface({ QINTERFACE_STABILIZER }, n - magic, 0, rng, CMPLX_DEFAULT_ARG, false, false)));
+        std::dynamic_pointer_cast<QBdt>(testCase)->Attach(std::dynamic_pointer_cast<QEngine>(CreateQuantumInterface(
+            { QINTERFACE_STABILIZER_HYBRID }, n - magic, 0, rng, CMPLX_DEFAULT_ARG, false, false)));
 
         std::vector<std::vector<int>> gate1QbRands(Depth);
         std::vector<std::vector<MultiQubitGate>> gateMultiQbRands(Depth);

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -3581,6 +3581,17 @@ TEST_CASE("test_attach")
     REQUIRE_THAT(qftReg, HasProbability(1, 1, 0x1));
     qftReg->H(0);
     REQUIRE_THAT(qftReg, HasProbability(0x3));
+
+    qftReg->SetPermutation(0x1);
+    qftReg->H(0);
+    qftReg->AntiCY(1, 0);
+    qftReg->Z(0);
+    qftReg->CNOT(1, 0);
+    qftReg->CNOT(1, 0);
+    qftReg->Z(0);
+    qftReg->AntiCY(1, 0);
+    qftReg->H(0);
+    REQUIRE(qftReg->MAll() == 1);
 }
 
 int qRand(int high, QInterfacePtr q)

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -3597,20 +3597,16 @@ TEST_CASE("test_attach")
     qftReg->X(0);
     REQUIRE(qftReg->MAll() == 0x2);
 
-    qftReg->SetPermutation(0x3);
+    qftReg->SetPermutation(0x1);
     qftReg->H(0);
-    qftReg->X(1);
     qftReg->CNOT(0, 1);
     qftReg->X(0);
-    qftReg->X(1);
     qftReg->CNOT(1, 0);
     qftReg->CNOT(1, 0);
-    qftReg->X(1);
     qftReg->X(0);
     qftReg->CNOT(0, 1);
-    qftReg->X(1);
     qftReg->H(0);
-    REQUIRE(qftReg->MAll() == 0x3);
+    REQUIRE(qftReg->MAll() == 0x1);
 }
 
 int qRand(int high, QInterfacePtr q)


### PR DESCRIPTION
`QBdt` can almost correctly `Attach()` to `QEngine` types. In fact, gate primitive unit tests generally pass with "attached" qubits, except for mirror circuit integration tests.

In the meantime, `QBdt` has been significantly improved, by using a `std::set` to skip branching on gate depth node peers. `QPager` and `QStabilizerHybrid` also now provide preliminary for support for the `QEngine` polymorphism.

Finishing `QBdt::Attach()` support might take about a week or so, but everything besides that, herein, is unaffected or improved, including simple `QBdt` simulation.