### PR TITLE
QBdt debugging/optimization

### DIFF
--- a/src/qbdt/tree.cpp
+++ b/src/qbdt/tree.cpp
@@ -762,21 +762,20 @@ void QBdt::ApplyControlledSingle(
         }
 
         if (isKet) {
+            leaf->Branch();
             QEnginePtr qi = NODE_TO_QENGINE(leaf);
-            if (qis.find(qi) == qis.end()) {
-                try {
-                    if (isAnti) {
-                        qi->MACMtrx(ketControls.get(), ketControlsVec.size(), mtrx, target - bdtQubitCount);
-                    } else {
-                        qi->MCMtrx(ketControls.get(), ketControlsVec.size(), mtrx, target - bdtQubitCount);
-                    }
-                } catch (const std::domain_error&) {
-                    isFail = true;
-
-                    return (bitCapInt)(qPower - ONE_BCI);
+            try {
+                if (isAnti) {
+                    qi->MACMtrx(ketControls.get(), ketControlsVec.size(), mtrx, target - bdtQubitCount);
+                } else {
+                    qi->MCMtrx(ketControls.get(), ketControlsVec.size(), mtrx, target - bdtQubitCount);
                 }
-                qis.insert(qi);
+            } catch (const std::domain_error&) {
+                isFail = true;
+
+                return (bitCapInt)(qPower - ONE_BCI);
             }
+            qis.insert(qi);
         } else if (qns.find(leaf) == qns.end()) {
 #if ENABLE_COMPLEX_X2
             leaf->Apply2x2(mtrxCol1, mtrxCol2, bdtQubitCount - target);

--- a/src/qbdt/tree.cpp
+++ b/src/qbdt/tree.cpp
@@ -643,7 +643,6 @@ void QBdt::ApplySingle(const complex* mtrx, bitLenInt target)
                 // WARNING: Mutates loop control variable!
                 return (bitCapInt)(pow2(maxQubit - j) - ONE_BCI);
             }
-            leaf->Branch();
             leaf = leaf->branches[SelectBit(i, maxQubit - (j + 1U))];
         }
 


### PR DESCRIPTION
One qubit gates do not require branching from above, but controlled gates do. This doesn't completely fix `Attach()`, and, in fact, it makes the `test_mirror_near_clifford` success rate lower, but this likely because we have only first exposed the `QEngine` usage in nodes as surface area for debugging.