### PR TITLE
128-bit quad floating point

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,10 @@ if (ENABLE_PTHREAD)
 	endif (NOT ANDROID AND NOT MSVC)
 endif (ENABLE_PTHREAD)
 
+if (FPPOW GREATER 6)
+    set(QRACK_LIBS quadmath)
+endif (FPPOW GREATER 6)
+
 target_link_libraries (qrack_pinvoke ${QRACK_LIBS})
 if (NOT ENABLE_EMIT_LLVM)
     # Declare the unittest executable

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,7 @@ if (ENABLE_PTHREAD)
 endif (ENABLE_PTHREAD)
 
 if (FPPOW GREATER 6)
-    set(QRACK_LIBS quadmath)
+    set(QRACK_LIBS ${QRACK_LIBS} quadmath)
 endif (FPPOW GREATER 6)
 
 target_link_libraries (qrack_pinvoke ${QRACK_LIBS})

--- a/cmake/FpPow.cmake
+++ b/cmake/FpPow.cmake
@@ -4,9 +4,9 @@ if (FPPOW LESS 4)
     message(FATAL_ERROR "FPPOW must be at least 4, equivalent to \"half\" precision!")
 endif (FPPOW LESS 4)
 
-if (FPPOW GREATER 6)
-    message(FATAL_ERROR "FPPOW must be no greater than 6, equivalent to \"double\" precision!")
-endif (FPPOW GREATER 6)
+if (FPPOW GREATER 7)
+    message(FATAL_ERROR "FPPOW must be no greater than 7, equivalent to 128-bit precision!")
+endif (FPPOW GREATER 7)
 
 if (FPPOW LESS 5)
     set(ENABLE_COMPLEX_X2 OFF)

--- a/examples/cosmology.cpp
+++ b/examples/cosmology.cpp
@@ -17,9 +17,9 @@ using namespace Qrack;
 
 void StatePrep(QInterfacePtr qReg)
 {
-    real1_f theta = 2 * PI_R1 * qReg->Rand();
-    real1_f phi = 2 * PI_R1 * qReg->Rand();
-    real1_f lambda = 2 * PI_R1 * qReg->Rand();
+    real1_f theta = (real1_f)(2 * PI_R1 * qReg->Rand());
+    real1_f phi = (real1_f)(2 * PI_R1 * qReg->Rand());
+    real1_f lambda = (real1_f)(2 * PI_R1 * qReg->Rand());
     qReg->U(0, theta, phi, lambda);
 }
 

--- a/examples/qneuron_classification.cpp
+++ b/examples/qneuron_classification.cpp
@@ -157,11 +157,11 @@ void train(std::vector<std::vector<BoolH>>& rawYX, std::vector<real1>& etas, QIn
 
         if (permH.size() == 0) {
             for (i = 0; i < outputLayer.size(); i++) {
-                outputLayer[i]->LearnPermutation(row[0], etas[i] / rowCount);
+                outputLayer[i]->LearnPermutation(row[0], (real1_f)(etas[i] / rowCount));
             }
         } else {
             for (i = 0; i < outputLayer.size(); i++) {
-                outputLayer[i]->Learn(row[0], etas[i] / (rowCount * pow2Ocl(permH.size())));
+                outputLayer[i]->Learn(row[0], (real1_f)(etas[i] / (rowCount * pow2Ocl(permH.size()))));
             }
         }
     }
@@ -243,16 +243,16 @@ real1_f calculateAuc(std::vector<std::vector<BoolH>>& rawYX, std::vector<dfObser
     oFp = fp;
     totT = tp;
     totF = fp;
-    err = ((real1)fp) / rowCount;
+    err = ((real1_f)fp) / rowCount;
     optimumErr = err;
 
     std::set<real1>::iterator it = dfVals.begin();
     while (it != dfVals.end()) {
-        cutoff = *it;
+        cutoff = (real1_f)*it;
         it++;
 
-        lTp = (real1)tp / totT;
-        lFp = (real1)fp / totF;
+        lTp = (real1_f)tp / totT;
+        lFp = (real1_f)fp / totF;
 
         tp = 0;
         fp = 0;
@@ -275,18 +275,18 @@ real1_f calculateAuc(std::vector<std::vector<BoolH>>& rawYX, std::vector<dfObser
             }
         }
 
-        dTp = lTp - ((real1)tp / totT);
-        dFp = lFp - ((real1)fp / totF);
-        auc += dFp * (((real1)tp / totT) + (dTp / 2));
+        dTp = lTp - ((real1_f)tp / totT);
+        dFp = lFp - ((real1_f)fp / totF);
+        auc += dFp * (((real1_f)tp / totT) + (dTp / 2));
 
-        err = ((real1)((fp * fp) + (fn * fn))) / (rowCount * rowCount);
+        err = ((real1_f)((fp * fp) + (fn * fn))) / (rowCount * rowCount);
         if (err < optimumErr) {
             optimumErr = err;
 
             if (it == dfVals.end()) {
                 optimumCutoff = 1;
             } else {
-                optimumCutoff = cutoff + (((*it) - cutoff) / 2);
+                optimumCutoff = cutoff + ((((real1_f)*it) - cutoff) / 2);
             }
 
             oTp = tp;

--- a/examples/quantum_associative_memory.cpp
+++ b/examples/quantum_associative_memory.cpp
@@ -52,7 +52,7 @@ int main()
         for (bitLenInt i = 0; i < OutputCount; i++) {
             qReg->SetPermutation(perm);
             bit = (comp & pow2(i)) != 0;
-            outputLayer[i]->LearnPermutation(bit, eta);
+            outputLayer[i]->LearnPermutation(bit, (real1_f)eta);
         }
     }
 

--- a/examples/quantum_perceptron.cpp
+++ b/examples/quantum_perceptron.cpp
@@ -44,7 +44,7 @@ int main()
         std::cout << "Epoch " << (perm + 1U) << " out of " << ControlPower << std::endl;
         qReg->SetPermutation(perm);
         isPowerOf2 = ((perm != 0) && ((perm & (perm - 1U)) == 0));
-        qPerceptron->LearnPermutation(isPowerOf2, eta);
+        qPerceptron->LearnPermutation(isPowerOf2, (real1_f)eta);
     }
 
     std::cout << "Should be close to 1 for powers of two, and close to 0 for all else..." << std::endl;

--- a/examples/teleport.cpp
+++ b/examples/teleport.cpp
@@ -23,9 +23,9 @@ void StatePrep(QInterfacePtr qReg)
     // "Alice" has a qubit to teleport.
 
     // (To test consistency, comment out this U() gate.)
-    real1_f theta = 2 * PI_R1 * qReg->Rand();
-    real1_f phi = 2 * PI_R1 * qReg->Rand();
-    real1_f lambda = 2 * PI_R1 * qReg->Rand();
+    real1_f theta = (real1_f)(2 * PI_R1 * qReg->Rand());
+    real1_f phi = (real1_f)(2 * PI_R1 * qReg->Rand());
+    real1_f lambda = (real1_f)(2 * PI_R1 * qReg->Rand());
     qReg->U(0, theta, phi, lambda);
     std::cout << "Alice is sending: U(theta=" << theta << ", phi=" << phi << ", lambda=" << lambda << ")" << std::endl;
 

--- a/include/common/parallel_for.hpp
+++ b/include/common/parallel_for.hpp
@@ -76,7 +76,7 @@ public:
     void par_for_qbdt(const bitCapInt begin, const bitCapInt end, BdtFunc fn);
 
     /** Calculate the normal for the array, (with flooring). */
-    real1_f par_norm(const bitCapIntOcl maxQPower, const StateVectorPtr stateArray, real1_f norm_thresh = ZERO_R1);
+    real1_f par_norm(const bitCapIntOcl maxQPower, const StateVectorPtr stateArray, real1_f norm_thresh = ZERO_R1_F);
 
     /** Calculate the normal for the array, (without flooring.) */
     real1_f par_norm_exact(const bitCapIntOcl maxQPower, const StateVectorPtr stateArray);

--- a/include/common/qrack_types.hpp
+++ b/include/common/qrack_types.hpp
@@ -151,6 +151,7 @@ typedef double real1_f;
 #else
 #include <boost/multiprecision/float128.hpp>
 #include <quadmath.h>
+#include <limits>
 namespace Qrack {
 typedef std::complex<boost::multiprecision::float128> complex;
 typedef boost::multiprecision::float128 real1;
@@ -166,7 +167,7 @@ typedef double real1_f;
 // Half of the amplitude of 64 maximally superposed qubits in any permutation
 #define REAL1_EPSILON ((real1_f)2e-129)
 // Minimum representable difference from 1
-#define FP_NORM_EPSILON ((real1_f)1.92592994438723585305597794258492732e-34)
+#define FP_NORM_EPSILON std::numeric_limits<boost::multiprecision::float128>::epsilon()
 } // namespace Qrack
 #endif
 
@@ -174,7 +175,8 @@ typedef double real1_f;
 #define ZERO_CMPLX complex(ZERO_R1, ZERO_R1)
 #define I_CMPLX complex(ZERO_R1, ONE_R1)
 #define CMPLX_DEFAULT_ARG complex(REAL1_DEFAULT_ARG, REAL1_DEFAULT_ARG)
-#define TRYDECOMPOSE_EPSILON (8 * FP_NORM_EPSILON)
+#define TRYDECOMPOSE_EPSILON ((real1_f)(8 * FP_NORM_EPSILON))
+#define FP_NORM_EPSILON_F ((real1_f)FP_NORM_EPSILON)
 
 namespace Qrack {
 typedef std::shared_ptr<complex> BitOp;

--- a/include/common/qrack_types.hpp
+++ b/include/common/qrack_types.hpp
@@ -83,7 +83,9 @@ typedef std::complex<__fp16> complex;
 typedef __fp16 real1;
 typedef float real1_f;
 #define ZERO_R1 0.0f
+#define ZERO_R1_F 0.0f
 #define ONE_R1 1.0f
+#define ONE_R1_F 1.0f
 #define PI_R1 ((real1_f)M_PI)
 #define SQRT2_R1 ((real1_f)M_SQRT2)
 #define SQRT1_2_R1 ((real1_f)M_SQRT2)
@@ -97,7 +99,9 @@ typedef std::complex<half_float::half> complex;
 typedef half_float::half real1;
 typedef float real1_f;
 #define ZERO_R1 ((real1)0.0f)
+#define ZERO_R1_F 0.0f
 #define ONE_R1 ((real1)1.0f)
+#define ONE_R1_F 1.0f
 #define PI_R1 ((real1)M_PI)
 #define SQRT2_R1 ((real1)M_SQRT2)
 #define SQRT1_2_R1 ((real1)M_SQRT1_2)
@@ -114,7 +118,9 @@ typedef std::complex<float> complex;
 typedef float real1;
 typedef float real1_f;
 #define ZERO_R1 0.0f
+#define ZERO_R1_F 0.0f
 #define ONE_R1 1.0f
+#define ONE_R1_F 1.0f
 #define PI_R1 ((real1_f)M_PI)
 #define SQRT2_R1 ((real1_f)M_SQRT2)
 #define SQRT1_2_R1 ((real1_f)M_SQRT1_2)
@@ -124,13 +130,15 @@ typedef float real1_f;
 // Minimum representable difference from 1
 #define FP_NORM_EPSILON 1.192092896e-07f
 } // namespace Qrack
-#else
+#elif FPPOW < 7
 namespace Qrack {
 typedef std::complex<double> complex;
 typedef double real1;
 typedef double real1_f;
 #define ZERO_R1 0.0
+#define ZERO_R1_F 0.0
 #define ONE_R1 1.0
+#define ONE_R1_F 1.0
 #define PI_R1 M_PI
 #define SQRT2_R1 M_SQRT2
 #define SQRT1_2_R1 M_SQRT1_2
@@ -139,6 +147,26 @@ typedef double real1_f;
 #define REAL1_EPSILON 2e-65
 // Minimum representable difference from 1
 #define FP_NORM_EPSILON 2.2204460492503131e-16
+} // namespace Qrack
+#else
+#include <boost/multiprecision/float128.hpp>
+#include <quadmath.h>
+namespace Qrack {
+typedef std::complex<boost::multiprecision::float128> complex;
+typedef boost::multiprecision::float128 real1;
+typedef double real1_f;
+#define ZERO_R1 ((real1)0.0)
+#define ZERO_R1_F 0.0
+#define ONE_R1 ((real1)1.0)
+#define ONE_R1_F 1.0
+#define PI_R1 ((real1)M_PI)
+#define SQRT2_R1 ((real1)M_SQRT2)
+#define SQRT1_2_R1 ((real1)M_SQRT1_2)
+#define REAL1_DEFAULT_ARG -999.0
+// Half of the amplitude of 64 maximally superposed qubits in any permutation
+#define REAL1_EPSILON ((real1_f)2e-129)
+// Minimum representable difference from 1
+#define FP_NORM_EPSILON ((real1_f)1.92592994438723585305597794258492732e-34)
 } // namespace Qrack
 #endif
 

--- a/include/common/qrack_types.hpp
+++ b/include/common/qrack_types.hpp
@@ -19,6 +19,7 @@
 #include <cmath>
 #include <complex>
 #include <functional>
+#include <limits>
 #include <memory>
 #include <random>
 
@@ -92,8 +93,6 @@ typedef float real1_f;
 #define REAL1_DEFAULT_ARG -999.0f
 // Half of the amplitude of 16 maximally superposed qubits in any permutation
 #define REAL1_EPSILON 2e-17f
-// Minimum representable difference from 1
-#define FP_NORM_EPSILON 0.0009765625f
 #else
 typedef std::complex<half_float::half> complex;
 typedef half_float::half real1;
@@ -108,8 +107,6 @@ typedef float real1_f;
 #define REAL1_DEFAULT_ARG ((real1)-999.0f)
 // Half of the amplitude of 16 maximally superposed qubits in any permutation
 #define REAL1_EPSILON ((real1)2e-17f)
-// Minimum representable difference from 1
-#define FP_NORM_EPSILON ((real1)0.0009765625f)
 #endif
 } // namespace Qrack
 #elif FPPOW < 6
@@ -127,8 +124,6 @@ typedef float real1_f;
 #define REAL1_DEFAULT_ARG -999.0f
 // Half of the amplitude of 32 maximally superposed qubits in any permutation
 #define REAL1_EPSILON 2e-33f
-// Minimum representable difference from 1
-#define FP_NORM_EPSILON 1.192092896e-07f
 } // namespace Qrack
 #elif FPPOW < 7
 namespace Qrack {
@@ -145,12 +140,9 @@ typedef double real1_f;
 #define REAL1_DEFAULT_ARG -999.0
 // Half of the amplitude of 64 maximally superposed qubits in any permutation
 #define REAL1_EPSILON 2e-65
-// Minimum representable difference from 1
-#define FP_NORM_EPSILON 2.2204460492503131e-16
 } // namespace Qrack
 #else
 #include <boost/multiprecision/float128.hpp>
-#include <limits>
 #include <quadmath.h>
 namespace Qrack {
 typedef std::complex<boost::multiprecision::float128> complex;
@@ -167,7 +159,6 @@ typedef double real1_f;
 // Half of the amplitude of 64 maximally superposed qubits in any permutation
 #define REAL1_EPSILON 2e-129
 // Minimum representable difference from 1
-#define FP_NORM_EPSILON std::numeric_limits<boost::multiprecision::float128>::epsilon()
 } // namespace Qrack
 #endif
 
@@ -175,8 +166,9 @@ typedef double real1_f;
 #define ZERO_CMPLX complex(ZERO_R1, ZERO_R1)
 #define I_CMPLX complex(ZERO_R1, ONE_R1)
 #define CMPLX_DEFAULT_ARG complex(REAL1_DEFAULT_ARG, REAL1_DEFAULT_ARG)
-#define TRYDECOMPOSE_EPSILON ((real1_f)(8 * FP_NORM_EPSILON))
+#define FP_NORM_EPSILON std::numeric_limits<real1>::epsilon()
 #define FP_NORM_EPSILON_F ((real1_f)FP_NORM_EPSILON)
+#define TRYDECOMPOSE_EPSILON ((real1_f)(8 * FP_NORM_EPSILON))
 
 namespace Qrack {
 typedef std::shared_ptr<complex> BitOp;

--- a/include/common/qrack_types.hpp
+++ b/include/common/qrack_types.hpp
@@ -150,8 +150,8 @@ typedef double real1_f;
 } // namespace Qrack
 #else
 #include <boost/multiprecision/float128.hpp>
-#include <quadmath.h>
 #include <limits>
+#include <quadmath.h>
 namespace Qrack {
 typedef std::complex<boost::multiprecision::float128> complex;
 typedef boost::multiprecision::float128 real1;
@@ -165,7 +165,7 @@ typedef double real1_f;
 #define SQRT1_2_R1 ((real1)M_SQRT1_2)
 #define REAL1_DEFAULT_ARG -999.0
 // Half of the amplitude of 64 maximally superposed qubits in any permutation
-#define REAL1_EPSILON ((real1_f)2e-129)
+#define REAL1_EPSILON 2e-129
 // Minimum representable difference from 1
 #define FP_NORM_EPSILON std::numeric_limits<boost::multiprecision::float128>::epsilon()
 } // namespace Qrack

--- a/include/qbdt.hpp
+++ b/include/qbdt.hpp
@@ -130,13 +130,13 @@ public:
         qrack_rand_gen_ptr rgp = nullptr, complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = false,
         bool randomGlobalPhase = true, bool useHostMem = false, int deviceId = -1, bool useHardwareRNG = true,
         bool useSparseStateVec = false, real1_f norm_thresh = REAL1_EPSILON, std::vector<int> ignored = {},
-        bitLenInt qubitThreshold = 0, real1_f separation_thresh = FP_NORM_EPSILON);
+        bitLenInt qubitThreshold = 0, real1_f separation_thresh = FP_NORM_EPSILON_F);
 
     QBdt(bitLenInt qBitCount, bitCapInt initState = 0, qrack_rand_gen_ptr rgp = nullptr,
         complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = false, bool randomGlobalPhase = true,
         bool useHostMem = false, int deviceId = -1, bool useHardwareRNG = true, bool useSparseStateVec = false,
         real1_f norm_thresh = REAL1_EPSILON, std::vector<int> ignored = {}, bitLenInt qubitThreshold = 0,
-        real1_f separation_thresh = FP_NORM_EPSILON)
+        real1_f separation_thresh = FP_NORM_EPSILON_F)
         : QBdt({ QINTERFACE_OPTIMAL_SCHROEDINGER }, qBitCount, initState, rgp, phaseFac, doNorm, randomGlobalPhase,
               useHostMem, deviceId, useHardwareRNG, useSparseStateVec, norm_thresh, ignored, qubitThreshold,
               separation_thresh)

--- a/include/qbdt.hpp
+++ b/include/qbdt.hpp
@@ -151,7 +151,7 @@ public:
     }
 
     virtual void NormalizeState(
-        real1_f nrm = REAL1_DEFAULT_ARG, real1_f norm_thresh = REAL1_DEFAULT_ARG, real1_f phaseArg = ZERO_R1)
+        real1_f nrm = REAL1_DEFAULT_ARG, real1_f norm_thresh = REAL1_DEFAULT_ARG, real1_f phaseArg = ZERO_R1_F)
     {
         root->Normalize(bdtQubitCount);
     }

--- a/include/qengine.hpp
+++ b/include/qengine.hpp
@@ -80,7 +80,7 @@ public:
     virtual real1_f GetRunningNorm()
     {
         Finish();
-        return runningNorm;
+        return (real1_f)runningNorm;
     }
 
     /** Set all amplitudes to 0, and optionally temporarily deallocate state vector RAM */
@@ -110,7 +110,7 @@ public:
      * for the next normalization operation. */
     virtual void QueueSetRunningNorm(real1_f runningNrm) = 0;
 
-    virtual void ZMask(bitCapInt mask) { PhaseParity(PI_R1, mask); }
+    virtual void ZMask(bitCapInt mask) { PhaseParity((real1_f)PI_R1, mask); }
 
     virtual bool ForceM(bitLenInt qubitIndex, bool result, bool doForce = true, bool doApply = true);
     virtual bitCapInt ForceM(const bitLenInt* bits, bitLenInt length, const bool* values, bool doApply = true);

--- a/include/qengine_cpu.hpp
+++ b/include/qengine_cpu.hpp
@@ -48,7 +48,7 @@ public:
         complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = false, bool randomGlobalPhase = true, bool ignored = false,
         int ignored2 = -1, bool useHardwareRNG = true, bool useSparseStateVec = false,
         real1_f norm_thresh = REAL1_EPSILON, std::vector<int> ignored3 = {}, bitLenInt ignored4 = 0,
-        real1_f ignored5 = FP_NORM_EPSILON);
+        real1_f ignored5 = FP_NORM_EPSILON_F);
 
     virtual ~QEngineCPU() { Dump(); }
 

--- a/include/qengine_cpu.hpp
+++ b/include/qengine_cpu.hpp
@@ -78,7 +78,7 @@ public:
     virtual real1_f FirstNonzeroPhase()
     {
         if (!stateVec) {
-            return ZERO_R1;
+            return ZERO_R1_F;
         }
 
         return QInterface::FirstNonzeroPhase();
@@ -312,7 +312,7 @@ public:
     virtual real1_f ProbParity(bitCapInt mask);
     virtual bool ForceMParity(bitCapInt mask, bool result, bool doForce = true);
     virtual void NormalizeState(
-        real1_f nrm = REAL1_DEFAULT_ARG, real1_f norm_thresh = REAL1_DEFAULT_ARG, real1_f phaseArg = ZERO_R1);
+        real1_f nrm = REAL1_DEFAULT_ARG, real1_f norm_thresh = REAL1_DEFAULT_ARG, real1_f phaseArg = ZERO_R1_F);
     virtual real1_f SumSqrDiff(QInterfacePtr toCompare)
     {
         return SumSqrDiff(std::dynamic_pointer_cast<QEngineCPU>(toCompare));

--- a/include/qengine_opencl.hpp
+++ b/include/qengine_opencl.hpp
@@ -282,7 +282,7 @@ public:
     virtual real1_f FirstNonzeroPhase()
     {
         if (!stateBuffer) {
-            return ZERO_R1;
+            return ZERO_R1_F;
         }
 
         return QInterface::FirstNonzeroPhase();
@@ -439,7 +439,7 @@ public:
     virtual real1_f SumSqrDiff(QEngineOCLPtr toCompare);
 
     virtual void NormalizeState(
-        real1_f nrm = REAL1_DEFAULT_ARG, real1_f norm_thresh = REAL1_DEFAULT_ARG, real1_f phaseArg = ZERO_R1);
+        real1_f nrm = REAL1_DEFAULT_ARG, real1_f norm_thresh = REAL1_DEFAULT_ARG, real1_f phaseArg = ZERO_R1_F);
     ;
     virtual void UpdateRunningNorm(real1_f norm_thresh = REAL1_DEFAULT_ARG);
     virtual void Finish() { clFinish(); };
@@ -561,7 +561,7 @@ protected:
         const bitCapIntOcl* qPowersSorted, bool doCalcNorm, SPECIAL_2X2 special,
         real1_f norm_thresh = REAL1_DEFAULT_ARG);
 
-    virtual void BitMask(bitCapIntOcl mask, OCLAPI api_call, real1_f phase = PI_R1);
+    virtual void BitMask(bitCapIntOcl mask, OCLAPI api_call, real1_f phase = (real1_f)PI_R1);
 
     virtual void ApplyM(bitCapInt mask, bool result, complex nrm);
     virtual void ApplyM(bitCapInt mask, bitCapInt result, complex nrm);

--- a/include/qengine_opencl.hpp
+++ b/include/qengine_opencl.hpp
@@ -206,7 +206,7 @@ public:
         complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = false, bool randomGlobalPhase = true,
         bool useHostMem = false, int devID = -1, bool useHardwareRNG = true, bool ignored = false,
         real1_f norm_thresh = REAL1_EPSILON, std::vector<int> ignored2 = {}, bitLenInt ignored4 = 0,
-        real1_f ignored3 = FP_NORM_EPSILON);
+        real1_f ignored3 = FP_NORM_EPSILON_F);
 
     virtual ~QEngineOCL() { FreeAll(); }
 

--- a/include/qengineshard.hpp
+++ b/include/qengineshard.hpp
@@ -667,7 +667,7 @@ public:
     real1_f Prob()
     {
         if (!isProbDirty || !unit) {
-            return norm(amp1);
+            return (real1_f)norm(amp1);
         }
 
         return unit->Prob(mapped);

--- a/include/qhybrid.hpp
+++ b/include/qhybrid.hpp
@@ -42,7 +42,7 @@ public:
         complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = false, bool randomGlobalPhase = true,
         bool useHostMem = false, int deviceId = -1, bool useHardwareRNG = true, bool useSparseStateVec = false,
         real1_f norm_thresh = REAL1_EPSILON, std::vector<int> ignored = {}, bitLenInt qubitThreshold = 0,
-        real1_f ignored2 = FP_NORM_EPSILON);
+        real1_f ignored2 = FP_NORM_EPSILON_F);
 
     QEnginePtr MakeEngine(bool isOpenCL, bitCapInt initState = 0);
 

--- a/include/qhybrid.hpp
+++ b/include/qhybrid.hpp
@@ -420,7 +420,7 @@ public:
 
     virtual void UpdateRunningNorm(real1_f norm_thresh = REAL1_DEFAULT_ARG) { engine->UpdateRunningNorm(norm_thresh); }
     virtual void NormalizeState(
-        real1_f nrm = REAL1_DEFAULT_ARG, real1_f norm_thresh = REAL1_DEFAULT_ARG, real1_f phaseArg = ZERO_R1)
+        real1_f nrm = REAL1_DEFAULT_ARG, real1_f norm_thresh = REAL1_DEFAULT_ARG, real1_f phaseArg = ZERO_R1_F)
     {
         engine->NormalizeState(nrm, norm_thresh, phaseArg);
     }

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -163,15 +163,15 @@ protected:
 
     // Compilers have difficulty figuring out types and overloading if the "norm" handle is passed to std::transform. If
     // you need a safe pointer to norm(), try this:
-    static inline real1_f normHelper(complex c) { return norm(c); }
+    static inline real1_f normHelper(complex c) { return (real1_f)norm(c); }
 
     static inline real1_f clampProb(real1_f toClamp)
     {
-        if (toClamp < ZERO_R1) {
-            toClamp = ZERO_R1;
+        if (toClamp < ZERO_R1_F) {
+            toClamp = ZERO_R1_F;
         }
-        if (toClamp > ONE_R1) {
-            toClamp = ONE_R1;
+        if (toClamp > ONE_R1_F) {
+            toClamp = ONE_R1_F;
         }
         return toClamp;
     }
@@ -193,7 +193,7 @@ protected:
     complex GetNonunitaryPhase()
     {
         if (randGlobalPhase) {
-            real1_f angle = Rand() * 2 * PI_R1;
+            real1_f angle = Rand() * 2 * (real1_f)PI_R1;
             return complex((real1)cos(angle), (real1)sin(angle));
         } else {
             return ONE_CMPLX;
@@ -660,7 +660,7 @@ public:
      */
     virtual void IU2(bitLenInt target, real1_f phi, real1_f lambda)
     {
-        U(target, M_PI / 2, -lambda - PI_R1, -phi + PI_R1);
+        U(target, (real1_f)(M_PI / 2), (real1_f)(-lambda - PI_R1), (real1_f)(-phi + PI_R1));
     }
 
     /**
@@ -1982,7 +1982,7 @@ public:
      *
      * \warning PSEUDO-QUANTUM
      */
-    virtual real1_f ProbAll(bitCapInt fullRegister) { return clampProb(norm(GetAmplitude(fullRegister))); }
+    virtual real1_f ProbAll(bitCapInt fullRegister) { return clampProb((real1_f)norm(GetAmplitude(fullRegister))); }
 
     /**
      * Direct measure of register permutation probability
@@ -2099,7 +2099,7 @@ public:
      * \warning PSEUDO-QUANTUM
      */
     virtual void NormalizeState(
-        real1_f nrm = REAL1_DEFAULT_ARG, real1_f norm_thresh = REAL1_DEFAULT_ARG, real1_f phaseArg = ZERO_R1) = 0;
+        real1_f nrm = REAL1_DEFAULT_ARG, real1_f norm_thresh = REAL1_DEFAULT_ARG, real1_f phaseArg = ZERO_R1_F) = 0;
 
     /**
      * If asynchronous work is still running, block until it finishes. Note that this is never necessary to get correct,

--- a/include/qmaskfusion.hpp
+++ b/include/qmaskfusion.hpp
@@ -635,7 +635,7 @@ public:
     virtual real1_f Prob(bitLenInt qubitIndex)
     {
         if (zxShards[qubitIndex].isX) {
-            return clampProb(ONE_R1 - engine->Prob(qubitIndex));
+            return clampProb(ONE_R1_F - engine->Prob(qubitIndex));
         }
 
         return engine->Prob(qubitIndex);
@@ -674,7 +674,7 @@ public:
 
     virtual void UpdateRunningNorm(real1_f norm_thresh = REAL1_DEFAULT_ARG) { engine->UpdateRunningNorm(norm_thresh); }
     virtual void NormalizeState(
-        real1_f nrm = REAL1_DEFAULT_ARG, real1_f norm_thresh = REAL1_DEFAULT_ARG, real1_f phaseArg = ZERO_R1)
+        real1_f nrm = REAL1_DEFAULT_ARG, real1_f norm_thresh = REAL1_DEFAULT_ARG, real1_f phaseArg = ZERO_R1_F)
     {
         engine->NormalizeState(nrm, norm_thresh, phaseArg);
     }

--- a/include/qmaskfusion.hpp
+++ b/include/qmaskfusion.hpp
@@ -172,12 +172,12 @@ public:
         qrack_rand_gen_ptr rgp = nullptr, complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = false,
         bool randomGlobalPhase = true, bool useHostMem = false, int deviceId = -1, bool useHardwareRNG = true,
         bool useSparseStateVec = false, real1_f norm_thresh = REAL1_EPSILON, std::vector<int> devList = {},
-        bitLenInt qubitThreshold = 0, real1_f separation_thresh = FP_NORM_EPSILON);
+        bitLenInt qubitThreshold = 0, real1_f separation_thresh = FP_NORM_EPSILON_F);
     QMaskFusion(bitLenInt qBitCount, bitCapInt initState = 0, qrack_rand_gen_ptr rgp = nullptr,
         complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = false, bool randomGlobalPhase = true,
         bool useHostMem = false, int deviceId = -1, bool useHardwareRNG = true, bool useSparseStateVec = false,
         real1_f norm_thresh = REAL1_EPSILON, std::vector<int> devList = {}, bitLenInt qubitThreshold = 0,
-        real1_f separation_thresh = FP_NORM_EPSILON)
+        real1_f separation_thresh = FP_NORM_EPSILON_F)
 #if ENABLE_OPENCL
         : QMaskFusion({ OCLEngine::Instance().GetDeviceCount() ? QINTERFACE_OPTIMAL_BASE : QINTERFACE_CPU }, qBitCount,
               initState, rgp, phaseFac, doNorm, randomGlobalPhase, useHostMem, deviceId, useHardwareRNG,

--- a/include/qpager.hpp
+++ b/include/qpager.hpp
@@ -111,13 +111,13 @@ public:
         qrack_rand_gen_ptr rgp = nullptr, complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = false,
         bool ignored = false, bool useHostMem = false, int deviceId = -1, bool useHardwareRNG = true,
         bool useSparseStateVec = false, real1_f norm_thresh = REAL1_EPSILON, std::vector<int> devList = {},
-        bitLenInt qubitThreshold = 0, real1_f separation_thresh = FP_NORM_EPSILON);
+        bitLenInt qubitThreshold = 0, real1_f separation_thresh = FP_NORM_EPSILON_F);
 
     QPager(bitLenInt qBitCount, bitCapInt initState = 0, qrack_rand_gen_ptr rgp = nullptr,
         complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = false, bool ignored = false, bool useHostMem = false,
         int deviceId = -1, bool useHardwareRNG = true, bool useSparseStateVec = false,
         real1_f norm_thresh = REAL1_EPSILON, std::vector<int> devList = {}, bitLenInt qubitThreshold = 0,
-        real1_f separation_thresh = FP_NORM_EPSILON)
+        real1_f separation_thresh = FP_NORM_EPSILON_F)
         : QPager({ QINTERFACE_MASK_FUSION }, qBitCount, initState, rgp, phaseFac, doNorm, ignored, useHostMem, deviceId,
               useHardwareRNG, useSparseStateVec, norm_thresh, devList, qubitThreshold, separation_thresh)
     {
@@ -127,7 +127,7 @@ public:
         qrack_rand_gen_ptr rgp = nullptr, complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = false,
         bool ignored2 = false, bool useHostMem = false, int deviceId = -1, bool useHardwareRNG = true,
         bool useSparseStateVec = false, real1_f norm_thresh = REAL1_EPSILON, std::vector<int> devList = {},
-        bitLenInt qubitThreshold = 0, real1_f separation_thresh = FP_NORM_EPSILON);
+        bitLenInt qubitThreshold = 0, real1_f separation_thresh = FP_NORM_EPSILON_F);
 
     virtual void SetConcurrency(uint32_t threadsPerEngine)
     {

--- a/include/qpager.hpp
+++ b/include/qpager.hpp
@@ -253,7 +253,7 @@ public:
     }
     virtual real1_f GetRunningNorm()
     {
-        real1_f toRet = ZERO_R1;
+        real1_f toRet = ZERO_R1_F;
         for (bitCapIntOcl i = 0; i < qPages.size(); i++) {
             toRet += qPages[i]->GetRunningNorm();
         }
@@ -269,7 +269,7 @@ public:
             }
         }
 
-        return ZERO_R1;
+        return ZERO_R1_F;
     }
 
     virtual void SetQuantumState(const complex* inputState);
@@ -326,7 +326,7 @@ public:
     virtual void CUniformParityRZ(const bitLenInt* controls, bitLenInt controlLen, bitCapInt mask, real1_f angle);
 
     virtual void XMask(bitCapInt mask);
-    virtual void ZMask(bitCapInt mask) { PhaseParity(PI_R1, mask); }
+    virtual void ZMask(bitCapInt mask) { PhaseParity((real1_f)PI_R1, mask); }
     virtual void PhaseParity(real1_f radians, bitCapInt mask);
 
     virtual bool ForceM(bitLenInt qubit, bool result, bool doForce = true, bool doApply = true);
@@ -379,7 +379,7 @@ public:
     virtual real1_f ProbParity(bitCapInt mask)
     {
         if (!mask) {
-            return ZERO_R1;
+            return ZERO_R1_F;
         }
 
         CombineEngines();
@@ -388,7 +388,7 @@ public:
     virtual bool ForceMParity(bitCapInt mask, bool result, bool doForce = true)
     {
         if (!mask) {
-            return ZERO_R1;
+            return ZERO_R1_F;
         }
 
         CombineEngines();
@@ -398,7 +398,7 @@ public:
 
     virtual void UpdateRunningNorm(real1_f norm_thresh = REAL1_DEFAULT_ARG);
     virtual void NormalizeState(
-        real1_f nrm = REAL1_DEFAULT_ARG, real1_f norm_thresh = REAL1_DEFAULT_ARG, real1_f phaseArg = ZERO_R1);
+        real1_f nrm = REAL1_DEFAULT_ARG, real1_f norm_thresh = REAL1_DEFAULT_ARG, real1_f phaseArg = ZERO_R1_F);
 
     virtual void Finish()
     {

--- a/include/qstabilizer.hpp
+++ b/include/qstabilizer.hpp
@@ -238,9 +238,9 @@ public:
 
         SetPermutation(0);
 
-        const real1 prob = (real1)clampProb(norm(inputState[1]));
+        const real1 prob = (real1)clampProb((real1_f)norm(inputState[1]));
         const real1 sqrtProb = sqrt(prob);
-        const real1 sqrt1MinProb = (real1)sqrt(clampProb(ONE_R1 - prob));
+        const real1 sqrt1MinProb = (real1)sqrt(clampProb((real1_f)(ONE_R1 - prob)));
         const complex phase0 = std::polar(ONE_R1, arg(inputState[0]));
         const complex phase1 = std::polar(ONE_R1, arg(inputState[1]));
         const complex mtrx[4] = { sqrt1MinProb * phase0, sqrtProb * phase0, sqrtProb * phase1, -sqrt1MinProb * phase1 };
@@ -346,7 +346,7 @@ public:
     bool CanDecomposeDispose(const bitLenInt start, const bitLenInt length);
 
     virtual void NormalizeState(
-        real1_f nrm = REAL1_DEFAULT_ARG, real1_f norm_thresh = REAL1_DEFAULT_ARG, real1_f phaseArg = ZERO_R1)
+        real1_f nrm = REAL1_DEFAULT_ARG, real1_f norm_thresh = REAL1_DEFAULT_ARG, real1_f phaseArg = ZERO_R1_F)
     {
         if (!randGlobalPhase) {
             phaseOffset *= std::polar(ONE_R1, (real1)phaseArg);

--- a/include/qstabilizer.hpp
+++ b/include/qstabilizer.hpp
@@ -113,7 +113,7 @@ public:
     QStabilizer(bitLenInt n, bitCapInt perm = 0, qrack_rand_gen_ptr rgp = nullptr, complex ignored = CMPLX_DEFAULT_ARG,
         bool doNorm = false, bool randomGlobalPhase = true, bool ignored2 = false, int ignored3 = -1,
         bool useHardwareRNG = true, bool ignored4 = false, real1_f ignored5 = REAL1_EPSILON,
-        std::vector<int> ignored6 = {}, bitLenInt ignored7 = 0, real1_f ignored8 = FP_NORM_EPSILON);
+        std::vector<int> ignored6 = {}, bitLenInt ignored7 = 0, real1_f ignored8 = FP_NORM_EPSILON_F);
 
     QInterfacePtr Clone()
     {

--- a/include/qstabilizerhybrid.hpp
+++ b/include/qstabilizerhybrid.hpp
@@ -86,9 +86,9 @@ protected:
         const bool isZ1 = stabilizer->M(qubit);
 
         if (isZ1) {
-            prob = norm(shard->gate[3]);
+            prob = (real1_f)norm(shard->gate[3]);
         } else {
-            prob = norm(shard->gate[2]);
+            prob = (real1_f)norm(shard->gate[2]);
         }
 
         bool result;
@@ -733,7 +733,7 @@ public:
     virtual real1_f ProbParity(bitCapInt mask)
     {
         if (!mask) {
-            return ZERO_R1;
+            return ZERO_R1_F;
         }
 
         if (!(mask & (mask - ONE_BCI))) {
@@ -989,7 +989,7 @@ public:
     }
 
     virtual void NormalizeState(
-        real1_f nrm = REAL1_DEFAULT_ARG, real1_f norm_thresh = REAL1_DEFAULT_ARG, real1_f phaseArg = ZERO_R1)
+        real1_f nrm = REAL1_DEFAULT_ARG, real1_f norm_thresh = REAL1_DEFAULT_ARG, real1_f phaseArg = ZERO_R1_F)
     {
         if (abs(nrm) <= FP_NORM_EPSILON) {
             ZeroAmplitudes();

--- a/include/qstabilizerhybrid.hpp
+++ b/include/qstabilizerhybrid.hpp
@@ -193,13 +193,13 @@ public:
         qrack_rand_gen_ptr rgp = nullptr, complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = false,
         bool randomGlobalPhase = true, bool useHostMem = false, int deviceId = -1, bool useHardwareRNG = true,
         bool useSparseStateVec = false, real1_f norm_thresh = REAL1_EPSILON, std::vector<int> devList = {},
-        bitLenInt qubitThreshold = 0, real1_f separation_thresh = FP_NORM_EPSILON);
+        bitLenInt qubitThreshold = 0, real1_f separation_thresh = FP_NORM_EPSILON_F);
 
     QStabilizerHybrid(bitLenInt qBitCount, bitCapInt initState = 0, qrack_rand_gen_ptr rgp = nullptr,
         complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = false, bool randomGlobalPhase = true,
         bool useHostMem = false, int deviceId = -1, bool useHardwareRNG = true, bool useSparseStateVec = false,
         real1_f norm_thresh = REAL1_EPSILON, std::vector<int> devList = {}, bitLenInt qubitThreshold = 0,
-        real1_f separation_thresh = FP_NORM_EPSILON)
+        real1_f separation_thresh = FP_NORM_EPSILON_F)
         : QStabilizerHybrid({ QINTERFACE_OPTIMAL_BASE }, qBitCount, initState, rgp, phaseFac, doNorm, randomGlobalPhase,
               useHostMem, deviceId, useHardwareRNG, useSparseStateVec, norm_thresh, devList, qubitThreshold,
               separation_thresh)

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -73,7 +73,7 @@ public:
                 unit->SetConcurrency(threadsPerEngine);
                 return true;
             },
-            ZERO_R1, ZERO_R1, ZERO_R1, threadsPerEngine);
+            ZERO_R1_F, ZERO_R1_F, ZERO_R1_F, threadsPerEngine);
     }
 
     virtual void SetReactiveSeparate(bool isAggSep) { isReactiveSeparate = isAggSep; }
@@ -257,7 +257,7 @@ public:
     virtual real1_f SumSqrDiff(QUnitPtr toCompare);
     virtual void UpdateRunningNorm(real1_f norm_thresh = REAL1_DEFAULT_ARG);
     virtual void NormalizeState(
-        real1_f nrm = REAL1_DEFAULT_ARG, real1_f norm_thresh = REAL1_DEFAULT_ARG, real1_f phaseArg = ZERO_R1);
+        real1_f nrm = REAL1_DEFAULT_ARG, real1_f norm_thresh = REAL1_DEFAULT_ARG, real1_f phaseArg = ZERO_R1_F);
     virtual void Finish();
     virtual bool isFinished();
     virtual void Dump()
@@ -345,8 +345,8 @@ protected:
         std::vector<bitLenInt*>::iterator first, std::vector<bitLenInt*>::iterator last);
 
     typedef bool (*ParallelUnitFn)(QInterfacePtr unit, real1_f param1, real1_f param2, real1_f param3, int32_t param4);
-    bool ParallelUnitApply(ParallelUnitFn fn, real1_f param1 = ZERO_R1, real1_f param2 = ZERO_R1,
-        real1_f param3 = ZERO_R1, int32_t param4 = 0);
+    bool ParallelUnitApply(ParallelUnitFn fn, real1_f param1 = ZERO_R1_F, real1_f param2 = ZERO_R1_F,
+        real1_f param3 = ZERO_R1_F, int32_t param4 = 0);
 
     virtual bool SeparateBit(bool value, bitLenInt qubit);
 

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -50,13 +50,13 @@ public:
         qrack_rand_gen_ptr rgp = nullptr, complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = false,
         bool randomGlobalPhase = true, bool useHostMem = false, int deviceId = -1, bool useHardwareRNG = true,
         bool useSparseStateVec = false, real1_f norm_thresh = REAL1_EPSILON, std::vector<int> devIDs = {},
-        bitLenInt qubitThreshold = 0, real1_f separation_thresh = FP_NORM_EPSILON);
+        bitLenInt qubitThreshold = 0, real1_f separation_thresh = FP_NORM_EPSILON_F);
 
     QUnit(bitLenInt qBitCount, bitCapInt initState = 0, qrack_rand_gen_ptr rgp = nullptr,
         complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = false, bool randomGlobalPhase = true,
         bool useHostMem = false, int deviceId = -1, bool useHardwareRNG = true, bool useSparseStateVec = false,
         real1_f norm_thresh = REAL1_EPSILON, std::vector<int> devIDs = {}, bitLenInt qubitThreshold = 0,
-        real1_f separation_thresh = FP_NORM_EPSILON)
+        real1_f separation_thresh = FP_NORM_EPSILON_F)
         : QUnit({ QINTERFACE_STABILIZER_HYBRID }, qBitCount, initState, rgp, phaseFac, doNorm, randomGlobalPhase,
               useHostMem, deviceId, useHardwareRNG, useSparseStateVec, norm_thresh, devIDs, qubitThreshold,
               separation_thresh)

--- a/include/qunitmulti.hpp
+++ b/include/qunitmulti.hpp
@@ -73,13 +73,13 @@ public:
         qrack_rand_gen_ptr rgp = nullptr, complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = false,
         bool randomGlobalPhase = true, bool useHostMem = false, int deviceID = -1, bool useHardwareRNG = true,
         bool useSparseStateVec = false, real1_f norm_thresh = REAL1_EPSILON, std::vector<int> devList = {},
-        bitLenInt qubitThreshold = 0, real1_f separation_thresh = FP_NORM_EPSILON);
+        bitLenInt qubitThreshold = 0, real1_f separation_thresh = FP_NORM_EPSILON_F);
 
     QUnitMulti(bitLenInt qBitCount, bitCapInt initState = 0, qrack_rand_gen_ptr rgp = nullptr,
         complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = false, bool randomGlobalPhase = true,
         bool useHostMem = false, int deviceID = -1, bool useHardwareRNG = true, bool useSparseStateVec = false,
         real1_f norm_thresh = REAL1_EPSILON, std::vector<int> devList = {}, bitLenInt qubitThreshold = 0,
-        real1_f separation_thresh = FP_NORM_EPSILON)
+        real1_f separation_thresh = FP_NORM_EPSILON_F)
         : QUnitMulti({ QINTERFACE_STABILIZER_HYBRID }, qBitCount, initState, rgp, phaseFac, doNorm, randomGlobalPhase,
               useHostMem, deviceID, useHardwareRNG, useSparseStateVec, norm_thresh, devList, qubitThreshold,
               separation_thresh)

--- a/include/statevector.hpp
+++ b/include/statevector.hpp
@@ -48,7 +48,7 @@ public:
     complex* amplitudes;
 
 protected:
-    static real1_f normHelper(const complex& c) { return norm(c); }
+    static real1_f normHelper(const complex& c) { return (real1_f)norm(c); }
 
     complex* Alloc(bitCapIntOcl elemCount)
     {

--- a/src/common/functions.cpp
+++ b/src/common/functions.cpp
@@ -119,7 +119,7 @@ void _expLog2x2(const complex* matrix2x2, complex* outMatrix2x2, bool isExp)
         complex trace = matrix2x2[0] + matrix2x2[3];
         complex determinant = (matrix2x2[0] * matrix2x2[3]) - (matrix2x2[1] * matrix2x2[2]);
         complex quadraticRoot = trace * trace - ((real1)4.0f) * determinant;
-        std::complex<real1_f> qrtf(real(quadraticRoot), imag(quadraticRoot));
+        complex qrtf((real1)real(quadraticRoot), (real1)imag(quadraticRoot));
         qrtf = sqrt(qrtf);
         quadraticRoot = complex((real1)real(qrtf), (real1)imag(qrtf));
         complex eigenvalue1 = (trace + quadraticRoot) / (real1)2.0f;
@@ -136,11 +136,11 @@ void _expLog2x2(const complex* matrix2x2, complex* outMatrix2x2, bool isExp)
         expOfGate[2] = ZERO_CMPLX;
         expOfGate[3] = eigenvalue2;
 
-        real1 nrm = (real1)std::sqrt(norm(jacobian[0]) + norm(jacobian[2]));
+        real1 nrm = (real1)std::sqrt((real1_f)(norm(jacobian[0]) + norm(jacobian[2])));
         jacobian[0] /= nrm;
         jacobian[2] /= nrm;
 
-        nrm = (real1)std::sqrt(norm(jacobian[1]) + norm(jacobian[3]));
+        nrm = (real1)std::sqrt((real1_f)(norm(jacobian[1]) + norm(jacobian[3])));
         jacobian[1] /= nrm;
         jacobian[3] /= nrm;
 
@@ -160,18 +160,18 @@ void _expLog2x2(const complex* matrix2x2, complex* outMatrix2x2, bool isExp)
         // In this branch, we calculate e^(matrix2x2).
 
         // Note: For a (2x2) hermitian input gate, this theoretically produces a unitary output transformation.
-        expOfGate[0] = ((real1)std::exp(real(expOfGate[0]))) *
+        expOfGate[0] = ((real1)std::exp((real1_f)real(expOfGate[0]))) *
             complex((real1)cos(imag(expOfGate[0])), (real1)sin(imag(expOfGate[0])));
         expOfGate[1] = ZERO_CMPLX;
         expOfGate[2] = ZERO_CMPLX;
-        expOfGate[3] = ((real1)std::exp(real(expOfGate[3]))) *
+        expOfGate[3] = ((real1)std::exp((real1_f)real(expOfGate[3]))) *
             complex((real1)cos(imag(expOfGate[3])), (real1)sin(imag(expOfGate[3])));
     } else {
         // In this branch, we calculate log(matrix2x2).
-        expOfGate[0] = complex((real1)std::log(abs(expOfGate[0])), (real1)arg(expOfGate[0]));
+        expOfGate[0] = complex((real1)std::log((real1_f)abs(expOfGate[0])), (real1)arg(expOfGate[0]));
         expOfGate[1] = ZERO_CMPLX;
         expOfGate[2] = ZERO_CMPLX;
-        expOfGate[3] = complex((real1)std::log(abs(expOfGate[3])), (real1)arg(expOfGate[3]));
+        expOfGate[3] = complex((real1)std::log((real1_f)abs(expOfGate[3])), (real1)arg(expOfGate[3]));
     }
 
     if (!isDiag) {

--- a/src/common/functions.cpp
+++ b/src/common/functions.cpp
@@ -119,7 +119,7 @@ void _expLog2x2(const complex* matrix2x2, complex* outMatrix2x2, bool isExp)
         complex trace = matrix2x2[0] + matrix2x2[3];
         complex determinant = (matrix2x2[0] * matrix2x2[3]) - (matrix2x2[1] * matrix2x2[2]);
         complex quadraticRoot = trace * trace - ((real1)4.0f) * determinant;
-        complex qrtf((real1)real(quadraticRoot), (real1)imag(quadraticRoot));
+        std::complex<real1_f> qrtf((real1_f)real(quadraticRoot), (real1_f)imag(quadraticRoot));
         qrtf = sqrt(qrtf);
         quadraticRoot = complex((real1)real(qrtf), (real1)imag(qrtf));
         complex eigenvalue1 = (trace + quadraticRoot) / (real1)2.0f;

--- a/src/common/parallel_for.cpp
+++ b/src/common/parallel_for.cpp
@@ -223,10 +223,10 @@ real1_f ParallelFor::par_norm(const bitCapIntOcl itemCount, const StateVectorPtr
         return par_norm_exact(itemCount, stateArray);
     }
 
-    real1_f nrmSqr = ZERO_R1;
+    real1_f nrmSqr = ZERO_R1_F;
     if (itemCount < pStride) {
         for (bitCapIntOcl j = 0; j < itemCount; j++) {
-            const real1_f nrm = norm(stateArray->read(j));
+            const real1_f nrm = (real1_f)norm(stateArray->read(j));
             if (nrm >= norm_thresh) {
                 nrmSqr += nrm;
             }
@@ -247,7 +247,7 @@ real1_f ParallelFor::par_norm(const bitCapIntOcl itemCount, const StateVectorPtr
     for (unsigned cpu = 0; cpu != threads; ++cpu) {
         futures[cpu] = ATOMIC_ASYNC(&idx, &itemCount, stateArray, &Stride, &norm_thresh)
         {
-            real1_f sqrNorm = ZERO_R1;
+            real1_f sqrNorm = ZERO_R1_F;
             for (;;) {
                 bitCapIntOcl i;
                 ATOMIC_INC();
@@ -258,7 +258,7 @@ real1_f ParallelFor::par_norm(const bitCapIntOcl itemCount, const StateVectorPtr
                 const bitCapIntOcl maxJ = ((l + Stride) < itemCount) ? Stride : (itemCount - l);
                 for (bitCapIntOcl j = 0; j < maxJ; j++) {
                     bitCapIntOcl k = i * Stride + j;
-                    const real1_f nrm = norm(stateArray->read(k));
+                    const real1_f nrm = (real1_f)norm(stateArray->read(k));
                     if (nrm >= norm_thresh) {
                         sqrNorm += nrm;
                     }
@@ -277,10 +277,10 @@ real1_f ParallelFor::par_norm(const bitCapIntOcl itemCount, const StateVectorPtr
 
 real1_f ParallelFor::par_norm_exact(const bitCapIntOcl itemCount, const StateVectorPtr stateArray)
 {
-    real1_f nrmSqr = ZERO_R1;
+    real1_f nrmSqr = ZERO_R1_F;
     if (itemCount < pStride) {
         for (bitCapIntOcl j = 0; j < itemCount; j++) {
-            nrmSqr += norm(stateArray->read(j));
+            nrmSqr += (real1_f)norm(stateArray->read(j));
         }
 
         return nrmSqr;
@@ -298,7 +298,7 @@ real1_f ParallelFor::par_norm_exact(const bitCapIntOcl itemCount, const StateVec
     for (unsigned cpu = 0; cpu != threads; ++cpu) {
         futures[cpu] = ATOMIC_ASYNC(&idx, &itemCount, &Stride, stateArray)
         {
-            real1_f sqrNorm = ZERO_R1;
+            real1_f sqrNorm = ZERO_R1_F;
             for (;;) {
                 bitCapIntOcl i;
                 ATOMIC_INC();
@@ -308,7 +308,7 @@ real1_f ParallelFor::par_norm_exact(const bitCapIntOcl itemCount, const StateVec
                 }
                 const bitCapIntOcl maxJ = ((l + Stride) < itemCount) ? Stride : (itemCount - l);
                 for (bitCapIntOcl j = 0; j < maxJ; j++) {
-                    sqrNorm += norm(stateArray->read(i * Stride + j));
+                    sqrNorm += (real1_f)norm(stateArray->read(i * Stride + j));
                 }
             }
             return sqrNorm;

--- a/src/common/parallel_for.cpp
+++ b/src/common/parallel_for.cpp
@@ -223,8 +223,8 @@ real1_f ParallelFor::par_norm(const bitCapIntOcl itemCount, const StateVectorPtr
         return par_norm_exact(itemCount, stateArray);
     }
 
-    real1 nrmSqr = ZERO_R1;
     if (itemCount < pStride) {
+        real1 nrmSqr = ZERO_R1;
         const real1 nrm_thresh = (real1)norm_thresh;
         for (bitCapIntOcl j = 0; j < itemCount; j++) {
             const real1 nrm = norm(stateArray->read(j));
@@ -266,10 +266,11 @@ real1_f ParallelFor::par_norm(const bitCapIntOcl itemCount, const StateVectorPtr
                     }
                 }
             }
-            return sqrNorm;
+            return (real1_f)sqrNorm;
         });
     }
 
+    real1_f nrmSqr = ZERO_R1_F;
     for (unsigned cpu = 0; cpu != threads; ++cpu) {
         nrmSqr += futures[cpu].get();
     }
@@ -279,8 +280,8 @@ real1_f ParallelFor::par_norm(const bitCapIntOcl itemCount, const StateVectorPtr
 
 real1_f ParallelFor::par_norm_exact(const bitCapIntOcl itemCount, const StateVectorPtr stateArray)
 {
-    real1 nrmSqr = ZERO_R1;
     if (itemCount < pStride) {
+        real1 nrmSqr = ZERO_R1;
         for (bitCapIntOcl j = 0; j < itemCount; j++) {
             nrmSqr += norm(stateArray->read(j));
         }
@@ -300,7 +301,7 @@ real1_f ParallelFor::par_norm_exact(const bitCapIntOcl itemCount, const StateVec
     for (unsigned cpu = 0; cpu != threads; ++cpu) {
         futures[cpu] = ATOMIC_ASYNC(&idx, &itemCount, &Stride, stateArray)
         {
-            real1_f sqrNorm = ZERO_R1_F;
+            real1 sqrNorm = ZERO_R1;
             for (;;) {
                 bitCapIntOcl i;
                 ATOMIC_INC();
@@ -310,13 +311,14 @@ real1_f ParallelFor::par_norm_exact(const bitCapIntOcl itemCount, const StateVec
                 }
                 const bitCapIntOcl maxJ = ((l + Stride) < itemCount) ? Stride : (itemCount - l);
                 for (bitCapIntOcl j = 0; j < maxJ; j++) {
-                    sqrNorm += (real1_f)norm(stateArray->read(i * Stride + j));
+                    sqrNorm += norm(stateArray->read(i * Stride + j));
                 }
             }
-            return sqrNorm;
+            return (real1_f)sqrNorm;
         });
     }
 
+    real1_f nrmSqr = ZERO_R1_F;
     for (unsigned cpu = 0; cpu != threads; ++cpu) {
         nrmSqr += futures[cpu].get();
     }

--- a/src/common/rdrandwrapper.cpp
+++ b/src/common/rdrandwrapper.cpp
@@ -162,8 +162,8 @@ real1_f RdRandom::Next()
 {
     unsigned v = NextRaw();
 
-    real1_f res = ZERO_R1;
-    real1_f part = ONE_R1;
+    real1_f res = ZERO_R1_F;
+    real1_f part = ONE_R1_F;
     for (unsigned i = 0U; i < 32U; i++) {
         part /= 2;
         if ((v >> i) & 1U) {

--- a/src/pinvoke_api.cpp
+++ b/src/pinvoke_api.cpp
@@ -727,7 +727,7 @@ MICROSOFT_QUANTUM_DECL void Dump(_In_ unsigned sid, _In_ ProbAmpCallback callbac
         simulatorErrors[sid] = 1;
     }
     for (size_t i = 0; i < wfnl; i++) {
-        if (!callback(i, real(wfn[i]), imag(wfn[i]))) {
+        if (!callback(i, (real1_f)real(wfn[i]), (real1_f)imag(wfn[i]))) {
             break;
         }
     }
@@ -2244,7 +2244,7 @@ MICROSOFT_QUANTUM_DECL void TimeEvolve(_In_ unsigned sid, _In_ double t, _In_ un
 
     try {
         QInterfacePtr simulator = simulators[sid];
-        simulator->TimeEvolve(h, (real1)t);
+        simulator->TimeEvolve(h, (real1_f)t);
     } catch (...) {
         simulatorErrors[sid] = 1;
     }

--- a/src/pinvoke_api.cpp
+++ b/src/pinvoke_api.cpp
@@ -574,7 +574,7 @@ MICROSOFT_QUANTUM_DECL unsigned init_count_pager(_In_ unsigned q, _In_ bool hp)
     if (q) {
         try {
             simulator = CreateQuantumInterface(simulatorType, q, 0, randNumGen, CMPLX_DEFAULT_ARG, false, true, hp, -1,
-                true, false, REAL1_EPSILON, deviceList, 0, FP_NORM_EPSILON);
+                true, false, REAL1_EPSILON, deviceList, 0, FP_NORM_EPSILON_F);
         } catch (...) {
             isSuccess = false;
         }

--- a/src/qbdt/qengine_node.cpp
+++ b/src/qbdt/qengine_node.cpp
@@ -183,8 +183,8 @@ void QBdtQEngineNode::PushSpecial(const complex* mtrx, QBdtNodeInterfacePtr& b1)
         qReg1 = qReg->CloneEmpty();
     }
 
-    qReg0->NormalizeState(ONE_R1 / norm(scale), REAL1_DEFAULT_ARG, std::arg(scale));
-    qReg1->NormalizeState(ONE_R1 / norm(b1->scale), REAL1_DEFAULT_ARG, std::arg(b1->scale));
+    qReg0->NormalizeState((real1_f)(ONE_R1 / norm(scale)), REAL1_DEFAULT_ARG, (real1_f)std::arg(scale));
+    qReg1->NormalizeState((real1_f)(ONE_R1 / norm(b1->scale)), REAL1_DEFAULT_ARG, (real1_f)std::arg(b1->scale));
 
     scale = SQRT1_2_R1;
     b1->scale = SQRT1_2_R1;

--- a/src/qengine/arithmetic.cpp
+++ b/src/qengine/arithmetic.cpp
@@ -959,7 +959,7 @@ bitCapInt QEngineCPU::IndexedLDA(bitLenInt indexStart, bitLenInt indexLength, bi
 
     ResetStateVec(nStateVec);
 
-    real1_f average = ZERO_R1;
+    real1_f average = ZERO_R1_F;
 #if ENABLE_VM6502Q_DEBUG
     average = GetExpectation(valueStart, valueLength);
 #endif
@@ -1070,7 +1070,7 @@ bitCapInt QEngineCPU::IndexedADC(bitLenInt indexStart, bitLenInt indexLength, bi
     // just calculated.
     ResetStateVec(nStateVec);
 
-    real1_f average = ZERO_R1;
+    real1_f average = ZERO_R1_F;
 #if ENABLE_VM6502Q_DEBUG
     average = GetExpectation(valueStart, valueLength);
 #endif
@@ -1186,7 +1186,7 @@ bitCapInt QEngineCPU::IndexedSBC(bitLenInt indexStart, bitLenInt indexLength, bi
     // just calculated.
     ResetStateVec(nStateVec);
 
-    real1_f average = ZERO_R1;
+    real1_f average = ZERO_R1_F;
 #if ENABLE_VM6502Q_DEBUG
     average = GetExpectation(valueStart, valueLength);
 #endif

--- a/src/qengine/qengine.cpp
+++ b/src/qengine/qengine.cpp
@@ -44,7 +44,7 @@ real1_f QEngine::ProbAll(bitCapInt fullRegister)
         NormalizeState();
     }
 
-    return clampProb(norm(GetAmplitude(fullRegister)));
+    return clampProb((real1_f)norm(GetAmplitude(fullRegister)));
 }
 
 /// PSEUDO-QUANTUM - Acts like a measurement gate, except with a specified forced result.
@@ -78,7 +78,7 @@ bool QEngine::ForceM(bitLenInt qubit, bool result, bool doForce, bool doApply)
 
     if (doApply && (nrmlzr != ONE_R1)) {
         bitCapInt qPower = pow2(qubit);
-        ApplyM(qPower, result, GetNonunitaryPhase() / (real1)(std::sqrt(nrmlzr)));
+        ApplyM(qPower, result, GetNonunitaryPhase() / (real1)(std::sqrt((real1_f)nrmlzr)));
     }
 
     return result;
@@ -129,7 +129,7 @@ bitCapInt QEngine::ForceM(const bitLenInt* bits, bitLenInt length, const bool* v
             result |= values[j] ? pow2(bits[j]) : 0;
         }
         nrmlzr = ProbMask(regMask, result);
-        nrm = phase / (real1)(std::sqrt(nrmlzr));
+        nrm = phase / (real1)(std::sqrt((real1_f)nrmlzr));
         if (nrmlzr != ONE_R1) {
             ApplyM(regMask, result, nrm);
         }
@@ -182,7 +182,7 @@ bitCapInt QEngine::ForceM(const bitLenInt* bits, bitLenInt length, const bool* v
 
     qPowers.reset();
 
-    nrm = phase / (real1)(std::sqrt(nrmlzr));
+    nrm = phase / (real1)(std::sqrt((real1_f)nrmlzr));
 
     if (doApply && (nrmlzr != ONE_R1)) {
         ApplyM(regMask, result, nrm);
@@ -537,7 +537,7 @@ bitCapInt QEngine::ForceMReg(bitLenInt start, bitLenInt length, bitCapInt result
         ProbRegAll(start, length, probArray.get());
 
         real1_f prob = Rand();
-        real1_f lowerProb = ZERO_R1;
+        real1_f lowerProb = ZERO_R1_F;
         result = lengthPower - ONE_BCI;
 
         /*
@@ -546,7 +546,7 @@ bitCapInt QEngine::ForceMReg(bitLenInt start, bitLenInt length, bitCapInt result
          * vector.
          */
         while ((lowerProb < prob) && (lcv < lengthPower)) {
-            lowerProb += probArray[lcv];
+            lowerProb += (real1_f)probArray[lcv];
             if (probArray[lcv] > ZERO_R1) {
                 nrmlzr = probArray[lcv];
                 result = lcv;
@@ -559,7 +559,7 @@ bitCapInt QEngine::ForceMReg(bitLenInt start, bitLenInt length, bitCapInt result
 
     if (doApply) {
         const bitCapInt resultPtr = result << (bitCapIntOcl)start;
-        const complex nrm = GetNonunitaryPhase() / (real1)(std::sqrt(nrmlzr));
+        const complex nrm = GetNonunitaryPhase() / (real1)(std::sqrt((real1_f)nrmlzr));
         ApplyM(regMask, resultPtr, nrm);
     }
 

--- a/src/qengine/state.cpp
+++ b/src/qengine/state.cpp
@@ -417,7 +417,7 @@ void QEngineCPU::Apply2x2(bitCapIntOcl offset1, bitCapIntOcl offset2, const comp
             const complex mtrx3 = mtrx[3];
             const bitCapIntOcl* qPowersSorted = qPowersSortedS.get();
 
-            const real1_f norm_thresh = (real1_f)((nrm_thresh < ZERO_R1) ? amplitudeFloor : nrm_thresh);
+            const real1 norm_thresh = (nrm_thresh < ZERO_R1) ? amplitudeFloor : (real1)nrm_thresh;
             const unsigned numCores = GetConcurrencyLevel();
 
             std::unique_ptr<real1[]> rngNrm(new real1[numCores]());

--- a/src/qengine/state.cpp
+++ b/src/qengine/state.cpp
@@ -118,7 +118,7 @@ void QEngineCPU::SetPermutation(bitCapInt perm, complex phaseFac)
     if (phaseFac == CMPLX_DEFAULT_ARG) {
         complex phase;
         if (randGlobalPhase) {
-            real1_f angle = Rand() * 2 * PI_R1;
+            real1_f angle = Rand() * 2 * (real1_f)PI_R1;
             phase = complex((real1)cos(angle), (real1)sin(angle));
         } else {
             phase = ONE_CMPLX;
@@ -417,7 +417,7 @@ void QEngineCPU::Apply2x2(bitCapIntOcl offset1, bitCapIntOcl offset2, const comp
             const complex mtrx3 = mtrx[3];
             const bitCapIntOcl* qPowersSorted = qPowersSortedS.get();
 
-            const real1_f norm_thresh = (nrm_thresh < ZERO_R1) ? amplitudeFloor : nrm_thresh;
+            const real1_f norm_thresh = (real1_f)((nrm_thresh < ZERO_R1) ? amplitudeFloor : nrm_thresh);
             const unsigned numCores = GetConcurrencyLevel();
 
             std::unique_ptr<real1[]> rngNrm(new real1[numCores]());
@@ -1055,7 +1055,8 @@ void QEngineCPU::DecomposeDispose(bitLenInt start, bitLenInt length, QEngineCPUP
 
         par_for(0, partPower, [&](const bitCapIntOcl& lcv, const unsigned& cpu) {
             destination->stateVec->write(lcv,
-                (real1)(std::sqrt(partStateProb[lcv])) * complex(cos(partStateAngle[lcv]), sin(partStateAngle[lcv])));
+                (real1)(std::sqrt((real1_f)partStateProb[lcv])) *
+                    complex(cos(partStateAngle[lcv]), sin(partStateAngle[lcv])));
         });
 
         partStateProb.reset();
@@ -1068,7 +1069,7 @@ void QEngineCPU::DecomposeDispose(bitLenInt start, bitLenInt length, QEngineCPUP
 
     par_for(0, remainderPower, [&](const bitCapIntOcl& lcv, const unsigned& cpu) {
         stateVec->write(lcv,
-            (real1)(std::sqrt(remainderStateProb[lcv])) *
+            (real1)(std::sqrt((real1_f)remainderStateProb[lcv])) *
                 complex(cos(remainderStateAngle[lcv]), sin(remainderStateAngle[lcv])));
     });
 }
@@ -1143,7 +1144,7 @@ real1_f QEngineCPU::Prob(bitLenInt qubit)
     Finish();
 
     if (!stateVec) {
-        return ZERO_R1;
+        return ZERO_R1_F;
     }
 
     const bitCapIntOcl qPower = pow2Ocl(qubit);
@@ -1167,7 +1168,7 @@ real1_f QEngineCPU::Prob(bitLenInt qubit)
         oneChance += oneChanceBuff[i];
     }
 
-    return clampProb(oneChance);
+    return clampProb((real1_f)oneChance);
 }
 
 // Returns probability of permutation of the register
@@ -1179,7 +1180,7 @@ real1_f QEngineCPU::ProbReg(bitLenInt start, bitLenInt length, bitCapInt permuta
     Finish();
 
     if (!stateVec) {
-        return ZERO_R1;
+        return ZERO_R1_F;
     }
 
     const int num_threads = GetConcurrencyLevel();
@@ -1203,7 +1204,7 @@ real1_f QEngineCPU::ProbReg(bitLenInt start, bitLenInt length, bitCapInt permuta
         prob += probs[thrd];
     }
 
-    return clampProb(prob);
+    return clampProb((real1_f)prob);
 }
 
 // Returns probability of permutation of the mask
@@ -1215,7 +1216,7 @@ real1_f QEngineCPU::ProbMask(bitCapInt mask, bitCapInt permutation)
     Finish();
 
     if (!stateVec) {
-        return ZERO_R1;
+        return ZERO_R1_F;
     }
 
     bitCapIntOcl v = (bitCapIntOcl)mask; // count the number of bits set in v
@@ -1248,7 +1249,7 @@ real1_f QEngineCPU::ProbMask(bitCapInt mask, bitCapInt permutation)
         prob += probs[thrd];
     }
 
-    return clampProb(prob);
+    return clampProb((real1_f)prob);
 }
 
 real1_f QEngineCPU::ProbParity(bitCapInt mask)
@@ -1259,7 +1260,7 @@ real1_f QEngineCPU::ProbParity(bitCapInt mask)
     Finish();
 
     if (!stateVec || !mask) {
-        return ZERO_R1;
+        return ZERO_R1_F;
     }
 
     real1 oddChance = ZERO_R1;
@@ -1293,7 +1294,7 @@ real1_f QEngineCPU::ProbParity(bitCapInt mask)
         oddChance += oddChanceBuff[i];
     }
 
-    return clampProb(oddChance);
+    return clampProb((real1_f)oddChance);
 }
 
 bool QEngineCPU::ForceMParity(bitCapInt mask, bool result, bool doForce)
@@ -1353,17 +1354,17 @@ bool QEngineCPU::ForceMParity(bitCapInt mask, bool result, bool doForce)
 real1_f QEngineCPU::SumSqrDiff(QEngineCPUPtr toCompare)
 {
     if (!toCompare) {
-        return ONE_R1;
+        return ONE_R1_F;
     }
 
     if (this == toCompare.get()) {
-        return ZERO_R1;
+        return ZERO_R1_F;
     }
 
     // If the qubit counts are unequal, these can't be approximately equal objects.
     if (qubitCount != toCompare->qubitCount) {
         // Max square difference:
-        return ONE_R1;
+        return ONE_R1_F;
     }
 
     // Make sure both engines are normalized
@@ -1378,17 +1379,17 @@ real1_f QEngineCPU::SumSqrDiff(QEngineCPUPtr toCompare)
     toCompare->Finish();
 
     if (!stateVec && !toCompare->stateVec) {
-        return ZERO_R1;
+        return ZERO_R1_F;
     }
 
     if (!stateVec) {
         toCompare->UpdateRunningNorm();
-        return toCompare->runningNorm;
+        return (real1_f)(toCompare->runningNorm);
     }
 
     if (!toCompare->stateVec) {
         UpdateRunningNorm();
-        return runningNorm;
+        return (real1_f)runningNorm;
     }
 
     if (randGlobalPhase) {
@@ -1415,7 +1416,7 @@ real1_f QEngineCPU::SumSqrDiff(QEngineCPUPtr toCompare)
         totInner += partInner[i];
     }
 
-    return ONE_R1 - clampProb(norm(totInner));
+    return ONE_R1_F - clampProb((real1_f)norm(totInner));
 }
 
 void QEngineCPU::ApplyM(bitCapInt regMask, bitCapInt result, complex nrm)
@@ -1471,7 +1472,7 @@ void QEngineCPU::NormalizeState(real1_f nrm_f, real1_f norm_thresh_f, real1_f ph
     if (norm_thresh < ZERO_R1) {
         norm_thresh = amplitudeFloor;
     }
-    nrm = ONE_R1 / std::sqrt(nrm);
+    nrm = ONE_R1 / std::sqrt((real1_f)nrm);
     complex cNrm = std::polar(nrm, (real1)phaseArg);
 
     if (norm_thresh <= ZERO_R1) {
@@ -1502,7 +1503,7 @@ void QEngineCPU::UpdateRunningNorm(real1_f norm_thresh)
     }
 
     if (norm_thresh < ZERO_R1) {
-        norm_thresh = amplitudeFloor;
+        norm_thresh = (real1_f)amplitudeFloor;
     }
     runningNorm = par_norm(maxQPowerOcl, stateVec, norm_thresh);
 

--- a/src/qengine/utility.cpp
+++ b/src/qengine/utility.cpp
@@ -59,7 +59,7 @@ real1_f QEngineCPU::GetExpectation(bitLenInt valueStart, bitLenInt valueLength)
         average /= totProb;
     }
 
-    return average;
+    return (real1_f)average;
 }
 
 } // namespace Qrack

--- a/src/qinterface/qinterface.cpp
+++ b/src/qinterface/qinterface.cpp
@@ -25,7 +25,7 @@ QInterface::QInterface(
     bitLenInt n, qrack_rand_gen_ptr rgp, bool doNorm, bool useHardwareRNG, bool randomGlobalPhase, real1_f norm_thresh)
     : qubitCount(n)
     , maxQPower(pow2(qubitCount))
-    , rand_distribution(0.0, 1.0)
+    , rand_distribution(ZERO_R1_F, ONE_R1_F)
     , hardware_rand_generator(NULL)
     , doNormalize(doNorm)
     , randGlobalPhase(randomGlobalPhase)
@@ -259,7 +259,7 @@ real1_f QInterface::ProbReg(bitLenInt start, bitLenInt length, bitCapInt permuta
         }
     }
 
-    return prob;
+    return (real1_f)prob;
 }
 
 /// Returns probability of permutation of the mask
@@ -272,7 +272,7 @@ real1_f QInterface::ProbMask(bitCapInt mask, bitCapInt permutation)
         }
     }
 
-    return prob;
+    return (real1_f)prob;
 }
 
 /// "Circular shift right" - (Uses swap-based algorithm for speed)

--- a/src/qstabilizer.cpp
+++ b/src/qstabilizer.cpp
@@ -357,7 +357,7 @@ real1_f QStabilizer::FirstNonzeroPhase()
     const bitCapIntOcl permCount = pow2Ocl(g);
     const bitCapIntOcl permCountMin1 = permCount - ONE_BCI;
     const bitLenInt elemCount = qubitCount << 1U;
-    const real1_f nrm = sqrt(ONE_R1 / permCount);
+    const real1_f nrm = sqrt((real1_f)(ONE_R1 / permCount));
 
     seed(g);
 
@@ -378,7 +378,7 @@ real1_f QStabilizer::FirstNonzeroPhase()
         }
     }
 
-    return ZERO_R1;
+    return ZERO_R1_F;
 }
 
 /// Convert the state to ket notation (warning: could be huge!)
@@ -391,7 +391,7 @@ void QStabilizer::GetQuantumState(complex* stateVec)
     const bitCapIntOcl permCount = pow2Ocl(g);
     const bitCapIntOcl permCountMin1 = permCount - ONE_BCI;
     const bitLenInt elemCount = qubitCount << 1U;
-    const real1_f nrm = sqrt(ONE_R1 / permCount);
+    const real1_f nrm = sqrt((real1_f)(ONE_R1 / permCount));
 
     seed(g);
 
@@ -420,7 +420,7 @@ void QStabilizer::GetQuantumState(QInterfacePtr eng)
     const bitCapIntOcl permCount = pow2Ocl(g);
     const bitCapIntOcl permCountMin1 = permCount - ONE_BCI;
     const bitLenInt elemCount = qubitCount << 1U;
-    const real1_f nrm = sqrt(ONE_R1 / permCount);
+    const real1_f nrm = sqrt((real1_f)(ONE_R1 / permCount));
 
     seed(g);
 
@@ -450,7 +450,7 @@ void QStabilizer::GetProbs(real1* outputProbs)
     const bitCapIntOcl permCount = pow2Ocl(g);
     const bitCapIntOcl permCountMin1 = permCount - ONE_BCI;
     const bitLenInt elemCount = qubitCount << 1U;
-    const real1_f nrm = sqrt(ONE_R1 / permCount);
+    const real1_f nrm = sqrt((real1_f)(ONE_R1 / permCount));
 
     seed(g);
 
@@ -479,7 +479,7 @@ complex QStabilizer::GetAmplitude(bitCapInt perm)
     const bitCapIntOcl permCount = pow2Ocl(g);
     const bitCapIntOcl permCountMin1 = permCount - ONE_BCI;
     const bitLenInt elemCount = qubitCount << 1U;
-    const real1_f nrm = sqrt(ONE_R1 / permCount);
+    const real1_f nrm = sqrt((real1_f)(ONE_R1 / permCount));
 
     seed(g);
 
@@ -500,7 +500,7 @@ complex QStabilizer::GetAmplitude(bitCapInt perm)
         }
     }
 
-    return ZERO_R1;
+    return ZERO_CMPLX;
 }
 
 /// Apply a CNOT gate with control and target
@@ -1038,17 +1038,17 @@ void QStabilizer::DecomposeDispose(const bitLenInt start, const bitLenInt length
 real1_f QStabilizer::ApproxCompareHelper(QStabilizerPtr toCompare, bool isDiscreteBool, real1_f error_tol)
 {
     if (!toCompare) {
-        return ONE_R1;
+        return ONE_R1_F;
     }
 
     if (this == toCompare.get()) {
-        return ZERO_R1;
+        return ZERO_R1_F;
     }
 
     // If the qubit counts are unequal, these can't be approximately equal objects.
     if (qubitCount != toCompare->qubitCount) {
         // Max square difference:
-        return ONE_R1;
+        return ONE_R1_F;
     }
 
     toCompare->Finish();
@@ -1058,43 +1058,43 @@ real1_f QStabilizer::ApproxCompareHelper(QStabilizerPtr toCompare, bool isDiscre
     complex proj = ZERO_CMPLX;
 
     if (isDiscreteBool) {
-        real1_f potential = ZERO_R1;
-        real1_f oPotential = ZERO_R1;
+        real1_f potential = ZERO_R1_F;
+        real1_f oPotential = ZERO_R1_F;
         for (bitCapInt i = 0U; i < maxQPower; i++) {
             const complex amp = GetAmplitude(i);
             const complex oAmp = toCompare->GetAmplitude(i);
 
-            potential += norm(amp);
-            oPotential += norm(oAmp);
+            potential += (real1_f)norm(amp);
+            oPotential += (real1_f)norm(oAmp);
             if ((potential - oPotential) > error_tol) {
-                return ONE_R1;
+                return ONE_R1_F;
             }
 
             proj += conj(amp) * oAmp;
-            const real1_f prob = clampProb(norm(proj));
+            const real1_f prob = clampProb((real1_f)norm(proj));
             if (error_tol >= (ONE_R1 - prob)) {
-                return ZERO_R1;
+                return ZERO_R1_F;
             }
         }
 
-        return ONE_R1 - clampProb(norm(proj));
+        return ONE_R1_F - clampProb((real1_f)norm(proj));
     }
 
     for (bitCapInt i = 0U; i < maxQPower; i++) {
         proj += conj(GetAmplitude(i)) * toCompare->GetAmplitude(i);
     }
 
-    return ONE_R1 - clampProb(norm(proj));
+    return ONE_R1_F - clampProb((real1_f)norm(proj));
 }
 
 real1_f QStabilizer::Prob(bitLenInt qubit)
 {
     if (IsSeparableZ(qubit)) {
-        return M(qubit) ? ONE_R1 : ZERO_R1;
+        return M(qubit) ? ONE_R1_F : ZERO_R1_F;
     }
 
     // Otherwise, state appears locally maximally mixed.
-    return ONE_R1 / 2;
+    return ONE_R1_F / 2;
 }
 
 void QStabilizer::Mtrx(const complex* mtrx, bitLenInt target)

--- a/src/qstabilizerhybrid.cpp
+++ b/src/qstabilizerhybrid.cpp
@@ -311,9 +311,9 @@ void QStabilizerHybrid::SetQuantumState(const complex* inputState)
             stabilizer = MakeStabilizer(0);
         }
 
-        const real1 prob = (real1)clampProb(norm(inputState[1]));
+        const real1 prob = (real1)clampProb((real1_f)norm(inputState[1]));
         const real1 sqrtProb = sqrt(prob);
-        const real1 sqrt1MinProb = (real1)sqrt(clampProb(ONE_R1 - prob));
+        const real1 sqrt1MinProb = (real1)sqrt(clampProb((real1_f)(ONE_R1 - prob)));
         const complex phase0 = std::polar(ONE_R1, arg(inputState[0]));
         const complex phase1 = std::polar(ONE_R1, arg(inputState[1]));
         const complex mtrx[4] = { sqrt1MinProb * phase0, sqrtProb * phase0, sqrtProb * phase1, -sqrt1MinProb * phase1 };
@@ -616,21 +616,21 @@ real1_f QStabilizerHybrid::Prob(bitLenInt qubit)
         // Bit was already rotated to Z basis, if separable.
         if (stabilizer->IsSeparableZ(qubit)) {
             if (stabilizer->M(qubit)) {
-                return norm(shards[qubit]->gate[3]);
+                return (real1_f)norm(shards[qubit]->gate[3]);
             }
-            return norm(shards[qubit]->gate[2]);
+            return (real1_f)norm(shards[qubit]->gate[2]);
         }
 
         // Otherwise, buffer will not change the fact that state appears maximally mixed.
-        return ONE_R1 / 2;
+        return ONE_R1_F / 2;
     }
 
     if (stabilizer->IsSeparableZ(qubit)) {
-        return stabilizer->M(qubit) ? ONE_R1 : ZERO_R1;
+        return stabilizer->M(qubit) ? ONE_R1_F : ZERO_R1_F;
     }
 
     // Otherwise, state appears locally maximally mixed.
-    return ONE_R1 / 2;
+    return ONE_R1_F / 2;
 }
 
 bool QStabilizerHybrid::ForceM(bitLenInt qubit, bool result, bool doForce, bool doApply)
@@ -771,17 +771,17 @@ void QStabilizerHybrid::MultiShotMeasureMask(
 real1_f QStabilizerHybrid::ApproxCompareHelper(QStabilizerHybridPtr toCompare, bool isDiscreteBool, real1_f error_tol)
 {
     if (!toCompare) {
-        return ONE_R1;
+        return ONE_R1_F;
     }
 
     if (this == toCompare.get()) {
-        return ZERO_R1;
+        return ZERO_R1_F;
     }
 
     // If the qubit counts are unequal, these can't be approximately equal objects.
     if (qubitCount != toCompare->qubitCount) {
         // Max square difference:
-        return ONE_R1;
+        return ONE_R1_F;
     }
 
     QStabilizerHybridPtr thisClone = stabilizer ? std::dynamic_pointer_cast<QStabilizerHybrid>(Clone()) : NULL;
@@ -798,7 +798,7 @@ real1_f QStabilizerHybrid::ApproxCompareHelper(QStabilizerHybridPtr toCompare, b
 
     if (thisClone && thisClone->stabilizer && thatClone && thatClone->stabilizer) {
         if (isDiscreteBool) {
-            return thisClone->stabilizer->ApproxCompare(thatClone->stabilizer, error_tol) ? ZERO_R1 : ONE_R1;
+            return thisClone->stabilizer->ApproxCompare(thatClone->stabilizer, error_tol) ? ZERO_R1_F : ONE_R1_F;
         } else {
             return thisClone->stabilizer->SumSqrDiff(thatClone->stabilizer);
         }
@@ -815,7 +815,7 @@ real1_f QStabilizerHybrid::ApproxCompareHelper(QStabilizerHybridPtr toCompare, b
     QInterfacePtr thisEngine = thisClone ? thisClone->engine : engine;
     QInterfacePtr thatEngine = thatClone ? thatClone->engine : toCompare->engine;
 
-    const real1_f toRet = isDiscreteBool ? (thisEngine->ApproxCompare(thatEngine, error_tol) ? ZERO_R1 : ONE_R1)
+    const real1_f toRet = isDiscreteBool ? (thisEngine->ApproxCompare(thatEngine, error_tol) ? ZERO_R1_F : ONE_R1_F)
                                          : thisEngine->SumSqrDiff(thatEngine);
 
     if (toRet > TRYDECOMPOSE_EPSILON) {

--- a/test/accuracy.cpp
+++ b/test/accuracy.cpp
@@ -77,7 +77,7 @@ void benchmarkLoopVariable(std::function<void(QInterfacePtr, int)> fn, bitLenInt
 
             testAmp2 = qftReg->GetAmplitude(0);
 
-            err = norm(testAmp2 - testAmp1);
+            err = (real1_f)norm(testAmp2 - testAmp1);
 
             // Collect interval data
             trialErrors[i] = err;

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -1441,9 +1441,9 @@ TEST_CASE("test_dense", "[supreme]")
 
         for (int d = 0; d < benchmarkDepth; d++) {
             for (bitLenInt i = 0; i < n; i++) {
-                const real1 theta = 4 * PI_R1 * qReg->Rand();
-                const real1 phi = 4 * PI_R1 * qReg->Rand();
-                const real1 lambda = 4 * PI_R1 * qReg->Rand();
+                const real1_f theta = 4 * (real1_f)PI_R1 * qReg->Rand();
+                const real1_f phi = 4 * (real1_f)PI_R1 * qReg->Rand();
+                const real1_f lambda = 4 * (real1_f)PI_R1 * qReg->Rand();
                 qReg->U(i, (real1_f)theta, (real1_f)phi, (real1_f)lambda);
             }
 

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -1092,8 +1092,8 @@ TEST_CASE("test_stabilizer_t_nn", "[supreme]")
                 //"Position" transforms:
 
                 // Continuous Z root gates option:
-                gateRand = 2 * PI_R1 * qReg->Rand();
-                qReg->Phase(ONE_R1, std::polar(ONE_R1, (real1)gateRand), i);
+                gateRand = (real1_f)(2 * PI_R1 * qReg->Rand());
+                qReg->Phase(ONE_CMPLX, std::polar(ONE_R1, (real1)gateRand), i);
 
                 // Discrete Z root gates option:
                 /*
@@ -1441,7 +1441,10 @@ TEST_CASE("test_dense", "[supreme]")
 
         for (int d = 0; d < benchmarkDepth; d++) {
             for (bitLenInt i = 0; i < n; i++) {
-                qReg->U(i, 4 * PI_R1 * qReg->Rand(), 4 * PI_R1 * qReg->Rand(), 4 * PI_R1 * qReg->Rand());
+                const real1 theta = 4 * PI_R1 * qReg->Rand();
+                const real1 phi = 4 * PI_R1 * qReg->Rand();
+                const real1 lambda = 4 * PI_R1 * qReg->Rand();
+                qReg->U(i, (real1_f)theta, (real1_f)phi, (real1_f)lambda);
             }
 
             gate = gateSequence.front();
@@ -1595,8 +1598,8 @@ TEST_CASE("test_stabilizer_t_cc_nn", "[supreme]")
                 // "Position transforms:
 
                 // Continuous Z root gates option:
-                gateRand = 2 * PI_R1 * qReg->Rand();
-                qReg->Phase(ONE_R1, std::polar(ONE_R1, (real1)gateRand), i);
+                gateRand = (real1_f)(2 * PI_R1 * qReg->Rand());
+                qReg->Phase(ONE_CMPLX, std::polar(ONE_R1, (real1)gateRand), i);
 
                 // Discrete Z root gates option:
                 /*
@@ -1846,8 +1849,8 @@ TEST_CASE("test_stabilizer_ct_nn", "[supreme]")
                 // "Position transforms:
 
                 // Continuous Z root gates option:
-                gateRand = 2 * PI_R1 * qReg->Rand();
-                qReg->Phase(ONE_R1, std::polar(ONE_R1, (real1)gateRand), i);
+                gateRand = (real1_f)(2 * PI_R1 * qReg->Rand());
+                qReg->Phase(ONE_CMPLX, std::polar(ONE_R1, (real1)gateRand), i);
 
                 // Discrete Z root gates option:
                 /*
@@ -2026,9 +2029,9 @@ TEST_CASE("test_universal_circuit_continuous", "[supreme]")
             for (d = 0; d < benchmarkDepth; d++) {
 
                 for (i = 0; i < n; i++) {
-                    theta = 2 * PI_R1 * qReg->Rand();
-                    phi = 2 * PI_R1 * qReg->Rand();
-                    lambda = 2 * PI_R1 * qReg->Rand();
+                    theta = (real1_f)(2 * PI_R1 * qReg->Rand());
+                    phi = (real1_f)(2 * PI_R1 * qReg->Rand());
+                    lambda = (real1_f)(2 * PI_R1 * qReg->Rand());
 
                     qReg->U(i, theta, phi, lambda);
                 }
@@ -2747,7 +2750,7 @@ TEST_CASE("test_universal_circuit_digital_cross_entropy", "[supreme]")
 
     real1_f uniformRandomCount = ITERATIONS / (real1_f)permCount;
     int goldBinResult;
-    real1_f crossEntropy = ZERO_R1;
+    real1_f crossEntropy = ZERO_R1_F;
     for (perm = 0; perm < permCount; perm++) {
         measurementBin = goldStandardResult.find(perm);
         if (measurementBin == goldStandardResult.end()) {
@@ -2757,16 +2760,16 @@ TEST_CASE("test_universal_circuit_digital_cross_entropy", "[supreme]")
         }
         crossEntropy += (uniformRandomCount - goldBinResult) * (uniformRandomCount - goldBinResult);
     }
-    if (crossEntropy < ZERO_R1) {
-        crossEntropy = ZERO_R1;
+    if (crossEntropy < ZERO_R1_F) {
+        crossEntropy = ZERO_R1_F;
     }
-    crossEntropy = ONE_R1 - sqrt(crossEntropy) / ITERATIONS;
+    crossEntropy = ONE_R1_F - sqrt(crossEntropy) / ITERATIONS;
     std::cout << "Gold standard vs. uniform random cross entropy (out of 1.0): " << crossEntropy << std::endl;
 
     std::map<bitCapInt, int> goldStandardResult2 = goldStandard->MultiShotMeasureMask(qPowers, n, ITERATIONS);
 
     int testBinResult;
-    crossEntropy = ZERO_R1;
+    crossEntropy = ZERO_R1_F;
     for (perm = 0; perm < permCount; perm++) {
         measurementBin = goldStandardResult.find(perm);
         if (measurementBin == goldStandardResult.end()) {
@@ -2783,10 +2786,10 @@ TEST_CASE("test_universal_circuit_digital_cross_entropy", "[supreme]")
         }
         crossEntropy += (testBinResult - goldBinResult) * (testBinResult - goldBinResult);
     }
-    if (crossEntropy < ZERO_R1) {
-        crossEntropy = ZERO_R1;
+    if (crossEntropy < ZERO_R1_F) {
+        crossEntropy = ZERO_R1_F;
     }
-    crossEntropy = ONE_R1 - sqrt(crossEntropy) / ITERATIONS;
+    crossEntropy = ONE_R1_F - sqrt(crossEntropy) / ITERATIONS;
     std::cout << "Gold standard vs. gold standard cross entropy (out of 1.0): " << crossEntropy << std::endl;
 
     QInterfacePtr testCase = CreateQuantumInterface({ testEngineType, testSubEngineType }, n, 0, rng, ONE_CMPLX,
@@ -2837,7 +2840,7 @@ TEST_CASE("test_universal_circuit_digital_cross_entropy", "[supreme]")
     // faster benchmark. This will not test the effect of the MReg() method.
     // testCaseResult = testCase->MultiShotMeasureMask(qPowers, n, ITERATIONS);
 
-    crossEntropy = ZERO_R1;
+    crossEntropy = ZERO_R1_F;
     for (perm = 0; perm < permCount; perm++) {
         measurementBin = goldStandardResult.find(perm);
         if (measurementBin == goldStandardResult.end()) {
@@ -2854,10 +2857,10 @@ TEST_CASE("test_universal_circuit_digital_cross_entropy", "[supreme]")
         }
         crossEntropy += (testBinResult - goldBinResult) * (testBinResult - goldBinResult);
     }
-    if (crossEntropy < ZERO_R1) {
-        crossEntropy = ZERO_R1;
+    if (crossEntropy < ZERO_R1_F) {
+        crossEntropy = ZERO_R1_F;
     }
-    crossEntropy = ONE_R1 - sqrt(crossEntropy) / ITERATIONS;
+    crossEntropy = ONE_R1_F - sqrt(crossEntropy) / ITERATIONS;
     std::cout << "Gold standard vs. test case cross entropy (out of 1.0): " << crossEntropy << std::endl;
 
     std::map<bitCapInt, int> testCaseResult2;
@@ -2895,7 +2898,7 @@ TEST_CASE("test_universal_circuit_digital_cross_entropy", "[supreme]")
     }
     testCaseResult2 = testCase->MultiShotMeasureMask(qPowers, n, ITERATIONS);
 
-    crossEntropy = ZERO_R1;
+    crossEntropy = ZERO_R1_F;
     for (perm = 0; perm < permCount; perm++) {
         measurementBin = testCaseResult.find(perm);
         if (measurementBin == testCaseResult.end()) {
@@ -2912,9 +2915,9 @@ TEST_CASE("test_universal_circuit_digital_cross_entropy", "[supreme]")
         }
         crossEntropy += (testBinResult - goldBinResult) * (testBinResult - goldBinResult);
     }
-    if (crossEntropy < ZERO_R1) {
-        crossEntropy = ZERO_R1;
+    if (crossEntropy < ZERO_R1_F) {
+        crossEntropy = ZERO_R1_F;
     }
-    crossEntropy = ONE_R1 - sqrt(crossEntropy) / ITERATIONS;
+    crossEntropy = ONE_R1_F - sqrt(crossEntropy) / ITERATIONS;
     std::cout << "Test case vs. (duplicate) test case cross entropy (out of 1.0): " << crossEntropy << std::endl;
 }

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -271,24 +271,24 @@ TEST_CASE("test_exp2x2_log2x2")
     complex mtrx2[4];
 
     exp2x2(mtrx1, mtrx2);
-    REQUIRE_FLOAT(real(mtrx2[0]), M_E);
-    REQUIRE_FLOAT(imag(mtrx2[0]), ZERO_R1);
-    REQUIRE_FLOAT(real(mtrx2[1]), ZERO_R1);
-    REQUIRE_FLOAT(imag(mtrx2[1]), ZERO_R1);
-    REQUIRE_FLOAT(real(mtrx2[2]), ZERO_R1);
-    REQUIRE_FLOAT(imag(mtrx2[2]), ZERO_R1);
-    REQUIRE_FLOAT(real(mtrx2[3]), M_E);
-    REQUIRE_FLOAT(imag(mtrx2[3]), ZERO_R1);
+    REQUIRE_FLOAT((real1_f)real(mtrx2[0]), M_E);
+    REQUIRE_FLOAT((real1_f)imag(mtrx2[0]), ZERO_R1_F);
+    REQUIRE_FLOAT((real1_f)real(mtrx2[1]), ZERO_R1_F);
+    REQUIRE_FLOAT((real1_f)imag(mtrx2[1]), ZERO_R1_F);
+    REQUIRE_FLOAT((real1_f)real(mtrx2[2]), ZERO_R1_F);
+    REQUIRE_FLOAT((real1_f)imag(mtrx2[2]), ZERO_R1_F);
+    REQUIRE_FLOAT((real1_f)real(mtrx2[3]), M_E);
+    REQUIRE_FLOAT((real1_f)imag(mtrx2[3]), ZERO_R1_F);
 
     log2x2(mtrx2, mtrx1);
-    REQUIRE_FLOAT(real(mtrx1[0]), ONE_R1);
-    REQUIRE_FLOAT(imag(mtrx1[0]), ZERO_R1);
-    REQUIRE_FLOAT(real(mtrx1[1]), ZERO_R1);
-    REQUIRE_FLOAT(imag(mtrx1[1]), ZERO_R1);
-    REQUIRE_FLOAT(real(mtrx1[2]), ZERO_R1);
-    REQUIRE_FLOAT(imag(mtrx1[2]), ZERO_R1);
-    REQUIRE_FLOAT(real(mtrx1[3]), ONE_R1);
-    REQUIRE_FLOAT(imag(mtrx1[3]), ZERO_R1);
+    REQUIRE_FLOAT((real1_f)real(mtrx1[0]), ONE_R1_F);
+    REQUIRE_FLOAT((real1_f)imag(mtrx1[0]), ZERO_R1_F);
+    REQUIRE_FLOAT((real1_f)real(mtrx1[1]), ZERO_R1_F);
+    REQUIRE_FLOAT((real1_f)imag(mtrx1[1]), ZERO_R1_F);
+    REQUIRE_FLOAT((real1_f)real(mtrx1[2]), ZERO_R1_F);
+    REQUIRE_FLOAT((real1_f)imag(mtrx1[2]), ZERO_R1_F);
+    REQUIRE_FLOAT((real1_f)real(mtrx1[3]), ONE_R1_F);
+    REQUIRE_FLOAT((real1_f)imag(mtrx1[3]), ZERO_R1_F);
 }
 
 #if ENABLE_OPENCL && !ENABLE_SNUCL
@@ -323,7 +323,7 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_global_phase")
     qftReg->X(0);
     qftReg->Z(0);
     qftReg->X(0);
-    REQUIRE_FLOAT(-ONE_R1, real(qftReg->GetAmplitude(0x00)));
+    REQUIRE_FLOAT(-ONE_R1_F, (real1_f)real(qftReg->GetAmplitude(0x00)));
 
     qftReg = CreateQuantumInterface(
         { testEngineType, testSubEngineType, testSubSubEngineType }, 1U, 0, rng, CMPLX_DEFAULT_ARG, false, false);
@@ -331,7 +331,7 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_global_phase")
     qftReg->X(0);
     qftReg->S(0);
     qftReg->X(0);
-    REQUIRE_FLOAT(ONE_R1, imag(qftReg->GetAmplitude(0x00)));
+    REQUIRE_FLOAT(ONE_R1_F, (real1_f)imag(qftReg->GetAmplitude(0x00)));
 
     qftReg = CreateQuantumInterface(
         { testEngineType, testSubEngineType, testSubSubEngineType }, 1U, 0, rng, CMPLX_DEFAULT_ARG, false, false);
@@ -339,39 +339,39 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_global_phase")
     qftReg->X(0);
     qftReg->IS(0);
     qftReg->X(0);
-    REQUIRE_FLOAT(-ONE_R1, imag(qftReg->GetAmplitude(0x00)));
+    REQUIRE_FLOAT(-ONE_R1_F, (real1_f)imag(qftReg->GetAmplitude(0x00)));
 
     qftReg = CreateQuantumInterface(
         { testEngineType, testSubEngineType, testSubSubEngineType }, 1U, 0, rng, CMPLX_DEFAULT_ARG, false, false);
     qftReg->Y(0);
     qftReg->X(0);
-    REQUIRE_FLOAT(ONE_R1, imag(qftReg->GetAmplitude(0x00)));
+    REQUIRE_FLOAT(ONE_R1_F, (real1_f)imag(qftReg->GetAmplitude(0x00)));
 
     qftReg = CreateQuantumInterface(
         { testEngineType, testSubEngineType, testSubSubEngineType }, 1U, 0, rng, CMPLX_DEFAULT_ARG, false, false);
     qftReg->X(0);
     qftReg->Y(0);
-    REQUIRE_FLOAT(-ONE_R1, imag(qftReg->GetAmplitude(0x00)));
+    REQUIRE_FLOAT(-ONE_R1_F, (real1_f)imag(qftReg->GetAmplitude(0x00)));
 
     qftReg = CreateQuantumInterface(
         { testEngineType, testSubEngineType, testSubSubEngineType }, 2U, 0, rng, CMPLX_DEFAULT_ARG, false, false);
     qftReg->X(0);
     qftReg->X(1);
     qftReg->CZ(0, 1);
-    REQUIRE_FLOAT(-ONE_R1, real(qftReg->GetAmplitude(0x03)));
+    REQUIRE_FLOAT(-ONE_R1_F, (real1_f)real(qftReg->GetAmplitude(0x03)));
 
     qftReg = CreateQuantumInterface(
         { testEngineType, testSubEngineType, testSubSubEngineType }, 2U, 0, rng, CMPLX_DEFAULT_ARG, false, false);
     qftReg->X(0);
     qftReg->CY(0, 1);
-    REQUIRE_FLOAT(ONE_R1, imag(qftReg->GetAmplitude(0x03)));
+    REQUIRE_FLOAT(ONE_R1_F, (real1_f)imag(qftReg->GetAmplitude(0x03)));
 
     qftReg = CreateQuantumInterface(
         { testEngineType, testSubEngineType, testSubSubEngineType }, 2U, 0, rng, CMPLX_DEFAULT_ARG, false, false);
     qftReg->X(0);
     qftReg->X(1);
     qftReg->CY(0, 1);
-    REQUIRE_FLOAT(-ONE_R1, imag(qftReg->GetAmplitude(0x01)));
+    REQUIRE_FLOAT(-ONE_R1_F, (real1_f)imag(qftReg->GetAmplitude(0x01)));
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_cnot")
@@ -656,35 +656,35 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_anticisqrtswap")
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_fsim")
 {
-    real1_f theta = 3 * PI_R1 / 2;
+    real1_f theta = (real1_f)(3 * PI_R1 / 2);
 
     qftReg->SetPermutation(1);
-    qftReg->FSim(theta, ZERO_R1, 0, 1);
+    qftReg->FSim(theta, ZERO_R1_F, 0, 1);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x02));
 
     qftReg->SetPermutation(0);
     qftReg->H(0, 2);
-    qftReg->FSim(theta, ZERO_R1, 0, 1);
-    qftReg->FSim(theta, ZERO_R1, 0, 1);
+    qftReg->FSim(theta, ZERO_R1_F, 0, 1);
+    qftReg->FSim(theta, ZERO_R1_F, 0, 1);
     qftReg->H(0, 2);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x03));
 
-    real1_f phi = PI_R1;
+    real1_f phi = (real1_f)PI_R1;
 
     qftReg->SetReg(0, 8, 0x35);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x35));
     qftReg->H(0, 4);
-    qftReg->FSim(ZERO_R1, phi, 4, 0);
-    qftReg->FSim(ZERO_R1, phi, 5, 1);
-    qftReg->FSim(ZERO_R1, phi, 6, 2);
-    qftReg->FSim(ZERO_R1, phi, 7, 3);
+    qftReg->FSim(ZERO_R1_F, phi, 4, 0);
+    qftReg->FSim(ZERO_R1_F, phi, 5, 1);
+    qftReg->FSim(ZERO_R1_F, phi, 6, 2);
+    qftReg->FSim(ZERO_R1_F, phi, 7, 3);
     qftReg->H(0, 4);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x36));
 
     qftReg->SetPermutation(0x03);
     qftReg->H(0);
-    qftReg->FSim(ZERO_R1, phi, 0, 1);
-    qftReg->FSim(ZERO_R1, phi, 0, 1);
+    qftReg->FSim(ZERO_R1_F, phi, 0, 1);
+    qftReg->FSim(ZERO_R1_F, phi, 0, 1);
     qftReg->H(0);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x03));
 }
@@ -921,7 +921,7 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_s")
     qftReg->S(0);
     qftReg->IS(0);
     qftReg->Phase(ONE_CMPLX, I_CMPLX, 0);
-    REQUIRE_FLOAT(ONE_R1 / 2, qftReg->Prob(0));
+    REQUIRE_FLOAT(ONE_R1_F / 2, qftReg->Prob(0));
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_is")
@@ -1161,13 +1161,13 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_phaseparity")
     qftReg->SetPermutation(0x40001);
     REQUIRE_THAT(qftReg, HasProbability(0, 20, 0x40001));
     qftReg->H(18, 2);
-    qftReg->PhaseParity(PI_R1 / 2, pow2Ocl(0) | pow2Ocl(18) | pow2Ocl(19));
-    qftReg->PhaseParity(PI_R1 / 2, pow2Ocl(0) | pow2Ocl(18) | pow2Ocl(19));
+    qftReg->PhaseParity((real1_f)(PI_R1 / 2), pow2Ocl(0) | pow2Ocl(18) | pow2Ocl(19));
+    qftReg->PhaseParity((real1_f)(PI_R1 / 2), pow2Ocl(0) | pow2Ocl(18) | pow2Ocl(19));
     qftReg->H(18, 2);
     REQUIRE_THAT(qftReg, HasProbability(0, 20, 0x80001));
     qftReg->H(18, 2);
-    qftReg->PhaseParity(PI_R1 / 2, pow2Ocl(0) | pow2Ocl(18) | pow2Ocl(19));
-    qftReg->PhaseParity(PI_R1 / 2, pow2Ocl(18) | pow2Ocl(19));
+    qftReg->PhaseParity((real1_f)(PI_R1 / 2), pow2Ocl(0) | pow2Ocl(18) | pow2Ocl(19));
+    qftReg->PhaseParity((real1_f)(PI_R1 / 2), pow2Ocl(18) | pow2Ocl(19));
     qftReg->H(18, 2);
     REQUIRE_THAT(qftReg, HasProbability(0, 20, 0x80001));
 }
@@ -1625,12 +1625,12 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_uniform_c_single")
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_ai")
 {
-    real1_f azimuth = 0.9f * PI_R1;
-    real1_f inclination = 0.7f * PI_R1;
+    real1_f azimuth = (real1_f)(0.9f * PI_R1);
+    real1_f inclination = (real1_f)(0.7f * PI_R1);
 
-    real1_f probZ = (ONE_R1 / 2) - cos(inclination) / 2;
-    real1_f probX = (ONE_R1 / 2) - sin(inclination) * cos(azimuth) / 2;
-    real1_f probY = (ONE_R1 / 2) - sin(inclination) * sin(azimuth) / 2;
+    real1_f probZ = (ONE_R1_F / 2) - cos(inclination) / 2;
+    real1_f probX = (ONE_R1_F / 2) - sin(inclination) * cos(azimuth) / 2;
+    real1_f probY = (ONE_R1_F / 2) - sin(inclination) * sin(azimuth) / 2;
 
     qftReg->SetPermutation(0);
     qftReg->AI(0, azimuth, inclination);
@@ -2739,7 +2739,7 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_tryseparate")
     for (i = 0; i < 8; i++) {
         qftReg->TrySeparate(i);
         toSep[0] = i;
-        qftReg->TrySeparate(toSep, 1, FP_NORM_EPSILON);
+        qftReg->TrySeparate(toSep, 1, FP_NORM_EPSILON_F);
     }
 
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 85));
@@ -2752,7 +2752,7 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_tryseparate")
     qftReg->TrySeparate(0, 1);
     toSep[0] = 0;
     toSep[1] = 1;
-    qftReg->TrySeparate(toSep, 2, FP_NORM_EPSILON);
+    qftReg->TrySeparate(toSep, 2, FP_NORM_EPSILON_F);
     qftReg->CNOT(0, 1);
     qftReg->Z(0);
     qftReg->H(0);
@@ -3032,8 +3032,8 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_probbitsall")
     qftReg->H(2);
 
     qftReg->ProbBitsAll(bits, 2U, probs1);
-    REQUIRE_FLOAT(probs1[0], 0.5);
-    REQUIRE_FLOAT(probs1[1], 0.5);
+    REQUIRE_FLOAT((real1_f)probs1[0], 0.5);
+    REQUIRE_FLOAT((real1_f)probs1[1], 0.5);
     REQUIRE(probs1[2] < 0.01);
     REQUIRE(probs1[3] < 0.01);
 }
@@ -3043,7 +3043,7 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_expectationbitsall")
     qftReg = CreateQuantumInterface({ testEngineType, testSubEngineType, testSubSubEngineType }, 8, 0, rng);
     bitLenInt bits[8] = { 0, 1, 2, 3, 4, 5, 6, 7 };
     qftReg->H(0, 8);
-    REQUIRE_FLOAT(qftReg->ExpectationBitsAll(bits, 8U), 127 + (ONE_R1 / 2))
+    REQUIRE_FLOAT(qftReg->ExpectationBitsAll(bits, 8U), 127 + (ONE_R1_F / 2))
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_probparity")
@@ -3061,11 +3061,11 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_probparity")
 
     qftReg->SetPermutation(0x0);
     qftReg->H(0);
-    REQUIRE_FLOAT(QPARITY(qftReg)->ProbParity(0x3), ONE_R1 / 2);
+    REQUIRE_FLOAT(QPARITY(qftReg)->ProbParity(0x3), ONE_R1_F / 2);
 
     qftReg->SetPermutation(0x0);
     qftReg->H(1);
-    REQUIRE_FLOAT(QPARITY(qftReg)->ProbParity(0x3), ONE_R1 / 2);
+    REQUIRE_FLOAT(QPARITY(qftReg)->ProbParity(0x3), ONE_R1_F / 2);
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_mparity")
@@ -3105,26 +3105,26 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_uniformparityrz")
 {
     qftReg->SetPermutation(0);
     qftReg->H(0);
-    QPARITY(qftReg)->UniformParityRZ(1, M_PI_2);
+    QPARITY(qftReg)->UniformParityRZ(1, (real1_f)M_PI_2);
     qftReg->H(0);
     REQUIRE_THAT(qftReg, HasProbability(0x1));
 
     qftReg->SetPermutation(0x3);
     qftReg->H(0, 3);
-    QPARITY(qftReg)->UniformParityRZ(0x7, M_PI_2);
+    QPARITY(qftReg)->UniformParityRZ(0x7, (real1_f)M_PI_2);
     qftReg->H(0, 3);
     REQUIRE_THAT(qftReg, HasProbability(0x4));
 
     qftReg->SetPermutation(0x1);
     qftReg->H(0, 3);
-    QPARITY(qftReg)->UniformParityRZ(0x7, M_PI_2);
-    QPARITY(qftReg)->UniformParityRZ(0x7, M_PI_2);
+    QPARITY(qftReg)->UniformParityRZ(0x7, (real1_f)M_PI_2);
+    QPARITY(qftReg)->UniformParityRZ(0x7, (real1_f)M_PI_2);
     qftReg->H(0, 3);
     REQUIRE_THAT(qftReg, HasProbability(0x1));
 
     qftReg->SetPermutation(0x01);
     qftReg->H(0);
-    QPARITY(qftReg)->UniformParityRZ(1, M_PI_4);
+    QPARITY(qftReg)->UniformParityRZ(1, (real1_f)M_PI_4);
     qftReg->S(0);
     qftReg->H(0);
     REQUIRE_THAT(qftReg, HasProbability(0));
@@ -3230,9 +3230,9 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_getquantumstate")
     qftReg->GetQuantumState(state);
     for (bitCapIntOcl i = 0; i < 16; i++) {
         if (i == 0x0b) {
-            REQUIRE_FLOAT(norm(state[i]), ONE_R1);
+            REQUIRE_FLOAT((real1_f)norm(state[i]), ONE_R1_F);
         } else {
-            REQUIRE_FLOAT(norm(state[i]), ZERO_R1);
+            REQUIRE_FLOAT((real1_f)norm(state[i]), ZERO_R1_F);
         }
     }
     qftReg->SetQuantumState(state);
@@ -3251,9 +3251,9 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_getprobs")
     qftReg->GetProbs(state);
     for (bitCapIntOcl i = 0; i < 16; i++) {
         if (i == 0x0b) {
-            REQUIRE_FLOAT(state[i], ONE_R1);
+            REQUIRE_FLOAT((real1_f)state[i], ONE_R1_F);
         } else {
-            REQUIRE_FLOAT(state[i], ZERO_R1);
+            REQUIRE_FLOAT((real1_f)state[i], ZERO_R1_F);
         }
     }
 }
@@ -3263,7 +3263,7 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_normalize")
     qftReg->SetPermutation(0x03);
     qftReg->UpdateRunningNorm();
     qftReg->NormalizeState();
-    REQUIRE_FLOAT(norm(qftReg->GetAmplitude(0x03)), ONE_R1);
+    REQUIRE_FLOAT((real1_f)norm(qftReg->GetAmplitude(0x03)), ONE_R1_F);
 }
 
 #if ENABLE_ALU
@@ -3686,26 +3686,26 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_inc")
     qftReg->SetPermutation(255);
     qftReg->H(7);
     QALU(qftReg)->INC(1, 0, 8);
-    REQUIRE_FLOAT(ONE_R1 / 2, qftReg->ProbAll(0));
-    REQUIRE_FLOAT(ONE_R1 / 2, qftReg->ProbAll(128));
+    REQUIRE_FLOAT(ONE_R1_F / 2, (real1_f)qftReg->ProbAll(0));
+    REQUIRE_FLOAT(ONE_R1_F / 2, (real1_f)qftReg->ProbAll(128));
 
     qftReg->SetPermutation(255);
     qftReg->H(7);
     qftReg->H(1);
     QALU(qftReg)->INC(1, 0, 8);
-    REQUIRE_FLOAT(ONE_R1 / 4, qftReg->ProbAll(0));
-    REQUIRE_FLOAT(ONE_R1 / 4, qftReg->ProbAll(126));
-    REQUIRE_FLOAT(ONE_R1 / 4, qftReg->ProbAll(128));
-    REQUIRE_FLOAT(ONE_R1 / 4, qftReg->ProbAll(254));
+    REQUIRE_FLOAT(ONE_R1_F / 4, (real1_f)qftReg->ProbAll(0));
+    REQUIRE_FLOAT(ONE_R1_F / 4, (real1_f)qftReg->ProbAll(126));
+    REQUIRE_FLOAT(ONE_R1_F / 4, (real1_f)qftReg->ProbAll(128));
+    REQUIRE_FLOAT(ONE_R1_F / 4, (real1_f)qftReg->ProbAll(254));
 
     qftReg->SetPermutation(0);
     qftReg->H(7);
     qftReg->H(1);
     QALU(qftReg)->INC(1, 0, 8);
-    REQUIRE_FLOAT(ONE_R1 / 4, qftReg->ProbAll(1));
-    REQUIRE_FLOAT(ONE_R1 / 4, qftReg->ProbAll(3));
-    REQUIRE_FLOAT(ONE_R1 / 4, qftReg->ProbAll(129));
-    REQUIRE_FLOAT(ONE_R1 / 4, qftReg->ProbAll(131));
+    REQUIRE_FLOAT(ONE_R1_F / 4, (real1_f)qftReg->ProbAll(1));
+    REQUIRE_FLOAT(ONE_R1_F / 4, (real1_f)qftReg->ProbAll(3));
+    REQUIRE_FLOAT(ONE_R1_F / 4, (real1_f)qftReg->ProbAll(129));
+    REQUIRE_FLOAT(ONE_R1_F / 4, (real1_f)qftReg->ProbAll(131));
 
     qftReg->SetPermutation(1);
     QALU(qftReg)->INC(8, 0, 8);
@@ -3745,20 +3745,20 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_incs")
     qftReg->SetPermutation(255);
     qftReg->H(8);
     QALU(qftReg)->INCS(1, 0, 8, 8);
-    REQUIRE_FLOAT(ONE_R1 / 2, qftReg->ProbAll(256));
-    REQUIRE_FLOAT(ONE_R1 / 2, qftReg->ProbAll(0));
+    REQUIRE_FLOAT(ONE_R1_F / 2, (real1_f)qftReg->ProbAll(256));
+    REQUIRE_FLOAT(ONE_R1_F / 2, (real1_f)qftReg->ProbAll(0));
 
     qftReg->SetPermutation(0);
     qftReg->H(0);
     QALU(qftReg)->INCS(1, 0, 8, 8);
-    REQUIRE_FLOAT(ONE_R1 / 2, qftReg->ProbAll(1));
-    REQUIRE_FLOAT(ONE_R1 / 2, qftReg->ProbAll(2));
+    REQUIRE_FLOAT(ONE_R1_F / 2, (real1_f)qftReg->ProbAll(1));
+    REQUIRE_FLOAT(ONE_R1_F / 2, (real1_f)qftReg->ProbAll(2));
 
     qftReg->SetPermutation(256);
     qftReg->H(7);
     QALU(qftReg)->INCS(1, 0, 8, 8);
-    REQUIRE_FLOAT(ONE_R1 / 2, qftReg->ProbAll(257));
-    REQUIRE_FLOAT(ONE_R1 / 2, qftReg->ProbAll(385));
+    REQUIRE_FLOAT(ONE_R1_F / 2, (real1_f)qftReg->ProbAll(257));
+    REQUIRE_FLOAT(ONE_R1_F / 2, (real1_f)qftReg->ProbAll(385));
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_incc")
@@ -3780,14 +3780,14 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_incc")
     qftReg->SetPermutation(255);
     qftReg->H(7);
     QALU(qftReg)->INCC(1, 0, 8, 8);
-    REQUIRE_FLOAT(ONE_R1 / 2, qftReg->ProbAll(256));
-    REQUIRE_FLOAT(ONE_R1 / 2, qftReg->ProbAll(128));
+    REQUIRE_FLOAT(ONE_R1_F / 2, (real1_f)qftReg->ProbAll(256));
+    REQUIRE_FLOAT(ONE_R1_F / 2, (real1_f)qftReg->ProbAll(128));
 
     qftReg->SetPermutation(255);
     qftReg->H(7);
     QALU(qftReg)->INCC(255, 0, 8, 8);
-    REQUIRE_FLOAT(ONE_R1 / 2, qftReg->ProbAll(510));
-    REQUIRE_FLOAT(ONE_R1 / 2, qftReg->ProbAll(382));
+    REQUIRE_FLOAT(ONE_R1_F / 2, (real1_f)qftReg->ProbAll(510));
+    REQUIRE_FLOAT(ONE_R1_F / 2, (real1_f)qftReg->ProbAll(382));
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_incsc")
@@ -3822,18 +3822,18 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_incsc")
     qftReg->H(0);
     qftReg->H(1);
     QALU(qftReg)->INCSC(1, 0, 2, 3, 2);
-    REQUIRE_FLOAT(ONE_R1 / 4, qftReg->ProbAll(1));
-    REQUIRE_FLOAT(ONE_R1 / 4, qftReg->ProbAll(2));
-    REQUIRE_FLOAT(ONE_R1 / 4, qftReg->ProbAll(3));
-    REQUIRE_FLOAT(ONE_R1 / 4, qftReg->ProbAll(4));
+    REQUIRE_FLOAT(ONE_R1_F / 4, (real1_f)qftReg->ProbAll(1));
+    REQUIRE_FLOAT(ONE_R1_F / 4, (real1_f)qftReg->ProbAll(2));
+    REQUIRE_FLOAT(ONE_R1_F / 4, (real1_f)qftReg->ProbAll(3));
+    REQUIRE_FLOAT(ONE_R1_F / 4, (real1_f)qftReg->ProbAll(4));
 
     qftReg->SetPermutation(0);
     qftReg->H(0);
     qftReg->H(9);
     QALU(qftReg)->INCSC(1, 0, 8, 9, 8);
     qftReg->H(9);
-    REQUIRE_FLOAT(ONE_R1 / 2, qftReg->ProbAll(1));
-    REQUIRE_FLOAT(ONE_R1 / 2, qftReg->ProbAll(2));
+    REQUIRE_FLOAT(ONE_R1_F / 2, (real1_f)qftReg->ProbAll(1));
+    REQUIRE_FLOAT(ONE_R1_F / 2, (real1_f)qftReg->ProbAll(2));
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_cinc", "[travis_xfail]")
@@ -4069,8 +4069,8 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_mul")
     qftReg->SetPermutation(0);
     qftReg->H(0);
     QALU(qftReg)->MUL(8, 0, 8, 8);
-    REQUIRE_FLOAT(ONE_R1 / 2, qftReg->ProbAll(0));
-    REQUIRE_FLOAT(ONE_R1 / 2, qftReg->ProbAll(8));
+    REQUIRE_FLOAT(ONE_R1_F / 2, (real1_f)qftReg->ProbAll(0));
+    REQUIRE_FLOAT(ONE_R1_F / 2, (real1_f)qftReg->ProbAll(8));
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_div")
@@ -4088,8 +4088,8 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_div")
     qftReg->SetPermutation(0);
     qftReg->H(3);
     QALU(qftReg)->DIV(8, 0, 8, 8);
-    REQUIRE_FLOAT(ONE_R1 / 2, qftReg->ProbAll(0));
-    REQUIRE_FLOAT(ONE_R1 / 2, qftReg->ProbAll(1));
+    REQUIRE_FLOAT(ONE_R1_F / 2, (real1_f)qftReg->ProbAll(0));
+    REQUIRE_FLOAT(ONE_R1_F / 2, (real1_f)qftReg->ProbAll(1));
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_mulmodnout")
@@ -4101,8 +4101,8 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_mulmodnout")
     qftReg->SetPermutation(0);
     qftReg->H(3);
     QALU(qftReg)->MULModNOut(2, 256U, 0, 8, 8);
-    REQUIRE_FLOAT(ONE_R1 / 2, qftReg->ProbAll(0));
-    REQUIRE_FLOAT(ONE_R1 / 2, qftReg->ProbAll(8 | (16 << 8)));
+    REQUIRE_FLOAT(ONE_R1_F / 2, (real1_f)qftReg->ProbAll(0));
+    REQUIRE_FLOAT(ONE_R1_F / 2, (real1_f)qftReg->ProbAll(8 | (16 << 8)));
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_imulmodnout")
@@ -4121,16 +4121,16 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_powmodnout")
     qftReg->SetPermutation(0);
     qftReg->H(1);
     QALU(qftReg)->POWModNOut(2, 256U, 0, 8, 8);
-    REQUIRE_FLOAT(ONE_R1 / 2, qftReg->ProbAll(1 << 8));
-    REQUIRE_FLOAT(ONE_R1 / 2, qftReg->ProbAll(2 | (4 << 8)));
+    REQUIRE_FLOAT(ONE_R1_F / 2, (real1_f)qftReg->ProbAll(1 << 8));
+    REQUIRE_FLOAT(ONE_R1_F / 2, (real1_f)qftReg->ProbAll(2 | (4 << 8)));
 
     qftReg->SetPermutation(0);
     qftReg->H(0, 2);
     QALU(qftReg)->POWModNOut(2, 256U, 0, 8, 8);
-    REQUIRE_FLOAT(ONE_R1 / 4, qftReg->ProbAll(0 | (1 << 8)));
-    REQUIRE_FLOAT(ONE_R1 / 4, qftReg->ProbAll(1 | (2 << 8)));
-    REQUIRE_FLOAT(ONE_R1 / 4, qftReg->ProbAll(2 | (4 << 8)));
-    REQUIRE_FLOAT(ONE_R1 / 4, qftReg->ProbAll(3 | (8 << 8)));
+    REQUIRE_FLOAT(ONE_R1_F / 4, (real1_f)qftReg->ProbAll(0 | (1 << 8)));
+    REQUIRE_FLOAT(ONE_R1_F / 4, (real1_f)qftReg->ProbAll(1 | (2 << 8)));
+    REQUIRE_FLOAT(ONE_R1_F / 4, (real1_f)qftReg->ProbAll(2 | (4 << 8)));
+    REQUIRE_FLOAT(ONE_R1_F / 4, (real1_f)qftReg->ProbAll(3 | (8 << 8)));
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_cmul")
@@ -4193,8 +4193,8 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_cmulmodnout", "[travis_xfail]")
     qftReg->SetPermutation(3);
     qftReg->H(16);
     QALU(qftReg)->CMULModNOut(3, 256U, 0, 8, 8, controls, 1);
-    REQUIRE_FLOAT(ONE_R1 / 2, qftReg->ProbAll(3));
-    REQUIRE_FLOAT(ONE_R1 / 2, qftReg->ProbAll(3 | (9 << 8) | (1 << 16)));
+    REQUIRE_FLOAT(ONE_R1_F / 2, (real1_f)qftReg->ProbAll(3));
+    REQUIRE_FLOAT(ONE_R1_F / 2, (real1_f)qftReg->ProbAll(3 | (9 << 8) | (1 << 16)));
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_cimulmodnout")
@@ -4227,8 +4227,8 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_cpowmodnout", "[travis_xfail]")
     qftReg->SetPermutation(3);
     qftReg->H(16);
     QALU(qftReg)->CPOWModNOut(3, 256U, 0, 8, 8, controls, 1);
-    REQUIRE_FLOAT(ONE_R1 / 2, qftReg->ProbAll(3));
-    REQUIRE_FLOAT(ONE_R1 / 2, qftReg->ProbAll(3 | (27 << 8) | (1 << 16)));
+    REQUIRE_FLOAT(ONE_R1_F / 2, (real1_f)qftReg->ProbAll(3));
+    REQUIRE_FLOAT(ONE_R1_F / 2, (real1_f)qftReg->ProbAll(3 | (27 << 8) | (1 << 16)));
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_c_phase_flip_if_less", "[travis_xfail]")
@@ -4664,10 +4664,10 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_timeevolve")
     h[0] = h0;
 
     qftReg->SetPermutation(0);
-    qftReg->TimeEvolve(h, tDiff);
+    qftReg->TimeEvolve(h, (real1_f)tDiff);
 
-    REQUIRE_FLOAT(abs(qftReg->Prob(0) - sin(aParam * tDiff) * sin(aParam * tDiff)), 0);
-    REQUIRE_FLOAT(abs((ONE_R1 - qftReg->Prob(0)) - cos(aParam * tDiff) * cos(aParam * tDiff)), 0);
+    REQUIRE_FLOAT((real1_f)abs(qftReg->Prob(0) - sin(aParam * tDiff) * sin(aParam * tDiff)), 0);
+    REQUIRE_FLOAT((real1_f)abs((ONE_R1 - qftReg->Prob(0)) - cos(aParam * tDiff) * cos(aParam * tDiff)), 0);
 
     bitLenInt controls[1] = { 1 };
     bool controlToggles[1] = { false };
@@ -4682,38 +4682,38 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_timeevolve")
     // Hamiltonian terms.
 
     qftReg->SetPermutation(2);
-    qftReg->TimeEvolve(h, tDiff);
+    qftReg->TimeEvolve(h, (real1_f)tDiff);
 
-    REQUIRE_FLOAT(abs(qftReg->Prob(0) - sin(aParam * tDiff) * sin(aParam * tDiff)), 0);
-    REQUIRE_FLOAT(abs((ONE_R1 - qftReg->Prob(0)) - cos(aParam * tDiff) * cos(aParam * tDiff)), 0);
+    REQUIRE_FLOAT((real1_f)abs(qftReg->Prob(0) - sin(aParam * tDiff) * sin(aParam * tDiff)), 0);
+    REQUIRE_FLOAT((real1_f)abs((ONE_R1 - qftReg->Prob(0)) - cos(aParam * tDiff) * cos(aParam * tDiff)), 0);
 
     controlToggles[0] = true;
     HamiltonianOpPtr h2 = std::make_shared<HamiltonianOp>(controls, 1, 0, o2neg1, false, controlToggles);
     h[0] = h2;
 
     qftReg->SetPermutation(2);
-    qftReg->TimeEvolve(h, tDiff);
+    qftReg->TimeEvolve(h, (real1_f)tDiff);
 
-    REQUIRE_FLOAT(qftReg->Prob(0), ZERO_R1);
+    REQUIRE_FLOAT(qftReg->Prob(0), ZERO_R1_F);
 
     controlToggles[0] = false;
     HamiltonianOpPtr h3 = std::make_shared<HamiltonianOp>(controls, 1, 0, o2neg1, true, controlToggles);
     h[0] = h3;
 
     qftReg->SetPermutation(2);
-    qftReg->TimeEvolve(h, tDiff);
+    qftReg->TimeEvolve(h, (real1_f)tDiff);
 
-    REQUIRE_FLOAT(qftReg->Prob(0), ZERO_R1);
+    REQUIRE_FLOAT(qftReg->Prob(0), ZERO_R1_F);
 
     controlToggles[0] = true;
     HamiltonianOpPtr h4 = std::make_shared<HamiltonianOp>(controls, 1, 0, o2neg1, true, controlToggles);
     h[0] = h4;
 
     qftReg->SetPermutation(2);
-    qftReg->TimeEvolve(h, tDiff);
+    qftReg->TimeEvolve(h, (real1_f)tDiff);
 
-    REQUIRE_FLOAT(abs(qftReg->Prob(0) - sin(aParam * tDiff) * sin(aParam * tDiff)), 0);
-    REQUIRE_FLOAT(abs((ONE_R1 - qftReg->Prob(0)) - cos(aParam * tDiff) * cos(aParam * tDiff)), 0);
+    REQUIRE_FLOAT((real1_f)abs(qftReg->Prob(0) - sin(aParam * tDiff) * sin(aParam * tDiff)), 0);
+    REQUIRE_FLOAT((real1_f)abs((ONE_R1 - qftReg->Prob(0)) - cos(aParam * tDiff) * cos(aParam * tDiff)), 0);
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_timeevolve_uniform")
@@ -4741,10 +4741,10 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_timeevolve_uniform")
     REQUIRE(h0->uniform);
 
     qftReg->SetPermutation(2);
-    qftReg->TimeEvolve(h, tDiff);
+    qftReg->TimeEvolve(h, (real1_f)tDiff);
 
-    REQUIRE_FLOAT(abs(qftReg->Prob(0) - sin(aParam * tDiff) * sin(aParam * tDiff)), 0);
-    REQUIRE_FLOAT(abs((ONE_R1 - qftReg->Prob(0)) - cos(aParam * tDiff) * cos(aParam * tDiff)), 0);
+    REQUIRE_FLOAT((real1_f)abs(qftReg->Prob(0) - sin(aParam * tDiff) * sin(aParam * tDiff)), 0);
+    REQUIRE_FLOAT((real1_f)abs((ONE_R1 - qftReg->Prob(0)) - cos(aParam * tDiff) * cos(aParam * tDiff)), 0);
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_qfusion_controlled")
@@ -4767,8 +4767,8 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_qfusion_controlled")
     for (bitCapInt i = 0; i < 8; i++) {
         a = qftReg->GetAmplitude(i);
         b = qftReg2->GetAmplitude(i);
-        REQUIRE_FLOAT(real(a), real(b));
-        REQUIRE_FLOAT(imag(a), imag(b));
+        REQUIRE_FLOAT((real1_f)real(a), (real1_f)real(b));
+        REQUIRE_FLOAT((real1_f)imag(a), (real1_f)imag(b));
     }
 }
 
@@ -4949,10 +4949,10 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_h_cnot_rand")
 
     complex state[4];
     qftReg->GetQuantumState(state);
-    REQUIRE_FLOAT(norm(state[0]), ONE_R1 / 2);
-    REQUIRE_FLOAT(norm(state[1]), ZERO_R1);
-    REQUIRE_FLOAT(norm(state[2]), ZERO_R1);
-    REQUIRE_FLOAT(norm(state[3]), ONE_R1 / 2);
+    REQUIRE_FLOAT((real1_f)norm(state[0]), ONE_R1_F / 2);
+    REQUIRE_FLOAT((real1_f)norm(state[1]), ZERO_R1_F);
+    REQUIRE_FLOAT((real1_f)norm(state[2]), ZERO_R1_F);
+    REQUIRE_FLOAT((real1_f)norm(state[3]), ONE_R1_F / 2);
 
     bitCapInt qPowers[2] = { 1, 2 };
     std::map<bitCapInt, int> results = qftReg->MultiShotMeasureMask(qPowers, 2U, 1000);


### PR DESCRIPTION
This adds support for (CPU-only, no GPU support) 128-bit floating point ("`quad`") type for `real1`.

This is limited to compilers with support for a `quad`-type primitive, like GCC and Intel.