### PR TITLE
#966: Reorganize inline methods

### DIFF
--- a/include/common/dispatchqueue.hpp
+++ b/include/common/dispatchqueue.hpp
@@ -23,12 +23,10 @@
 #define _USE_MATH_DEFINES
 
 #include <condition_variable>
-#include <cstdint>
 #include <functional>
 #include <future>
 #include <mutex>
 #include <queue>
-#include <vector>
 
 namespace Qrack {
 

--- a/include/common/dispatchqueue.hpp
+++ b/include/common/dispatchqueue.hpp
@@ -36,7 +36,13 @@ class DispatchQueue {
     typedef std::function<void(void)> fp_t;
 
 public:
-    DispatchQueue();
+    DispatchQueue()
+        : quit_(false)
+        , isFinished_(true)
+        , isStarted_(false)
+    {
+        // Intentionally left blank.
+    }
     ~DispatchQueue();
 
     // dispatch and copy

--- a/include/common/parallel_for.hpp
+++ b/include/common/parallel_for.hpp
@@ -15,7 +15,6 @@
 /* Needed for bitCapInt typedefs. */
 #include "qrack_types.hpp"
 
-#include <algorithm>
 #include <set>
 #include <vector>
 

--- a/include/common/rdrandwrapper.hpp
+++ b/include/common/rdrandwrapper.hpp
@@ -16,10 +16,6 @@
 
 #if ENABLE_DEVRAND
 #include <sys/random.h>
-#elif ENABLE_RNDFILE
-#include <future>
-#include <string>
-#include <vector>
 #endif
 
 #if ENABLE_RDRAND

--- a/include/common/rdrandwrapper.hpp
+++ b/include/common/rdrandwrapper.hpp
@@ -14,7 +14,9 @@
 
 #include "qrack_types.hpp"
 
-#if ENABLE_RNDFILE && !ENABLE_DEVRAND
+#if ENABLE_DEVRAND
+#include <sys/random.h>
+#elif ENABLE_RNDFILE
 #include <future>
 #include <string>
 #include <vector>
@@ -41,7 +43,19 @@ public:
         return instance;
     }
 
-    unsigned NextRaw();
+    unsigned NextRaw()
+    {
+        size_t fSize = 0;
+        unsigned v;
+        while (fSize < 1) {
+            fSize = fread(&v, sizeof(unsigned), 1, dataFile);
+            if (fSize < 1) {
+                _readNextRandDataFile();
+            }
+        }
+
+        return v;
+    }
 
 private:
     RandFile() { _readNextRandDataFile(); }
@@ -63,9 +77,86 @@ public:
 #endif
 
 class RdRandom {
+private:
+    bool getRdRand(unsigned* pv)
+    {
+#if ENABLE_RDRAND || ENABLE_DEVRAND
+        const int max_rdrand_tries = 10;
+        for (int i = 0; i < max_rdrand_tries; ++i) {
+#if ENABLE_DEVRAND
+            if (sizeof(unsigned) == getrandom(reinterpret_cast<char*>(pv), sizeof(unsigned), 0))
+#else
+            if (_rdrand32_step(pv))
+#endif
+                return true;
+        }
+#endif
+        return false;
+    }
+
 public:
-    bool SupportsRDRAND();
-    unsigned NextRaw();
-    real1_f Next();
+    bool SupportsRDRAND()
+    {
+#if ENABLE_RDRAND
+        const unsigned flag_RDRAND = (1 << 30);
+
+#if _MSC_VER
+        int ex[4];
+        __cpuid(ex, 1);
+
+        return ((ex[2] & flag_RDRAND) == flag_RDRAND);
+#else
+        unsigned eax, ebx, ecx, edx;
+        ecx = 0;
+        __get_cpuid(1, &eax, &ebx, &ecx, &edx);
+
+        return ((ecx & flag_RDRAND) == flag_RDRAND);
+#endif
+
+#else
+        return false;
+#endif
+    }
+
+#if ENABLE_RNDFILE && !ENABLE_DEVRAND
+    unsigned NextRaw() { return RandFile::getInstance().NextRaw(); }
+#else
+    unsigned NextRaw()
+    {
+        unsigned v;
+        if (!getRdRand(&v)) {
+            throw std::runtime_error("Random number generator failed up to retry limit.");
+        }
+
+        return v;
+    }
+#endif
+
+    real1_f Next()
+    {
+        unsigned v = NextRaw();
+
+        real1_f res = ZERO_R1_F;
+        real1_f part = ONE_R1_F;
+        for (unsigned i = 0U; i < 32U; i++) {
+            part /= 2;
+            if ((v >> i) & 1U) {
+                res += part;
+            }
+        }
+
+#if FPPOW > 5
+        v = NextRaw();
+
+        for (unsigned i = 0U; i < 32U; i++) {
+            part /= 2;
+            if ((v >> i) & 1U) {
+                res += part;
+            }
+        }
+#endif
+
+        return res;
+    }
 };
 } // namespace Qrack

--- a/include/qengine.hpp
+++ b/include/qengine.hpp
@@ -19,8 +19,6 @@
 #include "qalu.hpp"
 #endif
 
-#include <algorithm>
-
 namespace Qrack {
 
 class QEngine;

--- a/include/qengine_opencl.hpp
+++ b/include/qengine_opencl.hpp
@@ -210,75 +210,7 @@ public:
 
     virtual ~QEngineOCL() { FreeAll(); }
 
-    virtual void FreeAll()
-    {
-        ZeroAmplitudes();
-
-        powersBuffer = NULL;
-        if (nrmArray) {
-            FreeAligned(nrmArray);
-            nrmArray = NULL;
-        }
-
-        SubtractAlloc(totalOclAllocSize);
-    }
-
-    virtual void ZeroAmplitudes()
-    {
-        clDump();
-        runningNorm = ZERO_R1;
-
-        if (!stateBuffer) {
-            return;
-        }
-
-        ResetStateBuffer(NULL);
-        FreeStateVec();
-
-        SubtractAlloc(sizeof(complex) * maxQPowerOcl);
-    }
-
-    virtual void FreeStateVec(complex* sv = NULL)
-    {
-        bool doReset = false;
-        if (sv == NULL) {
-            sv = stateVec;
-            doReset = true;
-        }
-
-        if (sv) {
-#if defined(_WIN32)
-            _aligned_free(sv);
-#else
-            free(sv);
-#endif
-        }
-
-        if (doReset) {
-            stateVec = NULL;
-        }
-    }
-
     virtual bool IsZeroAmplitude() { return !stateBuffer; }
-
-    virtual void CopyStateVec(QEnginePtr src)
-    {
-        if (src->IsZeroAmplitude()) {
-            ZeroAmplitudes();
-            return;
-        }
-
-        if (!stateBuffer) {
-            ReinitBuffer();
-        }
-
-        LockSync(CL_MAP_WRITE);
-        src->GetQuantumState(stateVec);
-        UnlockSync();
-
-        runningNorm = src->GetRunningNorm();
-    }
-
     virtual real1_f FirstNonzeroPhase()
     {
         if (!stateBuffer) {
@@ -287,6 +219,11 @@ public:
 
         return QInterface::FirstNonzeroPhase();
     }
+
+    virtual void FreeAll();
+    virtual void ZeroAmplitudes();
+    virtual void FreeStateVec(complex* sv = NULL);
+    virtual void CopyStateVec(QEnginePtr src);
 
     virtual void GetAmplitudePage(complex* pagePtr, bitCapIntOcl offset, bitCapIntOcl length);
     virtual void SetAmplitudePage(const complex* pagePtr, bitCapIntOcl offset, bitCapIntOcl length);

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -16,7 +16,6 @@
 #include "common/rdrandwrapper.hpp"
 #include "hamiltonian.hpp"
 
-#include <ctime>
 #include <map>
 #include <vector>
 

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -176,8 +176,6 @@ protected:
         return toClamp;
     }
 
-    template <typename GateFunc> void ControlledLoopFixture(bitLenInt length, GateFunc gate);
-
     void FreeAligned(void* toFree)
     {
         if (toFree) {

--- a/include/qpager.hpp
+++ b/include/qpager.hpp
@@ -84,27 +84,7 @@ protected:
     void Init();
 
     virtual void GetSetAmplitudePage(
-        complex* pagePtr, const complex* cPagePtr, bitCapIntOcl offset, bitCapIntOcl length)
-    {
-        const bitCapIntOcl pageLength = (bitCapIntOcl)pageMaxQPower();
-        bitCapIntOcl perm = 0U;
-        for (bitCapIntOcl i = 0; i < qPages.size(); i++) {
-            if ((perm + length) < offset) {
-                continue;
-            }
-            if (perm >= (offset + length)) {
-                break;
-            }
-            const bitCapInt partOffset = (perm < offset) ? (offset - perm) : 0U;
-            const bitCapInt partLength = (length < pageLength) ? length : pageLength;
-            if (cPagePtr) {
-                qPages[i]->SetAmplitudePage(cPagePtr, (bitCapIntOcl)partOffset, (bitCapIntOcl)partLength);
-            } else {
-                qPages[i]->GetAmplitudePage(pagePtr, (bitCapIntOcl)partOffset, (bitCapIntOcl)partLength);
-            }
-            perm += pageLength;
-        }
-    }
+        complex* pagePtr, const complex* cPagePtr, bitCapIntOcl offset, bitCapIntOcl length);
 
 public:
     QPager(std::vector<QInterfaceEngine> eng, bitLenInt qBitCount, bitCapInt initState = 0,
@@ -305,7 +285,7 @@ public:
     virtual void Dispose(bitLenInt start, bitLenInt length);
     virtual void Dispose(bitLenInt start, bitLenInt length, bitCapInt disposedPerm);
 
-    virtual void Mtrx(const complex* mtrx, bitLenInt qubitIndex);
+    virtual void Mtrx(const complex* mtrx, bitLenInt target);
     virtual void Phase(complex topLeft, complex bottomRight, bitLenInt qubitIndex)
     {
         ApplySingleEither(false, topLeft, bottomRight, qubitIndex);

--- a/include/qunitmulti.hpp
+++ b/include/qunitmulti.hpp
@@ -17,8 +17,6 @@
 #include "qinterface.hpp"
 #include "qunit.hpp"
 
-#include <algorithm>
-
 namespace Qrack {
 
 struct QEngineInfo {

--- a/src/common/dispatchqueue.cpp
+++ b/src/common/dispatchqueue.cpp
@@ -15,14 +15,6 @@
 #include "dispatchqueue.hpp"
 
 namespace Qrack {
-
-DispatchQueue::DispatchQueue()
-    : quit_(false)
-    , isFinished_(true)
-    , isStarted_(false)
-{
-}
-
 DispatchQueue::~DispatchQueue()
 {
     std::unique_lock<std::mutex> lock(lock_);

--- a/src/common/rdrandwrapper.cpp
+++ b/src/common/rdrandwrapper.cpp
@@ -17,8 +17,10 @@
 #include <chrono>
 #include <dirent.h>
 #include <fstream>
+#include <string>
 #include <sys/types.h>
 #include <thread>
+#include <vector>
 #endif
 
 namespace Qrack {

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -12,6 +12,8 @@
 
 #include "qengine_opencl.hpp"
 
+#include <algorithm>
+
 namespace Qrack {
 
 // Mask definition for Apply2x2()

--- a/src/qengine/qengine.cpp
+++ b/src/qengine/qengine.cpp
@@ -12,6 +12,8 @@
 
 #include "qengine.hpp"
 
+#include <algorithm>
+
 namespace Qrack {
 
 bool QEngine::IsIdentity(const complex* mtrx, bool isControlled)

--- a/src/qpager.cpp
+++ b/src/qpager.cpp
@@ -191,6 +191,28 @@ QEnginePtr QPager::MakeEngine(bitLenInt length, bitCapInt perm, int deviceId)
         false, false, useHostRam, deviceId, useRDRAND, isSparse, (real1_f)amplitudeFloor));
 }
 
+void QPager::GetSetAmplitudePage(complex* pagePtr, const complex* cPagePtr, bitCapIntOcl offset, bitCapIntOcl length)
+{
+    const bitCapIntOcl pageLength = (bitCapIntOcl)pageMaxQPower();
+    bitCapIntOcl perm = 0U;
+    for (bitCapIntOcl i = 0; i < qPages.size(); i++) {
+        if ((perm + length) < offset) {
+            continue;
+        }
+        if (perm >= (offset + length)) {
+            break;
+        }
+        const bitCapInt partOffset = (perm < offset) ? (offset - perm) : 0U;
+        const bitCapInt partLength = (length < pageLength) ? length : pageLength;
+        if (cPagePtr) {
+            qPages[i]->SetAmplitudePage(cPagePtr, (bitCapIntOcl)partOffset, (bitCapIntOcl)partLength);
+        } else {
+            qPages[i]->GetAmplitudePage(pagePtr, (bitCapIntOcl)partOffset, (bitCapIntOcl)partLength);
+        }
+        perm += pageLength;
+    }
+}
+
 void QPager::CombineEngines(bitLenInt bit)
 {
     if (bit > qubitCount) {


### PR DESCRIPTION
This doesn't seem to grossly affect execution speed or binary size, but this is close to a reasonable standard for inline methods. (Per #966.)