### PR TITLE
int64_t OpenCL device count

### DIFF
--- a/include/qbdt.hpp
+++ b/include/qbdt.hpp
@@ -35,12 +35,13 @@ class QBdt : public QParity, public QInterface {
 #endif
 protected:
     std::vector<QInterfaceEngine> engines;
-    int devID;
+    int64_t devID;
     QBdtNodeInterfacePtr root;
     bitLenInt attachedQubitCount;
     bitLenInt bdtQubitCount;
     bitCapInt bdtMaxQPower;
     bool isAttached;
+    std::vector<int64_t> deviceIDs;
 
     virtual void SetQubitCount(bitLenInt qb, bitLenInt aqb)
     {
@@ -128,14 +129,14 @@ protected:
 public:
     QBdt(std::vector<QInterfaceEngine> eng, bitLenInt qBitCount, bitCapInt initState = 0,
         qrack_rand_gen_ptr rgp = nullptr, complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = false,
-        bool randomGlobalPhase = true, bool useHostMem = false, int deviceId = -1, bool useHardwareRNG = true,
-        bool useSparseStateVec = false, real1_f norm_thresh = REAL1_EPSILON, std::vector<int> ignored = {},
+        bool randomGlobalPhase = true, bool useHostMem = false, int64_t deviceId = -1, bool useHardwareRNG = true,
+        bool useSparseStateVec = false, real1_f norm_thresh = REAL1_EPSILON, std::vector<int64_t> ignored = {},
         bitLenInt qubitThreshold = 0, real1_f separation_thresh = FP_NORM_EPSILON_F);
 
     QBdt(bitLenInt qBitCount, bitCapInt initState = 0U, qrack_rand_gen_ptr rgp = nullptr,
         complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = false, bool randomGlobalPhase = true,
-        bool useHostMem = false, int deviceId = -1, bool useHardwareRNG = true, bool useSparseStateVec = false,
-        real1_f norm_thresh = REAL1_EPSILON, std::vector<int> ignored = {}, bitLenInt qubitThreshold = 0U,
+        bool useHostMem = false, int64_t deviceId = -1, bool useHardwareRNG = true, bool useSparseStateVec = false,
+        real1_f norm_thresh = REAL1_EPSILON, std::vector<int64_t> ignored = {}, bitLenInt qubitThreshold = 0U,
         real1_f separation_thresh = FP_NORM_EPSILON_F)
         : QBdt({ QINTERFACE_OPTIMAL_SCHROEDINGER }, qBitCount, initState, rgp, phaseFac, doNorm, randomGlobalPhase,
               useHostMem, deviceId, useHardwareRNG, useSparseStateVec, norm_thresh, ignored, qubitThreshold,
@@ -145,7 +146,7 @@ public:
 
     virtual bool isBinaryDecisionTree() { return true; };
 
-    virtual void SetDevice(int dID) {}
+    virtual void SetDevice(int64_t dID) {}
 
     virtual void UpdateRunningNorm(real1_f norm_thresh = REAL1_DEFAULT_ARG)
     {

--- a/include/qengine_cpu.hpp
+++ b/include/qengine_cpu.hpp
@@ -46,8 +46,8 @@ protected:
 public:
     QEngineCPU(bitLenInt qBitCount, bitCapInt initState, qrack_rand_gen_ptr rgp = nullptr,
         complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = false, bool randomGlobalPhase = true, bool ignored = false,
-        int ignored2 = -1, bool useHardwareRNG = true, bool useSparseStateVec = false,
-        real1_f norm_thresh = REAL1_EPSILON, std::vector<int> ignored3 = {}, bitLenInt ignored4 = 0U,
+        int64_t ignored2 = -1, bool useHardwareRNG = true, bool useSparseStateVec = false,
+        real1_f norm_thresh = REAL1_EPSILON, std::vector<int64_t> ignored3 = {}, bitLenInt ignored4 = 0U,
         real1_f ignored5 = FP_NORM_EPSILON_F);
 
     ~QEngineCPU() { Dump(); }
@@ -75,7 +75,7 @@ public:
 #endif
     }
 
-    void SetDevice(int dID) {}
+    void SetDevice(int64_t dID) {}
 
     real1_f FirstNonzeroPhase()
     {

--- a/include/qengine_opencl.hpp
+++ b/include/qengine_opencl.hpp
@@ -186,7 +186,7 @@ typedef std::shared_ptr<PoolItem> PoolItemPtr;
 class QEngineOCL : public QEngine {
 protected:
     complex* stateVec;
-    int deviceID;
+    int64_t deviceID;
     DeviceContextPtr device_context;
     std::vector<EventVecPtr> wait_refs;
     std::list<QueueItem> wait_queue_items;
@@ -246,8 +246,8 @@ public:
 
     QEngineOCL(bitLenInt qBitCount, bitCapInt initState, qrack_rand_gen_ptr rgp = nullptr,
         complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = false, bool randomGlobalPhase = true,
-        bool useHostMem = false, int devID = -1, bool useHardwareRNG = true, bool ignored = false,
-        real1_f norm_thresh = REAL1_EPSILON, std::vector<int> ignored2 = {}, bitLenInt ignored4 = 0U,
+        bool useHostMem = false, int64_t devID = -1, bool useHardwareRNG = true, bool ignored = false,
+        real1_f norm_thresh = REAL1_EPSILON, std::vector<int64_t> ignored2 = {}, bitLenInt ignored4 = 0U,
         real1_f ignored3 = FP_NORM_EPSILON_F);
 
     ~QEngineOCL()
@@ -408,7 +408,7 @@ public:
     bool ForceMParity(bitCapInt mask, bool result, bool doForce = true);
     real1_f ExpectationBitsAll(const bitLenInt* bits, bitLenInt length, bitCapInt offset = 0);
 
-    void SetDevice(int dID);
+    void SetDevice(int64_t dID);
     int64_t GetDevice() { return deviceID; }
 
     void SetQuantumState(const complex* inputState);
@@ -480,7 +480,7 @@ protected:
 
     void Compose(OCLAPI apiCall, bitCapIntOcl* bciArgs, QEngineOCLPtr toCopy);
 
-    void InitOCL(int devID);
+    void InitOCL(int64_t devID);
     PoolItemPtr GetFreePoolItem();
 
     real1_f ParSum(real1* toSum, bitCapIntOcl maxI);

--- a/include/qhybrid.hpp
+++ b/include/qhybrid.hpp
@@ -29,7 +29,7 @@ typedef std::shared_ptr<QHybrid> QHybridPtr;
 class QHybrid : public QEngine {
 protected:
     QEnginePtr engine;
-    int devID;
+    int64_t devID;
     complex phaseFactor;
     bool useRDRAND;
     bool isSparse;
@@ -38,13 +38,13 @@ protected:
     bool isGpu;
     bool isPager;
     real1_f separabilityThreshold;
-    std::vector<int> deviceIDs;
+    std::vector<int64_t> deviceIDs;
 
 public:
     QHybrid(bitLenInt qBitCount, bitCapInt initState = 0U, qrack_rand_gen_ptr rgp = nullptr,
         complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = false, bool randomGlobalPhase = true,
-        bool useHostMem = false, int deviceId = -1, bool useHardwareRNG = true, bool useSparseStateVec = false,
-        real1_f norm_thresh = REAL1_EPSILON, std::vector<int> devList = {}, bitLenInt qubitThreshold = 0U,
+        bool useHostMem = false, int64_t deviceId = -1, bool useHardwareRNG = true, bool useSparseStateVec = false,
+        real1_f norm_thresh = REAL1_EPSILON, std::vector<int64_t> devList = {}, bitLenInt qubitThreshold = 0U,
         real1_f ignored2 = FP_NORM_EPSILON_F);
 
     void SetQubitCount(bitLenInt qb)
@@ -466,7 +466,7 @@ public:
 
     QInterfacePtr Clone();
 
-    void SetDevice(int dID)
+    void SetDevice(int64_t dID)
     {
         devID = dID;
         engine->SetDevice(dID);

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -2246,7 +2246,7 @@ public:
     /**
      *  Set the device index, if more than one device is available.
      */
-    virtual void SetDevice(int dID) = 0;
+    virtual void SetDevice(int64_t dID) = 0;
 
     /**
      *  Get the device index. ("-1" is default).

--- a/include/qmaskfusion.hpp
+++ b/include/qmaskfusion.hpp
@@ -44,8 +44,8 @@ class QMaskFusion : public QEngine {
 protected:
     QEnginePtr engine;
     std::vector<QInterfaceEngine> engTypes;
-    int devID;
-    std::vector<int> devices;
+    int64_t devID;
+    std::vector<int64_t> devices;
     complex phaseFactor;
     bool useRDRAND;
     bool isSparse;
@@ -170,13 +170,13 @@ protected:
 public:
     QMaskFusion(std::vector<QInterfaceEngine> eng, bitLenInt qBitCount, bitCapInt initState = 0U,
         qrack_rand_gen_ptr rgp = nullptr, complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = false,
-        bool randomGlobalPhase = true, bool useHostMem = false, int deviceId = -1, bool useHardwareRNG = true,
-        bool useSparseStateVec = false, real1_f norm_thresh = REAL1_EPSILON, std::vector<int> devList = {},
+        bool randomGlobalPhase = true, bool useHostMem = false, int64_t deviceId = -1, bool useHardwareRNG = true,
+        bool useSparseStateVec = false, real1_f norm_thresh = REAL1_EPSILON, std::vector<int64_t> devList = {},
         bitLenInt qubitThreshold = 0U, real1_f separation_thresh = FP_NORM_EPSILON_F);
     QMaskFusion(bitLenInt qBitCount, bitCapInt initState = 0U, qrack_rand_gen_ptr rgp = nullptr,
         complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = false, bool randomGlobalPhase = true,
-        bool useHostMem = false, int deviceId = -1, bool useHardwareRNG = true, bool useSparseStateVec = false,
-        real1_f norm_thresh = REAL1_EPSILON, std::vector<int> devList = {}, bitLenInt qubitThreshold = 0U,
+        bool useHostMem = false, int64_t deviceId = -1, bool useHardwareRNG = true, bool useSparseStateVec = false,
+        real1_f norm_thresh = REAL1_EPSILON, std::vector<int64_t> devList = {}, bitLenInt qubitThreshold = 0U,
         real1_f separation_thresh = FP_NORM_EPSILON_F)
         : QMaskFusion({ QINTERFACE_OPTIMAL_BASE }, qBitCount, initState, rgp, phaseFac, doNorm, randomGlobalPhase,
               useHostMem, deviceId, useHardwareRNG, useSparseStateVec, norm_thresh, devList, qubitThreshold,
@@ -675,7 +675,7 @@ public:
 
     QInterfacePtr Clone();
 
-    void SetDevice(int dID)
+    void SetDevice(int64_t dID)
     {
         devID = dID;
         engine->SetDevice(dID);

--- a/include/qpager.hpp
+++ b/include/qpager.hpp
@@ -30,7 +30,7 @@ protected:
     complex phaseFactor;
     bool isSparse;
     std::vector<QEnginePtr> qPages;
-    std::vector<int> deviceIDs;
+    std::vector<int64_t> deviceIDs;
     std::vector<bool> devicesHostPointer;
 
     bool useHardwareThreshold;
@@ -96,14 +96,14 @@ protected:
 public:
     QPager(std::vector<QInterfaceEngine> eng, bitLenInt qBitCount, bitCapInt initState = 0U,
         qrack_rand_gen_ptr rgp = nullptr, complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = false,
-        bool ignored = false, bool useHostMem = false, int deviceId = -1, bool useHardwareRNG = true,
-        bool useSparseStateVec = false, real1_f norm_thresh = REAL1_EPSILON, std::vector<int> devList = {},
+        bool ignored = false, bool useHostMem = false, int64_t deviceId = -1, bool useHardwareRNG = true,
+        bool useSparseStateVec = false, real1_f norm_thresh = REAL1_EPSILON, std::vector<int64_t> devList = {},
         bitLenInt qubitThreshold = 0U, real1_f separation_thresh = FP_NORM_EPSILON_F);
 
     QPager(bitLenInt qBitCount, bitCapInt initState = 0U, qrack_rand_gen_ptr rgp = nullptr,
         complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = false, bool ignored = false, bool useHostMem = false,
-        int deviceId = -1, bool useHardwareRNG = true, bool useSparseStateVec = false,
-        real1_f norm_thresh = REAL1_EPSILON, std::vector<int> devList = {}, bitLenInt qubitThreshold = 0U,
+        int64_t deviceId = -1, bool useHardwareRNG = true, bool useSparseStateVec = false,
+        real1_f norm_thresh = REAL1_EPSILON, std::vector<int64_t> devList = {}, bitLenInt qubitThreshold = 0U,
         real1_f separation_thresh = FP_NORM_EPSILON_F)
 #if ENABLE_OPENCL
         : QPager({ OCLEngine::Instance().GetDeviceCount() ? QINTERFACE_OPENCL : QINTERFACE_CPU }, qBitCount, initState,
@@ -118,8 +118,8 @@ public:
 
     QPager(QEnginePtr enginePtr, std::vector<QInterfaceEngine> eng, bitLenInt qBitCount, bitCapInt ignored = 0U,
         qrack_rand_gen_ptr rgp = nullptr, complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = false,
-        bool ignored2 = false, bool useHostMem = false, int deviceId = -1, bool useHardwareRNG = true,
-        bool useSparseStateVec = false, real1_f norm_thresh = REAL1_EPSILON, std::vector<int> devList = {},
+        bool ignored2 = false, bool useHostMem = false, int64_t deviceId = -1, bool useHardwareRNG = true,
+        bool useSparseStateVec = false, real1_f norm_thresh = REAL1_EPSILON, std::vector<int64_t> devList = {},
         bitLenInt qubitThreshold = 0U, real1_f separation_thresh = FP_NORM_EPSILON_F);
 
     void SetConcurrency(uint32_t threadsPerEngine)
@@ -421,7 +421,7 @@ public:
 
     QInterfacePtr Clone();
 
-    void SetDevice(int dID)
+    void SetDevice(int64_t dID)
     {
         deviceIDs.clear();
         deviceIDs.push_back(dID);

--- a/include/qstabilizer.hpp
+++ b/include/qstabilizer.hpp
@@ -97,9 +97,9 @@ protected:
 
 public:
     QStabilizer(bitLenInt n, bitCapInt perm = 0U, qrack_rand_gen_ptr rgp = nullptr, complex ignored = CMPLX_DEFAULT_ARG,
-        bool doNorm = false, bool randomGlobalPhase = true, bool ignored2 = false, int ignored3 = -1,
+        bool doNorm = false, bool randomGlobalPhase = true, bool ignored2 = false, int64_t ignored3 = -1,
         bool useHardwareRNG = true, bool ignored4 = false, real1_f ignored5 = REAL1_EPSILON,
-        std::vector<int> ignored6 = {}, bitLenInt ignored7 = 0U, real1_f ignored8 = FP_NORM_EPSILON_F);
+        std::vector<int64_t> ignored6 = {}, bitLenInt ignored7 = 0U, real1_f ignored8 = FP_NORM_EPSILON_F);
 
     QInterfacePtr Clone()
     {
@@ -159,7 +159,7 @@ public:
         }
     }
 
-    void SetDevice(int dID) {}
+    void SetDevice(int64_t dID) {}
 
     bool Rand()
     {

--- a/include/qstabilizerhybrid.hpp
+++ b/include/qstabilizerhybrid.hpp
@@ -33,7 +33,7 @@ protected:
     QEnginePtr engine;
     QStabilizerPtr stabilizer;
     std::vector<MpsShardPtr> shards;
-    int devID;
+    int64_t devID;
     complex phaseFactor;
     bool doNormalize;
     bool isSparse;
@@ -41,7 +41,7 @@ protected:
     real1_f separabilityThreshold;
     bitLenInt thresholdQubits;
     bitLenInt maxPageQubits;
-    std::vector<int> deviceIDs;
+    std::vector<int64_t> deviceIDs;
 
     QStabilizerPtr MakeStabilizer(bitCapInt perm = 0U);
     QEnginePtr MakeEngine(bitCapInt perm = 0U);
@@ -66,14 +66,14 @@ protected:
 public:
     QStabilizerHybrid(std::vector<QInterfaceEngine> eng, bitLenInt qBitCount, bitCapInt initState = 0U,
         qrack_rand_gen_ptr rgp = nullptr, complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = false,
-        bool randomGlobalPhase = true, bool useHostMem = false, int deviceId = -1, bool useHardwareRNG = true,
-        bool useSparseStateVec = false, real1_f norm_thresh = REAL1_EPSILON, std::vector<int> devList = {},
+        bool randomGlobalPhase = true, bool useHostMem = false, int64_t deviceId = -1, bool useHardwareRNG = true,
+        bool useSparseStateVec = false, real1_f norm_thresh = REAL1_EPSILON, std::vector<int64_t> devList = {},
         bitLenInt qubitThreshold = 0U, real1_f separation_thresh = FP_NORM_EPSILON_F);
 
     QStabilizerHybrid(bitLenInt qBitCount, bitCapInt initState = 0U, qrack_rand_gen_ptr rgp = nullptr,
         complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = false, bool randomGlobalPhase = true,
-        bool useHostMem = false, int deviceId = -1, bool useHardwareRNG = true, bool useSparseStateVec = false,
-        real1_f norm_thresh = REAL1_EPSILON, std::vector<int> devList = {}, bitLenInt qubitThreshold = 0U,
+        bool useHostMem = false, int64_t deviceId = -1, bool useHardwareRNG = true, bool useSparseStateVec = false,
+        real1_f norm_thresh = REAL1_EPSILON, std::vector<int64_t> devList = {}, bitLenInt qubitThreshold = 0U,
         real1_f separation_thresh = FP_NORM_EPSILON_F)
         : QStabilizerHybrid({ QINTERFACE_OPTIMAL_BASE }, qBitCount, initState, rgp, phaseFac, doNorm, randomGlobalPhase,
               useHostMem, deviceId, useHardwareRNG, useSparseStateVec, norm_thresh, devList, qubitThreshold,
@@ -775,7 +775,7 @@ public:
 
     QInterfacePtr Clone();
 
-    void SetDevice(int dID)
+    void SetDevice(int64_t dID)
     {
         devID = dID;
         if (engine) {

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -31,7 +31,7 @@ class QUnit : public QParity, public QInterface {
 #endif
 protected:
     std::vector<QInterfaceEngine> engines;
-    int devID;
+    int64_t devID;
     QEngineShardMap shards;
     complex phaseFactor;
     bool doNormalize;
@@ -41,21 +41,21 @@ protected:
     bool isReactiveSeparate;
     bitLenInt thresholdQubits;
     real1_f separabilityThreshold;
-    std::vector<int> deviceIDs;
+    std::vector<int64_t> deviceIDs;
 
     QInterfacePtr MakeEngine(bitLenInt length, bitCapInt perm);
 
 public:
     QUnit(std::vector<QInterfaceEngine> eng, bitLenInt qBitCount, bitCapInt initState = 0U,
         qrack_rand_gen_ptr rgp = nullptr, complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = false,
-        bool randomGlobalPhase = true, bool useHostMem = false, int deviceId = -1, bool useHardwareRNG = true,
-        bool useSparseStateVec = false, real1_f norm_thresh = REAL1_EPSILON, std::vector<int> devIDs = {},
+        bool randomGlobalPhase = true, bool useHostMem = false, int64_t deviceId = -1, bool useHardwareRNG = true,
+        bool useSparseStateVec = false, real1_f norm_thresh = REAL1_EPSILON, std::vector<int64_t> devIDs = {},
         bitLenInt qubitThreshold = 0U, real1_f separation_thresh = FP_NORM_EPSILON_F);
 
     QUnit(bitLenInt qBitCount, bitCapInt initState = 0U, qrack_rand_gen_ptr rgp = nullptr,
         complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = false, bool randomGlobalPhase = true,
-        bool useHostMem = false, int deviceId = -1, bool useHardwareRNG = true, bool useSparseStateVec = false,
-        real1_f norm_thresh = REAL1_EPSILON, std::vector<int> devIDs = {}, bitLenInt qubitThreshold = 0U,
+        bool useHostMem = false, int64_t deviceId = -1, bool useHardwareRNG = true, bool useSparseStateVec = false,
+        real1_f norm_thresh = REAL1_EPSILON, std::vector<int64_t> devIDs = {}, bitLenInt qubitThreshold = 0U,
         real1_f separation_thresh = FP_NORM_EPSILON_F)
         : QUnit({ QINTERFACE_STABILIZER_HYBRID }, qBitCount, initState, rgp, phaseFac, doNorm, randomGlobalPhase,
               useHostMem, deviceId, useHardwareRNG, useSparseStateVec, norm_thresh, devIDs, qubitThreshold,
@@ -69,17 +69,17 @@ public:
     {
         QInterface::SetConcurrency(threadsPerEngine);
         ParallelUnitApply(
-            [](QInterfacePtr unit, real1_f unused1, real1_f unused2, real1_f unused3, int32_t threadsPerEngine) {
+            [](QInterfacePtr unit, real1_f unused1, real1_f unused2, real1_f unused3, int64_t threadsPerEngine) {
                 unit->SetConcurrency(threadsPerEngine);
                 return true;
             },
-            ZERO_R1_F, ZERO_R1_F, ZERO_R1_F, threadsPerEngine);
+            ZERO_R1_F, ZERO_R1_F, ZERO_R1_F, (uint32_t)threadsPerEngine);
     }
 
     virtual void SetReactiveSeparate(bool isAggSep) { isReactiveSeparate = isAggSep; }
     virtual bool GetReactiveSeparate() { return isReactiveSeparate; }
 
-    virtual void SetDevice(int dID);
+    virtual void SetDevice(int64_t dID);
     virtual int64_t GetDevice() { return devID; }
 
     virtual void SetQuantumState(const complex* inputState);
@@ -358,9 +358,9 @@ protected:
     virtual QInterfacePtr EntangleInCurrentBasis(
         std::vector<bitLenInt*>::iterator first, std::vector<bitLenInt*>::iterator last);
 
-    typedef bool (*ParallelUnitFn)(QInterfacePtr unit, real1_f param1, real1_f param2, real1_f param3, int32_t param4);
+    typedef bool (*ParallelUnitFn)(QInterfacePtr unit, real1_f param1, real1_f param2, real1_f param3, int64_t param4);
     bool ParallelUnitApply(ParallelUnitFn fn, real1_f param1 = ZERO_R1_F, real1_f param2 = ZERO_R1_F,
-        real1_f param3 = ZERO_R1_F, int32_t param4 = 0);
+        real1_f param3 = ZERO_R1_F, int64_t param4 = 0);
 
     virtual bool SeparateBit(bool value, bitLenInt qubit);
 

--- a/include/qunitmulti.hpp
+++ b/include/qunitmulti.hpp
@@ -21,7 +21,7 @@ namespace Qrack {
 
 struct QEngineInfo {
     QInterfacePtr unit;
-    bitLenInt deviceIndex;
+    size_t deviceIndex;
 
     QEngineInfo()
         : unit(NULL)
@@ -29,7 +29,7 @@ struct QEngineInfo {
     {
     }
 
-    QEngineInfo(QInterfacePtr u, bitLenInt devIndex)
+    QEngineInfo(QInterfacePtr u, size_t devIndex)
         : unit(u)
         , deviceIndex(devIndex)
     {
@@ -69,14 +69,14 @@ protected:
 public:
     QUnitMulti(std::vector<QInterfaceEngine> eng, bitLenInt qBitCount, bitCapInt initState = 0U,
         qrack_rand_gen_ptr rgp = nullptr, complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = false,
-        bool randomGlobalPhase = true, bool useHostMem = false, int deviceID = -1, bool useHardwareRNG = true,
-        bool useSparseStateVec = false, real1_f norm_thresh = REAL1_EPSILON, std::vector<int> devList = {},
+        bool randomGlobalPhase = true, bool useHostMem = false, int64_t deviceID = -1, bool useHardwareRNG = true,
+        bool useSparseStateVec = false, real1_f norm_thresh = REAL1_EPSILON, std::vector<int64_t> devList = {},
         bitLenInt qubitThreshold = 0U, real1_f separation_thresh = FP_NORM_EPSILON_F);
 
     QUnitMulti(bitLenInt qBitCount, bitCapInt initState = 0U, qrack_rand_gen_ptr rgp = nullptr,
         complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = false, bool randomGlobalPhase = true,
-        bool useHostMem = false, int deviceID = -1, bool useHardwareRNG = true, bool useSparseStateVec = false,
-        real1_f norm_thresh = REAL1_EPSILON, std::vector<int> devList = {}, bitLenInt qubitThreshold = 0U,
+        bool useHostMem = false, int64_t deviceID = -1, bool useHardwareRNG = true, bool useSparseStateVec = false,
+        real1_f norm_thresh = REAL1_EPSILON, std::vector<int64_t> devList = {}, bitLenInt qubitThreshold = 0U,
         real1_f separation_thresh = FP_NORM_EPSILON_F)
         : QUnitMulti({ QINTERFACE_STABILIZER_HYBRID }, qBitCount, initState, rgp, phaseFac, doNorm, randomGlobalPhase,
               useHostMem, deviceID, useHardwareRNG, useSparseStateVec, norm_thresh, devList, qubitThreshold,

--- a/src/pinvoke_api.cpp
+++ b/src/pinvoke_api.cpp
@@ -578,7 +578,7 @@ MICROSOFT_QUANTUM_DECL uintq init_count_pager(_In_ uintq q, _In_ bool hp)
 
     simulatorType.push_back(QINTERFACE_OPTIMAL);
 
-    std::vector<int> deviceList;
+    std::vector<int64_t> deviceList;
 #if ENABLE_OPENCL
     std::vector<DeviceContextPtr> deviceContext = OCLEngine::Instance().GetDeviceContextPtrVector();
     for (size_t i = 0U; i < deviceContext.size(); ++i) {

--- a/src/qbdt/tree.cpp
+++ b/src/qbdt/tree.cpp
@@ -21,7 +21,8 @@ namespace Qrack {
 
 QBdt::QBdt(std::vector<QInterfaceEngine> eng, bitLenInt qBitCount, bitCapInt initState, qrack_rand_gen_ptr rgp,
     complex phaseFac, bool doNorm, bool randomGlobalPhase, bool useHostMem, int64_t deviceId, bool useHardwareRNG,
-    bool useSparseStateVec, real1_f norm_thresh, std::vector<int64_t> devIds, bitLenInt qubitThreshold, real1_f sep_thresh)
+    bool useSparseStateVec, real1_f norm_thresh, std::vector<int64_t> devIds, bitLenInt qubitThreshold,
+    real1_f sep_thresh)
     : QInterface(qBitCount, rgp, doNorm, useHardwareRNG, randomGlobalPhase, doNorm ? norm_thresh : ZERO_R1_F)
     , engines(eng)
     , devID(deviceId)

--- a/src/qbdt/tree.cpp
+++ b/src/qbdt/tree.cpp
@@ -20,8 +20,8 @@
 namespace Qrack {
 
 QBdt::QBdt(std::vector<QInterfaceEngine> eng, bitLenInt qBitCount, bitCapInt initState, qrack_rand_gen_ptr rgp,
-    complex phaseFac, bool doNorm, bool randomGlobalPhase, bool useHostMem, int deviceId, bool useHardwareRNG,
-    bool useSparseStateVec, real1_f norm_thresh, std::vector<int> ignored, bitLenInt qubitThreshold, real1_f sep_thresh)
+    complex phaseFac, bool doNorm, bool randomGlobalPhase, bool useHostMem, int64_t deviceId, bool useHardwareRNG,
+    bool useSparseStateVec, real1_f norm_thresh, std::vector<int64_t> devIds, bitLenInt qubitThreshold, real1_f sep_thresh)
     : QInterface(qBitCount, rgp, doNorm, useHardwareRNG, randomGlobalPhase, doNorm ? norm_thresh : ZERO_R1_F)
     , engines(eng)
     , devID(deviceId)
@@ -30,6 +30,7 @@ QBdt::QBdt(std::vector<QInterfaceEngine> eng, bitLenInt qBitCount, bitCapInt ini
     , bdtQubitCount(qBitCount)
     , bdtMaxQPower(pow2(qBitCount))
     , isAttached(false)
+    , deviceIDs(devIds)
 {
 #if ENABLE_PTHREAD
     SetConcurrency(std::thread::hardware_concurrency());
@@ -42,7 +43,7 @@ QBdtQEngineNodePtr QBdt::MakeQEngineNode(complex scale, bitLenInt qbCount, bitCa
     return std::make_shared<QBdtQEngineNode>(scale,
         std::dynamic_pointer_cast<QEngine>(
             CreateQuantumInterface(engines, qbCount, perm, rand_generator, ONE_CMPLX, doNormalize, randGlobalPhase,
-                false, devID, hardware_rand_generator != NULL, false, (real1_f)amplitudeFloor)));
+                false, devID, hardware_rand_generator != NULL, false, (real1_f)amplitudeFloor, deviceIDs)));
 }
 
 void QBdt::FallbackMtrx(const complex* mtrx, bitLenInt target)

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -77,8 +77,8 @@ namespace Qrack {
     }
 
 QEngineOCL::QEngineOCL(bitLenInt qBitCount, bitCapInt initState, qrack_rand_gen_ptr rgp, complex phaseFac, bool doNorm,
-    bool randomGlobalPhase, bool useHostMem, int devID, bool useHardwareRNG, bool ignored, real1_f norm_thresh,
-    std::vector<int> devList, bitLenInt qubitThreshold, real1_f sep_thresh)
+    bool randomGlobalPhase, bool useHostMem, int64_t devID, bool useHardwareRNG, bool ignored, real1_f norm_thresh,
+    std::vector<int64_t> devList, bitLenInt qubitThreshold, real1_f sep_thresh)
     : QEngine(qBitCount, rgp, doNorm, randomGlobalPhase, useHostMem, useHardwareRNG, norm_thresh)
     , stateVec(NULL)
     , deviceID(devID)
@@ -538,7 +538,7 @@ void QEngineOCL::DispatchQueue()
     }
 }
 
-void QEngineOCL::SetDevice(int dID)
+void QEngineOCL::SetDevice(int64_t dID)
 {
     if (!(OCLEngine::Instance().GetDeviceCount())) {
         FreeAll();
@@ -549,9 +549,9 @@ void QEngineOCL::SetDevice(int dID)
 
     clFinish();
 
-    int oldContextId = device_context ? device_context->context_id : 0;
+    int64_t oldContextId = device_context ? device_context->context_id : 0;
     const DeviceContextPtr nDeviceContext = OCLEngine::Instance().GetDeviceContextPtr(dID);
-    const int defDevId = (int)OCLEngine::Instance().GetDefaultDeviceID();
+    const int64_t defDevId = (int)OCLEngine::Instance().GetDefaultDeviceID();
 
     std::unique_ptr<complex[]> copyVec = NULL;
 
@@ -686,7 +686,7 @@ real1_f QEngineOCL::ParSum(real1* toSum, bitCapIntOcl maxI)
     return (real1_f)totSum;
 }
 
-void QEngineOCL::InitOCL(int devID) { SetDevice(devID); }
+void QEngineOCL::InitOCL(int64_t devID) { SetDevice(devID); }
 
 void QEngineOCL::ResetStateVec(complex* nStateVec)
 {
@@ -1275,7 +1275,7 @@ void QEngineOCL::Compose(OCLAPI apiCall, bitCapIntOcl* bciArgs, QEngineOCLPtr to
     }
 
     const bool isMigrate = (device_context->context_id != toCopy->device_context->context_id);
-    const int oDevId = toCopy->deviceID;
+    const int64_t oDevId = toCopy->deviceID;
     if (isMigrate) {
         toCopy->SetDevice(deviceID);
     }
@@ -1413,7 +1413,7 @@ void QEngineOCL::DecomposeDispose(bitLenInt start, bitLenInt length, QEngineOCLP
     }
 
     const bool isMigrate = destination && (device_context->context_id != destination->device_context->context_id);
-    const int oDevId = destination ? destination->deviceID : 0;
+    const int64_t oDevId = destination ? destination->deviceID : 0;
     if (isMigrate) {
         destination->SetDevice(deviceID);
     }
@@ -2887,7 +2887,7 @@ real1_f QEngineOCL::SumSqrDiff(QEngineOCLPtr toCompare)
     toCompare->clFinish();
 
     const bool isMigrate = (device_context->context_id != toCompare->device_context->context_id);
-    const int oDevId = toCompare->deviceID;
+    const int64_t oDevId = toCompare->deviceID;
     if (isMigrate) {
         toCompare->SetDevice(deviceID);
     }

--- a/src/qengine/state.cpp
+++ b/src/qengine/state.cpp
@@ -41,8 +41,8 @@ namespace Qrack {
  * phase usually makes sense only if they are initialized at the same time.
  */
 QEngineCPU::QEngineCPU(bitLenInt qBitCount, bitCapInt initState, qrack_rand_gen_ptr rgp, complex phaseFac, bool doNorm,
-    bool randomGlobalPhase, bool useHostMem, int deviceID, bool useHardwareRNG, bool useSparseStateVec,
-    real1_f norm_thresh, std::vector<int> devList, bitLenInt qubitThreshold, real1_f sep_thresh)
+    bool randomGlobalPhase, bool useHostMem, int64_t deviceID, bool useHardwareRNG, bool useSparseStateVec,
+    real1_f norm_thresh, std::vector<int64_t> devList, bitLenInt qubitThreshold, real1_f sep_thresh)
     : QEngine(qBitCount, rgp, doNorm, randomGlobalPhase, true, useHardwareRNG, norm_thresh)
     , isSparse(useSparseStateVec)
 {

--- a/src/qhybrid.cpp
+++ b/src/qhybrid.cpp
@@ -15,8 +15,8 @@
 namespace Qrack {
 
 QHybrid::QHybrid(bitLenInt qBitCount, bitCapInt initState, qrack_rand_gen_ptr rgp, complex phaseFac, bool doNorm,
-    bool randomGlobalPhase, bool useHostMem, int deviceId, bool useHardwareRNG, bool useSparseStateVec,
-    real1_f norm_thresh, std::vector<int> devList, bitLenInt qubitThreshold, real1_f sep_thresh)
+    bool randomGlobalPhase, bool useHostMem, int64_t deviceId, bool useHardwareRNG, bool useSparseStateVec,
+    real1_f norm_thresh, std::vector<int64_t> devList, bitLenInt qubitThreshold, real1_f sep_thresh)
     : QEngine(qBitCount, rgp, doNorm, randomGlobalPhase, useHostMem, useHardwareRNG, norm_thresh)
     , devID(deviceId)
     , phaseFactor(phaseFac)

--- a/src/qmaskfusion.cpp
+++ b/src/qmaskfusion.cpp
@@ -19,8 +19,8 @@
 namespace Qrack {
 
 QMaskFusion::QMaskFusion(std::vector<QInterfaceEngine> eng, bitLenInt qBitCount, bitCapInt initState,
-    qrack_rand_gen_ptr rgp, complex phaseFac, bool doNorm, bool randomGlobalPhase, bool useHostMem, int deviceId,
-    bool useHardwareRNG, bool useSparseStateVec, real1_f norm_thresh, std::vector<int> devList,
+    qrack_rand_gen_ptr rgp, complex phaseFac, bool doNorm, bool randomGlobalPhase, bool useHostMem, int64_t deviceId,
+    bool useHardwareRNG, bool useSparseStateVec, real1_f norm_thresh, std::vector<int64_t> devList,
     bitLenInt qubitThreshold, real1_f sep_thresh)
     : QEngine(qBitCount, rgp, doNorm, randomGlobalPhase, useHostMem, useHardwareRNG, norm_thresh)
     , engTypes(eng)

--- a/src/qpager.cpp
+++ b/src/qpager.cpp
@@ -19,8 +19,8 @@
 namespace Qrack {
 
 QPager::QPager(std::vector<QInterfaceEngine> eng, bitLenInt qBitCount, bitCapInt initState, qrack_rand_gen_ptr rgp,
-    complex phaseFac, bool ignored, bool ignored2, bool useHostMem, int deviceId, bool useHardwareRNG,
-    bool useSparseStateVec, real1_f norm_thresh, std::vector<int> devList, bitLenInt qubitThreshold, real1_f sep_thresh)
+    complex phaseFac, bool ignored, bool ignored2, bool useHostMem, int64_t deviceId, bool useHardwareRNG,
+    bool useSparseStateVec, real1_f norm_thresh, std::vector<int64_t> devList, bitLenInt qubitThreshold, real1_f sep_thresh)
     : QEngine(qBitCount, rgp, false, false, useHostMem, useHardwareRNG, norm_thresh)
     , engines(eng)
     , devID(deviceId)
@@ -53,8 +53,8 @@ QPager::QPager(std::vector<QInterfaceEngine> eng, bitLenInt qBitCount, bitCapInt
 }
 
 QPager::QPager(QEnginePtr enginePtr, std::vector<QInterfaceEngine> eng, bitLenInt qBitCount, bitCapInt initState,
-    qrack_rand_gen_ptr rgp, complex phaseFac, bool ignored, bool ignored2, bool useHostMem, int deviceId,
-    bool useHardwareRNG, bool useSparseStateVec, real1_f norm_thresh, std::vector<int> devList,
+    qrack_rand_gen_ptr rgp, complex phaseFac, bool ignored, bool ignored2, bool useHostMem, int64_t deviceId,
+    bool useHardwareRNG, bool useSparseStateVec, real1_f norm_thresh, std::vector<int64_t> devList,
     bitLenInt qubitThreshold, real1_f sep_thresh)
     : QEngine(qBitCount, rgp, false, false, useHostMem, useHardwareRNG, norm_thresh)
     , engines(eng)

--- a/src/qpager.cpp
+++ b/src/qpager.cpp
@@ -20,7 +20,8 @@ namespace Qrack {
 
 QPager::QPager(std::vector<QInterfaceEngine> eng, bitLenInt qBitCount, bitCapInt initState, qrack_rand_gen_ptr rgp,
     complex phaseFac, bool ignored, bool ignored2, bool useHostMem, int64_t deviceId, bool useHardwareRNG,
-    bool useSparseStateVec, real1_f norm_thresh, std::vector<int64_t> devList, bitLenInt qubitThreshold, real1_f sep_thresh)
+    bool useSparseStateVec, real1_f norm_thresh, std::vector<int64_t> devList, bitLenInt qubitThreshold,
+    real1_f sep_thresh)
     : QEngine(qBitCount, rgp, false, false, useHostMem, useHardwareRNG, norm_thresh)
     , engines(eng)
     , devID(deviceId)

--- a/src/qstabilizer.cpp
+++ b/src/qstabilizer.cpp
@@ -36,8 +36,8 @@
 namespace Qrack {
 
 QStabilizer::QStabilizer(bitLenInt n, bitCapInt perm, qrack_rand_gen_ptr rgp, complex ignored, bool doNorm,
-    bool randomGlobalPhase, bool ignored2, int ignored3, bool useHardwareRNG, bool ignored4, real1_f ignored5,
-    std::vector<int> ignored6, bitLenInt ignored7, real1_f ignored8)
+    bool randomGlobalPhase, bool ignored2, int64_t ignored3, bool useHardwareRNG, bool ignored4, real1_f ignored5,
+    std::vector<int64_t> ignored6, bitLenInt ignored7, real1_f ignored8)
     : QInterface(n, rgp, doNorm, useHardwareRNG, randomGlobalPhase, REAL1_EPSILON)
     , x((n << 1U) + 1U, BoolVector(n, false))
     , z((n << 1U) + 1U, BoolVector(n, false))

--- a/src/qstabilizerhybrid.cpp
+++ b/src/qstabilizerhybrid.cpp
@@ -28,8 +28,8 @@
 namespace Qrack {
 
 QStabilizerHybrid::QStabilizerHybrid(std::vector<QInterfaceEngine> eng, bitLenInt qBitCount, bitCapInt initState,
-    qrack_rand_gen_ptr rgp, complex phaseFac, bool doNorm, bool randomGlobalPhase, bool useHostMem, int deviceId,
-    bool useHardwareRNG, bool useSparseStateVec, real1_f norm_thresh, std::vector<int> devList,
+    qrack_rand_gen_ptr rgp, complex phaseFac, bool doNorm, bool randomGlobalPhase, bool useHostMem, int64_t deviceId,
+    bool useHardwareRNG, bool useSparseStateVec, real1_f norm_thresh, std::vector<int64_t> devList,
     bitLenInt qubitThreshold, real1_f sep_thresh)
     : QEngine(qBitCount, rgp, doNorm, randomGlobalPhase, useHostMem, useHardwareRNG, norm_thresh)
     , engineTypes(eng)

--- a/src/qstabilizerhybrid.cpp
+++ b/src/qstabilizerhybrid.cpp
@@ -246,7 +246,7 @@ QInterfacePtr QStabilizerHybrid::Clone()
 {
     QStabilizerHybridPtr c = std::make_shared<QStabilizerHybrid>(engineTypes, qubitCount, 0, rand_generator,
         phaseFactor, doNormalize, randGlobalPhase, useHostRam, devID, useRDRAND, isSparse, (real1_f)amplitudeFloor,
-        std::vector<int>{}, thresholdQubits, separabilityThreshold);
+        std::vector<int64_t>{}, thresholdQubits, separabilityThreshold);
 
     Finish();
     c->Finish();
@@ -272,7 +272,7 @@ QEnginePtr QStabilizerHybrid::CloneEmpty()
 {
     QStabilizerHybridPtr c = std::make_shared<QStabilizerHybrid>(engineTypes, qubitCount, 0U, rand_generator,
         phaseFactor, doNormalize, randGlobalPhase, useHostRam, devID, useRDRAND, isSparse, (real1_f)amplitudeFloor,
-        std::vector<int>{}, thresholdQubits, separabilityThreshold);
+        std::vector<int64_t>{}, thresholdQubits, separabilityThreshold);
     c->Finish();
 
     c->stabilizer = NULL;
@@ -354,7 +354,7 @@ QInterfacePtr QStabilizerHybrid::Decompose(bitLenInt start, bitLenInt length)
 {
     QStabilizerHybridPtr dest = std::make_shared<QStabilizerHybrid>(engineTypes, length, 0, rand_generator, phaseFactor,
         doNormalize, randGlobalPhase, useHostRam, devID, useRDRAND, isSparse, (real1_f)amplitudeFloor,
-        std::vector<int>{}, thresholdQubits, separabilityThreshold);
+        std::vector<int64_t>{}, thresholdQubits, separabilityThreshold);
 
     Decompose(start, dest);
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -63,8 +63,8 @@
 namespace Qrack {
 
 QUnit::QUnit(std::vector<QInterfaceEngine> eng, bitLenInt qBitCount, bitCapInt initState, qrack_rand_gen_ptr rgp,
-    complex phaseFac, bool doNorm, bool randomGlobalPhase, bool useHostMem, int deviceID, bool useHardwareRNG,
-    bool useSparseStateVec, real1_f norm_thresh, std::vector<int> devList, bitLenInt qubitThreshold, real1_f sep_thresh)
+    complex phaseFac, bool doNorm, bool randomGlobalPhase, bool useHostMem, int64_t deviceID, bool useHardwareRNG,
+    bool useSparseStateVec, real1_f norm_thresh, std::vector<int64_t> devList, bitLenInt qubitThreshold, real1_f sep_thresh)
     : QInterface(qBitCount, rgp, doNorm, useHardwareRNG, randomGlobalPhase, norm_thresh)
     , engines(eng)
     , devID(deviceID)
@@ -3402,7 +3402,7 @@ void QUnit::CPhaseFlipIfLess(bitCapInt greaterPerm, bitLenInt start, bitLenInt l
 }
 #endif
 
-bool QUnit::ParallelUnitApply(ParallelUnitFn fn, real1_f param1, real1_f param2, real1_f param3, int32_t param4)
+bool QUnit::ParallelUnitApply(ParallelUnitFn fn, real1_f param1, real1_f param2, real1_f param3, int64_t param4)
 {
     std::vector<QInterfacePtr> units;
     for (bitLenInt i = 0U; i < shards.size(); ++i) {
@@ -3421,7 +3421,7 @@ bool QUnit::ParallelUnitApply(ParallelUnitFn fn, real1_f param1, real1_f param2,
 void QUnit::UpdateRunningNorm(real1_f norm_thresh)
 {
     ParallelUnitApply(
-        [](QInterfacePtr unit, real1_f norm_thresh, real1_f unused2, real1_f unused3, int32_t unused4) {
+        [](QInterfacePtr unit, real1_f norm_thresh, real1_f unused2, real1_f unused3, int64_t unused4) {
             unit->UpdateRunningNorm(norm_thresh);
             return true;
         },
@@ -3431,7 +3431,7 @@ void QUnit::UpdateRunningNorm(real1_f norm_thresh)
 void QUnit::NormalizeState(real1_f nrm, real1_f norm_thresh, real1_f phaseArg)
 {
     ParallelUnitApply(
-        [](QInterfacePtr unit, real1_f nrm, real1_f norm_thresh, real1_f phaseArg, int32_t unused) {
+        [](QInterfacePtr unit, real1_f nrm, real1_f norm_thresh, real1_f phaseArg, int64_t unused) {
             unit->NormalizeState(nrm, norm_thresh, phaseArg);
             return true;
         },
@@ -3440,7 +3440,7 @@ void QUnit::NormalizeState(real1_f nrm, real1_f norm_thresh, real1_f phaseArg)
 
 void QUnit::Finish()
 {
-    ParallelUnitApply([](QInterfacePtr unit, real1_f unused1, real1_f unused2, real1_f unused3, int32_t unused4) {
+    ParallelUnitApply([](QInterfacePtr unit, real1_f unused1, real1_f unused2, real1_f unused3, int64_t unused4) {
         unit->Finish();
         return true;
     });
@@ -3449,14 +3449,14 @@ void QUnit::Finish()
 bool QUnit::isFinished()
 {
     return ParallelUnitApply([](QInterfacePtr unit, real1_f unused1, real1_f unused2, real1_f unused3,
-                                 int32_t unused4) { return unit->isFinished(); });
+                                 int64_t unused4) { return unit->isFinished(); });
 }
 
-void QUnit::SetDevice(int dID)
+void QUnit::SetDevice(int64_t dID)
 {
     devID = dID;
     ParallelUnitApply(
-        [](QInterfacePtr unit, real1_f unused1, real1_f forceReInit, real1_f unused2, int32_t dID) {
+        [](QInterfacePtr unit, real1_f unused1, real1_f forceReInit, real1_f unused2, int64_t dID) {
             unit->SetDevice(dID);
             return true;
         },

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -64,7 +64,8 @@ namespace Qrack {
 
 QUnit::QUnit(std::vector<QInterfaceEngine> eng, bitLenInt qBitCount, bitCapInt initState, qrack_rand_gen_ptr rgp,
     complex phaseFac, bool doNorm, bool randomGlobalPhase, bool useHostMem, int64_t deviceID, bool useHardwareRNG,
-    bool useSparseStateVec, real1_f norm_thresh, std::vector<int64_t> devList, bitLenInt qubitThreshold, real1_f sep_thresh)
+    bool useSparseStateVec, real1_f norm_thresh, std::vector<int64_t> devList, bitLenInt qubitThreshold,
+    real1_f sep_thresh)
     : QInterface(qBitCount, rgp, doNorm, useHardwareRNG, randomGlobalPhase, norm_thresh)
     , engines(eng)
     , devID(deviceID)

--- a/src/qunitmulti.cpp
+++ b/src/qunitmulti.cpp
@@ -16,8 +16,8 @@
 namespace Qrack {
 
 QUnitMulti::QUnitMulti(std::vector<QInterfaceEngine> eng, bitLenInt qBitCount, bitCapInt initState,
-    qrack_rand_gen_ptr rgp, complex phaseFac, bool doNorm, bool randomGlobalPhase, bool useHostMem, int deviceID,
-    bool useHardwareRNG, bool useSparseStateVec, real1_f norm_thresh, std::vector<int> devList,
+    qrack_rand_gen_ptr rgp, complex phaseFac, bool doNorm, bool randomGlobalPhase, bool useHostMem, int64_t deviceID,
+    bool useHardwareRNG, bool useSparseStateVec, real1_f norm_thresh, std::vector<int64_t> devList,
     bitLenInt qubitThreshold, real1_f sep_thresh)
     : QUnit(eng, qBitCount, initState, rgp, phaseFac, doNorm, randomGlobalPhase, useHostMem, -1, useHardwareRNG,
           useSparseStateVec, norm_thresh, devList, qubitThreshold, sep_thresh)
@@ -68,7 +68,7 @@ QInterfacePtr QUnitMulti::MakeEngine(bitLenInt length, bitCapInt perm)
 
     // Suppress passing device list, since QUnitMulti occupies all devices in the list
     QInterfacePtr toRet = CreateQuantumInterface(engines, length, perm, rand_generator, phaseFactor, doNormalize,
-        randGlobalPhase, useHostRam, deviceId, useRDRAND, isSparse, (real1_f)amplitudeFloor, std::vector<int>{},
+        randGlobalPhase, useHostRam, deviceId, useRDRAND, isSparse, (real1_f)amplitudeFloor, std::vector<int64_t>{},
         thresholdQubits, separabilityThreshold);
 
     return toRet;
@@ -83,7 +83,7 @@ std::vector<QEngineInfo> QUnitMulti::GetQInfos()
     for (auto&& shard : shards) {
         if (shard.unit && (std::find(qips.begin(), qips.end(), shard.unit) == qips.end())) {
             qips.push_back(shard.unit);
-            int deviceIndex = std::distance(
+            size_t deviceIndex = std::distance(
                 deviceList.begin(), std::find_if(deviceList.begin(), deviceList.end(), [&](DeviceInfo di) {
                     return di.id == (shard.unit->GetDevice() < 0) ? OCLEngine::Instance().GetDefaultDeviceID()
                                                                   : (size_t)shard.unit->GetDevice();

--- a/test/benchmarks_main.cpp
+++ b/test/benchmarks_main.cpp
@@ -43,7 +43,7 @@ int benchmarkSamples = 100;
 int benchmarkDepth = 20;
 int benchmarkMaxMagic = -1;
 int timeout = -1;
-std::vector<int> devList;
+std::vector<int64_t> devList;
 bool optimal = false;
 bool optimal_single = false;
 

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -38,7 +38,7 @@ bool isBinaryOutput;
 int benchmarkSamples = 100;
 int benchmarkDepth = 20;
 int benchmarkMaxMagic = -1;
-std::vector<int> devList;
+std::vector<int64_t> devList;
 
 #define SHOW_OCL_BANNER()                                                                                              \
     if (OCLEngine::Instance().GetDeviceCount()) {                                                                      \

--- a/test/tests.hpp
+++ b/test/tests.hpp
@@ -45,7 +45,7 @@ extern int benchmarkSamples;
 extern int benchmarkDepth;
 extern int benchmarkMaxMagic;
 extern int timeout;
-extern std::vector<int> devList;
+extern std::vector<int64_t> devList;
 extern bool optimal;
 extern bool optimal_single;
 


### PR DESCRIPTION
We will likely never need 2^64+ bits of OpenCL device addressing in our lifetimes, or many lifetimes after. However, conceivably, we could at some time exceed 2^32 devices, (or 2^31, with sign degeneracy in Qrack). By finishing the already vestigial shift toward the assumption of 64-bit device indices, we future-proof this, probably forever, even if the OpenCL standard might assume 32 bits of device enumeration, for now.

I need to make sure this works with XACC. If it doesn't, I will hold off on merge, to also update the XACC plugin. However, I'm guessing this probably won't break that build, and then I'll be merging, shortly.